### PR TITLE
Adding dispatch of an event before and after applyAllUpdates()

### DIFF
--- a/app/code/core/Mage/Core/Model/Resource/Setup.php
+++ b/app/code/core/Mage/Core/Model/Resource/Setup.php
@@ -218,6 +218,7 @@ class Mage_Core_Model_Resource_Setup
      */
     static public function applyAllUpdates()
     {
+    	Mage::dispatchEvent('apply_db_schema_updates_before');
         Mage::app()->setUpdateMode(true);
         self::$_hadUpdates = false;
 
@@ -243,6 +244,7 @@ class Mage_Core_Model_Resource_Setup
         }
 
         Mage::app()->setUpdateMode(false);
+        Mage::dispatchEvent('apply_db_schema_updates_after');
         self::$_schemaUpdatesChecked = true;
         return true;
     }


### PR DESCRIPTION
This allows for the ability to put in a mechanism to prevent errors from
being displayed to users if more than one make a request in the same
span of time that the install/upgrade scripts are running.  

This mechanism could be: waiting, sending to an separate page, etc.  

Now, we would not have to turn on maintenance mode...potentially.
