### PR TITLE
Support advanced text column filters.

### DIFF
--- a/app/code/Mage/Backend/Block/Widget/Grid/Column/Filter/Abstract.php
+++ b/app/code/Mage/Backend/Block/Widget/Grid/Column/Filter/Abstract.php
@@ -104,6 +104,13 @@ class Mage_Backend_Block_Widget_Grid_Column_Filter_Abstract extends Mage_Backend
      */
     public function getCondition()
     {
+        // Support advanced filters by prefixing query with REGEXP or LIKE
+        if (substr($this->getValue(), 0, 7) == 'REGEXP ') {
+            return array('regexp' => substr($this->getValue(), 7));
+        }
+        if (substr($this->getValue(), 0, 5) == 'LIKE ') {
+            return array('like' => substr($this->getValue(), 5));
+        }
         $helper = Mage::getResourceHelper('Mage_Core');
         $likeExpression = $helper->addLikeEscape($this->getValue(), array('position' => 'any'));
         return array('like' => $likeExpression);


### PR DESCRIPTION
Allows the user to use advanced filtering in the grids. Very useful for filtering down SKUs and probably many other things.

E.g. many times people want to search for say David and not Davidson and a number only at the end of a string and nowhere else.

LIKE David
LIKE %500

And of course geeks can use REGEXP all day long..

REGEXP ^[[:digit:]]{3}-

EDIT: In case it wasn't already known to some, current behavior assumes you always want your query to be LIKE %David%. This keeps the current behavior unless the user actually types LIKE or REGEXP at the beginning of their query.
