### PR TITLE
support of federal units of Brazil with 27 states

### DIFF
--- a/app/code/core/Mage/Directory/data/directory_setup/data-install-1.6.0.0.php
+++ b/app/code/core/Mage/Directory/data/directory_setup/data-install-1.6.0.0.php
@@ -283,7 +283,38 @@ $data = array(
     array('LT', 'LT-MR', 'Marijampolės Apskritis'), array('LT', 'LT-PN', 'Panevėžio Apskritis'),
     array('LT', 'LT-SA', 'Šiaulių Apskritis'), array('LT', 'LT-TA', 'Tauragės Apskritis'),
     array('LT', 'LT-TE', 'Telšių Apskritis'), array('LT', 'LT-UT', 'Utenos Apskritis'),
-    array('LT', 'LT-VL', 'Vilniaus Apskritis')
+    array('LT', 'LT-VL', 'Vilniaus Apskritis'),
+
+    //support of federal units of Brazil with 27 states
+    array('BR', 'AC', 'Acre'),
+    array('BR', 'AL', 'Alagoas'),
+    array('BR', 'AP', 'Amapá'),
+    array('BR', 'AM', 'Amazonas'),
+    array('BR', 'BA', 'Bahia'),
+    array('BR', 'CE', 'Ceará'),
+    array('BR', 'ES', 'Espírito Santo'),
+    array('BR', 'GO', 'Goiás'),
+    array('BR', 'MA', 'Maranhão'),
+    array('BR', 'MT', 'Mato Grosso'),
+    array('BR', 'MS', 'Mato Grosso do Sul'),
+    array('BR', 'MG', 'Minas Gerais'),
+    array('BR', 'PA', 'Pará'),
+    array('BR', 'PB', 'Paraíba'),
+    array('BR', 'PR', 'Paraná'),
+    array('BR', 'PE', 'Pernambuco'),
+    array('BR', 'PI', 'Piauí'),
+    array('BR', 'RJ', 'Rio de Janeiro'),
+    array('BR', 'RN', 'Rio Grande do Norte'),
+    array('BR', 'RS', 'Rio Grande do Sul'),
+    array('BR', 'RO', 'Rondônia'),
+    array('BR', 'RR', 'Roraima'),
+    array('BR', 'SC', 'Santa Catarina'),
+    array('BR', 'SP', 'São Paulo'),
+    array('BR', 'SE', 'Sergipe'),
+    array('BR', 'TO', 'Tocantins'),
+    array('BR', 'DF', 'Distrito Federal')
+    //support of federal units of Brazil with 27 states
+
 );
 
 foreach ($data as $row) {


### PR DESCRIPTION
...6.0.0.php

I see that in the native Magento2 is already pt_BR translation package, this was a breakthrough for users of magento in Brazil
I see that the support of the federal units of Brazil is not yet supported for Brazil, it would be very important if Magento2 added to support the 27 federal units of Brazil
Nowadays the form used to apply the support of the federal units of Brazil is done manually as shown below, and is usually done in the wrong way, because the need to implement proper support manual

http://www.cerebrum.com.br/forum/index.php?/topic/196-adicionando-os-estados-brasileiros-no-magento/
http://pt.wikipedia.org/wiki/Unidades_federativas_do_Brasil
