### PR TITLE
Incorrectly name file

### DIFF
--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_content_for_callback.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_content_for_callback.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category    Magento
+ * @package     Magento_Validator
+ * @subpackage  unit_tests
+ * @copyright   Copyright (c) 2013 X.commerce, Inc. (http://www.magentocommerce.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+-->
+<validation>
+    <entity name="catalog_product">
+        <rules>
+            <rule name="name_sku_and_price">
+                <entity_constraints>
+                    <constraint alias="eav_validator" class="Mage_Catalog_Model_Validator_Eav" >
+                        <!-- callback element should be empty -->
+                        <callback method="someMethod" class="Mage_Catalog_Model_Validator_Eav" >some test</callback>
+                    </constraint>
+                </entity_constraints>
+            </rule>
+        </rules>
+        <groups>
+            <group name="create">
+                <uses>
+                    <use rule="name_sku_and_price"/>
+                </uses>
+            </group>
+        </groups>
+    </entity>
+</validation>


### PR DESCRIPTION
Missing underscore in filename/incorrect file naming convention. Additionally creates undesired breakpoints when running chmod.
