### PR TITLE
MCACE-136 - Catalog API call assignProduct does not pass $identifierType...

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Category/Api.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Api.php
@@ -446,7 +446,7 @@ class Mage_Catalog_Model_Category_Api extends Mage_Catalog_Model_Api_Resource
     {
         $category = $this->_initCategory($categoryId);
         $positions = $category->getProductsPosition();
-        $productId = $this->_getProductId($productId);
+        $productId = $this->_getProductId($productId, $identifierType);
         $positions[$productId] = $position;
         $category->setPostedProducts($positions);
 


### PR DESCRIPTION
... to _getProductId

Fixed to match MCA-CE rev 153941
