### PR TITLE
Update app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php

### DIFF
--- a/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
+++ b/app/code/core/Mage/Tag/Model/Resource/Tag/Relation.php
@@ -198,6 +198,7 @@ class Mage_Tag_Model_Resource_Tag_Relation extends Mage_Core_Model_Resource_Db_A
             $write->delete($this->getMainTable(), array(
                 'product_id IN (?)' => $delete,
                 'store_id = ?'      => $model->getStoreId(),
+                'tag_id = ?' => $model->getTagId(),
             ));
         }
 


### PR DESCRIPTION
When deleting a product that is assign to a tag by unchecking the checkbox under "Products Tagged by Administrators" (Catalog -> Tags -> All Tags) it will also delete all tags associated with that product.

see http://www.magentocommerce.com/bug-tracking/issue?issue=14255
