### PR TITLE
Fix _forward secret key matching expects standard router matching

### DIFF
--- a/app/code/core/Mage/Backend/Model/Url.php
+++ b/app/code/core/Mage/Backend/Model/Url.php
@@ -149,12 +149,20 @@ class Mage_Backend_Model_Url extends Mage_Core_Model_Url
     {
         $salt = Mage::getSingleton('Mage_Core_Model_Session')->getFormKey();
 
-        $p = explode('/', trim($this->getRequest()->getOriginalPathInfo(), '/'));
+        $request = $this->getRequest();
         if (!$controller) {
-            $controller = !empty($p[1]) ? $p[1] : $this->getRequest()->getControllerName();
+            if ($request->getBeforeForwardInfo('controller_name') !== null) {
+                $controller = $request->getBeforeForwardInfo('controller_name');
+            } else {
+                $controller = $request->getControllerName();
+            }
         }
         if (!$action) {
-            $action = !empty($p[2]) ? $p[2] : $this->getRequest()->getActionName();
+            if ($request->getBeforeForwardInfo('action_name') !== null) {
+                $action = $request->getBeforeForwardInfo('action_name');
+            } else {
+                $action = $request->getActionName();
+            }
         }
 
         $secret = $controller . $action . $salt;


### PR DESCRIPTION
Background:
When you are in admin and using secret keys, the key in the request
has to match up with the controller + action + salt. If not you are
bounced to the dashboard. When you call _forward to get sent to a new
URL, the new dispatch loop call checks the secret key a second time.
The 'problem' at this stage is the secret key doesn't match up with
the controller and/or action portion. The 'fix' that currently is in
place is to grab the the original PATH_INFO from the request, split
 that on '/', grab indexes 1 and 2, and use those as the
controller and action.
Keep in mind, this only happens if the controller and/or action are
not passed directly to the getSecretKey call. Additionally, if
either of these is empty then it has a second try of getting the
controller or action name stored in the request object directly.

Ok, that's the background. Here's the 'bug':
If you have code in place that handles routing differently than the
standard routers, the getSecretKey method erroneously making
assumptions about the translation of a PATH_INFO string into a
module/controller/action array. And, as luck would have it, the
request object has a MUCH better method of working around the issue.
The is a getBeforeForwardInfo method that can give the original
request module/controller/action that was made. That info would
correspond to what getSecretKey expects.

This patch was also submitted as MCACE-144 to the Magento 1.6.2.0
MCA-CE contributor repository in Mage_Adminhtml_Model_Url.

Thanks to Lee Saferite for this one!
