### PR TITLE
Update app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Pr...

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
+++ b/app/code/core/Mage/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
@@ -83,7 +83,7 @@ class Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Price extends Varien_Data
             return null;
         }
 
-        return number_format($value, 2, null, '');
+        return $value;
     }
 
 }


### PR DESCRIPTION
...ice.php

Recently had an issue where the price of a product had 3 decimal points on the DB, 10.245 for example, but showed the rounded to 2 decimals price (10.25) on the admin panel product edit page.

When hitting save for that product from the admin panel, it would save the escaped value with 2 decimal points, replacing 10.245 with 10.25, which is completely undesirable and results in all kind of funny prices after taxes are applied.

Possible fixes: 
(1) Allow more decimal points. 4 seems reasonable, but the issue might persist.
(2) Simply return $value as it comes from the database, since the method already checks that is a numeric value.

Note: the other reason why the number_format was being done is to remove the thousand comma separator, but is_numeric('1,235') is false, so price data coming from the DB with comma thousand separators won't be valid anyway.
