### PR TITLE
Fixes named css reference to resolve bug where the frontend will not load

### DIFF
--- a/app/code/Magento/Widget/view/frontend/layout/default.xml
+++ b/app/code/Magento/Widget/view/frontend/layout/default.xml
@@ -27,7 +27,7 @@
     <referenceBlock name="head">
         <block class="Magento\Page\Block\Html\Head\Css" name="magento-cms-widgets-css">
             <arguments>
-                <argument name="file" xsi:type="string">Magento_VersionsCms::widgets.css</argument>
+                <argument name="file" xsi:type="string">Magento_Widget::widgets.css</argument>
             </arguments>
         </block>
     </referenceBlock>


### PR DESCRIPTION
This bug doesn't rear it's head on the EE version of Magento 2.0 since the VersionsCms module is present, but fails (as in stylesheets all turn up missing) the frontend page load here. It appears the EE Magento_Banners module contains this same mistake.
