### PR TITLE
Make topmenu HTML editable by the event page_block_html_topmenu_gethtml_after

### DIFF
--- a/app/code/core/Mage/Page/Block/Html/Topmenu.php
+++ b/app/code/core/Mage/Page/Block/Html/Topmenu.php
@@ -66,10 +66,13 @@ class Mage_Page_Block_Html_Topmenu extends Mage_Core_Block_Template
 
         $html = $this->_getHtml($this->_menu, $childrenWrapClass);
 
+        $transportObject = new Varien_Object();
+        $transportObject->setHtml($html);
         Mage::dispatchEvent('page_block_html_topmenu_gethtml_after', array(
             'menu' => $this->_menu,
-            'html' => $html
+            'transport' => $transportObject
         ));
+        $html = $transportObject->getHtml();
 
         return $html;
     }


### PR DESCRIPTION
Currently, the `page_block_html_topmenu_gethtml_after` event is dispatched like that:

```
$html = $this->_getHtml($this->_menu, $childrenWrapClass);
Mage::dispatchEvent('page_block_html_topmenu_gethtml_after', array(
    'menu' => $this->_menu,
    'html' => $html
));
```

Since `$html` is a string, it is not possible to alter it. But I think it should definitely be possible to alter it! Hence I wrapped it into a transport object like in the `core_block_abstract_to_html_after` event.

This pull request is based on a [Magento Stackexchange question](http://magento.stackexchange.com/questions/634/how-can-i-alter-a-string-passed-by-an-event/644).
