### PR TITLE
Add events to transactional email sending

### DIFF
--- a/app/code/core/Mage/Core/Helper/Mail.php
+++ b/app/code/core/Mage/Core/Helper/Mail.php
@@ -1,0 +1,17 @@
+<?php
+
+class Mage_Core_Helper_Mail extends Mage_Core_Helper_Abstract
+{
+    /**
+     * Return a mailer instance to be used by the Mage_Core_Model_Email_Template
+     *
+     * The used factory helper and method can be configured at global/email/factory_helper.
+     * Default is Mage_Core_Helper_Mail::getMailer.
+     *
+     * @return Zend_Mail
+     */
+    public function getMailer()
+    {
+        return new Zend_Mail('utf-8');
+    }
+}

--- a/app/code/core/Mage/Core/etc/config.xml
+++ b/app/code/core/Mage/Core/etc/config.xml
@@ -89,7 +89,13 @@
             <page_type>
                 <render_inherited>0</render_inherited>
             </page_type>
+            <design_fallback>
+                <allow_map_update>1</allow_map_update>
+            </design_fallback>
         </dev>
+        <email>
+            <factory_helper>Mage_Core_Helper_Mail::getMailer</factory_helper>
+        </email>
     </global>
     <frontend>
         <routers>
@@ -291,7 +297,7 @@
         </web>
         <admin>
             <startup>
-                <page>dashboard</page>
+                <menu_item_id>dashboard</menu_item_id>
             </startup>
             <url>
                 <use_custom>0</use_custom>

--- a/app/code/core/Mage/Newsletter/Model/Observer.php
+++ b/app/code/core/Mage/Newsletter/Model/Observer.php
@@ -69,4 +69,23 @@ class Mage_Newsletter_Model_Observer
 
          $collection->walk('sendPerSubscriber', array($countOfSubscritions));
     }
+
+    /**
+     * Set the subscriber store id on the transport object
+     *
+     * Set the subscriber store id on the transport object so the logo configuration for the
+     * subscriber store is read (which is not necessarily the current one).
+     *
+     * @param Varien_Object $observer
+     * @return Mage_Newsletter_Model_Observer
+     */
+    public function emailTemplateFilterBefore($observer)
+    {
+        // Only match newsletter subscriber events
+        $subscriber = $observer->getTransport()->getVariables()->getSubscriber();
+        if ($subscriber && $subscriber instanceof Mage_Newsletter_Model_Subscriber) {
+            $observer->getTransport()->setStoreId($subscriber->getStoreId());
+        }
+        return $this;
+    }
 }

--- a/app/code/core/Mage/Newsletter/etc/config.xml
+++ b/app/code/core/Mage/Newsletter/etc/config.xml
@@ -61,6 +61,16 @@
         <newsletter>
             <tempate_filter>Mage_Newsletter_Model_Template_Filter</tempate_filter>
         </newsletter>
+        <events>
+            <email_template_filter_before>
+                <observers>
+                    <newsletter>
+                        <class>Mage_Newsletter_Model_Observer</class>
+                        <method>emailTemplateFilterBefore</method>
+                    </newsletter>
+                </observers>
+            </email_template_filter_before>
+        </events>
     </global>
     <adminhtml>
         <events>


### PR DESCRIPTION
The purpose of the events is to enable modules to
- add attachments
- change email templates
- modify template variables
- add template variables
- modify email content

Also, the patch makes the mailer class factory method configurable.
The purpose is to enable modules to use a diferent mailer without
reverting to a rewrite of Mage_Core_Model_Email_Template.

Additionaly the undeclared dependency on Mage_Newsletter was
removed from Mage_Core_Model_Email_Template, and an event observer
added to the newsletter module taking care the business logic
is not changed.
