### PR TITLE
Event adminhtml_cms_page_edit_tab_content_prepare_form and $form->setValues($model->getData()); in wrong order

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
+++ b/app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
@@ -92,10 +92,12 @@ class Mage_Adminhtml_Block_Cms_Page_Edit_Tab_Content
                     ->setTemplate('cms/page/edit/form/renderer/content.phtml');
         $contentField->setRenderer($renderer);
 
+        Mage::dispatchEvent('adminhtml_cms_page_edit_tab_content_prepare_form', array('form' => $form));
+
         $form->setValues($model->getData());
         $this->setForm($form);
 
-        Mage::dispatchEvent('adminhtml_cms_page_edit_tab_content_prepare_form', array('form' => $form));
+
 
         return parent::_prepareForm();
     }


### PR DESCRIPTION
Problem exists in 1.7.0.2 too: http://www.magentocommerce.com/bug-tracking/issue?issue=14477

app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php:98 the event adminhtml_cms_page_edit_tab_content_prepare_form is dispatched. Two lines before the values are set on the form ($form->setValues($model->getData());)

This order is only in the content tab. In the other tabs: design, main and meta the order is the other way around, e.g.

app/code/core/Mage/Adminhtml/Block/Cms/Page/Edit/Tab/Design.php:125

Mage::dispatchEvent('adminhtml_cms_page_edit_tab_design_prepare_form', array('form' => $form));
$form->setValues($model->getData());
$this->setForm($form);

To add new fields to the form and fill them automatically from the database it is important to change the order of the event and the setValues statement.
