### PR TITLE
Tax formatting is locale aware and should not

### DIFF
--- a/app/code/core/Mage/Tax/Helper/Data.php
+++ b/app/code/core/Mage/Tax/Helper/Data.php
@@ -639,7 +639,7 @@ class Mage_Tax_Helper_Data extends Mage_Core_Helper_Abstract
                 $$rateVariable = '';
                 foreach ($$rateArray as $classId=>$rate) {
                     if ($rate) {
-                        $$rateVariable .= sprintf("WHEN %d THEN %12.4f ", $classId, $rate/100);
+                        $$rateVariable .= sprintf("WHEN %d THEN %12.4F ", $classId, $rate/100);
                     }
                 }
                 if ($$rateVariable) {


### PR DESCRIPTION
Tax helper is using %f that is locale aware. This leads to floats like "0,1960" that SQL does not understand. sprintf should not be locale aware, so we should use %F instead of %f 
