### PR TITLE
Fix for wrong coupon calculation.

### DIFF
--- a/app/code/Mage/SalesRule/Model/Validator.php
+++ b/app/code/Mage/SalesRule/Model/Validator.php
@@ -670,6 +670,9 @@ class Mage_SalesRule_Model_Validator extends Mage_Core_Model_Abstract
                     if (!$rule->getActions()->validate($item)) {
                         continue;
                     }
+                    if ($item->getNoDiscount() === TRUE) {
+                        continue;
+                    }
                     $qty = $this->_getItemQty($item, $rule);
                     $ruleTotalItemsPrice += $this->_getItemPrice($item) * $qty;
                     $ruleTotalBaseItemsPrice += $this->_getItemBasePrice($item) * $qty;


### PR DESCRIPTION
There is a missing check wether the item is excluded from discount.

This leads to a wrong calculation of the discount amount here:

https://github.com/magento/magento2/blob/master/app/code/Mage/SalesRule/Model/Validator.php/#L383-384

The reason is, that it calculates the share of the item on the total discount. Since the bug uses the no-discount item to calculate the base items total, the calculated discount is wrong (the no discount item never makes it to the `process()` method, as this takes the `noDiscount` into account).
