### PR TITLE
Add colleciton method "addAfterLoadCallback"

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/core/Mage/Catalog/Model/Resource/Product/Collection.php
@@ -508,6 +508,8 @@ class Mage_Catalog_Model_Resource_Product_Collection extends Mage_Catalog_Model_
      */
     protected function _afterLoad()
     {
+        parent::_afterLoad();
+
         if ($this->_addUrlRewrite) {
            $this->_addUrlRewrite($this->_urlRewriteCategory);
         }

--- a/app/code/core/Mage/Review/Model/Observer.php
+++ b/app/code/core/Mage/Review/Model/Observer.php
@@ -75,9 +75,8 @@ class Mage_Review_Model_Observer
     public function catalogBlockProductCollectionBeforeToHtml(Varien_Event_Observer $observer)
     {
         $productCollection = $observer->getEvent()->getCollection();
-        if ($productCollection instanceof Varien_Data_Collection) {
-            $productCollection->load();
-            Mage::getModel('Mage_Review_Model_Review')->appendSummary($productCollection);
+        if ($productCollection instanceof Varien_Data_Collection_Db) {
+            $productCollection->addAfterLoadCallback(array(Mage::getModel('Mage_Review_Model_Review'), 'appendSummary'));
         }
 
         return $this;

--- a/lib/Varien/Data/Collection/Db.php
+++ b/lib/Varien/Data/Collection/Db.php
@@ -101,6 +101,13 @@ class Varien_Data_Collection_Db extends Varien_Data_Collection
     protected $_isOrdersRendered = false;
 
     /**
+     * Callbacks to be executed after collection is loaded
+     *
+     * @var array
+     */
+    protected $_afterLoadCallbacks = array();
+
+    /**
      * @param Zend_Db_Adapter_Abstract|null $conn
      */
     public function __construct($conn = null)
@@ -669,8 +676,24 @@ class Varien_Data_Collection_Db extends Varien_Data_Collection
         return $this;
     }
 
+    /**
+     * @param callable $callback
+     * @return Varien_Data_Collection_Db
+     */
+    public function addAfterLoadCallback($callback)
+    {
+        $this->_afterLoadCallbacks[] = $callback;
+        return $this;
+    }
+
     protected function _afterLoad()
     {
+        foreach ($this->_afterLoadCallbacks as $callback) {
+            if (is_callable($callback)) {
+                call_user_func($callback, $this);
+            }
+        }
+        $this->_afterLoadCallbacks = array();
         return $this;
     }
 


### PR DESCRIPTION
This patch adds a new method to Varien_Data_Collection_Db which allows one to queue up callbacks which will be called _after_ the collection is loaded. This is important since some event observers (e.g. Mage_Review's product list observer)  act on the loaded collection, but it may be that other event observers need to first modify the query (e.g. add a filter or join). By using callbacks the event observers that need to act on a loaded collection can just add a callback and leave the query unloaded so that other event observers can still modify the query.
