### PR TITLE
Fixed camel case issue with resource validation for backend menu items

### DIFF
--- a/app/code/core/Mage/Backend/Model/Menu/Item/Validator.php
+++ b/app/code/core/Mage/Backend/Model/Menu/Item/Validator.php
@@ -71,7 +71,7 @@ class Mage_Backend_Model_Menu_Item_Validator
         $resourceValidator = new Zend_Validate();
         $resourceValidator->addValidator(new Zend_Validate_StringLength(array('min' => 8)));
         $resourceValidator->addValidator(
-            new Zend_Validate_Regex('/^[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}$/')
+            new Zend_Validate_Regex('/^[A-Z]+[A-Za-z0-9]{1,}_[A-Z]+[A-Za-z0-9]{1,}::[A-Za-z_0-9]{1,}$/')
         );
 
         $attributeValidator = new Zend_Validate();


### PR DESCRIPTION
This is a fix for the regex that handles the validation of backend menu items.  I discovered an issue with this when converting some 1.x modules to Magento 2.

I reported this issue on the Magento 2 repo:  https://github.com/magento/magento2/issues/79

Ultimately, while you can have camel cased package names for your module directories, when you setup menu item resources, the validation did not allow it.  This fix should take care of that.
