### PR TITLE
joinUrlRewrite. Join on non-existing column

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -1091,9 +1091,9 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
     {
         $this->joinTable(
             'core_url_rewrite',
-            'entity_id=entity_id',
+            'product_id=entity_id',
             array('request_path'),
-            '{{table}}.type = ' . Mage_Core_Model_Url_Rewrite::TYPE_PRODUCT,
+            null,
             'left'
         );
 


### PR DESCRIPTION
joinUrlRewrite() tried to join on a non-existing column in `core_url_rewrite`.
Before the fix, this join was done with the product entity_id, on the entity_id column of core_url_rewrite.
This column does not exists in core_url_rewrite.
I've changed to query to join on product_id in core_url_rewrite.

It also used a conditional statement where type = 2. But column `type` does not exist in core_url_rewrite. I've removed this conditional statement.

Before fix, Magento would throw an exception. After fix, it joins the correct columns
