### PR TITLE
Missing closing tag in New Order email template

### DIFF
--- a/app/code/core/Mage/Sales/view/email/order_new.html
+++ b/app/code/core/Mage/Sales/view/email/order_new.html
@@ -40,6 +40,7 @@ body,td { color:#2f2f2f; font:11px/1.35em Verdana, Arial, Helvetica, sans-serif;
                         If you have any questions about your order please contact us at <a href="mailto:{{config path='trans_email/ident_support/email'}}" style="color:#1E7EC8;">{{config path='trans_email/ident_support/email'}}</a> or call us at <span class="nobr">{{config path='general/store_information/phone'}}</span> Monday - Friday, 8am - 5pm PST.
                     </p>
                     <p style="font-size:12px; line-height:16px; margin:0;">Your order confirmation is below. Thank you again for your business.</p>
+                </td>
             </tr>
             <tr>
                 <td>


### PR DESCRIPTION
Added missing closing `</td>` tag to New Order template
