### PR TITLE
Resolve design flaws in core URL helper

### DIFF
--- a/app/code/core/Mage/Core/Helper/Url.php
+++ b/app/code/core/Mage/Core/Helper/Url.php
@@ -48,17 +48,7 @@ class Mage_Core_Helper_Url extends Mage_Core_Helper_Abstract
      */
     public function getCurrentUrl()
     {
-        $request = $this->_getRequest();
-        $port = $this->_getRequest()->getServer('SERVER_PORT');
-        if ($port) {
-            $defaultPorts = array(
-                Mage_Core_Controller_Request_Http::DEFAULT_HTTP_PORT,
-                Mage_Core_Controller_Request_Http::DEFAULT_HTTPS_PORT
-            );
-            $port = (in_array($port, $defaultPorts)) ? '' : ':' . $port;
-        }
-        $url = $request->getScheme() . '://' . $request->getHttpHost() . $port . $request->getServer('REQUEST_URI');
-        return $url;
+        return $this->_getUrl('*/*/*', array('_current' => true, '_use_rewrite' => true));
     }
 
     /**

--- a/dev/tests/integration/testsuite/Mage/Core/Helper/UrlTest.php
+++ b/dev/tests/integration/testsuite/Mage/Core/Helper/UrlTest.php
@@ -44,19 +44,17 @@ class Mage_Core_Helper_UrlTest extends PHPUnit_Framework_TestCase
 
     public function testGetCurrentUrl()
     {
-        $_SERVER['HTTP_HOST'] = 'example.com';
-        $_SERVER['REQUEST_URI'] = '/fancy_uri';
-        $this->assertEquals('http://example.com/fancy_uri', $this->_helper->getCurrentUrl());
+        $this->assertEquals('http://localhost/index.php/', $this->_helper->getCurrentUrl());
     }
 
     public function testGetCurrentBase64Url()
     {
-        $this->assertEquals('aHR0cDovL2xvY2FsaG9zdA,,', $this->_helper->getCurrentBase64Url());
+        $this->assertEquals('aHR0cDovL2xvY2FsaG9zdC9pbmRleC5waHAv', $this->_helper->getCurrentBase64Url());
     }
 
     public function testGetEncodedUrl()
     {
-        $this->assertEquals('aHR0cDovL2xvY2FsaG9zdA,,', $this->_helper->getEncodedUrl());
+        $this->assertEquals('aHR0cDovL2xvY2FsaG9zdC9pbmRleC5waHAv', $this->_helper->getEncodedUrl());
         $this->assertEquals('aHR0cDovL2V4YW1wbGUuY29tLw,,', $this->_helper->getEncodedUrl('http://example.com/'));
     }
 


### PR DESCRIPTION
Reverts the helper in `Mage_Core_Helper::getCurrentUrl()` back, to use the core URL Model again. Sucessfully tested on a Magento instance with port 8080.

related #228
