### PR TITLE
Update Merge.php

### DIFF
--- a/app/code/core/Mage/Core/Model/Layout/Merge.php
+++ b/app/code/core/Mage/Core/Model/Layout/Merge.php
@@ -639,7 +639,9 @@ class Mage_Core_Model_Layout_Merge
             $fileStr = str_replace($this->_subst['from'], $this->_subst['to'], $fileStr);
             /** @var $fileXml Mage_Core_Model_Layout_Element */
             $fileXml = simplexml_load_string($fileStr, $this->_elementClass);
-            $layoutStr .= $fileXml->innerXml();
+            if ($fileXml){
+                $layoutStr .= $fileXml->innerXml();
+            }
         }
         $layoutStr = '<layouts>' . $layoutStr . '</layouts>';
         $layoutXml = simplexml_load_string($layoutStr, $this->_elementClass);


### PR DESCRIPTION
Hi there,

There is an issue with Module layout xml files being blank and the _loadFileLayoutUpdatesXML() function erroring out on line 642.

How to reproduce -
Create a new magento 2 module but create a new front end or admin layout xml file but make the file blank with nothing inside it. Try to load the front end and it will produce the message.

This could be an issue when uploads of modules fails eg partial FTP uploads and so on.

Fatal error: Call to a member function innerXml() on a non-object in /home/mage2craig/public_html/app/code/core/Mage/Core/Model/Layout/Merge.php on line 643

Proposed Fix -
Check for the existence of the object before actually trying to include it eg as per the following code snippet - lines 641 to 642

$fileXml = simplexml_load_string($fileStr, $this->_elementClass);
if ($fileXml) {
$layoutStr .= $fileXml->innerXml();
}

Regards

mrploddy
