### PR TITLE
Change minimum required version to 5.3.2

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -61,9 +61,9 @@ if (file_exists($classMapPath)) {
 
 if (!defined('BARE_BOOTSTRAP')) {
     /* PHP version validation */
-    if (version_compare(phpversion(), '5.3.0', '<') === true) {
+    if (version_compare(phpversion(), '5.3.2', '<') === true) {
         if (PHP_SAPI == 'cli') {
-            echo 'Magento supports PHP 5.3.0 or newer. Please read http://www.magento.com/install.';
+            echo 'Magento supports PHP 5.3.2 or newer. Please read http://www.magento.com/install.';
         } else {
             echo <<<HTML
 <div style="font:12px/1.35em arial, helvetica, sans-serif;">
@@ -71,7 +71,7 @@ if (!defined('BARE_BOOTSTRAP')) {
         <h3 style="margin:0;font-size:1.7em;font-weight:normal;text-transform:none;text-align:left;color:#2f2f2f;">
         Whoops, it looks like you have an invalid PHP version.</h3>
     </div>
-    <p>Magento supports PHP 5.3.0 or newer.
+    <p>Magento supports PHP 5.3.2 or newer.
     <a href="http://www.magento.com/install" target="">Find out</a>
     how to install Magento using PHP-CGI as a work-around.
     </p>


### PR DESCRIPTION
I have changed minimum required version of PHP to 5.3.2 because of the stream_resolve_include_path function (http://php.net/manual/en/function.stream-resolve-include-path.php) which is used in lib\Magento\Autoload\IncludePath.php on line 42
