### PR TITLE
Bug in Mage_Page_Block_Html_Header->getIsHomePage

### DIFF
--- a/app/code/core/Mage/Page/Block/Html/Header.php
+++ b/app/code/core/Mage/Page/Block/Html/Header.php
@@ -45,7 +45,7 @@ class Mage_Page_Block_Html_Header extends Mage_Core_Block_Template
      */
     public function getIsHomePage()
     {
-        return $this->getUrl('') == $this->getUrl('*/*/*', array('_current'=>true, '_use_rewrite'=>true));
+        return $this->getUrl('',array('_current'=>true)) == $this->getUrl('*/*/*', array('_current'=>true, '_use_rewrite'=>true));
     }
 
     public function setLogo($logo_src, $logo_alt)


### PR DESCRIPTION
return 'false' when the URL has GET parameters

※exp
http://domain.com/?hoge=hoge
