### PR TITLE
Set standard logging prio to INFO

### DIFF
--- a/app/Mage.php
+++ b/app/Mage.php
@@ -692,7 +692,7 @@ final class Mage
      */
     public static function log($message, $level = null, $file = 'system.log', $forceLog = false)
     {
-        $level = is_null($level) ? Zend_Log::DEBUG : $level;
+        $level = is_null($level) ? Zend_Log::INFO : $level;
         if (empty($file) || $file == 'system.log') {
             $file = 'system.log';
             $key = Mage_Core_Model_Logger::LOGGER_SYSTEM;


### PR DESCRIPTION
Most Mage core code and module use log() very seldomly, not for real debug messages.
Setting this to info would allow us to log also real debug info.
