### PR TITLE
Throw exception if joinAttribute is used

### DIFF
--- a/app/code/core/Mage/Sales/Model/Resource/Collection/Abstract.php
+++ b/app/code/core/Mage/Sales/Model/Resource/Collection/Abstract.php
@@ -161,6 +161,6 @@ abstract class Mage_Sales_Model_Resource_Collection_Abstract extends Mage_Core_M
      */
     public function joinAttribute($alias, $attribute, $bind, $filter = null, $joinType = 'inner', $storeId = null)
     {
-        return $this;
+        throw new Exception('Not implemented.');
     }
 }


### PR DESCRIPTION
A exception is better than a silent fail: Silent fails can cause very business critical problems that go unnoticed.
