### PR TITLE
Fix issue with PHP_VERSION on Ubuntu servers

### DIFF
--- a/downloader/lib/Mage/Connect/Package.php
+++ b/downloader/lib/Mage/Connect/Package.php
@@ -575,8 +575,10 @@ END;
         $min = $this->getDependencyPhpVersionMin();
         $max = $this->getDependencyPhpVersionMax();
 
-        $minOk = $min? version_compare(PHP_VERSION, $min, ">=") : true;
-        $maxOk = $max? version_compare(PHP_VERSION, $max, "<=") : true;
+        $version = substr(PHP_VERSION,0,strpos(PHP_VERSION, "-"));
+
+        $minOk = $min? version_compare($version, $min, ">=") : true;
+        $maxOk = $max? version_compare($version, $max, "<=") : true;
 
         if(!$minOk || !$maxOk) {
             $err = "requires PHP version ";

--- a/lib/Mage/Connect/Package.php
+++ b/lib/Mage/Connect/Package.php
@@ -738,8 +738,10 @@ END;
         $min = $this->getDependencyPhpVersionMin();
         $max = $this->getDependencyPhpVersionMax();
 
-        $minOk = $min? version_compare(PHP_VERSION, $min, ">=") : true;
-        $maxOk = $max? version_compare(PHP_VERSION, $max, "<=") : true;
+        $version = substr(PHP_VERSION,0,strpos(PHP_VERSION, "-"));
+
+        $minOk = $min? version_compare($version, $min, ">=") : true;
+        $maxOk = $max? version_compare($version, $max, "<=") : true;
 
         if(!$minOk || !$maxOk) {
             $err = "requires PHP version ";


### PR DESCRIPTION
Hi,

I run Magento on Ubuntu server, I installed the php provided in the distribution packages. But this php package add a suffix to the PHP_VERSION constant

``` bash
$ php -r 'echo PHP_VERSION, "\n";'
5.3.10-1ubuntu3.4
```

This suffix make the version_compare test performed during the installation of a Magento module faill. 

``` bash
$ php -r 'var_dump(version_compare(PHP_VERSION, "5.3.10", "<="));'
bool(false) // but it should be true
```

This quick patch extract the real version of the PHP_VERSION string

``` bash
$ php -r 'echo substr(PHP_VERSION, 0, strpos(PHP_VERSION, "-")), "\n";'
5.3.10

$ php -r 'var_dump(version_compare(substr(PHP_VERSION, 0, strpos(PHP_VERSION, "-")), "5.3.10", "<="));'
bool(true)
```

and allow me to install the module I need.
