### PR TITLE
More meaningful exception message in Gd2

### DIFF
--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -145,10 +145,10 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
             $fileType = $this->_fileType;
         }
         if (empty(self::$_callbacks[$fileType])) {
-            throw new Exception($unsupportedText);
+            throw new Exception($unsupportedText. ' File type: ' . $fileType . ' File name: ' . $this->_fileName);
         }
         if (empty(self::$_callbacks[$fileType][$callbackType])) {
-            throw new Exception('Callback not found.');
+            throw new Exception('Callback not found. File type: ' . $fileType . ' Callback type: ' . $callbackType);
         }
         return self::$_callbacks[$fileType][$callbackType];
     }


### PR DESCRIPTION
Added more meaningful exception message in `Varien_Image_Adapter_Gd2::_getCallback()` method.
With this patch exception contains information helpful in debugging/solving a problem.
