### PR TITLE
Classmap needs to be prepended to autoloader stack to have any effect

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -88,7 +88,7 @@ if (file_exists($classMapPath)) {
     require_once BP . '/lib/Magento/Autoload/ClassMap.php';
     $classMap = new Magento_Autoload_ClassMap(BP);
     $classMap->addMap(unserialize(file_get_contents($classMapPath)));
-    spl_autoload_register(array($classMap, 'load'));
+    spl_autoload_register(array($classMap, 'load'), true, true);
 }
 
 $definitionsFile = BP . DS . 'var/di/definitions.php';


### PR DESCRIPTION
If the file var/classmap.ser exists an additional autoloader will be registrered that loads class according to a classmap instead of the include path, (which btw is an awesome improvement!)

Problem is, that the new autoloader will be appended to the autoloader stack resulting in all files being autoloaded be the includepath autoloader first (which will find all files and will never process to the classmap autoloader).

The function spl_autoload_register has a third parameter that allows to prepend the new autoloader instead of appending it. 

Another solution would be to move the complete classmap autoloader a couple of lines up in bootstrap.php before the regular autoloader.
