### PR TITLE
ImportExport: Fix notice if _attribute_set column is missing

### DIFF
--- a/app/code/Mage/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/Mage/ImportExport/Model/Import/Entity/Product.php
@@ -1027,7 +1027,7 @@ class Mage_ImportExport_Model_Import_Entity_Product extends Mage_ImportExport_Mo
                 if(!is_null($productType)) {
                     $previousType = $productType;
                 }
-                if(!is_null($rowData[self::COL_ATTR_SET])) {
+                if(isset($rowData[self::COL_ATTR_SET]) && !is_null($rowData[self::COL_ATTR_SET])) {
                     $previousAttributeSet = $rowData[Mage_ImportExport_Model_Import_Entity_Product::COL_ATTR_SET];
                 }
                 if (self::SCOPE_NULL == $rowScope) {


### PR DESCRIPTION
There are cases, especially when custom import adapters are used, where _attribute_set is not defined in a $row (not for the initial row of course). This is not a problem - but causes a notice.
