### PR TITLE
Fix product collection sort order to use option sort order.

### DIFF
--- a/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/core/Mage/Eav/Model/Entity/Attribute/Source/Table.php
@@ -131,10 +131,8 @@ class Mage_Eav_Model_Entity_Attribute_Source_Table extends Mage_Eav_Model_Entity
             ->getCheckSql("{$valueTable2}.value_id > 0", "{$valueTable2}.value", "{$valueTable1}.value");
 
         Mage::getResourceModel('Mage_Eav_Model_Resource_Entity_Attribute_Option')
-            ->addOptionValueToCollection($collection, $this->getAttribute(), $valueExpr);
-
-        $collection->getSelect()
-            ->order("{$this->getAttribute()->getAttributeCode()} {$dir}");
+            ->addOptionValueToCollection($collection, $this->getAttribute(), $valueExpr)
+            ->addOptionSortToCollection($collection, $this->getAttribute(), $valueExpr, $dir);
 
         return $this;
     }

--- a/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option.php
+++ b/app/code/core/Mage/Eav/Model/Resource/Entity/Attribute/Option.php
@@ -79,6 +79,30 @@ class Mage_Eav_Model_Resource_Entity_Attribute_Option extends Mage_Core_Model_Re
     }
 
     /**
+     * Add join with option sort order for collection select
+     *
+     * @param Mage_Eav_Model_Entity_Collection_Abstract $collection
+     * @param Mage_Eav_Model_Entity_Attribute $attribute
+     * @param Zend_Db_Expr $valueExpr
+     * @param string $dir
+     * @return Mage_Eav_Model_Resource_Entity_Attribute_Option
+     */
+    public function addOptionSortToCollection($collection, $attribute, $valueExpr, $dir)
+    {
+        $attributeCode  = $attribute->getAttributeCode();
+        $optionTable    = $attributeCode . '_option_sort';
+        $tableJoinCond  = "{$optionTable}.option_id={$valueExpr}";
+        $collection->getSelect()
+            ->joinLeft(
+                array($optionTable => $this->getTable('eav_attribute_option')),
+                $tableJoinCond,
+                array()
+            )
+            ->order("{$optionTable}.sort_order {$dir}");
+        return $this;
+    }
+
+    /**
      * Retrieve Select for update Flat data
      *
      * @param Mage_Eav_Model_Entity_Attribute_Abstract $attribute


### PR DESCRIPTION
Currently when you sort a product collection by a 'select' attribute the products are sorted by the attribute option labels. This pull request changes that to sort by the attribute option sort_order field.

Note, a similar patch works on Magento 1.x (using in production, queries are fast and indexed, confirmed with EXPLAIN), but I have not tested this code with Magento 2.
