### PR TITLE
Fix helper for determining system memory usage on Windows

### DIFF
--- a/dev/tests/integration/framework/Magento/Test/Helper/Memory.php
+++ b/dev/tests/integration/framework/Magento/Test/Helper/Memory.php
@@ -104,17 +104,15 @@ class Magento_Test_Helper_Memory
      */
     public function getWinProcessMemoryUsage($pid)
     {
-        $output = $this->_shell->execute('tasklist /fi %s /fo CSV', array("PID eq $pid"));
+        $output = $this->_shell->execute('tasklist /fi %s /fo CSV /nh', array("PID eq $pid"));
 
         /** @link http://www.php.net/manual/en/wrappers.data.php */
         $csvStream = 'data://text/plain;base64,' . base64_encode($output);
         $csvHandle = fopen($csvStream, 'r');
-        $keys = fgetcsv($csvHandle);
-        $values = fgetcsv($csvHandle);
+        $stats = fgetcsv($csvHandle);
         fclose($csvHandle);
-        $stats = array_combine($keys, $values);
 
-        $result = $stats['Mem Usage'];
+        $result = $stats[4];
 
         return self::convertToBytes($result);
     }


### PR DESCRIPTION
On Windows systems in other languages than English, the method `Magento_Test_Helper_Memory::getWinProcessMemoryUsage()` calls `Magento_Test_Helper_Memory::convertToBytes()` with an invalid argument, because the column names from the output of 'tasklist' are language specific.

The alternative usage of the column index seems to be stable over the various versions of Windows, where `tasklist` is available. Tested on Windows 8

related #237
