### PR TITLE
Add the 'edition' parameter to getVersion() and getVersionInfo()

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -132,7 +132,7 @@ final class Mage
     {
         $i = self::getVersionInfo();
         return trim("{$i['major']}.{$i['minor']}.{$i['revision']}" . ($i['patch'] != '' ? ".{$i['patch']}" : "")
-                        . "-{$i['stability']}{$i['number']}", '.-');
+                        . "-{$i['stability']}{$i['number']}{$i['edition']}", '.-');
     }
 
     /**
@@ -150,6 +150,7 @@ final class Mage
             'patch'     => '0',
             'stability' => 'dev',
             'number'    => '29',
+            'edition'   => 'CE',
         );
     }
 


### PR DESCRIPTION
Add the 'edition' parameter to getVersion() and getVersionInfo() to make it easier for developers to distinguish between Community and Enterprise editions.

Right now we have to do something like this;

```
$enterprise = Mage::getConfig()->getNode('modules/Enterprise_PageCache/active');
$checkForVersion = ($enterprise ? '1.12' : '1.7.0.0');
if(version_compare(Mage::getVersion(), $checkForVersion, '<')) {
    // do stuff for CE < 1.7.0.0 & EE < 1.12
} else {
    // do stuff for CE > 1.7.0.0 & EE > 1.12
}
```

Which is not 100% safe since the PageCache extension can be deactivated in an EE installation.
