### PR TITLE
Explicit nullification of App->$_store in Mage_Core_Model_App->_initStores()

### DIFF
--- a/app/code/core/Mage/Core/Model/App.php
+++ b/app/code/core/Mage/Core/Model/App.php
@@ -736,6 +736,7 @@ class Mage_Core_Model_App
      */
     protected function _initStores()
     {
+        $this->_store    = null;
         $this->_stores   = array();
         $this->_groups   = array();
         $this->_website  = null;


### PR DESCRIPTION
Added an explicit null of $_store, without it reinitStores() does not behave as expected in all cases.
