### PR TITLE
Fix that makes Mage_Install compatible with the new version of SimpleXml

### DIFF
--- a/app/code/core/Mage/Install/etc/config.xml
+++ b/app/code/core/Mage/Install/etc/config.xml
@@ -57,7 +57,7 @@
                 <initStatements>SET NAMES utf8</initStatements>
                 <min_version>4.1.20</min_version>
                 <extensions>
-                    <pdo_mysql/>
+                    <pdo_mysql>1</pdo_mysql>
                 </extensions>
             </mysql4>
         </databases>


### PR DESCRIPTION
Te new version of SimpleXml breaks the installation because it parses empty nodes differently. I am not very sure about the specifics of this but this issue has been reported all over the forums, StackOverflow, etc and its a very small fix 
