### PR TITLE
Update Zend.php

### DIFF
--- a/lib/Magento/Di/Zend.php
+++ b/lib/Magento/Di/Zend.php
@@ -122,6 +122,9 @@ class Magento_Di_Zend extends Zend\Di\Di implements Magento_Di
                     $parameters
                 );
             } else {
+                if ($name == "" || $name == false) {
+                	throw new Exception\RuntimeException("Invalid Class Name");	 
+            	}
                 $instance = new $name();
             }
             if ($isShared) {


### PR DESCRIPTION
I came across a bug with Payment methods and I'm guessing it might also come up elsewhere. 

I'm writing a test payment gateway for Sagepay form and in the <payment> declaration in the config.xml there was a spelling mistake in the payment code so that it didn't match up with the payment code declared in the Model eg

Config.xml
<sagepayformd>
                <group>sagepayform</group>
                <active>0</active>
                <model>JuicyMedia_Sagepayform_Model_Sagepayform</model>
                <title>Sagepayform</title>
                <allowspecific>0</allowspecific>
            </sagepayformd>

And in the Model - 
class JuicyMedia_Sagepayform_Model_Sagepayform extends Mage_Payment_Model_Method_Abstract
{
    protected $_code  = 'sagepayform';

Because there was this spelling mistake it was creating an exception in /lib/Magento/Di/Zend.php

This pull request therefore is a way of making sure that Magento error's out properly with an exception instead of a PHP fatal error message. 

This is only one specific use case but Im guessing there are other examples where this might occur.
