### PR TITLE
Fix issue with Mage/GoogleCheckout reference in Mage/Sales module

### DIFF
--- a/app/code/core/Mage/GoogleCheckout/etc/config.xml
+++ b/app/code/core/Mage/GoogleCheckout/etc/config.xml
@@ -131,6 +131,7 @@
             <googlecheckout>
                 <active>1</active>
                 <model>Mage_GoogleCheckout_Model_Payment</model>
+                <title>Google Checkout</title>
             </googlecheckout>
         </payment>
         <google>

--- a/app/code/core/Mage/Sales/etc/config.xml
+++ b/app/code/core/Mage/Sales/etc/config.xml
@@ -1451,11 +1451,6 @@
     </adminhtml>
     <default>
         <payment>
-            <googlecheckout>
-                <active>1</active>
-                <model>Mage_GoogleCheckout_Model_Payment</model>
-                <title>Google Checkout</title>
-            </googlecheckout>
         </payment>
         <sales>
             <totals_sort>


### PR DESCRIPTION
Currently if you disable Mage/GoogleCheckout module, during checkout process there will be a fatal error since payment model of google checkout module that is marked as active gets retrieved. It is wrong behavior, since sales module shouldn't depend on a particular payment method. 

The following pull request contain proper fix of that issue. 
