### PR TITLE
Add print/log query flags to collection

### DIFF
--- a/lib/Varien/Data/Collection/Db.php
+++ b/lib/Varien/Data/Collection/Db.php
@@ -690,11 +690,11 @@ class Varien_Data_Collection_Db extends Varien_Data_Collection
      */
     public function printLogQuery($printQuery = false, $logQuery = false, $sql = null)
     {
-        if ($printQuery) {
+        if ($printQuery || $this->getFlag('print_query')) {
             echo is_null($sql) ? $this->getSelect()->__toString() : $sql;
         }
 
-        if ($logQuery) {
+        if ($logQuery || $this->getFlag('log_query')) {
             Mage::log(is_null($sql) ? $this->getSelect()->__toString() : $sql);
         }
         return $this;


### PR DESCRIPTION
It is very frequent that I am editing code that deals with a collection and I want to print or log the query but finding the point at which the query is actually loaded is often not very easy and is often somewhere in core code which should not be edited. This patch allows one to set a flag on the collection so that when it is loaded it will be printed/logged. 

E.g., from an event observer:

```
$collection = $observer->getCollection();
$collection->addFieldToFilter('foo', 'bar');
$collection->setFlag('print_query', 1);
```
