### PR TITLE
have_innodb variable is deprecated and removed in MySQL 5.6.

### DIFF
--- a/app/code/core/Mage/Install/Model/Installer/Db/Mysql4.php
+++ b/app/code/core/Mage/Install/Model/Installer/Db/Mysql4.php
@@ -58,9 +58,9 @@ class Mage_Install_Model_Installer_Db_Mysql4 extends Mage_Install_Model_Installe
      */
     public function supportEngine()
     {
-        $variables  = $this->_getConnection()
-            ->fetchPairs('SHOW VARIABLES');
-        return (!isset($variables['have_innodb']) || $variables['have_innodb'] != 'YES') ? false : true;
+        $engines  = $this->_getConnection()
+            ->fetchPairs('SHOW ENGINES');
+        return (isset($engines['InnoDB']) && $engines['InnoDB'] != 'NO' && $engines['InnoDB'] != 'DISABLED');
     }
 
     /**


### PR DESCRIPTION
SHOW ENGINES used to check InnoDB.

see http://dev.mysql.com/doc/refman/5.1/en/server-system-variables.html#sysvar_have_innodb
