### PR TITLE
FIXED http://www.magentocommerce.com/bug-tracking/issue/?issue=7419

### DIFF
--- a/app/code/core/Mage/Core/Helper/Data.php
+++ b/app/code/core/Mage/Core/Helper/Data.php
@@ -331,9 +331,9 @@ class Mage_Core_Helper_Data extends Mage_Core_Helper_Abstract
 
             if ($german) {
                 // umlauts
-                $subst = array_merge($subst, array(
+                $subst = array(
                     196=>'Ae', 228=>'ae', 214=>'Oe', 246=>'oe', 220=>'Ue', 252=>'ue'
-                ));
+                ) + $subst;
             }
 
             $replacements[$german] = array();


### PR DESCRIPTION
in the method removeAccents is a parameter to use german replacement for umlauts like öäü. 

But this doesn't work, because array_merge destroys the key => value relation in the replace array.

The array union operator doesn't do that.
