### PR TITLE
Put grid object in global scope even when loaded via Ajax

### DIFF
--- a/app/code/core/Mage/Backend/view/adminhtml/widget/grid.phtml
+++ b/app/code/core/Mage/Backend/view/adminhtml/widget/grid.phtml
@@ -126,7 +126,7 @@ $numColumns = sizeof($this->getColumns());
 </div>
 <script type="text/javascript">
 //<![CDATA[
-    <?php echo $this->getJsObjectName() ?> = new varienGrid('<?php echo $this->getId() ?>', '<?php echo $this->getGridUrl() ?>', '<?php echo $this->getVarNamePage() ?>', '<?php echo $this->getVarNameSort() ?>', '<?php echo $this->getVarNameDir() ?>', '<?php echo $this->getVarNameFilter() ?>');
+    window.<?php echo $this->getJsObjectName() ?> = new varienGrid('<?php echo $this->getId() ?>', '<?php echo $this->getGridUrl() ?>', '<?php echo $this->getVarNamePage() ?>', '<?php echo $this->getVarNameSort() ?>', '<?php echo $this->getVarNameDir() ?>', '<?php echo $this->getVarNameFilter() ?>');
     <?php echo $this->getJsObjectName() ?>.useAjax = '<?php echo $this->getUseAjax() ?>';
     <?php if($this->getRowClickCallback()): ?>
         <?php echo $this->getJsObjectName() ?>.rowClickCallback = <?php echo $this->getRowClickCallback() ?>;


### PR DESCRIPTION
Mass actions in an ajax-enabled grid are broken when the grid container is loaded via ajax such as in an ajax-enabled tab. Adding window to the variable declaration forces it to be in the global scope so the following ajax requests can access the grid object.
