### PR TITLE
There is no sort-order "best value"

### DIFF
--- a/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Sortby.php
+++ b/app/code/core/Mage/Catalog/Model/Category/Attribute/Source/Sortby.php
@@ -53,7 +53,7 @@ class Mage_Catalog_Model_Category_Attribute_Source_Sortby
     {
         if (is_null($this->_options)) {
             $this->_options = array(array(
-                'label' => Mage::helper('Mage_Catalog_Helper_Data')->__('Best Value'),
+                'label' => Mage::helper('Mage_Catalog_Helper_Data')->__('Position'),
                 'value' => 'position'
             ));
             foreach ($this->_getCatalogConfig()->getAttributesUsedForSortBy() as $attribute) {

--- a/app/code/core/Mage/Catalog/Model/Config/Source/ListSort.php
+++ b/app/code/core/Mage/Catalog/Model/Config/Source/ListSort.php
@@ -43,7 +43,7 @@ class Mage_Catalog_Model_Config_Source_ListSort implements Mage_Core_Model_Optio
     {
         $options = array();
         $options[] = array(
-            'label' => Mage::helper('Mage_Catalog_Helper_Data')->__('Best Value'),
+            'label' => Mage::helper('Mage_Catalog_Helper_Data')->__('Position'),
             'value' => 'position'
         );
         foreach ($this->_getCatalogConfig()->getAttributesUsedForSortBy() as $attribute) {

--- a/app/code/core/Mage/Catalog/locale/de_DE/Mage_Catalog.csv
+++ b/app/code/core/Mage/Catalog/locale/de_DE/Mage_Catalog.csv
@@ -113,7 +113,6 @@
 "Backorders","Lieferückstand"
 "Based On","Basierend auf"
 "Before Order Confirmation","Vor der Bestellungsbestätigung"
-"Best Value","Bester Wert"
 "Block after Info Column","Nach Infospalte sperren"
 "Bottom Block Options Wrapper","Unterseite Sperroptionendeckblatt"
 "Bottom/Left","Unten/Links"

--- a/app/code/core/Mage/Catalog/locale/en_US/Mage_Catalog.csv
+++ b/app/code/core/Mage/Catalog/locale/en_US/Mage_Catalog.csv
@@ -113,7 +113,6 @@
 "Backorders","Backorders"
 "Based On","Based On"
 "Before Order Confirmation","Before Order Confirmation"
-"Best Value","Best Value"
 "Block after Info Column","Block after Info Column"
 "Bottom Block Options Wrapper","Bottom Block Options Wrapper"
 "Bottom/Left","Bottom/Left"

--- a/app/code/core/Mage/Catalog/locale/es_ES/Mage_Catalog.csv
+++ b/app/code/core/Mage/Catalog/locale/es_ES/Mage_Catalog.csv
@@ -113,7 +113,6 @@
 "Backorders","Pedidos Pendientes"
 "Based On","Basado en"
 "Before Order Confirmation","Antes de la Confirmación del Pedido"
-"Best Value","Mejor valor"
 "Block after Info Column","Bloque posterior a la columna de información"
 "Bottom Block Options Wrapper","Ajuste de opciones del bloque inferior"
 "Bottom/Left","Inferior/izquierda"

--- a/app/code/core/Mage/Catalog/locale/fr_FR/Mage_Catalog.csv
+++ b/app/code/core/Mage/Catalog/locale/fr_FR/Mage_Catalog.csv
@@ -113,7 +113,6 @@
 "Backorders","Ruptures de stock"
 "Based On","Basé sur"
 "Before Order Confirmation","Avant la confirmation de commande"
-"Best Value","Meilleure valeur"
 "Block after Info Column","Bloc après Colonne Info"
 "Bottom Block Options Wrapper","Bloc Inférieur Options d'Emballage"
 "Bottom/Left","Inférieur/Gauche"

--- a/app/code/core/Mage/Catalog/locale/nl_NL/Mage_Catalog.csv
+++ b/app/code/core/Mage/Catalog/locale/nl_NL/Mage_Catalog.csv
@@ -113,7 +113,6 @@
 "Backorders","Backorders"
 "Based On","Gebaseerd op"
 "Before Order Confirmation","Voor Bestelling Bevestiging"
-"Best Value","Beste Waarde"
 "Block after Info Column","Blok na Info Kolom"
 "Bottom Block Options Wrapper","Onderaan Blokkeer Opties Omslag"
 "Bottom/Left","Onderaan/Links"

--- a/app/code/core/Mage/Catalog/locale/pt_BR/Mage_Catalog.csv
+++ b/app/code/core/Mage/Catalog/locale/pt_BR/Mage_Catalog.csv
@@ -113,7 +113,6 @@
 "Backorders","Ordens em Atraso"
 "Based On","Baseado Em"
 "Before Order Confirmation","Antes de Confirmação de Ordem"
-"Best Value","Melhor Preço"
 "Block after Info Column","Bloco após Coluna de Informações"
 "Bottom Block Options Wrapper","Envoltório de Opções do Bloco de Fundo"
 "Bottom/Left","Fundo/Esquerdo"

--- a/app/code/core/Mage/Catalog/locale/zh_CN/Mage_Catalog.csv
+++ b/app/code/core/Mage/Catalog/locale/zh_CN/Mage_Catalog.csv
@@ -113,7 +113,6 @@
 "Backorders","缺货"
 "Based On","基于"
 "Before Order Confirmation","在订单确认之前"
-"Best Value","最佳值"
 "Block after Info Column","信息栏之后阻止"
 "Bottom Block Options Wrapper","底部阻止选项包装"
 "Bottom/Left","底部/左侧"


### PR DESCRIPTION
There is no such sort order. When "best value" is selected,
it actually become "position" in the frontend product lists.
