### PR TITLE
Passing args node value to observer object

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -1306,7 +1306,7 @@ class Mage_Core_Model_App
             }
 
             foreach ($events[$eventName]['observers'] as $obsName=>$obs) {
-                $observer->setData(array('event'=>$event));
+                $observer->setData(array('event'=>$event, 'args'=>$obs['args']));
                 Magento_Profiler::start('OBSERVER:' . $obsName);
                 switch ($obs['type']) {
                     case 'disabled':


### PR DESCRIPTION
There is a reference to a config node 'args' in Mage_Core_Model_App dispatchEvent which can be used when declaring observers in config.xml.  Unless mistaken, it currently appears to be unused. 

It is not clear what the intended use of this node is, and although I suspect not the original intention, but one potential use could be in passing some arguments to an observer.

This is something I noticed a while back and has came up again recently in a question on stackoverflow: http://stackoverflow.com/questions/11898878/using-args-in-magento-observer-declaration 

Please see attached commit, which passes the value of the args node along with observer object.  

Alternatively, if the args node is not to be used then the reference to it in Mage_Core_Model_App dispatchEvent could be removed to prevent any future confusion.
