### PR TITLE
Add method to prevent sending of response after action completes

### DIFF
--- a/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/Wysiwyg/ImagesController.php
@@ -182,6 +182,7 @@ class Mage_Adminhtml_Cms_Wysiwyg_ImagesController extends Mage_Adminhtml_Control
      */
     public function thumbnailAction()
     {
+        $this->getResponse()->disableOutput();
         $file = $this->getRequest()->getParam('file');
         $file = Mage::helper('Mage_Cms_Helper_Wysiwyg_Images')->idDecode($file);
         $thumb = $this->getStorage()->resizeOnTheFly($file);

--- a/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
+++ b/app/code/core/Mage/Adminhtml/controllers/Cms/WysiwygController.php
@@ -40,6 +40,7 @@ class Mage_Adminhtml_Cms_WysiwygController extends Mage_Adminhtml_Controller_Act
      */
     public function directiveAction()
     {
+        $this->getResponse()->disableOutput();
         $directive = $this->getRequest()->getParam('___directive');
         $directive = Mage::helper('Mage_Core_Helper_Data')->urlDecode($directive);
         $url = Mage::getModel('Mage_Core_Model_Email_Template_Filter')->filter($directive);

--- a/app/code/core/Mage/Core/Controller/Response/Http.php
+++ b/app/code/core/Mage/Core/Controller/Response/Http.php
@@ -40,6 +40,20 @@ class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
     protected static $_transportObject = null;
 
     /**
+     * @var bool
+     */
+    protected $_isOutputDisabled = false;
+
+    /**
+     * Disable response output; useful for situations where the response was already rendered such as
+     * with an image library that uses direct output.
+     */
+    public function disableOutput()
+    {
+        $this->_isOutputDisabled = true;
+    }
+
+    /**
      * Fixes CGI only one Status header allowed bug
      *
      * @link  http://bugs.php.net/bug.php?id=36705
@@ -77,10 +91,15 @@ class Mage_Core_Controller_Response_Http extends Zend_Controller_Response_Http
         return parent::sendHeaders();
     }
 
+    /**
+     * Dispatch an event before the response is rendered and only render response if it is not disabled.
+     */
     public function sendResponse()
     {
         Mage::dispatchEvent('http_response_send_before', array('response'=>$this));
-        return parent::sendResponse();
+        if ( ! $this->_isOutputDisabled) {
+            return parent::sendResponse();
+        }
     }
 
     /**


### PR DESCRIPTION
Magento needs some way for a controller action to output and then signal the router to _not_ attempt to send headers. There are cases like the wysiwyg thumbnails that generate "HEADERS ALREADY SENT" errors in the logs because the headers were sent by dynamic image output. I manually added an "exit;" inside the controllers to prevent this in production but there should be a more graceful solution since "exit;" prevents the use of event observers that are dispatched after the controller action. For example:

```
$this->getResponse()->disableOutput();
```
