### PR TITLE
Reset link type for getBaseUrl

### DIFF
--- a/app/code/core/Mage/Core/Model/Url.php
+++ b/app/code/core/Mage/Core/Model/Url.php
@@ -369,6 +369,8 @@ class Mage_Core_Model_Url extends Varien_Object
         }
         if (isset($params['_type'])) {
             $this->setType($params['_type']);
+        } else {
+            $this->setType(Mage_Core_Model_Store::URL_TYPE_LINK);
         }
         if (isset($params['_secure'])) {
             $this->setSecure($params['_secure']);


### PR DESCRIPTION
Mage_Core_Block_Abstract has cached $_urlBuilder object, so if we don't reset url type, getBaseUrl() without specific type will use previous url type.  Eg: http://localhost/media/wishlist/ instead of http://localhost/wishlist/ in top links.
