### PR TITLE
Enable redirecting to continue checkout if customer data was incomplete

### DIFF
--- a/app/code/core/Mage/Checkout/Controller/Action.php
+++ b/app/code/core/Mage/Checkout/Controller/Action.php
@@ -50,7 +50,10 @@ abstract class Mage_Checkout_Controller_Action extends Mage_Core_Controller_Fron
                     }
                 }
                 if ($redirect) {
-                    $this->_redirect('customer/account/edit');
+                    $referer = Mage::getUrl('*/*/*', array('_current' => true, '_use_rewrite' => true));
+                    $referer = Mage::helper('core')->urlEncode($referer);
+                    $arguments = array(Mage_Core_Controller_Varien_Action::PARAM_NAME_URL_ENCODED => $referer);
+                    $this->_redirect('customer/account/edit', $arguments);
                     $this->setFlag('', self::FLAG_NO_DISPATCH, true);
                 }
                 return false;

--- a/app/code/core/Mage/Customer/controllers/AccountController.php
+++ b/app/code/core/Mage/Customer/controllers/AccountController.php
@@ -805,7 +805,7 @@ class Mage_Customer_AccountController extends Mage_Core_Controller_Front_Action
                 $this->_getSession()->setCustomer($customer)
                     ->addSuccess($this->__('The account information has been saved.'));
 
-                $this->_redirect('customer/account');
+                $this->_redirectSuccess('customer/account');
                 return;
             } catch (Mage_Core_Exception $e) {
                 $this->_getSession()->setCustomerFormData($this->getRequest()->getPost())

--- a/app/code/core/Mage/Customer/view/frontend/form/edit.phtml
+++ b/app/code/core/Mage/Customer/view/frontend/form/edit.phtml
@@ -30,6 +30,7 @@
 <?php echo $this->getMessagesBlock()->getGroupedHtml() ?>
 <form action="<?php echo $this->getUrl('customer/account/editPost') ?>" method="post" id="form-validate">
     <div class="fieldset">
+        <input type="hidden" name="<?php echo Mage_Core_Controller_Varien_Action::PARAM_NAME_SUCCESS_URL ?>" value="<?php echo $this->htmlEscape($this->getRefererUrl()) ?>">
         <?php echo $this->getBlockHtml('formkey')?>
         <h2 class="legend"><?php echo $this->__('Account Information') ?></h2>
         <ul class="form-list">


### PR DESCRIPTION
At the begin of the checkout, in case a customer has incomplete account data, he is redirected to the account data update form.

When he now saves the data he is redirected to the customer area, not to the checkout.

This could lead the customers to stop the checkout process and the merchant would use sales.
