### PR TITLE
ImportExport: Easier debugging

### DIFF
--- a/app/code/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -746,6 +746,19 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
                             } else {
                                 $linkedId = $this->_oldSku[$linkedSku]['entity_id'];
                             }
+                            
+                            if ($linkedId == null) {
+                                // Import file links to a SKU which is skipped for some reasons -> leads to a "NULL"
+                                // link causing fatal errors.
+                                Mage::logException(
+                                    new Exception(
+                                        sprintf('WARNING: Orphaned link skipped: From SKU %s (ID %d) to SKU %s, Link type id: %d',
+                                            $sku, $productId, $linkedSku, $linkId)
+                                    )
+                                );
+                                continue;
+                            }
+                            
                             $linkKey = "{$productId}-{$linkedId}-{$linkId}";
 
                             if (!isset($linkRows[$linkKey])) {


### PR DESCRIPTION
Made the import more robust if import file links to a SKU which is skipped for some reasons -> leads to a "NULL" link causing fatal errors.

Steps to reproduce:
- Import file with SKU "1" in first line, but some errors (i.e. missing description)
- In second line SKU "2", valid product data, _links_upsell_sku contains the SKU "1"
