### PR TITLE
Spelling correction for 'email' within NOTICE OF LICENSE

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Block/Grid/Renderer/Actions.php
+++ b/app/code/Magento/AdminNotification/Block/Grid/Renderer/Actions.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Block/Grid/Renderer/Notice.php
+++ b/app/code/Magento/AdminNotification/Block/Grid/Renderer/Notice.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Block/Grid/Renderer/Severity.php
+++ b/app/code/Magento/AdminNotification/Block/Grid/Renderer/Severity.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Block/Inbox.php
+++ b/app/code/Magento/AdminNotification/Block/Inbox.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Block/System/Messages.php
+++ b/app/code/Magento/AdminNotification/Block/System/Messages.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Block/System/Messages/UnreadMessagePopup.php
+++ b/app/code/Magento/AdminNotification/Block/System/Messages/UnreadMessagePopup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Block/ToolbarEntry.php
+++ b/app/code/Magento/AdminNotification/Block/ToolbarEntry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Block/Window.php
+++ b/app/code/Magento/AdminNotification/Block/Window.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Helper/Data.php
+++ b/app/code/Magento/AdminNotification/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Config/Source/Frequency.php
+++ b/app/code/Magento/AdminNotification/Model/Config/Source/Frequency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Feed.php
+++ b/app/code/Magento/AdminNotification/Model/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Inbox.php
+++ b/app/code/Magento/AdminNotification/Model/Inbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/NotificationService.php
+++ b/app/code/Magento/AdminNotification/Model/NotificationService.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Observer.php
+++ b/app/code/Magento/AdminNotification/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Resource/Grid/Collection.php
+++ b/app/code/Magento/AdminNotification/Model/Resource/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Resource/Inbox.php
+++ b/app/code/Magento/AdminNotification/Model/Resource/Inbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Resource/Inbox/Collection.php
+++ b/app/code/Magento/AdminNotification/Model/Resource/Inbox/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Resource/Inbox/Collection/Critical.php
+++ b/app/code/Magento/AdminNotification/Model/Resource/Inbox/Collection/Critical.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Resource/Inbox/Collection/Unread.php
+++ b/app/code/Magento/AdminNotification/Model/Resource/Inbox/Collection/Unread.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Resource/System/Message.php
+++ b/app/code/Magento/AdminNotification/Model/Resource/System/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Resource/System/Message/Collection.php
+++ b/app/code/Magento/AdminNotification/Model/Resource/System/Message/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Resource/System/Message/Collection/Synchronized.php
+++ b/app/code/Magento/AdminNotification/Model/Resource/System/Message/Collection/Synchronized.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/Survey.php
+++ b/app/code/Magento/AdminNotification/Model/Survey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/System/Message.php
+++ b/app/code/Magento/AdminNotification/Model/System/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/System/Message/Baseurl.php
+++ b/app/code/Magento/AdminNotification/Model/System/Message/Baseurl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/System/Message/CacheOutdated.php
+++ b/app/code/Magento/AdminNotification/Model/System/Message/CacheOutdated.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/System/Message/Media/AbstractSynchronization.php
+++ b/app/code/Magento/AdminNotification/Model/System/Message/Media/AbstractSynchronization.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/System/Message/Media/Synchronization/Error.php
+++ b/app/code/Magento/AdminNotification/Model/System/Message/Media/Synchronization/Error.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/System/Message/Media/Synchronization/Success.php
+++ b/app/code/Magento/AdminNotification/Model/System/Message/Media/Synchronization/Success.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/System/Message/Security.php
+++ b/app/code/Magento/AdminNotification/Model/System/Message/Security.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/System/Message/Survey.php
+++ b/app/code/Magento/AdminNotification/Model/System/Message/Survey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/System/MessageInterface.php
+++ b/app/code/Magento/AdminNotification/Model/System/MessageInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/Model/System/MessageList.php
+++ b/app/code/Magento/AdminNotification/Model/System/MessageList.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/etc/adminhtml/acl.xml
+++ b/app/code/Magento/AdminNotification/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/etc/adminhtml/di.xml
+++ b/app/code/Magento/AdminNotification/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/etc/adminhtml/events.xml
+++ b/app/code/Magento/AdminNotification/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/etc/adminhtml/menu.xml
+++ b/app/code/Magento/AdminNotification/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/etc/adminhtml/routes.xml
+++ b/app/code/Magento/AdminNotification/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/etc/adminhtml/system.xml
+++ b/app/code/Magento/AdminNotification/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/etc/config.xml
+++ b/app/code/Magento/AdminNotification/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/etc/module.xml
+++ b/app/code/Magento/AdminNotification/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/sql/adminnotification_setup/install-1.6.0.0.php
+++ b/app/code/Magento/AdminNotification/sql/adminnotification_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/sql/adminnotification_setup/upgrade-1.6.0.0-2.0.0.0.php
+++ b/app/code/Magento/AdminNotification/sql/adminnotification_setup/upgrade-1.6.0.0-2.0.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/view/adminhtml/layout/adminhtml_notification_block.xml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/layout/adminhtml_notification_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/view/adminhtml/layout/adminhtml_notification_index.xml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/layout/adminhtml_notification_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/view/adminhtml/layout/default.xml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/view/adminhtml/notification/window.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/notification/window.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/view/adminhtml/system/messages.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/system/messages.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/view/adminhtml/system/messages/popup.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/system/messages/popup.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/view/adminhtml/system/notification.js
+++ b/app/code/Magento/AdminNotification/view/adminhtml/system/notification.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/view/adminhtml/toolbar_entry.js
+++ b/app/code/Magento/AdminNotification/view/adminhtml/toolbar_entry.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/AdminNotification/view/adminhtml/toolbar_entry.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/toolbar_entry.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Admin/Formkey.php
+++ b/app/code/Magento/Adminhtml/Block/Admin/Formkey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Backup.php
+++ b/app/code/Magento/Adminhtml/Block/Backup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Backup/Dialogs.php
+++ b/app/code/Magento/Adminhtml/Block/Backup/Dialogs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cache.php
+++ b/app/code/Magento/Adminhtml/Block/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cache/Additional.php
+++ b/app/code/Magento/Adminhtml/Block/Cache/Additional.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/AbstractCategory.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/AbstractCategory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Checkboxes/Tree.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Checkboxes/Tree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Helper/Image.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Helper/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Helper/Pricestep.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Helper/Pricestep.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Helper/Sortby/Available.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Helper/Sortby/Available.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Helper/Sortby/DefaultSortby.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Helper/Sortby/DefaultSortby.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Tab/Attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Tab/Design.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Tab/Design.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Tab/General.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Tab/General.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Tab/Product.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Tab/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Tree.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Tree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Category/Widget/Chooser.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Category/Widget/Chooser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Form/Renderer/Attribute/Urlkey.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Form/Renderer/Attribute/Urlkey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Form/Renderer/Config/DateFieldsOrder.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Form/Renderer/Config/DateFieldsOrder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Form/Renderer/Config/YearRange.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Form/Renderer/Config/YearRange.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Form/Renderer/Fieldset/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg/Content.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Helper/Form/Wysiwyg/Content.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Advanced.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Advanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Front.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Front.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Main.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/System.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tab/System.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/NewAttribute/Product/Attributes.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/NewAttribute/Product/Attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/NewAttribute/Product/Created.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/NewAttribute/Product/Created.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formattribute.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formattribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formgroup.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formgroup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Formset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Attribute.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Group.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Main/Tree/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Add.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Add.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main/Filter.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/Main/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Configure.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Configure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Error.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Error.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Configurable.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Grouped.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Options.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Qty.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset/Qty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Update/Result.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Composite/Update/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Created.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Created.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Attributes.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Inventory.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Inventory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Websites.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tab/Websites.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Action/Attribute/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/AttributeSet.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/AttributeSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Js.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Js.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/NewCategory.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/NewCategory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Ajax/Serializer.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Ajax/Serializer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Price.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Stock.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Alerts/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes/Create.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes/Create.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes/Search.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Attributes/Search.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Crosssell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Inventory.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Inventory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Option.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Popup/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Popup/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/AbstractType.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/AbstractType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Date.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/File.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Select.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Text.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Price.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/AbstractGroup.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Group/AbstractGroup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Recurring.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Recurring.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Tier.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Price/Tier.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Related.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Reviews.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Reviews.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Attribute.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Filter/Inventory.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Filter/Inventory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Checkbox.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Inventory.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid/Renderer/Inventory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Matrix.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Matrix.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Settings.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Settings.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Upsell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Websites.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Websites.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tabs/Configurable.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tabs/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tabs/Grouped.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Edit/Tabs/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Frontend/Product/Watermark.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Frontend/Product/Watermark.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Apply.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Apply.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/BaseImage.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/BaseImage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Boolean.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Category.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Config.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery/Content.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Image.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Enabled.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Enabled.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Price.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Msrp/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Weight.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Weight.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Options/Ajax.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Options/Ajax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Price.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Widget/Chooser.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Widget/Chooser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Product/Widget/Chooser/Container.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Product/Widget/Chooser/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Search.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Search.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Search/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Search/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Catalog/Search/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Catalog/Search/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Checkout/Agreement.php
+++ b/app/code/Magento/Adminhtml/Block/Checkout/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Checkout/Agreement/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Checkout/Agreement/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Checkout/Agreement/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Checkout/Agreement/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Checkout/Agreement/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Checkout/Agreement/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Block.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Block/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Block/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Block/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Block/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Block/Widget/Chooser.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Block/Widget/Chooser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Tab/Content.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Tab/Design.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Tab/Design.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Tab/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Tab/Meta.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Tab/Meta.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page/Grid/Renderer/Action.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page/Grid/Renderer/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Page/Widget/Chooser.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Page/Widget/Chooser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Wysiwyg/Images/Content.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Wysiwyg/Images/Content.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Files.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Files.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Newfolder.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Newfolder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Uploader.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Wysiwyg/Images/Content/Uploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
+++ b/app/code/Magento/Adminhtml/Block/Cms/Wysiwyg/Images/Tree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer.php
+++ b/app/code/Magento/Adminhtml/Block/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Renderer/Attribute/Group.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Renderer/Attribute/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Renderer/Newpass.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Renderer/Newpass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Renderer/Region.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Renderer/Region.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Account.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Account.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Addresses.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Cart.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Carts.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Carts.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Newsletter.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Newsletter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Filter/Status.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Filter/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Action.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Status.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Newsletter/Grid/Renderer/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Orders.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Orders.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Reviews.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Reviews.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Accordion.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Accordion.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Cart.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Grid/Renderer/Item.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Grid/Renderer/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Orders.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Orders.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Sales.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Sales.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/View/Wishlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Edit/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Form/Element/Boolean.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Form/Element/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Form/Element/File.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Form/Element/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Form/Element/Image.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Form/Element/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Grid/Filter/Country.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Grid/Filter/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Grid/Renderer/Multiaction.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Grid/Renderer/Multiaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Group.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Group/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Group/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Group/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Group/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Online.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Online.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Online/Filter.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Online/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Online/Grid/Renderer/Ip.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Online/Grid/Renderer/Ip.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Online/Grid/Renderer/Type.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Online/Grid/Renderer/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Online/Grid/Renderer/Url.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Online/Grid/Renderer/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/Sales/Order/Address/Form/Renderer/Vat.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/Sales/Order/Address/Form/Renderer/Vat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Customer/System/Config/Validatevat.php
+++ b/app/code/Magento/Adminhtml/Block/Customer/System/Config/Validatevat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/AbstractDashboard.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/AbstractDashboard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Bar.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Bar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Diagrams.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Diagrams.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Graph.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Graph.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Grids.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Grids.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Orders/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Orders/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Sales.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Sales.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Searches/Last.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Searches/Last.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Searches/Renderer/Searchquery.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Searches/Renderer/Searchquery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Searches/Top.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Searches/Top.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Amounts.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Amounts.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Customers/Most.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Customers/Most.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Customers/Newest.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Customers/Newest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Orders.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Orders.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Products/Ordered.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Products/Ordered.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Products/Viewed.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Tab/Products/Viewed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Dashboard/Totals.php
+++ b/app/code/Magento/Adminhtml/Block/Dashboard/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Denied.php
+++ b/app/code/Magento/Adminhtml/Block/Denied.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Html/Date.php
+++ b/app/code/Magento/Adminhtml/Block/Html/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Html/Select.php
+++ b/app/code/Magento/Adminhtml/Block/Html/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Media/Uploader.php
+++ b/app/code/Magento/Adminhtml/Block/Media/Uploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Messages.php
+++ b/app/code/Magento/Adminhtml/Block/Messages.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Problem.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Problem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Problem/Grid/Filter/Checkbox.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Problem/Grid/Filter/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Problem/Grid/Renderer/Checkbox.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Problem/Grid/Renderer/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Queue/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Queue/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Queue/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Queue/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Queue/Grid/Renderer/Action.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Queue/Grid/Renderer/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Queue/Preview.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Queue/Preview.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Queue/Preview/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Queue/Preview/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Subscriber.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Subscriber.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Subscriber/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Subscriber/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Checkbox.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Website.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Subscriber/Grid/Filter/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Subscriber/Grid/Renderer/Checkbox.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Subscriber/Grid/Renderer/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Template.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Template/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Template/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Template/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Template/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Template/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Template/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Action.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Sender.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Template/Grid/Renderer/Sender.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Template/Preview.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Template/Preview.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Newsletter/Template/Preview/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Newsletter/Template/Preview/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Page.php
+++ b/app/code/Magento/Adminhtml/Block/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Page/Footer.php
+++ b/app/code/Magento/Adminhtml/Block/Page/Footer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Page/Head.php
+++ b/app/code/Magento/Adminhtml/Block/Page/Head.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Page/Header.php
+++ b/app/code/Magento/Adminhtml/Block/Page/Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Page/Notices.php
+++ b/app/code/Magento/Adminhtml/Block/Page/Notices.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Page/System/Config/Robots/Reset.php
+++ b/app/code/Magento/Adminhtml/Block/Page/System/Config/Robots/Reset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Catalog.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Catalog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Js.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Js.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Tab/Actions.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Tab/Actions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Tab/Conditions.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Tab/Conditions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Tab/Main.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Tab/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Catalog/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Actions.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Actions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Conditions.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Conditions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid/Column/Renderer/Used.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Coupons/Grid/Column/Renderer/Used.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Labels.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Labels.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Main/Renderer/Checkbox.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/Main/Renderer/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Quote/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Widget/Chooser.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Widget/Chooser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Widget/Chooser/Daterange.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Widget/Chooser/Daterange.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Promo/Widget/Chooser/Sku.php
+++ b/app/code/Magento/Adminhtml/Block/Promo/Widget/Chooser/Sku.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Rating/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Rating/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Rating/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Rating/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Rating/Edit/Tab/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Rating/Edit/Tab/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Rating/Edit/Tab/Options.php
+++ b/app/code/Magento/Adminhtml/Block/Rating/Edit/Tab/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Rating/Edit/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Rating/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Rating/Rating.php
+++ b/app/code/Magento/Adminhtml/Block/Rating/Rating.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Config/Form/Field/MtdStart.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Config/Form/Field/MtdStart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Config/Form/Field/YtdStart.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Config/Form/Field/YtdStart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Filter/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Filter/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Grid/AbstractGrid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Grid/AbstractGrid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Grid/Column/Renderer/Blanknumber.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Grid/Column/Renderer/Blanknumber.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Grid/Column/Renderer/Currency.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Grid/Column/Renderer/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Grid/Column/Renderer/Customer.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Grid/Column/Renderer/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Grid/Column/Renderer/Product.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Grid/Column/Renderer/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Grid/Shopcart.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Grid/Shopcart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Product.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Product/Downloads.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Product/Downloads.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Product/Downloads/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Product/Downloads/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Product/Downloads/Renderer/Purchases.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Product/Downloads/Renderer/Purchases.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Product/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Product/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Product/Lowstock.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Product/Lowstock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Product/Lowstock/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Product/Lowstock/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Product/Viewed.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Product/Viewed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Product/Viewed/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Product/Viewed/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Review/Customer.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Review/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Review/Detail.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Review/Detail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Review/Detail/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Review/Detail/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Review/Product.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Review/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Bestsellers.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Bestsellers.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Bestsellers/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Bestsellers/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Coupons.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Coupons.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Coupons/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Coupons/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Grid/Column/Renderer/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Invoiced.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Invoiced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Invoiced/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Invoiced/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Refunded.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Refunded.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Refunded/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Refunded/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Sales.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Sales.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Sales/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Sales/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Shipping.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Shipping/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Shipping/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Tax.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Sales/Tax/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Sales/Tax/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Search.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Search.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Shopcart/Abandoned.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Shopcart/Abandoned.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Shopcart/Abandoned/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Shopcart/Abandoned/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Shopcart/Customer.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Shopcart/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Shopcart/Customer/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Shopcart/Customer/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Shopcart/Product.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Shopcart/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Shopcart/Product/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Shopcart/Product/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Wishlist.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Wishlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Report/Wishlist/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Report/Wishlist/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Add.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Add.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Add/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Add/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Grid/Filter/Type.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Grid/Filter/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Grid/Renderer/Type.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Grid/Renderer/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Main.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Product/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Product/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Rating/Detailed.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Rating/Detailed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Review/Rating/Summary.php
+++ b/app/code/Magento/Adminhtml/Block/Review/Rating/Summary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Creditmemo.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Creditmemo/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Creditmemo/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Invoice.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Invoice/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Invoice/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Items/AbstractItems.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Items/AbstractItems.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Items/Column/DefaultColumn.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Items/Column/DefaultColumn.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Items/Column/Name.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Items/Column/Name.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Items/Column/Name/Grouped.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Items/Column/Name/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Items/Column/Qty.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Items/Column/Qty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Items/Renderer/Configurable.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Items/Renderer/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Items/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Items/Renderer/DefaultRenderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/AbstractOrder.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/AbstractOrder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Address.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Address/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Address/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Comments/View.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Comments/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/AbstractCreate.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/AbstractCreate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Billing/Address.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Billing/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Billing/Method.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Billing/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Billing/Method/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Billing/Method/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Comment.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Comment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Coupons.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Coupons.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Coupons/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Coupons/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Customer.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Data.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Form/AbstractForm.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Form/AbstractForm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Form/Account.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Form/Account.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Form/Address.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Form/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Giftmessage.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Giftmessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Giftmessage/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Giftmessage/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Header.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Items.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Items/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Items/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Load.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Load.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Messages.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Messages.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Newsletter.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Newsletter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Newsletter/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Newsletter/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Search.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Search.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Search/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Price.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Product.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Qty.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Search/Grid/Renderer/Qty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Shipping/Address.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Shipping/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Shipping/Method.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Shipping/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Shipping/Method/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Shipping/Method/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/AbstractSidebar.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/AbstractSidebar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Cart.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Compared.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Compared.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Pcompared.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Pcompared.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Pviewed.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Pviewed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Reorder.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Reorder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Viewed.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Viewed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Wishlist.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Sidebar/Wishlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Store.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Store/Select.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Store/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/DefaultTotals.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/DefaultTotals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Discount.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Discount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Grandtotal.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Grandtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Shipping.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Subtotal.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Subtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Table.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Table.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Tax.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Create/Totals/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/Create.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/Create.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/Create/Adjustments.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/Create/Adjustments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/Create/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/Create/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/Create/Items.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/Create/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/Totals.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/View.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/View/Comments.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/View/Comments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/View/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/View/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/View/Items.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Creditmemo/View/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/Create.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/Create.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/Create/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/Create/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/Create/Items.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/Create/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/Create/Tracking.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/Create/Tracking.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/Totals.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/View.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/View/Comments.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/View/Comments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/View/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/View/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/View/Items.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Invoice/View/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Payment.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Create.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Create.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Create/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Create/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Create/Items.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Create/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Create/Tracking.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Create/Tracking.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Packaging.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Packaging/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Tracking/Info.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/Tracking/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/View.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/View/Comments.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/View/Comments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/View/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/View/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/View/Items.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/View/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/View/Tracking.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Shipment/View/Tracking.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Status.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Status/Assign.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Status/Assign.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Status/Assign/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Status/Assign/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Status/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Status/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Status/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Status/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Status/NewStatus.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Status/NewStatus.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Status/NewStatus/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Status/NewStatus/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Totalbar.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Totalbar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Totals.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Totals/Item.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Totals/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/Totals/Tax.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/Totals/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Giftmessage.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Giftmessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/History.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/History.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Info.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Items.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Items/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Items/Renderer/DefaultRenderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Messages.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Messages.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/Creditmemos.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/Creditmemos.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/History.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/History.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/Info.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/Invoices.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/Invoices.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/Shipments.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/Shipments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/Transactions.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tab/Transactions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Order/View/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Reorder/Renderer/Action.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Reorder/Renderer/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Shipment.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Shipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Shipment/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Shipment/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Totals.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Transactions.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Transactions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Transactions/Child/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Transactions/Child/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Transactions/Detail.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Transactions/Detail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Transactions/Detail/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Transactions/Detail/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sales/Transactions/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Sales/Transactions/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Shipping/Carrier/Tablerate/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Shipping/Carrier/Tablerate/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sitemap.php
+++ b/app/code/Magento/Adminhtml/Block/Sitemap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sitemap/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Sitemap/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sitemap/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Sitemap/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sitemap/Grid/Renderer/Action.php
+++ b/app/code/Magento/Adminhtml/Block/Sitemap/Grid/Renderer/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sitemap/Grid/Renderer/Link.php
+++ b/app/code/Magento/Adminhtml/Block/Sitemap/Grid/Renderer/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Sitemap/Grid/Renderer/Time.php
+++ b/app/code/Magento/Adminhtml/Block/Sitemap/Grid/Renderer/Time.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Account/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/System/Account/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Account/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/System/Account/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Cache/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/System/Cache/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Cache/Form.php
+++ b/app/code/Magento/Adminhtml/Block/System/Cache/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Design.php
+++ b/app/code/Magento/Adminhtml/Block/System/Design.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Design/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/System/Design/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Design/Edit/Tab/General.php
+++ b/app/code/Magento/Adminhtml/Block/System/Design/Edit/Tab/General.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Design/Edit/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/System/Design/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Email/Template.php
+++ b/app/code/Magento/Adminhtml/Block/System/Email/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Email/Template/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/System/Email/Template/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Email/Template/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/System/Email/Template/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Email/Template/Grid/Filter/Type.php
+++ b/app/code/Magento/Adminhtml/Block/System/Email/Template/Grid/Filter/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Email/Template/Grid/Renderer/Action.php
+++ b/app/code/Magento/Adminhtml/Block/System/Email/Template/Grid/Renderer/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Email/Template/Grid/Renderer/Sender.php
+++ b/app/code/Magento/Adminhtml/Block/System/Email/Template/Grid/Renderer/Sender.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Email/Template/Grid/Renderer/Type.php
+++ b/app/code/Magento/Adminhtml/Block/System/Email/Template/Grid/Renderer/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Email/Template/Preview.php
+++ b/app/code/Magento/Adminhtml/Block/System/Email/Template/Preview.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Shipping/Ups.php
+++ b/app/code/Magento/Adminhtml/Block/System/Shipping/Ups.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Delete.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Delete.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Delete/Form.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Delete/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Delete/Group.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Delete/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Delete/Website.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Delete/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Edit/AbstractForm.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Edit/AbstractForm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Edit/Form/Group.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Edit/Form/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Edit/Form/Store.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Edit/Form/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Edit/Form/Website.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Edit/Form/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Grid/Render/Group.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Grid/Render/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Grid/Render/Store.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Grid/Render/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Grid/Render/Website.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Grid/Render/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Store/Store.php
+++ b/app/code/Magento/Adminhtml/Block/System/Store/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Variable.php
+++ b/app/code/Magento/Adminhtml/Block/System/Variable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Variable/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/System/Variable/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/System/Variable/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/System/Variable/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rate/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rate/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rate/Grid/Renderer/Country.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rate/Grid/Renderer/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rate/Grid/Renderer/Data.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rate/Grid/Renderer/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rate/ImportExport.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rate/ImportExport.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rate/ImportExportHeader.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rate/ImportExportHeader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rate/Title.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rate/Title.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rate/Title/Fieldset.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rate/Title/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rate/Toolbar/Add.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rate/Toolbar/Add.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rate/Toolbar/Save.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rate/Toolbar/Save.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rule.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rule/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rule/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Tax/Rule/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Tax/Rule/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Template.php
+++ b/app/code/Magento/Adminhtml/Block/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Text/ListText.php
+++ b/app/code/Magento/Adminhtml/Block/Text/ListText.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Catalog/Category/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Catalog/Category/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Catalog/Category/Tree.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Catalog/Category/Tree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Catalog/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Catalog/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Catalog/Product/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Catalog/Product/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Catalog/Product/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Catalog/Product/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Edit.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Edit/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Link.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Urlrewrite/Selector.php
+++ b/app/code/Magento/Adminhtml/Block/Urlrewrite/Selector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget.php
+++ b/app/code/Magento/Adminhtml/Block/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Accordion.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Accordion.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Accordion/Item.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Accordion/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Breadcrumbs.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Breadcrumbs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Button.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Button.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Container.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Form.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Form/Container.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Form/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Form/Element.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Form/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Form/Element/Dependence.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Form/Element/Dependence.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Form/Element/Gallery.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Form/Element/Gallery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Form/Renderer/Element.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Form/Renderer/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Form/Renderer/Fieldset.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Form/Renderer/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Form/Renderer/Fieldset/Element.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Form/Renderer/Fieldset/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/AbstractFilter.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/AbstractFilter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Checkbox.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Country.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Datetime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/FilterInterface.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/FilterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Massaction.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Massaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Radio.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Radio.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Range.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Store.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Text.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Theme.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Filter/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/AbstractRenderer.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/AbstractRenderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Action.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Checkbox.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Concat.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Concat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Country.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Currency.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Date.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Datetime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Input.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Input.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Ip.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Ip.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Longtext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Massaction.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Massaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Number.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Number.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Options.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Price.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Radio.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Radio.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/RendererInterface.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/RendererInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Select.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Store.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Wrapline.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Column/Renderer/Wrapline.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Container.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Massaction.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Massaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Massaction/Item.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Massaction/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/AdditionalInterface.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/AdditionalInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/DefaultAdditional.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Massaction/Item/Additional/DefaultAdditional.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Grid/Serializer.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Grid/Serializer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Tab/TabInterface.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Tab/TabInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/Tabs.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Block/Widget/View/Container.php
+++ b/app/code/Magento/Adminhtml/Block/Widget/View/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Action.php
+++ b/app/code/Magento/Adminhtml/Controller/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Ajax.php
+++ b/app/code/Magento/Adminhtml/Controller/Ajax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Cache.php
+++ b/app/code/Magento/Adminhtml/Controller/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Category.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Category/Widget.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Category/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Product.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Product/Action/Attribute.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Product/Action/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Product/Attribute.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Product/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Product/Datafeeds.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Product/Datafeeds.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Product/Gallery.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Product/Gallery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Product/Group.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Product/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Product/Review.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Product/Review.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Product/Set.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Product/Set.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Product/Widget.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Product/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Catalog/Search.php
+++ b/app/code/Magento/Adminhtml/Controller/Catalog/Search.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Checkout/Agreement.php
+++ b/app/code/Magento/Adminhtml/Controller/Checkout/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Cms/Block.php
+++ b/app/code/Magento/Adminhtml/Controller/Cms/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Cms/Block/Widget.php
+++ b/app/code/Magento/Adminhtml/Controller/Cms/Block/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Cms/Page.php
+++ b/app/code/Magento/Adminhtml/Controller/Cms/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Cms/Page/Widget.php
+++ b/app/code/Magento/Adminhtml/Controller/Cms/Page/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Cms/Wysiwyg.php
+++ b/app/code/Magento/Adminhtml/Controller/Cms/Wysiwyg.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Cms/Wysiwyg/Images.php
+++ b/app/code/Magento/Adminhtml/Controller/Cms/Wysiwyg/Images.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Customer.php
+++ b/app/code/Magento/Adminhtml/Controller/Customer.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Customer/Cart/Product/Composite/Cart.php
+++ b/app/code/Magento/Adminhtml/Controller/Customer/Cart/Product/Composite/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Customer/Group.php
+++ b/app/code/Magento/Adminhtml/Controller/Customer/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Customer/Online.php
+++ b/app/code/Magento/Adminhtml/Controller/Customer/Online.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Customer/System/Config/Validatevat.php
+++ b/app/code/Magento/Adminhtml/Controller/Customer/System/Config/Validatevat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Customer/Wishlist/Product/Composite/Wishlist.php
+++ b/app/code/Magento/Adminhtml/Controller/Customer/Wishlist/Product/Composite/Wishlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Dashboard.php
+++ b/app/code/Magento/Adminhtml/Controller/Dashboard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Index.php
+++ b/app/code/Magento/Adminhtml/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Json.php
+++ b/app/code/Magento/Adminhtml/Controller/Json.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Newsletter/Problem.php
+++ b/app/code/Magento/Adminhtml/Controller/Newsletter/Problem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Newsletter/Queue.php
+++ b/app/code/Magento/Adminhtml/Controller/Newsletter/Queue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Newsletter/Subscriber.php
+++ b/app/code/Magento/Adminhtml/Controller/Newsletter/Subscriber.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Newsletter/Template.php
+++ b/app/code/Magento/Adminhtml/Controller/Newsletter/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Promo.php
+++ b/app/code/Magento/Adminhtml/Controller/Promo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Promo/Catalog.php
+++ b/app/code/Magento/Adminhtml/Controller/Promo/Catalog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Promo/Quote.php
+++ b/app/code/Magento/Adminhtml/Controller/Promo/Quote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Promo/Widget.php
+++ b/app/code/Magento/Adminhtml/Controller/Promo/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Rating.php
+++ b/app/code/Magento/Adminhtml/Controller/Rating.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Report.php
+++ b/app/code/Magento/Adminhtml/Controller/Report.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Report/AbstractReport.php
+++ b/app/code/Magento/Adminhtml/Controller/Report/AbstractReport.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Report/Customer.php
+++ b/app/code/Magento/Adminhtml/Controller/Report/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Report/Product.php
+++ b/app/code/Magento/Adminhtml/Controller/Report/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Report/Review.php
+++ b/app/code/Magento/Adminhtml/Controller/Report/Review.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Report/Sales.php
+++ b/app/code/Magento/Adminhtml/Controller/Report/Sales.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Report/Shopcart.php
+++ b/app/code/Magento/Adminhtml/Controller/Report/Shopcart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Report/Statistics.php
+++ b/app/code/Magento/Adminhtml/Controller/Report/Statistics.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Billing/Agreement.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Billing/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Creditmemo.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Creditmemo/AbstractCreditmemo.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Creditmemo/AbstractCreditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Invoice.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Invoice/AbstractInvoice.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Invoice/AbstractInvoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Order.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Order/Create.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Order/Create.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Order/Creditmemo.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Order/Creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Order/Edit.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Order/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Order/Invoice.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Order/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Order/Shipment.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Order/Shipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Order/Status.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Order/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Order/View/Giftmessage.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Order/View/Giftmessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Recurring/Profile.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Recurring/Profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Shipment.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Shipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Shipment/AbstractShipment.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Shipment/AbstractShipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sales/Transactions.php
+++ b/app/code/Magento/Adminhtml/Controller/Sales/Transactions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Sitemap.php
+++ b/app/code/Magento/Adminhtml/Controller/Sitemap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Survey.php
+++ b/app/code/Magento/Adminhtml/Controller/Survey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/System/Account.php
+++ b/app/code/Magento/Adminhtml/Controller/System/Account.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/System/Backup.php
+++ b/app/code/Magento/Adminhtml/Controller/System/Backup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/System/Config/System/Storage.php
+++ b/app/code/Magento/Adminhtml/Controller/System/Config/System/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/System/Design.php
+++ b/app/code/Magento/Adminhtml/Controller/System/Design.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/System/Email/Template.php
+++ b/app/code/Magento/Adminhtml/Controller/System/Email/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/System/Store.php
+++ b/app/code/Magento/Adminhtml/Controller/System/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/System/Variable.php
+++ b/app/code/Magento/Adminhtml/Controller/System/Variable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Tax/Rate.php
+++ b/app/code/Magento/Adminhtml/Controller/Tax/Rate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Tax/Rule.php
+++ b/app/code/Magento/Adminhtml/Controller/Tax/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Tax/Tax.php
+++ b/app/code/Magento/Adminhtml/Controller/Tax/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Controller/Urlrewrite.php
+++ b/app/code/Magento/Adminhtml/Controller/Urlrewrite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Exception.php
+++ b/app/code/Magento/Adminhtml/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Addresses.php
+++ b/app/code/Magento/Adminhtml/Helper/Addresses.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Catalog.php
+++ b/app/code/Magento/Adminhtml/Helper/Catalog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Catalog/Product/Composite.php
+++ b/app/code/Magento/Adminhtml/Helper/Catalog/Product/Composite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
+++ b/app/code/Magento/Adminhtml/Helper/Catalog/Product/Edit/Action/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Dashboard/AbstractDashboard.php
+++ b/app/code/Magento/Adminhtml/Helper/Dashboard/AbstractDashboard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Dashboard/Data.php
+++ b/app/code/Magento/Adminhtml/Helper/Dashboard/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Dashboard/Order.php
+++ b/app/code/Magento/Adminhtml/Helper/Dashboard/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Data.php
+++ b/app/code/Magento/Adminhtml/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Js.php
+++ b/app/code/Magento/Adminhtml/Helper/Js.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Media/Js.php
+++ b/app/code/Magento/Adminhtml/Helper/Media/Js.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Helper/Sales.php
+++ b/app/code/Magento/Adminhtml/Helper/Sales.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Customer/Renderer/Region.php
+++ b/app/code/Magento/Adminhtml/Model/Customer/Renderer/Region.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Email/Template.php
+++ b/app/code/Magento/Adminhtml/Model/Email/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Giftmessage/Save.php
+++ b/app/code/Magento/Adminhtml/Model/Giftmessage/Save.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/LayoutUpdate/Validator.php
+++ b/app/code/Magento/Adminhtml/Model/LayoutUpdate/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Newsletter/Renderer/Text.php
+++ b/app/code/Magento/Adminhtml/Model/Newsletter/Renderer/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Observer.php
+++ b/app/code/Magento/Adminhtml/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Report/Item.php
+++ b/app/code/Magento/Adminhtml/Model/Report/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Sales/Order.php
+++ b/app/code/Magento/Adminhtml/Model/Sales/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Sales/Order/Create.php
+++ b/app/code/Magento/Adminhtml/Model/Sales/Order/Create.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Sales/Order/Random.php
+++ b/app/code/Magento/Adminhtml/Model/Sales/Order/Random.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Search/Catalog.php
+++ b/app/code/Magento/Adminhtml/Model/Search/Catalog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Search/Customer.php
+++ b/app/code/Magento/Adminhtml/Model/Search/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Search/Order.php
+++ b/app/code/Magento/Adminhtml/Model/Search/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Session.php
+++ b/app/code/Magento/Adminhtml/Model/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/Model/Session/Quote.php
+++ b/app/code/Magento/Adminhtml/Model/Session/Quote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Adminhtml/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/etc/adminhtml/events.xml
+++ b/app/code/Magento/Adminhtml/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Adminhtml/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Adminhtml/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/etc/config.xml
+++ b/app/code/Magento/Adminhtml/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/etc/di.xml
+++ b/app/code/Magento/Adminhtml/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/etc/events.xml
+++ b/app/code/Magento/Adminhtml/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/etc/module.xml
+++ b/app/code/Magento/Adminhtml/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/etc/sales.xml
+++ b/app/code/Magento/Adminhtml/etc/sales.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/admin/access_denied.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/admin/access_denied.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/admin/formkey.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/admin/formkey.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/admin/overlay_popup.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/admin/overlay_popup.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/admin/page.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/admin/page.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/admin/popup.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/admin/popup.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/backup/dialogs.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/backup/dialogs.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/backup/left.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/backup/left.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/backup/list.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/backup/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/base-image-uploader.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/base-image-uploader.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/category-selector.css
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/category-selector.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/checkboxes/tree.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/checkboxes/tree.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/edit.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/edit.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/edit.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/edit/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/edit/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/form.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/form.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/tree.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/tree.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/widget/tree.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/category/widget/tree.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/form/renderer/fieldset/element.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/form/renderer/fieldset/element.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product-variation.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product-variation.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/js.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/labels.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/labels.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/new/created.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/new/created.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/options.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/options.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/set/main.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/set/main.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/set/main/tree/attribute.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/set/main/tree/attribute.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/set/main/tree/group.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/set/main/tree/group.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/set/toolbar/add.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/set/toolbar/add.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/set/toolbar/main.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/attribute/set/toolbar/main.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/configure.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/configure.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/configure.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/configure.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/configurable.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/configurable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/grouped.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/grouped.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/js.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/type/date.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/type/date.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/type/default.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/type/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/type/file.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/type/file.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/type/select.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/type/select.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/type/text.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/options/type/text.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/qty.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/composite/fieldset/qty.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/created.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/created.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/action/attribute.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/action/attribute.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/action/inventory.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/action/inventory.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/action/websites.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/action/websites.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/attribute_set.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/attribute_set.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/category/new/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/category/new/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options/option.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options/option.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options/type/date.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options/type/date.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options/type/file.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options/type/file.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options/type/select.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options/type/select.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options/type/text.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/options/type/text.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/price/group.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/price/group.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/price/tier.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/price/tier.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/serializer.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/serializer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/super/attribute-js-template.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/super/attribute-js-template.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/super/attribute-template.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/super/attribute-template.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/super/config.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/super/config.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/super/generator.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/super/generator.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/super/matrix.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/super/matrix.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/websites.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/edit/websites.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/helper/gallery.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/helper/gallery.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/js.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/price.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/price.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/tab/alert.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/tab/alert.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/tab/inventory.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/tab/inventory.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/widget/chooser/container.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/product/widget/chooser/container.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/type-switcher.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/type-switcher.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/catalog/wysiwyg/js.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/catalog/wysiwyg/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/cms/browser/content.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/cms/browser/content.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/cms/browser/content/files.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/cms/browser/content/files.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/cms/browser/content/uploader.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/cms/browser/content/uploader.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/cms/browser/tree.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/cms/browser/tree.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/cms/page/edit/form/renderer/content.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/cms/page/edit/form/renderer/content.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/edit/js.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/edit/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/edit/tab/account/form/renderer/group.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/edit/tab/account/form/renderer/group.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/edit/tab/js/addresses.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/edit/tab/js/addresses.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/online.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/online.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/sales/order/create/address/form/renderer/vat.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/sales/order/create/address/form/renderer/vat.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/system/config/validatevat.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/system/config/validatevat.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/tab/addresses.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/tab/addresses.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/tab/cart.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/tab/cart.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/tab/newsletter.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/tab/newsletter.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/tab/view.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/tab/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/customer/tab/view/sales.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/customer/tab/view/sales.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/dashboard/graph.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/dashboard/graph.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/dashboard/graph/disabled.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/dashboard/graph/disabled.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/dashboard/grid.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/dashboard/grid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/dashboard/index.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/dashboard/index.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/dashboard/salebar.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/dashboard/salebar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/dashboard/searches.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/dashboard/searches.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/dashboard/store/switcher.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/dashboard/store/switcher.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/dashboard/totalbar.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/dashboard/totalbar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/email/order/items.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/email/order/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/ADMINHTML_CATALOG_PRODUCT_COMPOSITE_CONFIGURE.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/ADMINHTML_CATALOG_PRODUCT_COMPOSITE_CONFIGURE.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/ADMINHTML_CATALOG_PRODUCT_COMPOSITE_CONFIGURE_ERROR.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/ADMINHTML_CATALOG_PRODUCT_COMPOSITE_CONFIGURE_ERROR.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/ADMINHTML_CATALOG_PRODUCT_COMPOSITE_UPDATE_RESULT.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/ADMINHTML_CATALOG_PRODUCT_COMPOSITE_UPDATE_RESULT.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cache_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cache_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cache_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cache_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_category_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_category_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_action_attribute_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_action_attribute_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_alertspricegrid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_alertspricegrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_alertsstockgrid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_alertsstockgrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_attribute_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_attribute_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_attribute_edit_popup.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_attribute_edit_popup.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_configurable.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_configurable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_configurable_new.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_configurable_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_crosssell.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_crosssell.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_crosssellgrid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_crosssellgrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_customoptions.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_customoptions.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_generatevariations.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_generatevariations.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_grouped.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_grouped.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_grouped_grid_popup.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_grouped_grid_popup.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_new.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_options.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_options.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_optionsimportgrid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_optionsimportgrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_related.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_related.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_relatedgrid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_relatedgrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_review_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_review_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_review_new.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_review_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_reviews.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_reviews.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_set_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_set_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_set_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_set_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_simple.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_simple.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_superconfig.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_superconfig.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_superconfig_config.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_superconfig_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_supergroup.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_supergroup.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_supergrouppopup.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_supergrouppopup.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_upsell.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_upsell.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_upsellgrid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_upsellgrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_virtual.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_catalog_product_virtual.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_block_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_block_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_block_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_block_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_block_new.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_block_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_page_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_page_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_page_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_page_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_page_new.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_page_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_wysiwyg_images_contents.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_wysiwyg_images_contents.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_wysiwyg_images_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_cms_wysiwyg_images_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_cart.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_cart.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_carts.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_carts.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_group_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_group_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_lastorders.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_lastorders.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_newsletter.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_newsletter.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_online_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_online_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_orders.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_orders.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_productreviews.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_productreviews.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_viewcart.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_viewcart.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_viewwishlist.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_customer_viewwishlist.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_dashboard_customersmost.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_dashboard_customersmost.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_dashboard_customersnewest.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_dashboard_customersnewest.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_dashboard_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_dashboard_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_dashboard_productsviewed.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_dashboard_productsviewed.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_denied.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_denied.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_problem_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_problem_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_problem_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_problem_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_problem_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_problem_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_queue_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_queue_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_queue_preview.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_queue_preview.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_subscriber_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_subscriber_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_subscriber_exportcsv.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_subscriber_exportcsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_subscriber_exportxml.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_subscriber_exportxml.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_subscriber_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_subscriber_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_subscriber_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_subscriber_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_template_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_template_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_template_preview.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_newsletter_template_preview.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_noroute.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_noroute.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_catalog_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_catalog_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_catalog_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_catalog_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_catalog_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_catalog_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_quote_couponsgrid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_quote_couponsgrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_quote_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_quote_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_quote_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_promo_quote_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_rating_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_rating_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_rating_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_rating_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_exportsearchcsv.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_exportsearchcsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_exportsearchexcel.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_exportsearchexcel.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_product_viewed.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_product_viewed.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_bestsellers.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_bestsellers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_coupons.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_coupons.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_invoiced.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_invoiced.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_refunded.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_refunded.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_sales.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_sales.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_shipping.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_shipping.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_tax.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_sales_tax.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_search.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_search.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_search_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_report_search_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_billing_agreement_customergrid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_billing_agreement_customergrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_billing_agreement_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_billing_agreement_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_billing_agreement_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_billing_agreement_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_billing_agreement_ordersgrid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_billing_agreement_ordersgrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_billing_agreement_view.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_billing_agreement_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_addcomment.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_addcomment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_address.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_address.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_customer_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_customer_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_billing_address.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_billing_address.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_billing_method.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_billing_method.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_comment.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_comment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_customer_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_customer_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_data.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_data.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_form_account.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_form_account.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_giftmessage.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_giftmessage.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_header.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_header.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_items.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_json.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_json.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_message.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_message.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_newsletter.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_newsletter.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_plain.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_plain.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_search.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_search.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_search_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_search_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_shipping_address.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_shipping_address.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_shipping_method.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_shipping_method.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_cart.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_cart.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_compared.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_compared.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_pcompared.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_pcompared.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_pviewed.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_pviewed.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_reorder.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_reorder.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_viewed.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_viewed.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_wishlist.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_sidebar_wishlist.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_totals.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_create_load_block_totals.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_creditmemo_addcomment.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_creditmemo_addcomment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_creditmemo_new.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_creditmemo_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_creditmemo_updateqty.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_creditmemo_updateqty.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_creditmemo_view.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_creditmemo_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_edit_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_edit_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_exportcsv.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_exportcsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_exportexcel.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_exportexcel.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_grid_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_invoice_addcomment.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_invoice_addcomment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_invoice_new.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_invoice_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_invoice_updateqty.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_invoice_updateqty.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_invoice_view.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_invoice_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_shipment_addcomment.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_shipment_addcomment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_shipment_addtrack.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_shipment_addtrack.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_shipment_new.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_shipment_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_shipment_removetrack.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_shipment_removetrack.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_shipment_view.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_shipment_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_status_assign.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_status_assign.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_status_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_status_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_status_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_status_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_status_newstatus.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_status_newstatus.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_transactions.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_transactions.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_view.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_order_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_recurring_profile_customergrid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_recurring_profile_customergrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_recurring_profile_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_recurring_profile_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_recurring_profile_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_recurring_profile_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_recurring_profile_orders.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_recurring_profile_orders.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_recurring_profile_view.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_recurring_profile_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_transactions_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_transactions_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_transactions_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_transactions_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_transactions_view.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_sales_transactions_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_account_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_account_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_backup_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_backup_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_backup_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_backup_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_backup_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_backup_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_design_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_design_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_design_grid_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_design_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_design_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_design_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_email_template_grid.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_email_template_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_email_template_grid_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_email_template_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_email_template_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_email_template_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_store_grid_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_store_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_store_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_store_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_variable_grid_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_variable_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_variable_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_system_variable_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rate_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rate_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rate_exportcsv.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rate_exportcsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rate_exportxml.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rate_exportxml.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rate_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rate_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rule_block.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rule_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rule_edit.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rule_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rule_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_tax_rule_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_urlrewrite_index.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/adminhtml_urlrewrite_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/catalog_product_view_type_configurable.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/catalog_product_view_type_configurable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/catalog_product_view_type_grouped.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/catalog_product_view_type_grouped.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/default.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/editor.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/editor.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/empty.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/empty.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/formkey.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/formkey.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/newsletter_queue_preview.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/newsletter_queue_preview.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/newsletter_template_preview.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/newsletter_template_preview.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/overlay_popup.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/overlay_popup.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/popup.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/popup.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/preview.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/preview.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/report_sales.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/report_sales.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/layout/systemPreview.xml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/layout/systemPreview.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/media/uploader.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/media/uploader.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/newsletter/preview/iframeswitcher.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/newsletter/preview/iframeswitcher.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/newsletter/preview/store.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/newsletter/preview/store.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/newsletter/problem/list.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/newsletter/problem/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/newsletter/queue/edit.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/newsletter/queue/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/newsletter/queue/preview.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/newsletter/queue/preview.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/newsletter/subscriber/list.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/newsletter/subscriber/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/newsletter/template/edit.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/newsletter/template/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/newsletter/template/list.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/newsletter/template/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/newsletter/template/preview.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/newsletter/template/preview.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/page/footer.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/page/footer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/page/head.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/page/head.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/page/header.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/page/header.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/page/js/calendar.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/page/js/calendar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/page/js/components.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/page/js/components.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/page/js/translate.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/page/js/translate.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/page/notices.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/page/notices.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/page/system/config/robots/reset.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/page/system/config/robots/reset.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/promo/fieldset.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/promo/fieldset.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/promo/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/promo/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/promo/js.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/promo/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/promo/rules.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/promo/rules.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/promo/salesrulejs.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/promo/salesrulejs.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/rating/detailed.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/rating/detailed.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/rating/options.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/rating/options.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/rating/stars/detailed.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/rating/stars/detailed.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/rating/stars/summary.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/rating/stars/summary.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/report/grid/container.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/report/grid/container.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/report/refresh/statistics.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/report/refresh/statistics.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/report/wishlist.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/report/wishlist.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/review/add.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/review/add.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/items/column/name.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/items/column/name.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/items/column/qty.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/items/column/qty.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/items/renderer/default.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/address/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/address/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/comments/view.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/comments/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/abstract.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/abstract.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/billing/method/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/billing/method/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/comment.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/comment.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/coupons/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/coupons/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/data.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/data.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/form/account.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/form/account.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/form/address.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/form/address.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/giftmessage.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/giftmessage.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/giftmessage.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/giftmessage.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/items.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/items/grid.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/items/grid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/js.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/newsletter/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/newsletter/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/scripts.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/scripts.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/shipping/method/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/shipping/method/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/sidebar.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/sidebar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/sidebar/items.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/sidebar/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/store/select.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/store/select.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals/default.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals/grandtotal.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals/grandtotal.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals/shipping.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals/shipping.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals/subtotal.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals/subtotal.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals/tax.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/create/totals/tax.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/create/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/create/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/create/items.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/create/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/create/items/renderer/configurable.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/create/items/renderer/configurable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/create/items/renderer/default.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/create/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/create/totals/adjustments.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/create/totals/adjustments.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/view/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/view/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/view/items.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/view/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/view/items/renderer/configurable.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/view/items/renderer/configurable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/view/items/renderer/default.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/creditmemo/view/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/giftoptions.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/giftoptions.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/giftoptions_tooltip.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/giftoptions_tooltip.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/create/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/create/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/create/items.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/create/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/create/items/renderer/configurable.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/create/items/renderer/configurable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/create/items/renderer/default.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/create/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/create/tracking.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/create/tracking.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/view/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/view/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/view/items.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/view/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/view/items/renderer/configurable.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/view/items/renderer/configurable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/view/items/renderer/default.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/invoice/view/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/create/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/create/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/create/items.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/create/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/create/items/renderer/configurable.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/create/items/renderer/configurable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/create/items/renderer/default.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/create/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/create/tracking.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/create/tracking.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/packaging.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/packaging.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/packaging/grid.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/packaging/grid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/packaging/packed.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/packaging/packed.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/packaging/popup.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/packaging/popup.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/tracking/info.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/tracking/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/view/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/view/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/view/items.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/view/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/view/items/renderer/configurable.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/view/items/renderer/configurable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/view/items/renderer/default.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/view/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/view/tracking.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/shipment/view/tracking.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totalbar.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totalbar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/discount.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/discount.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/due.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/due.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/footer.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/footer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/grand.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/grand.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/item.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/item.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/main.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/main.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/paid.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/paid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/refunded.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/refunded.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/shipping.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/shipping.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/tax.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/totals/tax.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/giftmessage.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/giftmessage.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/history.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/history.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/info.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/items.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/items/renderer/default.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/tab/history.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/tab/history.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/tab/info.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/tab/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/tracking.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/order/view/tracking.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/sales/transactions/detail.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/sales/transactions/detail.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/store/switcher/enhanced.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/store/switcher/enhanced.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/autocomplete.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/autocomplete.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/cache/additional.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/cache/additional.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/cache/edit.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/cache/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/design/edit.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/design/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/design/index.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/design/index.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/email/template/edit.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/email/template/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/email/template/list.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/email/template/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/email/template/preview.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/email/template/preview.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/info.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/search.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/search.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/shipping/applicable_country.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/shipping/applicable_country.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/shipping/ups.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/shipping/ups.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/system/variable/js.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/system/variable/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/class/page/edit.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/class/page/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/importExport.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/importExport.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/importExportHeader.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/importExportHeader.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/rate/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/rate/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/rate/js.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/rate/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/rate/title.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/rate/title.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/rule/edit.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/rule/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/rule/rate/form.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/rule/rate/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/class/add.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/class/add.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/class/save.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/class/save.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/rate/add.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/rate/add.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/rate/save.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/rate/save.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/rule/add.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/rule/add.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/rule/save.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/tax/toolbar/rule/save.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/urlrewrite/categories.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/urlrewrite/categories.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/urlrewrite/edit.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/urlrewrite/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/urlrewrite/selector.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/urlrewrite/selector.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/validation-rules.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/validation-rules.js
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/variables.js
+++ b/app/code/Magento/Adminhtml/view/adminhtml/variables.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/widget/tabshoriz.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/widget/tabshoriz.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Adminhtml/view/adminhtml/widget/tabsleft.phtml
+++ b/app/code/Magento/Adminhtml/view/adminhtml/widget/tabsleft.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/Block/Directpost/Form.php
+++ b/app/code/Magento/Authorizenet/Block/Directpost/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/Block/Directpost/Iframe.php
+++ b/app/code/Magento/Authorizenet/Block/Directpost/Iframe.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/Controller/Adminhtml/Authorizenet/Directpost/Payment.php
+++ b/app/code/Magento/Authorizenet/Controller/Adminhtml/Authorizenet/Directpost/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/Controller/Directpost/Payment.php
+++ b/app/code/Magento/Authorizenet/Controller/Directpost/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/Helper/Data.php
+++ b/app/code/Magento/Authorizenet/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/Model/Directpost.php
+++ b/app/code/Magento/Authorizenet/Model/Directpost.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/Model/Directpost/Observer.php
+++ b/app/code/Magento/Authorizenet/Model/Directpost/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/Model/Directpost/Request.php
+++ b/app/code/Magento/Authorizenet/Model/Directpost/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/Model/Directpost/Response.php
+++ b/app/code/Magento/Authorizenet/Model/Directpost/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/Model/Directpost/Session.php
+++ b/app/code/Magento/Authorizenet/Model/Directpost/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/etc/adminhtml/di.xml
+++ b/app/code/Magento/Authorizenet/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/etc/adminhtml/events.xml
+++ b/app/code/Magento/Authorizenet/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Authorizenet/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/etc/adminhtml/system.xml
+++ b/app/code/Magento/Authorizenet/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/etc/config.xml
+++ b/app/code/Magento/Authorizenet/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/etc/di.xml
+++ b/app/code/Magento/Authorizenet/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/etc/frontend/di.xml
+++ b/app/code/Magento/Authorizenet/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/etc/frontend/events.xml
+++ b/app/code/Magento/Authorizenet/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/etc/frontend/routes.xml
+++ b/app/code/Magento/Authorizenet/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/etc/module.xml
+++ b/app/code/Magento/Authorizenet/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/adminhtml/directpost/iframe.phtml
+++ b/app/code/Magento/Authorizenet/view/adminhtml/directpost/iframe.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/adminhtml/directpost/info.phtml
+++ b/app/code/Magento/Authorizenet/view/adminhtml/directpost/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/adminhtml/layout/adminhtml_authorizenet_directpost_payment_redirect.xml
+++ b/app/code/Magento/Authorizenet/view/adminhtml/layout/adminhtml_authorizenet_directpost_payment_redirect.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/adminhtml/layout/adminhtml_sales_order_create_index.xml
+++ b/app/code/Magento/Authorizenet/view/adminhtml/layout/adminhtml_sales_order_create_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/frontend/directpost/form.phtml
+++ b/app/code/Magento/Authorizenet/view/frontend/directpost/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/frontend/directpost/iframe.phtml
+++ b/app/code/Magento/Authorizenet/view/frontend/directpost/iframe.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/frontend/directpost/info.phtml
+++ b/app/code/Magento/Authorizenet/view/frontend/directpost/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/frontend/js/directpost.js
+++ b/app/code/Magento/Authorizenet/view/frontend/js/directpost.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/frontend/layout/authorizenet_directpost_payment_redirect.xml
+++ b/app/code/Magento/Authorizenet/view/frontend/layout/authorizenet_directpost_payment_redirect.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/frontend/layout/authorizenet_directpost_payment_response.xml
+++ b/app/code/Magento/Authorizenet/view/frontend/layout/authorizenet_directpost_payment_response.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/frontend/layout/checkout_onepage_index.xml
+++ b/app/code/Magento/Authorizenet/view/frontend/layout/checkout_onepage_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Authorizenet/view/frontend/layout/checkout_onepage_review.xml
+++ b/app/code/Magento/Authorizenet/view/frontend/layout/checkout_onepage_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/AbstractBlock.php
+++ b/app/code/Magento/Backend/Block/AbstractBlock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Cache/Grid/Column/Statuses.php
+++ b/app/code/Magento/Backend/Block/Cache/Grid/Column/Statuses.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Catalog/Product/Tab/Container.php
+++ b/app/code/Magento/Backend/Block/Catalog/Product/Tab/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Context.php
+++ b/app/code/Magento/Backend/Block/Context.php
@@ -14,7 +14,7 @@ namespace Magento\Backend\Block;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/GlobalSearch.php
+++ b/app/code/Magento/Backend/Block/GlobalSearch.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Menu.php
+++ b/app/code/Magento/Backend/Block/Menu.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Store/Switcher.php
+++ b/app/code/Magento/Backend/Block/Store/Switcher.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Store/Switcher/Form/Renderer/Fieldset.php
+++ b/app/code/Magento/Backend/Block/Store/Switcher/Form/Renderer/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Store/Switcher/Form/Renderer/Fieldset/Element.php
+++ b/app/code/Magento/Backend/Block/Store/Switcher/Form/Renderer/Fieldset/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Dwstree.php
+++ b/app/code/Magento/Backend/Block/System/Config/Dwstree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Edit.php
+++ b/app/code/Magento/Backend/Block/System/Config/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/Datetime.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/Datetime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/Export.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/Export.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/Factory.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/FieldArray/AbstractFieldArray.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/FieldArray/AbstractFieldArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/File.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/Heading.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/Heading.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/Image.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/Import.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/Import.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/Notification.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/Notification.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/Regexceptions.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/Regexceptions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Field/Select/Allowspecific.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Field/Select/Allowspecific.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Fieldset.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Fieldset/Factory.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Fieldset/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Form/Fieldset/Modules/DisableOutput.php
+++ b/app/code/Magento/Backend/Block/System/Config/Form/Fieldset/Modules/DisableOutput.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Switcher.php
+++ b/app/code/Magento/Backend/Block/System/Config/Switcher.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/System/Storage/Media/Synchronize.php
+++ b/app/code/Magento/Backend/Block/System/Config/System/Storage/Media/Synchronize.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/System/Config/Tabs.php
+++ b/app/code/Magento/Backend/Block/System/Config/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Template.php
+++ b/app/code/Magento/Backend/Block/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Template/Context.php
+++ b/app/code/Magento/Backend/Block/Template/Context.php
@@ -14,7 +14,7 @@ namespace Magento\Backend\Block\Template;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget.php
+++ b/app/code/Magento/Backend/Block/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Accordion.php
+++ b/app/code/Magento/Backend/Block/Widget/Accordion.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Accordion/Item.php
+++ b/app/code/Magento/Backend/Block/Widget/Accordion/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Breadcrumbs.php
+++ b/app/code/Magento/Backend/Block/Widget/Breadcrumbs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Button.php
+++ b/app/code/Magento/Backend/Block/Widget/Button.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Button/SplitButton.php
+++ b/app/code/Magento/Backend/Block/Widget/Button/SplitButton.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Container.php
+++ b/app/code/Magento/Backend/Block/Widget/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Form.php
+++ b/app/code/Magento/Backend/Block/Widget/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Form/Container.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Form/Element.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Form/Element/Dependence.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Element/Dependence.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Form/Element/Gallery.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Element/Gallery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Form/Generic.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Generic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Form/Renderer/Element.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Renderer/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Form/Renderer/Fieldset.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Renderer/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Form/Renderer/Fieldset/Element.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Renderer/Fieldset/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Extended.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/AbstractFilter.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/AbstractFilter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Checkbox.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Country.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Date.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Datetime.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Datetime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/FilterInterface.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/FilterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Massaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Massaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Radio.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Radio.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Range.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Range.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Select.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Select/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Select/Extended.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/SkipList.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/SkipList.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Store.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Text.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Theme.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Multistore.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Multistore.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/AbstractRenderer.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/AbstractRenderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Action.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Button.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Button.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Checkbox.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Checkboxes/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Checkboxes/Extended.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Concat.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Concat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Country.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Currency.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Date.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Datetime.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Datetime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/DraggableHandle.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/DraggableHandle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Input.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Input.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Ip.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Ip.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Longtext.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Longtext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Massaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Massaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Number.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Number.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Options.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Options/Converter.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Options/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Options/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Options/Extended.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Price.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Radio.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Radio.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Radio/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Radio/Extended.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/RendererInterface.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/RendererInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Select.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Select/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Select/Extended.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Store.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Text.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Wrapline.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Wrapline.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/ColumnSet.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/ColumnSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Container.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Export.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Export.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/ExportInterface.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/ExportInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Extended.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Additional.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Additional.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Item.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Item/Additional/AdditionalInterface.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Item/Additional/AdditionalInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Item/Additional/DefaultAdditional.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Item/Additional/DefaultAdditional.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Grid/Serializer.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Serializer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Tab/TabInterface.php
+++ b/app/code/Magento/Backend/Block/Widget/Tab/TabInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Block/Widget/View/Container.php
+++ b/app/code/Magento/Backend/Block/Widget/View/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Controller/AbstractAction.php
+++ b/app/code/Magento/Backend/Controller/AbstractAction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Controller/Adminhtml/Auth.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Auth.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Controller/Adminhtml/System.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Config.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Config/Save.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Config/Save.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Controller/Context.php
+++ b/app/code/Magento/Backend/Controller/Context.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Controller/Factory.php
+++ b/app/code/Magento/Backend/Controller/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Controller/Router/DefaultRouter.php
+++ b/app/code/Magento/Backend/Controller/Router/DefaultRouter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Controller/System/AbstractConfig.php
+++ b/app/code/Magento/Backend/Controller/System/AbstractConfig.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Helper/Data.php
+++ b/app/code/Magento/Backend/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Auth.php
+++ b/app/code/Magento/Backend/Model/Auth.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Auth/Credential/StorageInterface.php
+++ b/app/code/Magento/Backend/Model/Auth/Credential/StorageInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Auth/Exception.php
+++ b/app/code/Magento/Backend/Model/Auth/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Auth/Plugin/Exception.php
+++ b/app/code/Magento/Backend/Model/Auth/Plugin/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Auth/Session.php
+++ b/app/code/Magento/Backend/Model/Auth/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Auth/StorageInterface.php
+++ b/app/code/Magento/Backend/Model/Auth/StorageInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Authorization/RoleLocator.php
+++ b/app/code/Magento/Backend/Model/Authorization/RoleLocator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Cache/Resource/Grid/Collection.php
+++ b/app/code/Magento/Backend/Model/Cache/Resource/Grid/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config.php
+++ b/app/code/Magento/Backend/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Admin/Custom.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Admin/Custom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Admin/Custompath.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Admin/Custompath.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Admin/Observer.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Admin/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Admin/Password/Link/Expirationperiod.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Admin/Password/Link/Expirationperiod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Admin/Robots.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Admin/Robots.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Admin/Usecustom.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Admin/Usecustom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Admin/Usecustompath.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Admin/Usecustompath.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Admin/Usesecretkey.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Admin/Usesecretkey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Baseurl.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Baseurl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Cache.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Cookie.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Cookie.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Currency/AbstractCurrency.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Currency/AbstractCurrency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Currency/Allow.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Currency/Allow.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Currency/Base.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Currency/Base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Currency/Cron.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Currency/Cron.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Currency/DefaultCurrency.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Currency/DefaultCurrency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Datashare.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Datashare.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Design/Exception.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Design/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Email/Address.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Email/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Email/Logo.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Email/Logo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Email/Sender.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Email/Sender.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Encrypted.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Encrypted.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/File.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/File/RequestData.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/File/RequestData.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/File/RequestData/RequestDataInterface.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/File/RequestData/RequestDataInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Filename.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Filename.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Image.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Image/Adapter.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Image/Adapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Image/Favicon.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Image/Favicon.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Image/Logo.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Image/Logo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Image/Pdf.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Image/Pdf.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Locale.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Locale.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Locale/Timezone.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Locale/Timezone.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Log/Cron.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Log/Cron.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Secure.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Secure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Serialized.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Serialized.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Serialized/ArraySerialized.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Serialized/ArraySerialized.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Storage/Media/Database.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Storage/Media/Database.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Store.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Backend/Translate.php
+++ b/app/code/Magento/Backend/Model/Config/Backend/Translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/BackendClone/Factory.php
+++ b/app/code/Magento/Backend/Model/Config/BackendClone/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/BackendFactory.php
+++ b/app/code/Magento/Backend/Model/Config/BackendFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/CommentFactory.php
+++ b/app/code/Magento/Backend/Model/Config/CommentFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/CommentInterface.php
+++ b/app/code/Magento/Backend/Model/Config/CommentInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Factory.php
+++ b/app/code/Magento/Backend/Model/Config/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Loader.php
+++ b/app/code/Magento/Backend/Model/Config/Loader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/SchemaLocator.php
+++ b/app/code/Magento/Backend/Model/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/ScopeDefiner.php
+++ b/app/code/Magento/Backend/Model/Config/ScopeDefiner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Admin/Page.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Admin/Page.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Checktype.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Checktype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Currency.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Date/Short.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Date/Short.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Design/Robots.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Design/Robots.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Dev/Dbautoup.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Dev/Dbautoup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Email/Identity.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Email/Identity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Email/Method.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Email/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Email/Smtpauth.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Email/Smtpauth.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Email/Template.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Email/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Enabledisable.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Enabledisable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Image/Adapter.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Image/Adapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Locale.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Locale.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Locale/Country.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Locale/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Locale/Currency.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Locale/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Locale/Currency/All.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Locale/Currency/All.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Locale/Timezone.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Locale/Timezone.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Locale/Weekdays.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Locale/Weekdays.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Nooptreq.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Nooptreq.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Reports/Scope.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Reports/Scope.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Storage/Media/Database.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Storage/Media/Database.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Storage/Media/Storage.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Storage/Media/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Store.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Web/Protocol.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Web/Protocol.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Web/Redirect.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Web/Redirect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Website.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Website/OptionHash.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Website/OptionHash.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Yesno.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Yesno.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Source/Yesnocustom.php
+++ b/app/code/Magento/Backend/Model/Config/Source/Yesnocustom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/SourceFactory.php
+++ b/app/code/Magento/Backend/Model/Config/SourceFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure.php
+++ b/app/code/Magento/Backend/Model/Config/Structure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/AbstractElement.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/AbstractElement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/AbstractMapper.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/AbstractMapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Converter.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Data.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/AbstractComposite.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/AbstractComposite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Dependency/Field.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Dependency/Field.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Dependency/FieldFactory.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Dependency/FieldFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Dependency/Mapper.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Dependency/Mapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Field.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Field.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/FlyweightFactory.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/FlyweightFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Group.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Group/Proxy.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Group/Proxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Iterator.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Iterator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Iterator/Field.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Iterator/Field.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Iterator/Group.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Iterator/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Iterator/Section.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Iterator/Section.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Iterator/Tab.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Iterator/Tab.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Section.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Section.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Element/Tab.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Element/Tab.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/ElementInterface.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/ElementInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Mapper/Attribute/Inheritance.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Mapper/Attribute/Inheritance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Mapper/Dependencies.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Mapper/Dependencies.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Mapper/ExtendsMapper.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Mapper/ExtendsMapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Mapper/Factory.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Mapper/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Mapper/Helper/RelativePathConverter.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Mapper/Helper/RelativePathConverter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Mapper/Ignore.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Mapper/Ignore.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Mapper/Path.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Mapper/Path.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Mapper/Sorting.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Mapper/Sorting.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/MapperInterface.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/MapperInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Reader.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Reader.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/Search/Proxy.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/Search/Proxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Config/Structure/SearchInterface.php
+++ b/app/code/Magento/Backend/Model/Config/Structure/SearchInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Locale.php
+++ b/app/code/Magento/Backend/Model/Locale.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Locale/Manager.php
+++ b/app/code/Magento/Backend/Model/Locale/Manager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu.php
+++ b/app/code/Magento/Backend/Model/Menu.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/AbstractDirector.php
+++ b/app/code/Magento/Backend/Model/Menu/AbstractDirector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Builder.php
+++ b/app/code/Magento/Backend/Model/Menu/Builder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Builder/AbstractCommand.php
+++ b/app/code/Magento/Backend/Model/Menu/Builder/AbstractCommand.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Builder/Command/Add.php
+++ b/app/code/Magento/Backend/Model/Menu/Builder/Command/Add.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Builder/Command/Remove.php
+++ b/app/code/Magento/Backend/Model/Menu/Builder/Command/Remove.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Builder/Command/Update.php
+++ b/app/code/Magento/Backend/Model/Menu/Builder/Command/Update.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Builder/CommandFactory.php
+++ b/app/code/Magento/Backend/Model/Menu/Builder/CommandFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Config.php
+++ b/app/code/Magento/Backend/Model/Menu/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Config/Converter.php
+++ b/app/code/Magento/Backend/Model/Menu/Config/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Config/Menu/Dom.php
+++ b/app/code/Magento/Backend/Model/Menu/Config/Menu/Dom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Config/Reader.php
+++ b/app/code/Magento/Backend/Model/Menu/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Config/SchemaLocator.php
+++ b/app/code/Magento/Backend/Model/Menu/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Director/Director.php
+++ b/app/code/Magento/Backend/Model/Menu/Director/Director.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Filter/Iterator.php
+++ b/app/code/Magento/Backend/Model/Menu/Filter/Iterator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Item.php
+++ b/app/code/Magento/Backend/Model/Menu/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Item/Factory.php
+++ b/app/code/Magento/Backend/Model/Menu/Item/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Item/Validator.php
+++ b/app/code/Magento/Backend/Model/Menu/Item/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Menu/Iterator.php
+++ b/app/code/Magento/Backend/Model/Menu/Iterator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Observer.php
+++ b/app/code/Magento/Backend/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Router/NoRouteHandler.php
+++ b/app/code/Magento/Backend/Model/Router/NoRouteHandler.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Session.php
+++ b/app/code/Magento/Backend/Model/Session.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Url/Proxy.php
+++ b/app/code/Magento/Backend/Model/Url/Proxy.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Widget/Grid/AbstractTotals.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/AbstractTotals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Widget/Grid/Parser.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Parser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Widget/Grid/Row/GeneratorInterface.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Row/GeneratorInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Widget/Grid/Row/UrlGenerator.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Row/UrlGenerator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Widget/Grid/Row/UrlGeneratorFactory.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Row/UrlGeneratorFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Widget/Grid/Row/UrlGeneratorId.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Row/UrlGeneratorId.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Widget/Grid/SubTotals.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/SubTotals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Widget/Grid/Totals.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/Model/Widget/Grid/TotalsInterface.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/TotalsInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/adminhtml/cache.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/cache.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/adminhtml/di.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/adminhtml/events.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/config.xml
+++ b/app/code/Magento/Backend/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/di.xml
+++ b/app/code/Magento/Backend/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/menu.xsd
+++ b/app/code/Magento/Backend/etc/menu.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/module.xml
+++ b/app/code/Magento/Backend/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/system.xsd
+++ b/app/code/Magento/Backend/etc/system.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/etc/system_file.xsd
+++ b/app/code/Magento/Backend/etc/system_file.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/admin/login.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/admin/login.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/admin/login_buttons.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/admin/login_buttons.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_auth_login.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_auth_login.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/layout/default.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/menu.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/menu.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/store/switcher.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/store/switcher.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/store/switcher/form/renderer/fieldset.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/store/switcher/form/renderer/fieldset.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/store/switcher/form/renderer/fieldset/element.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/store/switcher/form/renderer/fieldset/element.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/system/config/edit.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/system/config/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/system/config/form/field/array.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/system/config/form/field/array.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/system/config/js.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/system/config/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/system/config/switcher.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/system/config/switcher.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/system/config/system/storage/media/synchronize.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/system/config/system/storage/media/synchronize.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/system/config/tabs.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/system/config/tabs.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/system/validation-rules.js
+++ b/app/code/Magento/Backend/view/adminhtml/system/validation-rules.js
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/accordion.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/accordion.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/breadcrumbs.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/breadcrumbs.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/button.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/button.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/button/split.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/button/split.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/form.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/form/container.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/form/container.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/form/element.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/form/element.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/form/element/gallery.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/form/element/gallery.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/form/renderer/element.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/form/renderer/element.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/form/renderer/fieldset.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/form/renderer/fieldset.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/form/renderer/fieldset/element.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/form/renderer/fieldset/element.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/grid.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/grid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/grid/column_set.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/grid/column_set.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/grid/container.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/grid/container.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/grid/container/empty.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/grid/container/empty.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/grid/export.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/grid/export.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/grid/extended.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/grid/extended.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/grid/massaction.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/grid/massaction.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/grid/massaction_extended.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/grid/massaction_extended.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/grid/serializer.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/grid/serializer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/tabs.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/tabs.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backend/view/adminhtml/widget/view/container.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/widget/view/container.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Block/Adminhtml/Grid/Column/Renderer/Download.php
+++ b/app/code/Magento/Backup/Block/Adminhtml/Grid/Column/Renderer/Download.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Block/Adminhtml/Grid/Column/Rollback.php
+++ b/app/code/Magento/Backup/Block/Adminhtml/Grid/Column/Rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Exception.php
+++ b/app/code/Magento/Backup/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Helper/Data.php
+++ b/app/code/Magento/Backup/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Model/Backup.php
+++ b/app/code/Magento/Backup/Model/Backup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Model/Config/Backend/Cron.php
+++ b/app/code/Magento/Backup/Model/Config/Backend/Cron.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Model/Config/Source/Type.php
+++ b/app/code/Magento/Backup/Model/Config/Source/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Model/Db.php
+++ b/app/code/Magento/Backup/Model/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Model/Fs/Collection.php
+++ b/app/code/Magento/Backup/Model/Fs/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Model/Grid/Options.php
+++ b/app/code/Magento/Backup/Model/Grid/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Model/Observer.php
+++ b/app/code/Magento/Backup/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Model/Resource/Db.php
+++ b/app/code/Magento/Backup/Model/Resource/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Model/Resource/Helper.php
+++ b/app/code/Magento/Backup/Model/Resource/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/Model/Resource/HelperFactory.php
+++ b/app/code/Magento/Backup/Model/Resource/HelperFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Backup/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Backup/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backup/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/etc/crontab.xml
+++ b/app/code/Magento/Backup/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Backup/etc/module.xml
+++ b/app/code/Magento/Backup/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Bundle.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Bundle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Extend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Special.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Attributes/Special.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tabs.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Sales/Order/Items/Renderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Adminhtml/Sales/Order/View/Items/Renderer.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Sales/Order/View/Items/Renderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Catalog/Product/Price.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Radio.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Radio.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Select.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Checkout/Cart/Item/Renderer.php
+++ b/app/code/Magento/Bundle/Block/Checkout/Cart/Item/Renderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Block/Sales/Order/Items/Renderer.php
+++ b/app/code/Magento/Bundle/Block/Sales/Order/Items/Renderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Controller/Adminhtml/Bundle/Product/Edit.php
+++ b/app/code/Magento/Bundle/Controller/Adminhtml/Bundle/Product/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Controller/Adminhtml/Bundle/Selection.php
+++ b/app/code/Magento/Bundle/Controller/Adminhtml/Bundle/Selection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Helper/Catalog/Product/Configuration.php
+++ b/app/code/Magento/Bundle/Helper/Catalog/Product/Configuration.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Helper/Data.php
+++ b/app/code/Magento/Bundle/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Observer.php
+++ b/app/code/Magento/Bundle/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Option.php
+++ b/app/code/Magento/Bundle/Model/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Plugin/QuoteItem.php
+++ b/app/code/Magento/Bundle/Model/Plugin/QuoteItem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Price/Index.php
+++ b/app/code/Magento/Bundle/Model/Price/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Product/Attribute/Source/Price/View.php
+++ b/app/code/Magento/Bundle/Model/Product/Attribute/Source/Price/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Product/Price.php
+++ b/app/code/Magento/Bundle/Model/Product/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Product/Type.php
+++ b/app/code/Magento/Bundle/Model/Product/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Resource/Bundle.php
+++ b/app/code/Magento/Bundle/Model/Resource/Bundle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Resource/Indexer/Price.php
+++ b/app/code/Magento/Bundle/Model/Resource/Indexer/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Resource/Indexer/Stock.php
+++ b/app/code/Magento/Bundle/Model/Resource/Indexer/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Resource/Option.php
+++ b/app/code/Magento/Bundle/Model/Resource/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Resource/Option/Collection.php
+++ b/app/code/Magento/Bundle/Model/Resource/Option/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Resource/Price/Index.php
+++ b/app/code/Magento/Bundle/Model/Resource/Price/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Resource/Selection.php
+++ b/app/code/Magento/Bundle/Model/Resource/Selection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Resource/Selection/Collection.php
+++ b/app/code/Magento/Bundle/Model/Resource/Selection/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/AbstractItems.php
+++ b/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/AbstractItems.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Creditmemo.php
+++ b/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
+++ b/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Shipment.php
+++ b/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Shipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Selection.php
+++ b/app/code/Magento/Bundle/Model/Selection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Source/Option/Selection/Price/Type.php
+++ b/app/code/Magento/Bundle/Model/Source/Option/Selection/Price/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/Model/Source/Option/Type.php
+++ b/app/code/Magento/Bundle/Model/Source/Option/Type.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/data/bundle_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Bundle/data/bundle_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/adminhtml/di.xml
+++ b/app/code/Magento/Bundle/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/adminhtml/events.xml
+++ b/app/code/Magento/Bundle/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Bundle/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/catalog_attributes.xml
+++ b/app/code/Magento/Bundle/etc/catalog_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/config.xml
+++ b/app/code/Magento/Bundle/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/di.xml
+++ b/app/code/Magento/Bundle/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/frontend/di.xml
+++ b/app/code/Magento/Bundle/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/frontend/events.xml
+++ b/app/code/Magento/Bundle/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/module.xml
+++ b/app/code/Magento/Bundle/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/pdf.xml
+++ b/app/code/Magento/Bundle/etc/pdf.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/product_types.xml
+++ b/app/code/Magento/Bundle/etc/product_types.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/etc/sales.xml
+++ b/app/code/Magento/Bundle/etc/sales.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/sql/bundle_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Bundle/sql/bundle_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/sql/bundle_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/Magento/Bundle/sql/bundle_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/sql/bundle_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/Magento/Bundle/sql/bundle_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/css/bundle-product.css
+++ b/app/code/Magento/Bundle/view/adminhtml/css/bundle-product.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/js/bundle-product.js
+++ b/app/code/Magento/Bundle/view/adminhtml/js/bundle-product.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_catalog_product_bundle.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_catalog_product_bundle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_customer_wishlist.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_customer_wishlist.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_creditmemo_new.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_creditmemo_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_creditmemo_updateqty.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_creditmemo_updateqty.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_creditmemo_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_creditmemo_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_invoice_new.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_invoice_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_invoice_updateqty.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_invoice_updateqty.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_invoice_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_invoice_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_shipment_new.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_shipment_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_shipment_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_shipment_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_view.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/adminhtml_sales_order_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/layout/catalog_product_view_type_bundle.xml
+++ b/app/code/Magento/Bundle/view/adminhtml/layout/catalog_product_view_type_bundle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/product/composite/fieldset/options/bundle.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/product/composite/fieldset/options/bundle.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/product/composite/fieldset/options/type/checkbox.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/product/composite/fieldset/options/type/checkbox.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/product/composite/fieldset/options/type/multi.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/product/composite/fieldset/options/type/multi.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/product/composite/fieldset/options/type/radio.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/product/composite/fieldset/options/type/radio.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/product/composite/fieldset/options/type/select.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/product/composite/fieldset/options/type/select.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/product/edit/bundle.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/product/edit/bundle.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/product/edit/bundle/option.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/product/edit/bundle/option.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/product/edit/bundle/option/search.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/product/edit/bundle/option/search.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/product/edit/bundle/option/selection.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/product/edit/bundle/option/selection.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/product/validation-rules.js
+++ b/app/code/Magento/Bundle/view/adminhtml/product/validation-rules.js
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/sales/creditmemo/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/sales/creditmemo/create/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/sales/creditmemo/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/sales/creditmemo/view/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/sales/invoice/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/sales/invoice/create/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/sales/invoice/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/sales/invoice/view/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/sales/order/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/sales/order/view/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/sales/shipment/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/sales/shipment/create/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/adminhtml/sales/shipment/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/sales/shipment/view/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/bundle.js
+++ b/app/code/Magento/Bundle/view/frontend/bundle.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/catalog/product/price.phtml
+++ b/app/code/Magento/Bundle/view/frontend/catalog/product/price.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/catalog/product/view/options/notice.phtml
+++ b/app/code/Magento/Bundle/view/frontend/catalog/product/view/options/notice.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/catalog/product/view/price.phtml
+++ b/app/code/Magento/Bundle/view/frontend/catalog/product/view/price.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/catalog/product/view/tierprices.phtml
+++ b/app/code/Magento/Bundle/view/frontend/catalog/product/view/tierprices.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle.phtml
+++ b/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle/option/checkbox.phtml
+++ b/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle/option/checkbox.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle/option/multi.phtml
+++ b/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle/option/multi.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle/option/radio.phtml
+++ b/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle/option/radio.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle/option/select.phtml
+++ b/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle/option/select.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle/options.phtml
+++ b/app/code/Magento/Bundle/view/frontend/catalog/product/view/type/bundle/options.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/email/order/items/creditmemo/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/email/order/items/creditmemo/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/email/order/items/invoice/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/email/order/items/invoice/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/email/order/items/order/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/email/order/items/order/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/email/order/items/shipment/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/email/order/items/shipment/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/js/float.js
+++ b/app/code/Magento/Bundle/view/frontend/js/float.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/js/product-summary.js
+++ b/app/code/Magento/Bundle/view/frontend/js/product-summary.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/js/slide.js
+++ b/app/code/Magento/Bundle/view/frontend/js/slide.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/catalog_category_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/catalog_product_compare_index.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/catalog_product_compare_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view_type_bundle.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view_type_bundle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view_type_simple.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view_type_simple.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/catalogsearch_advanced_result.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/catalogsearch_advanced_result.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/catalogsearch_result_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/checkout_cart_configure_type_bundle.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/checkout_cart_configure_type_bundle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/checkout_cart_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/checkout_multishipping_addresses.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/checkout_multishipping_addresses.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/checkout_multishipping_overview.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/checkout_multishipping_overview.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/checkout_multishipping_shipping.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/checkout_multishipping_shipping.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/checkout_onepage_review.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/checkout_onepage_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/default.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/paypal_express_review.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/paypal_express_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/paypal_express_review_details.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/paypal_express_review_details.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/paypaluk_express_review.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/paypaluk_express_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/paypaluk_express_review_details.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/paypaluk_express_review_details.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/rss_catalog_category.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/rss_catalog_category.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/rss_catalog_new.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/rss_catalog_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_creditmemo_items.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_creditmemo_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_invoice_items.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_invoice_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_items.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_shipment_items.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_email_order_shipment_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_guest_creditmemo.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_guest_creditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_guest_invoice.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_guest_invoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_guest_printorder.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_guest_printorder.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_guest_printordercreditmemo.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_guest_printordercreditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_guest_printorderinvoice.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_guest_printorderinvoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_guest_printordershipment.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_guest_printordershipment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_guest_shipment.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_guest_shipment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_guest_view.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_guest_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_creditmemo.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_creditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_invoice.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_invoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_printorder.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_printorder.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_printordercreditmemo.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_printordercreditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_printorderinvoice.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_printorderinvoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_printordershipment.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_printordershipment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_shipment.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_shipment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/sales_order_view.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/sales_order_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/layout/tag_product_list.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/tag_product_list.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/rss/catalog/product/price.phtml
+++ b/app/code/Magento/Bundle/view/frontend/rss/catalog/product/price.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/sales/order/creditmemo/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/sales/order/creditmemo/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/sales/order/invoice/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/sales/order/invoice/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/sales/order/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/sales/order/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Bundle/view/frontend/sales/order/shipment/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/sales/order/shipment/items/renderer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Block/Captcha.php
+++ b/app/code/Magento/Captcha/Block/Captcha.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Block/Captcha/DefaultCaptcha.php
+++ b/app/code/Magento/Captcha/Block/Captcha/DefaultCaptcha.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Controller/Adminhtml/Refresh.php
+++ b/app/code/Magento/Captcha/Controller/Adminhtml/Refresh.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Controller/Refresh.php
+++ b/app/code/Magento/Captcha/Controller/Refresh.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Model/CaptchaFactory.php
+++ b/app/code/Magento/Captcha/Model/CaptchaFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Model/Config/Font.php
+++ b/app/code/Magento/Captcha/Model/Config/Font.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Model/Config/Form/AbstractForm.php
+++ b/app/code/Magento/Captcha/Model/Config/Form/AbstractForm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Model/Config/Form/Backend.php
+++ b/app/code/Magento/Captcha/Model/Config/Form/Backend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Model/Config/Form/Frontend.php
+++ b/app/code/Magento/Captcha/Model/Config/Form/Frontend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Model/Config/Mode.php
+++ b/app/code/Magento/Captcha/Model/Config/Mode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Model/DefaultModel.php
+++ b/app/code/Magento/Captcha/Model/DefaultModel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Model/ModelInterface.php
+++ b/app/code/Magento/Captcha/Model/ModelInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Model/Observer.php
+++ b/app/code/Magento/Captcha/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/Model/Resource/Log.php
+++ b/app/code/Magento/Captcha/Model/Resource/Log.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/adminhtml/di.xml
+++ b/app/code/Magento/Captcha/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/adminhtml/events.xml
+++ b/app/code/Magento/Captcha/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Captcha/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/adminhtml/system.xml
+++ b/app/code/Magento/Captcha/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/config.xml
+++ b/app/code/Magento/Captcha/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/crontab.xml
+++ b/app/code/Magento/Captcha/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/di.xml
+++ b/app/code/Magento/Captcha/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/events.xml
+++ b/app/code/Magento/Captcha/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/frontend/events.xml
+++ b/app/code/Magento/Captcha/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/frontend/routes.xml
+++ b/app/code/Magento/Captcha/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/etc/module.xml
+++ b/app/code/Magento/Captcha/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/sql/captcha_setup/install-1.7.0.0.0.php
+++ b/app/code/Magento/Captcha/sql/captcha_setup/install-1.7.0.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/adminhtml/default.phtml
+++ b/app/code/Magento/Captcha/view/adminhtml/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/adminhtml/layout/adminhtml_auth_forgotpassword.xml
+++ b/app/code/Magento/Captcha/view/adminhtml/layout/adminhtml_auth_forgotpassword.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/adminhtml/layout/adminhtml_auth_login.xml
+++ b/app/code/Magento/Captcha/view/adminhtml/layout/adminhtml_auth_login.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/frontend/captcha.js
+++ b/app/code/Magento/Captcha/view/frontend/captcha.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/frontend/default.phtml
+++ b/app/code/Magento/Captcha/view/frontend/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/frontend/layout/checkout_onepage_index.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/checkout_onepage_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/frontend/layout/contacts_index_index.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/contacts_index_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/frontend/layout/customer_account_create.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/customer_account_create.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/frontend/layout/customer_account_forgotpassword.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/customer_account_forgotpassword.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/frontend/layout/customer_account_login.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/customer_account_login.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Captcha/view/frontend/onepage.js
+++ b/app/code/Magento/Captcha/view/frontend/onepage.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Adminhtml/System/Config/Form/Field/Select/Flatcatalog.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/System/Config/Form/Field/Select/Flatcatalog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Adminhtml/System/Config/Form/Field/Select/Flatproduct.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/System/Config/Form/Field/Select/Flatproduct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/Block/Breadcrumbs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Category/View.php
+++ b/app/code/Magento/Catalog/Block/Category/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Category/Widget/Link.php
+++ b/app/code/Magento/Catalog/Block/Category/Widget/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Layer/Filter/AbstractFilter.php
+++ b/app/code/Magento/Catalog/Block/Layer/Filter/AbstractFilter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Layer/Filter/Attribute.php
+++ b/app/code/Magento/Catalog/Block/Layer/Filter/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Layer/Filter/Category.php
+++ b/app/code/Magento/Catalog/Block/Layer/Filter/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Layer/Filter/Decimal.php
+++ b/app/code/Magento/Catalog/Block/Layer/Filter/Decimal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Layer/Filter/Price.php
+++ b/app/code/Magento/Catalog/Block/Layer/Filter/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Layer/State.php
+++ b/app/code/Magento/Catalog/Block/Layer/State.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Layer/View.php
+++ b/app/code/Magento/Catalog/Block/Layer/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Navigation.php
+++ b/app/code/Magento/Catalog/Block/Navigation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product.php
+++ b/app/code/Magento/Catalog/Block/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Compare/AbstractCompare.php
+++ b/app/code/Magento/Catalog/Block/Product/Compare/AbstractCompare.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Compare/ListCompare.php
+++ b/app/code/Magento/Catalog/Block/Product/Compare/ListCompare.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Compare/Sidebar.php
+++ b/app/code/Magento/Catalog/Block/Product/Compare/Sidebar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Configurable/AssociatedSelector/Backend/Grid/ColumnSet.php
+++ b/app/code/Magento/Catalog/Block/Product/Configurable/AssociatedSelector/Backend/Grid/ColumnSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Configurable/AssociatedSelector/Renderer/Id.php
+++ b/app/code/Magento/Catalog/Block/Product/Configurable/AssociatedSelector/Renderer/Id.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Configurable/AttributeSelector.php
+++ b/app/code/Magento/Catalog/Block/Product/Configurable/AttributeSelector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/Gallery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Grouped/AssociatedProducts.php
+++ b/app/code/Magento/Catalog/Block/Product/Grouped/AssociatedProducts.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Grouped/AssociatedProducts/ListAssociatedProducts.php
+++ b/app/code/Magento/Catalog/Block/Product/Grouped/AssociatedProducts/ListAssociatedProducts.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Image.php
+++ b/app/code/Magento/Catalog/Block/Product/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/ListProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/ListProduct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/NewProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/NewProduct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Price.php
+++ b/app/code/Magento/Catalog/Block/Product/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Price/Template.php
+++ b/app/code/Magento/Catalog/Block/Product/Price/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Crosssell.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Crosssell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Promotion.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Promotion.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Random.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Random.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Related.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Related.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Toolbar.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Toolbar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Upsell.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Upsell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Send.php
+++ b/app/code/Magento/Catalog/Block/Product/Send.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/TemplateSelector.php
+++ b/app/code/Magento/Catalog/Block/Product/TemplateSelector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View.php
+++ b/app/code/Magento/Catalog/Block/Product/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/AbstractView.php
+++ b/app/code/Magento/Catalog/Block/Product/View/AbstractView.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Additional.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Additional.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/BaseImage.php
+++ b/app/code/Magento/Catalog/Block/Product/View/BaseImage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Description.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Description.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Options.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Options/Type/Date.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/Type/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Options/Type/DefaultType.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/Type/DefaultType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Options/Type/File.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/Type/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Options/Type/Select.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/Type/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Options/Type/Text.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/Type/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Price.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Tabs.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Type/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Type/Grouped.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Type/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Type/Simple.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Type/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/View/Type/Virtual.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Type/Virtual.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Widget/Html/Pager.php
+++ b/app/code/Magento/Catalog/Block/Product/Widget/Html/Pager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Widget/Link.php
+++ b/app/code/Magento/Catalog/Block/Product/Widget/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
+++ b/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Block/Widget/Link.php
+++ b/app/code/Magento/Catalog/Block/Widget/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Controller/Category.php
+++ b/app/code/Magento/Catalog/Controller/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Controller/Index.php
+++ b/app/code/Magento/Catalog/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Controller/Product.php
+++ b/app/code/Magento/Catalog/Controller/Product.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Controller/Product/Compare.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Controller/Product/View/ViewInterface.php
+++ b/app/code/Magento/Catalog/Controller/Product/View/ViewInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Exception.php
+++ b/app/code/Magento/Catalog/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Category.php
+++ b/app/code/Magento/Catalog/Helper/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Category/Flat.php
+++ b/app/code/Magento/Catalog/Helper/Category/Flat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Data.php
+++ b/app/code/Magento/Catalog/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Flat/AbstractFlat.php
+++ b/app/code/Magento/Catalog/Helper/Flat/AbstractFlat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Image.php
+++ b/app/code/Magento/Catalog/Helper/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Output.php
+++ b/app/code/Magento/Catalog/Helper/Output.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Product.php
+++ b/app/code/Magento/Catalog/Helper/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Product/Compare.php
+++ b/app/code/Magento/Catalog/Helper/Product/Compare.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Product/Configuration.php
+++ b/app/code/Magento/Catalog/Helper/Product/Configuration.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Product/Configuration/ConfigurationInterface.php
+++ b/app/code/Magento/Catalog/Helper/Product/Configuration/ConfigurationInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Product/ConfigurationPool.php
+++ b/app/code/Magento/Catalog/Helper/Product/ConfigurationPool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Product/Flat.php
+++ b/app/code/Magento/Catalog/Helper/Product/Flat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Product/Options.php
+++ b/app/code/Magento/Catalog/Helper/Product/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Product/Url.php
+++ b/app/code/Magento/Catalog/Helper/Product/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Helper/Product/View.php
+++ b/app/code/Magento/Catalog/Helper/Product/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/AbstractModel.php
+++ b/app/code/Magento/Catalog/Model/AbstractModel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Attribute/Backend/Customlayoutupdate.php
+++ b/app/code/Magento/Catalog/Model/Attribute/Backend/Customlayoutupdate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Attribute/Config.php
+++ b/app/code/Magento/Catalog/Model/Attribute/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Attribute/Config/Converter.php
+++ b/app/code/Magento/Catalog/Model/Attribute/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Attribute/Config/Data.php
+++ b/app/code/Magento/Catalog/Model/Attribute/Config/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Attribute/Config/Reader.php
+++ b/app/code/Magento/Catalog/Model/Attribute/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Attribute/Config/SchemaLocator.php
+++ b/app/code/Magento/Catalog/Model/Attribute/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Sortby.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Sortby.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Urlkey.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Urlkey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Category/Attribute/Source/Layout.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Source/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Category/Attribute/Source/Mode.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Source/Mode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Category/Attribute/Source/Page.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Source/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Category/Attribute/Source/Sortby.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Source/Sortby.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Category/Indexer/Flat.php
+++ b/app/code/Magento/Catalog/Model/Category/Indexer/Flat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Category/Indexer/Product.php
+++ b/app/code/Magento/Catalog/Model/Category/Indexer/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config.php
+++ b/app/code/Magento/Catalog/Model/Config.php
@@ -12,7 +12,7 @@ namespace Magento\Catalog\Model;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Backend/Category.php
+++ b/app/code/Magento/Catalog/Model/Config/Backend/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Backend/Seo/Product.php
+++ b/app/code/Magento/Catalog/Model/Config/Backend/Seo/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/CatalogClone/Media/Image.php
+++ b/app/code/Magento/Catalog/Model/Config/CatalogClone/Media/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/Category.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/GridPerPage.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/GridPerPage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/ListMode.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/ListMode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/ListPerPage.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/ListPerPage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/ListSort.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/ListSort.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/Price/Scope.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Price/Scope.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/Price/Step.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Price/Step.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/Product/Options/Price.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Product/Options/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/Product/Options/Type.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Product/Options/Type.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/Product/Thumbnail.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Product/Thumbnail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/TimeFormat.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/TimeFormat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Config/Source/Watermark/Position.php
+++ b/app/code/Magento/Catalog/Model/Config/Source/Watermark/Position.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Design.php
+++ b/app/code/Magento/Catalog/Model/Design.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Entity/Attribute.php
+++ b/app/code/Magento/Catalog/Model/Entity/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Entity/Product/Attribute/Design/Options/Container.php
+++ b/app/code/Magento/Catalog/Model/Entity/Product/Attribute/Design/Options/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Factory.php
+++ b/app/code/Magento/Catalog/Model/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Index.php
+++ b/app/code/Magento/Catalog/Model/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Indexer/Url.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Layer.php
+++ b/app/code/Magento/Catalog/Model/Layer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Layer/Filter/AbstractFilter.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/AbstractFilter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Attribute.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Category.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Decimal.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Decimal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Factory.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Item.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Price.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Price/Algorithm.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Price/Algorithm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Layer/State.php
+++ b/app/code/Magento/Catalog/Model/Layer/State.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Observer.php
+++ b/app/code/Magento/Catalog/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Observer/Reindex.php
+++ b/app/code/Magento/Catalog/Model/Observer/Reindex.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Plugin/Log.php
+++ b/app/code/Magento/Catalog/Model/Plugin/Log.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Plugin/QuoteItemProductOption.php
+++ b/app/code/Magento/Catalog/Model/Plugin/QuoteItemProductOption.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Action.php
+++ b/app/code/Magento/Catalog/Model/Product/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Boolean.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Category.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Groupprice.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Groupprice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Groupprice/AbstractGroupprice.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Groupprice/AbstractGroupprice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Media.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Media.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Msrp.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Msrp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Price.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Recurring.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Recurring.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Startdate.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Startdate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Stock.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Tierprice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Urlkey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Weight.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Weight.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Frontend/Image.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Frontend/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Group.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Boolean.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Inputtype.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Inputtype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Layout.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Msrp/Type.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Msrp/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Msrp/Type/Enabled.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Msrp/Type/Enabled.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Msrp/Type/Price.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Msrp/Type/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Compare/Item.php
+++ b/app/code/Magento/Catalog/Model/Product/Compare/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Compare/ListCompare.php
+++ b/app/code/Magento/Catalog/Model/Product/Compare/ListCompare.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Condition.php
+++ b/app/code/Magento/Catalog/Model/Product/Condition.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Condition/ConditionInterface.php
+++ b/app/code/Magento/Catalog/Model/Product/Condition/ConditionInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Configuration/Item/ItemInterface.php
+++ b/app/code/Magento/Catalog/Model/Product/Configuration/Item/ItemInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Configuration/Item/Option.php
+++ b/app/code/Magento/Catalog/Model/Product/Configuration/Item/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Configuration/Item/Option/OptionInterface.php
+++ b/app/code/Magento/Catalog/Model/Product/Configuration/Item/Option/OptionInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Flat/Flag.php
+++ b/app/code/Magento/Catalog/Model/Product/Flat/Flag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Flat/Indexer.php
+++ b/app/code/Magento/Catalog/Model/Product/Flat/Indexer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Flat/Observer.php
+++ b/app/code/Magento/Catalog/Model/Product/Flat/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Image.php
+++ b/app/code/Magento/Catalog/Model/Product/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Image/View.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Indexer/Eav.php
+++ b/app/code/Magento/Catalog/Model/Product/Indexer/Eav.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Indexer/Flat.php
+++ b/app/code/Magento/Catalog/Model/Product/Indexer/Flat.php
@@ -12,7 +12,7 @@ namespace Magento\Catalog\Model\Product\Indexer;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Indexer/Price.php
+++ b/app/code/Magento/Catalog/Model/Product/Indexer/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Link.php
+++ b/app/code/Magento/Catalog/Model/Product/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Media/Config.php
+++ b/app/code/Magento/Catalog/Model/Product/Media/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Option.php
+++ b/app/code/Magento/Catalog/Model/Product/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Date.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/DefaultType.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/DefaultType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Factory.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Text.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Value.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Status.php
+++ b/app/code/Magento/Catalog/Model/Product/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type.php
+++ b/app/code/Magento/Catalog/Model/Product/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/Configurable/Attribute.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Configurable/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/Configurable/Price.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Configurable/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/Grouped.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/Grouped/Price.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Grouped/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/Pool.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Pool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/Price.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/Price/Factory.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Price/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/Simple.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Type/Virtual.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Virtual.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Url.php
+++ b/app/code/Magento/Catalog/Model/Product/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Visibility.php
+++ b/app/code/Magento/Catalog/Model/Product/Visibility.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Product/Website.php
+++ b/app/code/Magento/Catalog/Model/Product/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/ProductOptions/Config.php
+++ b/app/code/Magento/Catalog/Model/ProductOptions/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/ProductOptions/Config/Converter.php
+++ b/app/code/Magento/Catalog/Model/ProductOptions/Config/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/ProductOptions/Config/Reader.php
+++ b/app/code/Magento/Catalog/Model/ProductOptions/Config/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/ProductOptions/Config/SchemaLocator.php
+++ b/app/code/Magento/Catalog/Model/ProductOptions/Config/SchemaLocator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/ProductOptions/ConfigInterface.php
+++ b/app/code/Magento/Catalog/Model/ProductOptions/ConfigInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/ProductTypes/Config.php
+++ b/app/code/Magento/Catalog/Model/ProductTypes/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/ProductTypes/Config/Converter.php
+++ b/app/code/Magento/Catalog/Model/ProductTypes/Config/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/ProductTypes/Config/Reader.php
+++ b/app/code/Magento/Catalog/Model/ProductTypes/Config/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/ProductTypes/Config/SchemaLocator.php
+++ b/app/code/Magento/Catalog/Model/ProductTypes/Config/SchemaLocator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/ProductTypes/ConfigInterface.php
+++ b/app/code/Magento/Catalog/Model/ProductTypes/ConfigInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/AbstractResource.php
+++ b/app/code/Magento/Catalog/Model/Resource/AbstractResource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Attribute.php
+++ b/app/code/Magento/Catalog/Model/Resource/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Attribute/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Attribute/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Attribute/Frontend/Image.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Attribute/Frontend/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Attribute/Source/Layout.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Attribute/Source/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Attribute/Source/Mode.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Attribute/Source/Mode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Attribute/Source/Page.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Attribute/Source/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Collection/Factory.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Collection/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Flat.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Flat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Flat/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Flat/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Indexer/Product.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Indexer/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Category/Tree.php
+++ b/app/code/Magento/Catalog/Model/Resource/Category/Tree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Collection/AbstractCollection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Config.php
+++ b/app/code/Magento/Catalog/Model/Resource/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Eav/Attribute.php
+++ b/app/code/Magento/Catalog/Model/Resource/Eav/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Helper.php
+++ b/app/code/Magento/Catalog/Model/Resource/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Layer/Filter/Attribute.php
+++ b/app/code/Magento/Catalog/Model/Resource/Layer/Filter/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Layer/Filter/Decimal.php
+++ b/app/code/Magento/Catalog/Model/Resource/Layer/Filter/Decimal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Layer/Filter/Price.php
+++ b/app/code/Magento/Catalog/Model/Resource/Layer/Filter/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Action.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice/AbstractGroupprice.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Groupprice/AbstractGroupprice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Image.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Media.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Tierprice.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Tierprice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Backend/Urlkey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Attribute/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Collection/AssociatedProduct.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Collection/AssociatedProduct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Collection/AssociatedProductUpdater.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Collection/AssociatedProductUpdater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Compare/Item.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Compare/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Compare/Item/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Compare/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Flat.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Flat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Flat/Indexer.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Flat/Indexer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/AbstractIndexer.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/AbstractIndexer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Eav.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Eav.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Eav/AbstractEav.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Eav/AbstractEav.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Eav/Decimal.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Eav/Decimal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Eav/Source.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price/Configurable.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price/DefaultPrice.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price/DefaultPrice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price/Factory.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price/Grouped.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price/PriceInterface.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Price/PriceInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Link.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Link/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Link/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Link/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Link/Product/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Option.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Option/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Option/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Option/Value.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Option/Value/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Option/Value/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Relation.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Relation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Status.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Type/Configurable.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Type/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Type/Configurable/Attribute.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Type/Configurable/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Type/Configurable/Attribute/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Type/Configurable/Product/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Type/Grouped/AssociatedProductsCollection.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Type/Grouped/AssociatedProductsCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Product/Website.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Setup.php
+++ b/app/code/Magento/Catalog/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Resource/Url.php
+++ b/app/code/Magento/Catalog/Model/Resource/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Session.php
+++ b/app/code/Magento/Catalog/Model/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/System/Config/Backend/Catalog/Category/Flat.php
+++ b/app/code/Magento/Catalog/Model/System/Config/Backend/Catalog/Category/Flat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/System/Config/Backend/Catalog/Product/Flat.php
+++ b/app/code/Magento/Catalog/Model/System/Config/Backend/Catalog/Product/Flat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/System/Config/Backend/Catalog/Url/Rewrite/Suffix.php
+++ b/app/code/Magento/Catalog/Model/System/Config/Backend/Catalog/Url/Rewrite/Suffix.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Template/Filter.php
+++ b/app/code/Magento/Catalog/Model/Template/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Template/Filter/Factory.php
+++ b/app/code/Magento/Catalog/Model/Template/Filter/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/Model/Url.php
+++ b/app/code/Magento/Catalog/Model/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.12-1.6.0.0.13.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.12-1.6.0.0.13.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.13-1.6.0.0.14.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.13-1.6.0.0.14.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.16-1.6.0.0.17.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.16-1.6.0.0.17.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.17-1.6.0.0.18.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.17-1.6.0.0.18.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.18-1.6.0.0.19.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.18-1.6.0.0.19.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.19-1.6.0.0.20.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.19-1.6.0.0.20.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.20-1.6.0.0.21.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.20-1.6.0.0.21.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.21-1.6.0.0.22.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.21-1.6.0.0.22.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.4-1.6.0.0.5.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.4-1.6.0.0.5.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.8-1.6.0.0.9.php
+++ b/app/code/Magento/Catalog/data/catalog_setup/data-upgrade-1.6.0.0.8-1.6.0.0.9.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/adminhtml/di.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/adminhtml/events.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/adminhtml/system.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/catalog_attributes.xml
+++ b/app/code/Magento/Catalog/etc/catalog_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/catalog_attributes.xsd
+++ b/app/code/Magento/Catalog/etc/catalog_attributes.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/config.xml
+++ b/app/code/Magento/Catalog/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/crontab.xml
+++ b/app/code/Magento/Catalog/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/di.xml
+++ b/app/code/Magento/Catalog/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/eav_attributes.xml
+++ b/app/code/Magento/Catalog/etc/eav_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/events.xml
+++ b/app/code/Magento/Catalog/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/frontend/di.xml
+++ b/app/code/Magento/Catalog/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/frontend/events.xml
+++ b/app/code/Magento/Catalog/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/frontend/routes.xml
+++ b/app/code/Magento/Catalog/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/indexers.xml
+++ b/app/code/Magento/Catalog/etc/indexers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/module.xml
+++ b/app/code/Magento/Catalog/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/product_options.xml
+++ b/app/code/Magento/Catalog/etc/product_options.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/product_options.xsd
+++ b/app/code/Magento/Catalog/etc/product_options.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/product_options_merged.xsd
+++ b/app/code/Magento/Catalog/etc/product_options_merged.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/product_types.xml
+++ b/app/code/Magento/Catalog/etc/product_types.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/product_types.xsd
+++ b/app/code/Magento/Catalog/etc/product_types.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/product_types_merged.xsd
+++ b/app/code/Magento/Catalog/etc/product_types_merged.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/view.xml
+++ b/app/code/Magento/Catalog/etc/view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/etc/widget.xml
+++ b/app/code/Magento/Catalog/etc/widget.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/mysql4-upgrade-1.6.0.0.8-1.6.0.0.9.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/mysql4-upgrade-1.6.0.0.8-1.6.0.0.9.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.10-1.6.0.0.11.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.10-1.6.0.0.11.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.11-1.6.0.0.12.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.11-1.6.0.0.12.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.14-1.6.0.0.15.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.14-1.6.0.0.15.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.17-1.6.0.0.18.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.17-1.6.0.0.18.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.3-1.6.0.0.4.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.3-1.6.0.0.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.4-1.6.0.0.5.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.4-1.6.0.0.5.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.5-1.6.0.0.6.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.5-1.6.0.0.6.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.6-1.6.0.0.7.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.6-1.6.0.0.7.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.7-1.6.0.0.8.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.7-1.6.0.0.8.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.9-1.6.0.0.10.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.0.9-1.6.0.0.10.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.18-1.6.0.0.23.php
+++ b/app/code/Magento/Catalog/sql/catalog_setup/upgrade-1.6.0.18-1.6.0.0.23.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/js/category-tree.js
+++ b/app/code/Magento/Catalog/view/adminhtml/js/category-tree.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/js/custom-options.js
+++ b/app/code/Magento/Catalog/view/adminhtml/js/custom-options.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/js/grouped-product.js
+++ b/app/code/Magento/Catalog/view/adminhtml/js/grouped-product.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/js/new-category-dialog.js
+++ b/app/code/Magento/Catalog/view/adminhtml/js/new-category-dialog.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/js/product-gallery.js
+++ b/app/code/Magento/Catalog/view/adminhtml/js/product-gallery.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/js/rating.js
+++ b/app/code/Magento/Catalog/view/adminhtml/js/rating.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/product/configurable/affected-attribute-set-selector/form.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/product/configurable/affected-attribute-set-selector/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/product/configurable/affected-attribute-set-selector/js.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/product/configurable/affected-attribute-set-selector/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/product/configurable/attribute-selector/js.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/product/configurable/attribute-selector/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/product/edit/attribute/search.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/product/edit/attribute/search.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/product/edit/tabs.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/product/edit/tabs.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/product/grid/massaction_extended.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/product/grid/massaction_extended.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/product/grouped/container.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/product/grouped/container.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/product/grouped/grouped.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/product/grouped/grouped.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/product/grouped/list.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/product/grouped/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/adminhtml/product/product.css
+++ b/app/code/Magento/Catalog/view/adminhtml/product/product.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/category/view.phtml
+++ b/app/code/Magento/Catalog/view/frontend/category/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/category/widget/link/link_block.phtml
+++ b/app/code/Magento/Catalog/view/frontend/category/widget/link/link_block.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/category/widget/link/link_inline.phtml
+++ b/app/code/Magento/Catalog/view/frontend/category/widget/link/link_inline.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/compare.js
+++ b/app/code/Magento/Catalog/view/frontend/js/compare.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/configurable.js
+++ b/app/code/Magento/Catalog/view/frontend/js/configurable.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/date-option.js
+++ b/app/code/Magento/Catalog/view/frontend/js/date-option.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/file-option.js
+++ b/app/code/Magento/Catalog/view/frontend/js/file-option.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/gallery.js
+++ b/app/code/Magento/Catalog/view/frontend/js/gallery.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/list.js
+++ b/app/code/Magento/Catalog/view/frontend/js/list.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/msrp.js
+++ b/app/code/Magento/Catalog/view/frontend/js/msrp.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/price-option.js
+++ b/app/code/Magento/Catalog/view/frontend/js/price-option.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/related-products.js
+++ b/app/code/Magento/Catalog/view/frontend/js/related-products.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/tier-price.js
+++ b/app/code/Magento/Catalog/view/frontend/js/tier-price.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/js/zoom.js
+++ b/app/code/Magento/Catalog/view/frontend/js/zoom.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layer/filter.phtml
+++ b/app/code/Magento/Catalog/view/frontend/layer/filter.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layer/state.phtml
+++ b/app/code/Magento/Catalog/view/frontend/layer/state.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layer/view.phtml
+++ b/app/code/Magento/Catalog/view/frontend/layer/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/MAP_popup.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/MAP_popup.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/MAP_price_msrp_item.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/MAP_price_msrp_item.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/MAP_price_msrp_wishlist_item.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/MAP_price_msrp_wishlist_item.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view_type_default.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view_type_default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view_type_default_without_children.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view_type_default_without_children.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view_type_layered.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view_type_layered.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view_type_layered_without_children.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view_type_layered_without_children.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_compare_index.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_compare_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_gallery.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_gallery.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_configurable.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_configurable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_grouped.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_grouped.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_simple.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_simple.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_virtual.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view_type_virtual.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalogsearch_advanced_result.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalogsearch_advanced_result.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalogsearch_result_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/checkout_cart_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/checkout_onepage_failure.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/checkout_onepage_failure.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/checkout_onepage_success.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/checkout_onepage_success.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/default.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/review_product_list.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/review_product_list.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/tag_customer_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/tag_customer_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/tag_product_list.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/tag_product_list.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/wishlist_index_index.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/wishlist_index_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/wishlist_search_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/wishlist_search_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/layout/wishlist_shared_index.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/wishlist_shared_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/msrp/popup.phtml
+++ b/app/code/Magento/Catalog/view/frontend/msrp/popup.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/navigation/left.phtml
+++ b/app/code/Magento/Catalog/view/frontend/navigation/left.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/navigation/top.phtml
+++ b/app/code/Magento/Catalog/view/frontend/navigation/top.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/compare/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/compare/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/compare/sidebar.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/compare/sidebar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/gallery.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/image.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/image.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/image_with_borders.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/list/related.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/list/related.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/list/toolbar.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/list/toolbar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/list/upsell.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/list/upsell.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/new.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/new.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/price.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/price.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/price_msrp.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/price_msrp.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/price_msrp_item.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/price_msrp_item.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/price_msrp_noform.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/price_msrp_noform.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/price_msrp_rss.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/price_msrp_rss.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/additional.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/additional.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/addto.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/addto.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/addtocart.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/addtocart.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/attributes.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/attributes.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/base-image.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/base-image.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/description.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/description.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/gallery.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/options.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/options.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/options/js.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/options/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/options/type/date.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/options/type/default.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/options/type/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/options/type/file.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/options/type/select.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/options/type/select.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/options/type/text.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/options/wrapper.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/options/wrapper.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/options/wrapper/bottom.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/options/wrapper/bottom.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/price_clone.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/price_clone.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/tierprices.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/tierprices.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/type/default.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/type/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/type/grouped.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/type/grouped.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/type/options/configurable.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/view/type/options/configurable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/view/validation.js
+++ b/app/code/Magento/Catalog/view/frontend/product/view/validation.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/widget/link/link_block.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/widget/link/link_block.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/widget/link/link_inline.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/widget/link/link_inline.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/widget/new/column/new_default_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/widget/new/column/new_default_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/widget/new/column/new_images_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/widget/new/column/new_images_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/widget/new/column/new_names_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/widget/new/column/new_names_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/widget/new/content/new_grid.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/widget/new/content/new_grid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/product/widget/new/content/new_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/product/widget/new/content/new_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/rss/product/price.phtml
+++ b/app/code/Magento/Catalog/view/frontend/rss/product/price.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/widgets.css
+++ b/app/code/Magento/Catalog/view/frontend/widgets.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Catalog/view/frontend/zoom.css
+++ b/app/code/Magento/Catalog/view/frontend/zoom.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Block/Adminhtml/Form/Field/Customergroup.php
+++ b/app/code/Magento/CatalogInventory/Block/Adminhtml/Form/Field/Customergroup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Block/Adminhtml/Form/Field/Minsaleqty.php
+++ b/app/code/Magento/CatalogInventory/Block/Adminhtml/Form/Field/Minsaleqty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Block/Adminhtml/Form/Field/Stock.php
+++ b/app/code/Magento/CatalogInventory/Block/Adminhtml/Form/Field/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Block/Qtyincrements.php
+++ b/app/code/Magento/CatalogInventory/Block/Qtyincrements.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Block/Stockqty/AbstractStockqty.php
+++ b/app/code/Magento/CatalogInventory/Block/Stockqty/AbstractStockqty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Block/Stockqty/Composite.php
+++ b/app/code/Magento/CatalogInventory/Block/Stockqty/Composite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Block/Stockqty/DefaultStockqty.php
+++ b/app/code/Magento/CatalogInventory/Block/Stockqty/DefaultStockqty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Block/Stockqty/Type/Configurable.php
+++ b/app/code/Magento/CatalogInventory/Block/Stockqty/Type/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Block/Stockqty/Type/Grouped.php
+++ b/app/code/Magento/CatalogInventory/Block/Stockqty/Type/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Helper/Data.php
+++ b/app/code/Magento/CatalogInventory/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Helper/Minsaleqty.php
+++ b/app/code/Magento/CatalogInventory/Helper/Minsaleqty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Config/Backend/Managestock.php
+++ b/app/code/Magento/CatalogInventory/Model/Config/Backend/Managestock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Indexer/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Indexer/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Observer.php
+++ b/app/code/Magento/CatalogInventory/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Resource/Indexer/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Resource/Indexer/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Resource/Indexer/Stock/Configurable.php
+++ b/app/code/Magento/CatalogInventory/Model/Resource/Indexer/Stock/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Resource/Indexer/Stock/DefaultStock.php
+++ b/app/code/Magento/CatalogInventory/Model/Resource/Indexer/Stock/DefaultStock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Resource/Indexer/Stock/Grouped.php
+++ b/app/code/Magento/CatalogInventory/Model/Resource/Indexer/Stock/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Resource/Indexer/Stock/StockInterface.php
+++ b/app/code/Magento/CatalogInventory/Model/Resource/Indexer/Stock/StockInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Resource/Indexer/StockFactory.php
+++ b/app/code/Magento/CatalogInventory/Model/Resource/Indexer/StockFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Resource/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Resource/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Resource/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Resource/Stock/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Resource/Stock/Item/Collection.php
+++ b/app/code/Magento/CatalogInventory/Model/Resource/Stock/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Resource/Stock/Status.php
+++ b/app/code/Magento/CatalogInventory/Model/Resource/Stock/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Source/Backorders.php
+++ b/app/code/Magento/CatalogInventory/Model/Source/Backorders.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Source/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Source/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/Stock/Status.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/System/Config/Backend/Minqty.php
+++ b/app/code/Magento/CatalogInventory/Model/System/Config/Backend/Minqty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/System/Config/Backend/Minsaleqty.php
+++ b/app/code/Magento/CatalogInventory/Model/System/Config/Backend/Minsaleqty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/Model/System/Config/Backend/Qtyincrements.php
+++ b/app/code/Magento/CatalogInventory/Model/System/Config/Backend/Qtyincrements.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/data/cataloginventory_setup/data-upgrade-1.6.0.0.3-1.6.0.0.4.php
+++ b/app/code/Magento/CatalogInventory/data/cataloginventory_setup/data-upgrade-1.6.0.0.3-1.6.0.0.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/etc/adminhtml/acl.xml
+++ b/app/code/Magento/CatalogInventory/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/etc/adminhtml/events.xml
+++ b/app/code/Magento/CatalogInventory/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/etc/adminhtml/system.xml
+++ b/app/code/Magento/CatalogInventory/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/etc/config.xml
+++ b/app/code/Magento/CatalogInventory/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/etc/di.xml
+++ b/app/code/Magento/CatalogInventory/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/etc/events.xml
+++ b/app/code/Magento/CatalogInventory/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/etc/indexers.xml
+++ b/app/code/Magento/CatalogInventory/etc/indexers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/etc/module.xml
+++ b/app/code/Magento/CatalogInventory/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/etc/product_types.xml
+++ b/app/code/Magento/CatalogInventory/etc/product_types.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/sql/cataloginventory_setup/install-1.6.0.0.php
+++ b/app/code/Magento/CatalogInventory/sql/cataloginventory_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/Magento/CatalogInventory/sql/cataloginventory_setup/mysql4-upgrade-1.6.0.0-1.6.0.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/Magento/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
+++ b/app/code/Magento/CatalogInventory/sql/cataloginventory_setup/upgrade-1.6.0.0.2-1.6.0.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/view/adminhtml/layout/adminhtml_catalog_product_superconfig_config.xml
+++ b/app/code/Magento/CatalogInventory/view/adminhtml/layout/adminhtml_catalog_product_superconfig_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_configurable.xml
+++ b/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_configurable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_grouped.xml
+++ b/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_grouped.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_simple.xml
+++ b/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_simple.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_virtual.xml
+++ b/app/code/Magento/CatalogInventory/view/frontend/layout/catalog_product_view_type_virtual.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/view/frontend/qtyincrements.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/qtyincrements.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/view/frontend/stockqty/composite.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/stockqty/composite.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogInventory/view/frontend/stockqty/default.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/stockqty/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Helper/Data.php
+++ b/app/code/Magento/CatalogRule/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Flag.php
+++ b/app/code/Magento/CatalogRule/Model/Flag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Observer.php
+++ b/app/code/Magento/CatalogRule/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Resource/Grid/Collection.php
+++ b/app/code/Magento/CatalogRule/Model/Resource/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Resource/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Resource/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Resource/Rule/Collection.php
+++ b/app/code/Magento/CatalogRule/Model/Resource/Rule/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Resource/Rule/Product/Price.php
+++ b/app/code/Magento/CatalogRule/Model/Resource/Rule/Product/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Resource/Rule/Product/Price/Collection.php
+++ b/app/code/Magento/CatalogRule/Model/Resource/Rule/Product/Price/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Rule/Action/Collection.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Action/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Rule/Action/Product.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Action/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Rule/Condition/Combine.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Condition/Combine.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Rule/Condition/Product.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Condition/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Rule/Job.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Job.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/Model/Rule/Product/Price.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Product/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/data/catalogrule_setup/data-upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/Magento/CatalogRule/data/catalogrule_setup/data-upgrade-1.6.0.3-1.6.0.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/etc/adminhtml/acl.xml
+++ b/app/code/Magento/CatalogRule/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/etc/adminhtml/di.xml
+++ b/app/code/Magento/CatalogRule/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/etc/adminhtml/events.xml
+++ b/app/code/Magento/CatalogRule/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/etc/adminhtml/menu.xml
+++ b/app/code/Magento/CatalogRule/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/etc/crontab.xml
+++ b/app/code/Magento/CatalogRule/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/etc/crontab/events.xml
+++ b/app/code/Magento/CatalogRule/etc/crontab/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/etc/di.xml
+++ b/app/code/Magento/CatalogRule/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/etc/events.xml
+++ b/app/code/Magento/CatalogRule/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/etc/frontend/events.xml
+++ b/app/code/Magento/CatalogRule/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/etc/module.xml
+++ b/app/code/Magento/CatalogRule/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/sql/catalogrule_setup/install-1.6.0.0.php
+++ b/app/code/Magento/CatalogRule/sql/catalogrule_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/Magento/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/Magento/CatalogRule/sql/catalogrule_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Block/Advanced/Form.php
+++ b/app/code/Magento/CatalogSearch/Block/Advanced/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Block/Advanced/Result.php
+++ b/app/code/Magento/CatalogSearch/Block/Advanced/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Block/Autocomplete.php
+++ b/app/code/Magento/CatalogSearch/Block/Autocomplete.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Block/Layer.php
+++ b/app/code/Magento/CatalogSearch/Block/Layer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Block/Layer/Filter/Attribute.php
+++ b/app/code/Magento/CatalogSearch/Block/Layer/Filter/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Block/Result.php
+++ b/app/code/Magento/CatalogSearch/Block/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Block/Term.php
+++ b/app/code/Magento/CatalogSearch/Block/Term.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Controller/Advanced.php
+++ b/app/code/Magento/CatalogSearch/Controller/Advanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Controller/Ajax.php
+++ b/app/code/Magento/CatalogSearch/Controller/Ajax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Controller/Result.php
+++ b/app/code/Magento/CatalogSearch/Controller/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Controller/Term.php
+++ b/app/code/Magento/CatalogSearch/Controller/Term.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Helper/Data.php
+++ b/app/code/Magento/CatalogSearch/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Advanced.php
+++ b/app/code/Magento/CatalogSearch/Model/Advanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Config/Backend/Search/Type.php
+++ b/app/code/Magento/CatalogSearch/Model/Config/Backend/Search/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Config/Source/Search/Type.php
+++ b/app/code/Magento/CatalogSearch/Model/Config/Source/Search/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Fulltext.php
+++ b/app/code/Magento/CatalogSearch/Model/Fulltext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Fulltext/Observer.php
+++ b/app/code/Magento/CatalogSearch/Model/Fulltext/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Layer.php
+++ b/app/code/Magento/CatalogSearch/Model/Layer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Layer/Filter/Attribute.php
+++ b/app/code/Magento/CatalogSearch/Model/Layer/Filter/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Query.php
+++ b/app/code/Magento/CatalogSearch/Model/Query.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/Advanced.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/Advanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/Advanced/Collection.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/Advanced/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/EngineFactory.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/EngineFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/EngineInterface.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/EngineInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/EngineProvider.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/EngineProvider.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/Fulltext.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/Fulltext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/Fulltext/Collection.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/Fulltext/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/Fulltext/Engine.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/Fulltext/Engine.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/Helper.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/Indexer/Fulltext.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/Indexer/Fulltext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/Query.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/Query.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/Query/Collection.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/Query/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/Model/Resource/Search/Collection.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/Search/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/etc/adminhtml/acl.xml
+++ b/app/code/Magento/CatalogSearch/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/etc/adminhtml/di.xml
+++ b/app/code/Magento/CatalogSearch/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/etc/adminhtml/menu.xml
+++ b/app/code/Magento/CatalogSearch/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
+++ b/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/etc/config.xml
+++ b/app/code/Magento/CatalogSearch/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/etc/di.xml
+++ b/app/code/Magento/CatalogSearch/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/etc/frontend/di.xml
+++ b/app/code/Magento/CatalogSearch/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/etc/frontend/routes.xml
+++ b/app/code/Magento/CatalogSearch/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/etc/indexers.xml
+++ b/app/code/Magento/CatalogSearch/etc/indexers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/etc/module.xml
+++ b/app/code/Magento/CatalogSearch/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/sql/catalogsearch_setup/install-1.6.0.0.php
+++ b/app/code/Magento/CatalogSearch/sql/catalogsearch_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/adminhtml/layout/adminhtml_catalog_search_edit.xml
+++ b/app/code/Magento/CatalogSearch/view/adminhtml/layout/adminhtml_catalog_search_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/adminhtml/layout/adminhtml_catalog_search_grid_block.xml
+++ b/app/code/Magento/CatalogSearch/view/adminhtml/layout/adminhtml_catalog_search_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/adminhtml/layout/adminhtml_catalog_search_index.xml
+++ b/app/code/Magento/CatalogSearch/view/adminhtml/layout/adminhtml_catalog_search_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/advanced/form.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/advanced/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/advanced/result.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/advanced/result.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/form-mini.js
+++ b/app/code/Magento/CatalogSearch/view/frontend/form-mini.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/form.mini.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/form.mini.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_advanced_index.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_advanced_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_advanced_result.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_advanced_result.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_ajax_suggest.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_ajax_suggest.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_result_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_term_popular.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/catalogsearch_term_popular.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/layout/default.xml
+++ b/app/code/Magento/CatalogSearch/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/result.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/result.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CatalogSearch/view/frontend/term.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/term.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Block/Adminhtml/Validation.php
+++ b/app/code/Magento/Centinel/Block/Adminhtml/Validation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Block/Adminhtml/Validation/Form.php
+++ b/app/code/Magento/Centinel/Block/Adminhtml/Validation/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Block/Authentication.php
+++ b/app/code/Magento/Centinel/Block/Authentication.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Block/Authentication/Complete.php
+++ b/app/code/Magento/Centinel/Block/Authentication/Complete.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Block/Authentication/Start.php
+++ b/app/code/Magento/Centinel/Block/Authentication/Start.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Block/Logo.php
+++ b/app/code/Magento/Centinel/Block/Logo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Controller/Adminhtml/Centinel/Index.php
+++ b/app/code/Magento/Centinel/Controller/Adminhtml/Centinel/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Controller/Index.php
+++ b/app/code/Magento/Centinel/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Helper/Data.php
+++ b/app/code/Magento/Centinel/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Model/AbstractState.php
+++ b/app/code/Magento/Centinel/Model/AbstractState.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Model/Api.php
+++ b/app/code/Magento/Centinel/Model/Api.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Model/Config.php
+++ b/app/code/Magento/Centinel/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Model/Observer.php
+++ b/app/code/Magento/Centinel/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Model/Service.php
+++ b/app/code/Magento/Centinel/Model/Service.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Model/State/Jcb.php
+++ b/app/code/Magento/Centinel/Model/State/Jcb.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Model/State/Mastercard.php
+++ b/app/code/Magento/Centinel/Model/State/Mastercard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Model/State/Visa.php
+++ b/app/code/Magento/Centinel/Model/State/Visa.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/Model/StateFactory.php
+++ b/app/code/Magento/Centinel/Model/StateFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/etc/adminhtml/di.xml
+++ b/app/code/Magento/Centinel/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/etc/adminhtml/events.xml
+++ b/app/code/Magento/Centinel/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Centinel/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/etc/adminhtml/system.xml
+++ b/app/code/Magento/Centinel/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/etc/di.xml
+++ b/app/code/Magento/Centinel/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/etc/events.xml
+++ b/app/code/Magento/Centinel/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/etc/frontend/di.xml
+++ b/app/code/Magento/Centinel/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/etc/frontend/events.xml
+++ b/app/code/Magento/Centinel/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/etc/frontend/routes.xml
+++ b/app/code/Magento/Centinel/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/etc/module.xml
+++ b/app/code/Magento/Centinel/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/adminhtml/authentication/complete.phtml
+++ b/app/code/Magento/Centinel/view/adminhtml/authentication/complete.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/adminhtml/authentication/start.phtml
+++ b/app/code/Magento/Centinel/view/adminhtml/authentication/start.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_centinel_index_authenticationcomplete.xml
+++ b/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_centinel_index_authenticationcomplete.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_centinel_index_authenticationstart.xml
+++ b/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_centinel_index_authenticationstart.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_sales_order_create_index.xml
+++ b/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_sales_order_create_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_sales_order_create_load_block_card_validation.xml
+++ b/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_sales_order_create_load_block_card_validation.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_sales_order_create_load_block_data.xml
+++ b/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_sales_order_create_load_block_data.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_sales_order_create_start.xml
+++ b/app/code/Magento/Centinel/view/adminhtml/layout/adminhtml_sales_order_create_start.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/adminhtml/order_create.js
+++ b/app/code/Magento/Centinel/view/adminhtml/order_create.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/adminhtml/validation/form.phtml
+++ b/app/code/Magento/Centinel/view/adminhtml/validation/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/frontend/authentication.phtml
+++ b/app/code/Magento/Centinel/view/frontend/authentication.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/frontend/authentication/complete.phtml
+++ b/app/code/Magento/Centinel/view/frontend/authentication/complete.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/frontend/authentication/start.phtml
+++ b/app/code/Magento/Centinel/view/frontend/authentication/start.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/frontend/centinel-authenticate.js
+++ b/app/code/Magento/Centinel/view/frontend/centinel-authenticate.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/frontend/layout/centinel_index_authenticationcomplete.xml
+++ b/app/code/Magento/Centinel/view/frontend/layout/centinel_index_authenticationcomplete.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/frontend/layout/centinel_index_authenticationstart.xml
+++ b/app/code/Magento/Centinel/view/frontend/layout/centinel_index_authenticationstart.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/frontend/layout/checkout_multishipping_overview.xml
+++ b/app/code/Magento/Centinel/view/frontend/layout/checkout_multishipping_overview.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/frontend/layout/checkout_onepage_index.xml
+++ b/app/code/Magento/Centinel/view/frontend/layout/checkout_onepage_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/frontend/layout/checkout_onepage_review.xml
+++ b/app/code/Magento/Centinel/view/frontend/layout/checkout_onepage_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Centinel/view/frontend/logo.phtml
+++ b/app/code/Magento/Centinel/view/frontend/logo.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Agreements.php
+++ b/app/code/Magento/Checkout/Block/Agreements.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart.php
+++ b/app/code/Magento/Checkout/Block/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/AbstractCart.php
+++ b/app/code/Magento/Checkout/Block/Cart/AbstractCart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/Coupon.php
+++ b/app/code/Magento/Checkout/Block/Cart/Coupon.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/Crosssell.php
+++ b/app/code/Magento/Checkout/Block/Cart/Crosssell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/Item/Configure.php
+++ b/app/code/Magento/Checkout/Block/Cart/Item/Configure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/Item/Renderer.php
+++ b/app/code/Magento/Checkout/Block/Cart/Item/Renderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/Item/Renderer/Configurable.php
+++ b/app/code/Magento/Checkout/Block/Cart/Item/Renderer/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/Item/Renderer/Grouped.php
+++ b/app/code/Magento/Checkout/Block/Cart/Item/Renderer/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/Link.php
+++ b/app/code/Magento/Checkout/Block/Cart/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/Sidebar.php
+++ b/app/code/Magento/Checkout/Block/Cart/Sidebar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Cart/Totals.php
+++ b/app/code/Magento/Checkout/Block/Cart/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Link.php
+++ b/app/code/Magento/Checkout/Block/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/AbstractMultishipping.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/AbstractMultishipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/Address/Select.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/Address/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/Addresses.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/Addresses.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/Billing.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/Billing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/Billing/Items.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/Billing/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/Link.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/Overview.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/Overview.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/Payment/Info.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/Payment/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/State.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/State.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Multishipping/Success.php
+++ b/app/code/Magento/Checkout/Block/Multishipping/Success.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage.php
+++ b/app/code/Magento/Checkout/Block/Onepage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/AbstractOnepage.php
+++ b/app/code/Magento/Checkout/Block/Onepage/AbstractOnepage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Billing.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Billing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Failure.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Failure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Link.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Login.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Login.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Payment.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Payment/Info.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Payment/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Payment/Methods.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Payment/Methods.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Progress.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Progress.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Review.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Review.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Review/Info.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Review/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Shipping/Method.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Shipping/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Shipping/Method/Additional.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Shipping/Method/Additional.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Shipping/Method/Available.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Shipping/Method/Available.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Onepage/Success.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Success.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Success.php
+++ b/app/code/Magento/Checkout/Block/Success.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Total/DefaultTotal.php
+++ b/app/code/Magento/Checkout/Block/Total/DefaultTotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Total/Nominal.php
+++ b/app/code/Magento/Checkout/Block/Total/Nominal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Block/Total/Tax.php
+++ b/app/code/Magento/Checkout/Block/Total/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Controller/Action.php
+++ b/app/code/Magento/Checkout/Controller/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Controller/Cart.php
+++ b/app/code/Magento/Checkout/Controller/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Controller/Index.php
+++ b/app/code/Magento/Checkout/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Controller/Multishipping.php
+++ b/app/code/Magento/Checkout/Controller/Multishipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Controller/Multishipping/Address.php
+++ b/app/code/Magento/Checkout/Controller/Multishipping/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Controller/Onepage.php
+++ b/app/code/Magento/Checkout/Controller/Onepage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Exception.php
+++ b/app/code/Magento/Checkout/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Helper/Cart.php
+++ b/app/code/Magento/Checkout/Helper/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Helper/Data.php
+++ b/app/code/Magento/Checkout/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Helper/Url.php
+++ b/app/code/Magento/Checkout/Helper/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Agreement.php
+++ b/app/code/Magento/Checkout/Model/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Cart/CartInterface.php
+++ b/app/code/Magento/Checkout/Model/Cart/CartInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Config/Source/Cart/Summary.php
+++ b/app/code/Magento/Checkout/Model/Config/Source/Cart/Summary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Observer.php
+++ b/app/code/Magento/Checkout/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Resource/Agreement.php
+++ b/app/code/Magento/Checkout/Model/Resource/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Resource/Agreement/Collection.php
+++ b/app/code/Magento/Checkout/Model/Resource/Agreement/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Resource/Cart.php
+++ b/app/code/Magento/Checkout/Model/Resource/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Resource/Setup.php
+++ b/app/code/Magento/Checkout/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Session.php
+++ b/app/code/Magento/Checkout/Model/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Type/AbstractType.php
+++ b/app/code/Magento/Checkout/Model/Type/AbstractType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Type/Multishipping.php
+++ b/app/code/Magento/Checkout/Model/Type/Multishipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Type/Multishipping/State.php
+++ b/app/code/Magento/Checkout/Model/Type/Multishipping/State.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/Model/Type/Onepage.php
+++ b/app/code/Magento/Checkout/Model/Type/Onepage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Checkout/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/adminhtml/di.xml
+++ b/app/code/Magento/Checkout/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Checkout/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/adminhtml/system.xml
+++ b/app/code/Magento/Checkout/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/config.xml
+++ b/app/code/Magento/Checkout/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/di.xml
+++ b/app/code/Magento/Checkout/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/email_templates.xml
+++ b/app/code/Magento/Checkout/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/fieldset.xml
+++ b/app/code/Magento/Checkout/etc/fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/frontend/di.xml
+++ b/app/code/Magento/Checkout/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/frontend/events.xml
+++ b/app/code/Magento/Checkout/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/frontend/routes.xml
+++ b/app/code/Magento/Checkout/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/module.xml
+++ b/app/code/Magento/Checkout/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/etc/sales.xml
+++ b/app/code/Magento/Checkout/etc/sales.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/sql/checkout_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Checkout/sql/checkout_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/cart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/cart.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/cart/coupon.phtml
+++ b/app/code/Magento/Checkout/view/frontend/cart/coupon.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/cart/crosssell.phtml
+++ b/app/code/Magento/Checkout/view/frontend/cart/crosssell.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/cart/item/configure/updatecart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/cart/item/configure/updatecart.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/cart/item/default.phtml
+++ b/app/code/Magento/Checkout/view/frontend/cart/item/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/cart/shipping.phtml
+++ b/app/code/Magento/Checkout/view/frontend/cart/shipping.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/cart/sidebar.phtml
+++ b/app/code/Magento/Checkout/view/frontend/cart/sidebar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/cart/sidebar/default.phtml
+++ b/app/code/Magento/Checkout/view/frontend/cart/sidebar/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/cart/totals.phtml
+++ b/app/code/Magento/Checkout/view/frontend/cart/totals.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/accordion.js
+++ b/app/code/Magento/Checkout/view/frontend/js/accordion.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/components.phtml
+++ b/app/code/Magento/Checkout/view/frontend/js/components.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/discount-codes.js
+++ b/app/code/Magento/Checkout/view/frontend/js/discount-codes.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/multi-shipping.js
+++ b/app/code/Magento/Checkout/view/frontend/js/multi-shipping.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/opcheckout.js
+++ b/app/code/Magento/Checkout/view/frontend/js/opcheckout.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/overview.js
+++ b/app/code/Magento/Checkout/view/frontend/js/overview.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/payment-authentication.js
+++ b/app/code/Magento/Checkout/view/frontend/js/payment-authentication.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/payment.js
+++ b/app/code/Magento/Checkout/view/frontend/js/payment.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/js/region-updater.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/shopping-cart.js
+++ b/app/code/Magento/Checkout/view/frontend/js/shopping-cart.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/js/sidebar.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_configure.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_configure.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_configure_type_configurable.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_configure_type_configurable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_configure_type_simple.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_configure_type_simple.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_editaddress.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_editaddress.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_editbilling.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_editbilling.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_editshipping.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_editshipping.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_newbilling.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_newbilling.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_newshipping.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_newshipping.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_select.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_select.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_selectbilling.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_address_selectbilling.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_addresses.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_addresses.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_billing.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_billing.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_customer_address.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_customer_address.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_login.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_login.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_overview.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_overview.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_register.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_register.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_shipping.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_shipping.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_success.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_multishipping_success.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_additional.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_additional.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_failure.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_failure.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_index.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_paymentmethod.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_paymentmethod.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_progress.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_progress.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_review.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_shippingmethod.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_shippingmethod.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_success.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_onepage_success.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/layout/default.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/address/select.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/address/select.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/addresses.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/addresses.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/agreements.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/agreements.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/billing.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/billing.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/billing/items.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/billing/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/item/default.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/item/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/link.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/link.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/overview.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/overview.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/overview/item.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/overview/item.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/shipping.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/shipping.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/state.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/state.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/multishipping/success.phtml
+++ b/app/code/Magento/Checkout/view/frontend/multishipping/success.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/accordion.js
+++ b/app/code/Magento/Checkout/view/frontend/onepage/accordion.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/agreements.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/agreements.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/billing.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/billing.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/failure.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/failure.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/link.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/link.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/login.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/login.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/payment.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/payment.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/payment/methods.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/payment/methods.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/progress.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/progress.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/review.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/review.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/review/button.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/review/button.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/review/info.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/review/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/review/item.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/review/item.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/review/totals.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/review/totals.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/shipping.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/shipping.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/shipping_method.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/shipping_method.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/shipping_method/additional.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/shipping_method/additional.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/onepage/shipping_method/available.phtml
+++ b/app/code/Magento/Checkout/view/frontend/onepage/shipping_method/available.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/success.phtml
+++ b/app/code/Magento/Checkout/view/frontend/success.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/total/default.phtml
+++ b/app/code/Magento/Checkout/view/frontend/total/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/total/nominal.phtml
+++ b/app/code/Magento/Checkout/view/frontend/total/nominal.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Checkout/view/frontend/total/tax.phtml
+++ b/app/code/Magento/Checkout/view/frontend/total/tax.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Block/Block.php
+++ b/app/code/Magento/Cms/Block/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Block/Page.php
+++ b/app/code/Magento/Cms/Block/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Block/Widget/Block.php
+++ b/app/code/Magento/Cms/Block/Widget/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Block/Widget/Page/Link.php
+++ b/app/code/Magento/Cms/Block/Widget/Page/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Controller/Index.php
+++ b/app/code/Magento/Cms/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Controller/Page.php
+++ b/app/code/Magento/Cms/Controller/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Controller/Router.php
+++ b/app/code/Magento/Cms/Controller/Router.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Helper/Data.php
+++ b/app/code/Magento/Cms/Helper/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Helper/Page.php
+++ b/app/code/Magento/Cms/Helper/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Helper/Wysiwyg/Images.php
+++ b/app/code/Magento/Cms/Helper/Wysiwyg/Images.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Block.php
+++ b/app/code/Magento/Cms/Model/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Config/Source/Page.php
+++ b/app/code/Magento/Cms/Model/Config/Source/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Config/Source/Wysiwyg/Enabled.php
+++ b/app/code/Magento/Cms/Model/Config/Source/Wysiwyg/Enabled.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Observer.php
+++ b/app/code/Magento/Cms/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Page.php
+++ b/app/code/Magento/Cms/Model/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Page/Urlrewrite.php
+++ b/app/code/Magento/Cms/Model/Page/Urlrewrite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Resource/Block.php
+++ b/app/code/Magento/Cms/Model/Resource/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Resource/Block/Collection.php
+++ b/app/code/Magento/Cms/Model/Resource/Block/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Resource/Block/Grid/Collection.php
+++ b/app/code/Magento/Cms/Model/Resource/Block/Grid/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Resource/Page.php
+++ b/app/code/Magento/Cms/Model/Resource/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Resource/Page/Collection.php
+++ b/app/code/Magento/Cms/Model/Resource/Page/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Resource/Page/Service.php
+++ b/app/code/Magento/Cms/Model/Resource/Page/Service.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Resource/Page/Urlrewrite.php
+++ b/app/code/Magento/Cms/Model/Resource/Page/Urlrewrite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Resource/Setup.php
+++ b/app/code/Magento/Cms/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Template/Filter.php
+++ b/app/code/Magento/Cms/Model/Template/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Template/FilterProvider.php
+++ b/app/code/Magento/Cms/Model/Template/FilterProvider.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Wysiwyg/Config.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage/Collection.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/data/cms_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Cms/data/cms_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/data/cms_setup/data-upgrade-1.6.0.0.0-1.6.0.0.1.php
+++ b/app/code/Magento/Cms/data/cms_setup/data-upgrade-1.6.0.0.0-1.6.0.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/data/cms_setup/data-upgrade-1.6.0.0.2-1.6.0.0.3.php
+++ b/app/code/Magento/Cms/data/cms_setup/data-upgrade-1.6.0.0.2-1.6.0.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/data/cms_setup/data-upgrade-1.6.0.0.3-2.0.0.0.php
+++ b/app/code/Magento/Cms/data/cms_setup/data-upgrade-1.6.0.0.3-2.0.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Cms/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Cms/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/etc/adminhtml/system.xml
+++ b/app/code/Magento/Cms/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/etc/config.xml
+++ b/app/code/Magento/Cms/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/etc/di.xml
+++ b/app/code/Magento/Cms/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/etc/events.xml
+++ b/app/code/Magento/Cms/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/etc/frontend/events.xml
+++ b/app/code/Magento/Cms/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/etc/frontend/routes.xml
+++ b/app/code/Magento/Cms/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/etc/module.xml
+++ b/app/code/Magento/Cms/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/etc/widget.xml
+++ b/app/code/Magento/Cms/etc/widget.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/sql/cms_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Cms/sql/cms_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/sql/cms_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/Magento/Cms/sql/cms_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/adminhtml/js/folder-tree.js
+++ b/app/code/Magento/Cms/view/adminhtml/js/folder-tree.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/adminhtml/js/tiny_mce_form_submit.js
+++ b/app/code/Magento/Cms/view/adminhtml/js/tiny_mce_form_submit.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/content.phtml
+++ b/app/code/Magento/Cms/view/frontend/content.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/content_heading.phtml
+++ b/app/code/Magento/Cms/view/frontend/content_heading.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/default/home.phtml
+++ b/app/code/Magento/Cms/view/frontend/default/home.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/default/no-route.phtml
+++ b/app/code/Magento/Cms/view/frontend/default/no-route.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/layout/cms_index_defaultindex.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/cms_index_defaultindex.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/layout/cms_index_defaultnoroute.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/cms_index_defaultnoroute.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/layout/cms_index_index.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/cms_index_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/layout/cms_index_nocookies.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/cms_index_nocookies.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/layout/cms_index_noroute.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/cms_index_noroute.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/layout/cms_page_view.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/cms_page_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/layout/default.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/layout/print.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/print.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/meta.phtml
+++ b/app/code/Magento/Cms/view/frontend/meta.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/widget/link/link_block.phtml
+++ b/app/code/Magento/Cms/view/frontend/widget/link/link_block.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/widget/link/link_inline.phtml
+++ b/app/code/Magento/Cms/view/frontend/widget/link/link_inline.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/widget/static_block/default.phtml
+++ b/app/code/Magento/Cms/view/frontend/widget/static_block/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cms/view/frontend/widgets.css
+++ b/app/code/Magento/Cms/view/frontend/widgets.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Form.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/AbstractTab.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/AbstractTab.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Authors.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Authors.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Contents.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Contents.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Depends.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Depends.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Grid.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Load.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Load.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Local.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Local.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Package.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Package.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Release.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tab/Release.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tabs.php
+++ b/app/code/Magento/Connect/Block/Adminhtml/Extension/Custom/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Controller/Adminhtml/Extension/Custom.php
+++ b/app/code/Magento/Connect/Controller/Adminhtml/Extension/Custom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Controller/Adminhtml/Extension/Local.php
+++ b/app/code/Magento/Connect/Controller/Adminhtml/Extension/Local.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Helper/Data.php
+++ b/app/code/Magento/Connect/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Model/Extension.php
+++ b/app/code/Magento/Connect/Model/Extension.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Model/Extension/Collection.php
+++ b/app/code/Magento/Connect/Model/Extension/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/Model/Session.php
+++ b/app/code/Magento/Connect/Model/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Connect/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Connect/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Connect/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/etc/module.xml
+++ b/app/code/Magento/Connect/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/view/adminhtml/extension/custom/authors.phtml
+++ b/app/code/Magento/Connect/view/adminhtml/extension/custom/authors.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/view/adminhtml/extension/custom/contents.phtml
+++ b/app/code/Magento/Connect/view/adminhtml/extension/custom/contents.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/view/adminhtml/extension/custom/depends.phtml
+++ b/app/code/Magento/Connect/view/adminhtml/extension/custom/depends.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/view/adminhtml/extension/custom/load.phtml
+++ b/app/code/Magento/Connect/view/adminhtml/extension/custom/load.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/view/adminhtml/extension/custom/package.phtml
+++ b/app/code/Magento/Connect/view/adminhtml/extension/custom/package.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/view/adminhtml/extension/custom/release.phtml
+++ b/app/code/Magento/Connect/view/adminhtml/extension/custom/release.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/view/adminhtml/layout/adminhtml_extension_custom_edit.xml
+++ b/app/code/Magento/Connect/view/adminhtml/layout/adminhtml_extension_custom_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/view/adminhtml/layout/adminhtml_extension_custom_grid.xml
+++ b/app/code/Magento/Connect/view/adminhtml/layout/adminhtml_extension_custom_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Connect/view/adminhtml/layout/adminhtml_extension_custom_loadtab.xml
+++ b/app/code/Magento/Connect/view/adminhtml/layout/adminhtml_extension_custom_loadtab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/Controller/Index.php
+++ b/app/code/Magento/Contacts/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/Helper/Data.php
+++ b/app/code/Magento/Contacts/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/Model/System/Config/Backend/Links.php
+++ b/app/code/Magento/Contacts/Model/System/Config/Backend/Links.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Contacts/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/etc/adminhtml/system.xml
+++ b/app/code/Magento/Contacts/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/etc/config.xml
+++ b/app/code/Magento/Contacts/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/etc/email_templates.xml
+++ b/app/code/Magento/Contacts/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/etc/frontend/di.xml
+++ b/app/code/Magento/Contacts/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/etc/frontend/routes.xml
+++ b/app/code/Magento/Contacts/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/etc/module.xml
+++ b/app/code/Magento/Contacts/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/sql/contacts_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Contacts/sql/contacts_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/view/frontend/form.phtml
+++ b/app/code/Magento/Contacts/view/frontend/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/view/frontend/layout/contacts_index_index.xml
+++ b/app/code/Magento/Contacts/view/frontend/layout/contacts_index_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Contacts/view/frontend/layout/default.xml
+++ b/app/code/Magento/Contacts/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block.php
+++ b/app/code/Magento/Core/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/AbstractBlock.php
+++ b/app/code/Magento/Core/Block/AbstractBlock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Context.php
+++ b/app/code/Magento/Core/Block/Context.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Formkey.php
+++ b/app/code/Magento/Core/Block/Formkey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Html/Calendar.php
+++ b/app/code/Magento/Core/Block/Html/Calendar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Html/Date.php
+++ b/app/code/Magento/Core/Block/Html/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Html/Link.php
+++ b/app/code/Magento/Core/Block/Html/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Html/Select.php
+++ b/app/code/Magento/Core/Block/Html/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Messages.php
+++ b/app/code/Magento/Core/Block/Messages.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Store/Switcher.php
+++ b/app/code/Magento/Core/Block/Store/Switcher.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Template.php
+++ b/app/code/Magento/Core/Block/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Text.php
+++ b/app/code/Magento/Core/Block/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Text/ListText.php
+++ b/app/code/Magento/Core/Block/Text/ListText.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Text/TextList/Item.php
+++ b/app/code/Magento/Core/Block/Text/TextList/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Block/Text/TextList/Link.php
+++ b/app/code/Magento/Core/Block/Text/TextList/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Ajax.php
+++ b/app/code/Magento/Core/Controller/Ajax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Front/Action.php
+++ b/app/code/Magento/Core/Controller/Front/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Front/Router.php
+++ b/app/code/Magento/Core/Controller/Front/Router.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/FrontInterface.php
+++ b/app/code/Magento/Core/Controller/FrontInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Index.php
+++ b/app/code/Magento/Core/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Request/Http.php
+++ b/app/code/Magento/Core/Controller/Request/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Request/HttpProxy.php
+++ b/app/code/Magento/Core/Controller/Request/HttpProxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Response/Http.php
+++ b/app/code/Magento/Core/Controller/Response/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/AbstractAction.php
+++ b/app/code/Magento/Core/Controller/Varien/AbstractAction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/Action.php
+++ b/app/code/Magento/Core/Controller/Varien/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/Action/Context.php
+++ b/app/code/Magento/Core/Controller/Varien/Action/Context.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/Action/Factory.php
+++ b/app/code/Magento/Core/Controller/Varien/Action/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/Action/Forward.php
+++ b/app/code/Magento/Core/Controller/Varien/Action/Forward.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/Action/Redirect.php
+++ b/app/code/Magento/Core/Controller/Varien/Action/Redirect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/DispatchableInterface.php
+++ b/app/code/Magento/Core/Controller/Varien/DispatchableInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/Exception.php
+++ b/app/code/Magento/Core/Controller/Varien/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/Front.php
+++ b/app/code/Magento/Core/Controller/Varien/Front.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/Router/AbstractRouter.php
+++ b/app/code/Magento/Core/Controller/Varien/Router/AbstractRouter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/Router/Base.php
+++ b/app/code/Magento/Core/Controller/Varien/Router/Base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Controller/Varien/Router/DefaultRouter.php
+++ b/app/code/Magento/Core/Controller/Varien/Router/DefaultRouter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Exception.php
+++ b/app/code/Magento/Core/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/AbstractHelper.php
+++ b/app/code/Magento/Core/Helper/AbstractHelper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Context.php
+++ b/app/code/Magento/Core/Helper/Context.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Cookie.php
+++ b/app/code/Magento/Core/Helper/Cookie.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Css.php
+++ b/app/code/Magento/Core/Helper/Css.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Data.php
+++ b/app/code/Magento/Core/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/File/Storage.php
+++ b/app/code/Magento/Core/Helper/File/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/File/Storage/Database.php
+++ b/app/code/Magento/Core/Helper/File/Storage/Database.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Hint.php
+++ b/app/code/Magento/Core/Helper/Hint.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Http.php
+++ b/app/code/Magento/Core/Helper/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Js.php
+++ b/app/code/Magento/Core/Helper/Js.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/String.php
+++ b/app/code/Magento/Core/Helper/String.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Theme.php
+++ b/app/code/Magento/Core/Helper/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Translate.php
+++ b/app/code/Magento/Core/Helper/Translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Url.php
+++ b/app/code/Magento/Core/Helper/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Helper/Url/Rewrite.php
+++ b/app/code/Magento/Core/Helper/Url/Rewrite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/AbstractEntryPoint.php
+++ b/app/code/Magento/Core/Model/AbstractEntryPoint.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/AbstractModel.php
+++ b/app/code/Magento/Core/Model/AbstractModel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/AbstractShell.php
+++ b/app/code/Magento/Core/Model/AbstractShell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Acl/Cache.php
+++ b/app/code/Magento/Core/Model/Acl/Cache.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Acl/RootResource.php
+++ b/app/code/Magento/Core/Model/Acl/RootResource.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/App.php
+++ b/app/code/Magento/Core/Model/App.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/App/Area.php
+++ b/app/code/Magento/Core/Model/App/Area.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/App/Emulation.php
+++ b/app/code/Magento/Core/Model/App/Emulation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/App/Handler.php
+++ b/app/code/Magento/Core/Model/App/Handler.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/App/Proxy.php
+++ b/app/code/Magento/Core/Model/App/Proxy.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/App/State.php
+++ b/app/code/Magento/Core/Model/App/State.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/AppInterface.php
+++ b/app/code/Magento/Core/Model/AppInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/BlockFactory.php
+++ b/app/code/Magento/Core/Model/BlockFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache.php
+++ b/app/code/Magento/Core/Model/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Config.php
+++ b/app/code/Magento/Core/Model/Cache/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Config/Converter.php
+++ b/app/code/Magento/Core/Model/Cache/Config/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Config/Data.php
+++ b/app/code/Magento/Core/Model/Cache/Config/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Config/Reader.php
+++ b/app/code/Magento/Core/Model/Cache/Config/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Config/SchemaLocator.php
+++ b/app/code/Magento/Core/Model/Cache/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Frontend/Factory.php
+++ b/app/code/Magento/Core/Model/Cache/Frontend/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Frontend/Pool.php
+++ b/app/code/Magento/Core/Model/Cache/Frontend/Pool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/InstanceFactory.php
+++ b/app/code/Magento/Core/Model/Cache/InstanceFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Proxy.php
+++ b/app/code/Magento/Core/Model/Cache/Proxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/State.php
+++ b/app/code/Magento/Core/Model/Cache/State.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/StateInterface.php
+++ b/app/code/Magento/Core/Model/Cache/StateInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Type/AccessProxy.php
+++ b/app/code/Magento/Core/Model/Cache/Type/AccessProxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Type/Block.php
+++ b/app/code/Magento/Core/Model/Cache/Type/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Type/Collection.php
+++ b/app/code/Magento/Core/Model/Cache/Type/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Type/Config.php
+++ b/app/code/Magento/Core/Model/Cache/Type/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Type/FrontendPool.php
+++ b/app/code/Magento/Core/Model/Cache/Type/FrontendPool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Type/Layout.php
+++ b/app/code/Magento/Core/Model/Cache/Type/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/Type/Translate.php
+++ b/app/code/Magento/Core/Model/Cache/Type/Translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/TypeList.php
+++ b/app/code/Magento/Core/Model/Cache/TypeList.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cache/TypeListInterface.php
+++ b/app/code/Magento/Core/Model/Cache/TypeListInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/CacheInterface.php
+++ b/app/code/Magento/Core/Model/CacheInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Calculator.php
+++ b/app/code/Magento/Core/Model/Calculator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config.php
+++ b/app/code/Magento/Core/Model/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/AbstractStorage.php
+++ b/app/code/Magento/Core/Model/Config/AbstractStorage.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Base.php
+++ b/app/code/Magento/Core/Model/Config/Base.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/BaseFactory.php
+++ b/app/code/Magento/Core/Model/Config/BaseFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Cache.php
+++ b/app/code/Magento/Core/Model/Config/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Cache/Exception.php
+++ b/app/code/Magento/Core/Model/Config/Cache/Exception.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Data.php
+++ b/app/code/Magento/Core/Model/Config/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Data/BackendModelInterface.php
+++ b/app/code/Magento/Core/Model/Config/Data/BackendModelInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Data/BackendModelPool.php
+++ b/app/code/Magento/Core/Model/Config/Data/BackendModelPool.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/DataInterface.php
+++ b/app/code/Magento/Core/Model/Config/DataInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Element.php
+++ b/app/code/Magento/Core/Model/Config/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/FileResolver.php
+++ b/app/code/Magento/Core/Model/Config/FileResolver.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/FileResolver/Primary.php
+++ b/app/code/Magento/Core/Model/Config/FileResolver/Primary.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Initial.php
+++ b/app/code/Magento/Core/Model/Config/Initial.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Initial/Converter.php
+++ b/app/code/Magento/Core/Model/Config/Initial/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Initial/Reader.php
+++ b/app/code/Magento/Core/Model/Config/Initial/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Loader.php
+++ b/app/code/Magento/Core/Model/Config/Loader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Loader/Local.php
+++ b/app/code/Magento/Core/Model/Config/Loader/Local.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Loader/Primary.php
+++ b/app/code/Magento/Core/Model/Config/Loader/Primary.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/LoaderInterface.php
+++ b/app/code/Magento/Core/Model/Config/LoaderInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Local.php
+++ b/app/code/Magento/Core/Model/Config/Local.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/MetadataProcessor.php
+++ b/app/code/Magento/Core/Model/Config/MetadataProcessor.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Modules/Reader.php
+++ b/app/code/Magento/Core/Model/Config/Modules/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Primary.php
+++ b/app/code/Magento/Core/Model/Config/Primary.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Resource.php
+++ b/app/code/Magento/Core/Model/Config/Resource.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Resource/Primary.php
+++ b/app/code/Magento/Core/Model/Config/Resource/Primary.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/ResourceInterface.php
+++ b/app/code/Magento/Core/Model/Config/ResourceInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Scope.php
+++ b/app/code/Magento/Core/Model/Config/Scope.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Section/Converter.php
+++ b/app/code/Magento/Core/Model/Config/Section/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Section/Processor/Placeholder.php
+++ b/app/code/Magento/Core/Model/Config/Section/Processor/Placeholder.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Section/Reader/DefaultReader.php
+++ b/app/code/Magento/Core/Model/Config/Section/Reader/DefaultReader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Section/Reader/Store.php
+++ b/app/code/Magento/Core/Model/Config/Section/Reader/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Section/Reader/Website.php
+++ b/app/code/Magento/Core/Model/Config/Section/Reader/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Section/ReaderPool.php
+++ b/app/code/Magento/Core/Model/Config/Section/ReaderPool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Section/Store/Converter.php
+++ b/app/code/Magento/Core/Model/Config/Section/Store/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/SectionPool.php
+++ b/app/code/Magento/Core/Model/Config/SectionPool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Storage.php
+++ b/app/code/Magento/Core/Model/Config/Storage.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Storage/Writer/Db.php
+++ b/app/code/Magento/Core/Model/Config/Storage/Writer/Db.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Storage/WriterInterface.php
+++ b/app/code/Magento/Core/Model/Config/Storage/WriterInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/StorageInterface.php
+++ b/app/code/Magento/Core/Model/Config/StorageInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/ValidationState.php
+++ b/app/code/Magento/Core/Model/Config/ValidationState.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Config/Value.php
+++ b/app/code/Magento/Core/Model/Config/Value.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ConfigInterface.php
+++ b/app/code/Magento/Core/Model/ConfigInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Context.php
+++ b/app/code/Magento/Core/Model/Context.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Cookie.php
+++ b/app/code/Magento/Core/Model/Cookie.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/Config.php
+++ b/app/code/Magento/Core/Model/DataService/Config.php
@@ -14,7 +14,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/Config/Reader.php
+++ b/app/code/Magento/Core/Model/DataService/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/Config/Reader/Factory.php
+++ b/app/code/Magento/Core/Model/DataService/Config/Reader/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/ConfigInterface.php
+++ b/app/code/Magento/Core/Model/DataService/ConfigInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/Graph.php
+++ b/app/code/Magento/Core/Model/DataService/Graph.php
@@ -16,7 +16,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/Invoker.php
+++ b/app/code/Magento/Core/Model/DataService/Invoker.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/Path/Composite.php
+++ b/app/code/Magento/Core/Model/DataService/Path/Composite.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/Path/Navigator.php
+++ b/app/code/Magento/Core/Model/DataService/Path/Navigator.php
@@ -16,7 +16,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/Path/NodeInterface.php
+++ b/app/code/Magento/Core/Model/DataService/Path/NodeInterface.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/Path/Request.php
+++ b/app/code/Magento/Core/Model/DataService/Path/Request.php
@@ -15,7 +15,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/DataService/Repository.php
+++ b/app/code/Magento/Core/Model/DataService/Repository.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Date.php
+++ b/app/code/Magento/Core/Model/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Db/Updater.php
+++ b/app/code/Magento/Core/Model/Db/Updater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Db/UpdaterInterface.php
+++ b/app/code/Magento/Core/Model/Db/UpdaterInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design.php
+++ b/app/code/Magento/Core/Model/Design.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/Backend/Exceptions.php
+++ b/app/code/Magento/Core/Model/Design/Backend/Exceptions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/Backend/Theme.php
+++ b/app/code/Magento/Core/Model/Design/Backend/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/Fallback/Factory.php
+++ b/app/code/Magento/Core/Model/Design/Fallback/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/Fallback/Rule/Composite.php
+++ b/app/code/Magento/Core/Model/Design/Fallback/Rule/Composite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/Fallback/Rule/ModularSwitch.php
+++ b/app/code/Magento/Core/Model/Design/Fallback/Rule/ModularSwitch.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/Fallback/Rule/RuleInterface.php
+++ b/app/code/Magento/Core/Model/Design/Fallback/Rule/RuleInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/Fallback/Rule/Simple.php
+++ b/app/code/Magento/Core/Model/Design/Fallback/Rule/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/Fallback/Rule/Theme.php
+++ b/app/code/Magento/Core/Model/Design/Fallback/Rule/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/FileResolution/Strategy/Fallback.php
+++ b/app/code/Magento/Core/Model/Design/FileResolution/Strategy/Fallback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/FileResolution/Strategy/Fallback/CachingProxy.php
+++ b/app/code/Magento/Core/Model/Design/FileResolution/Strategy/Fallback/CachingProxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/FileResolution/Strategy/FileInterface.php
+++ b/app/code/Magento/Core/Model/Design/FileResolution/Strategy/FileInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/FileResolution/Strategy/LocaleInterface.php
+++ b/app/code/Magento/Core/Model/Design/FileResolution/Strategy/LocaleInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/FileResolution/Strategy/View/NotifiableInterface.php
+++ b/app/code/Magento/Core/Model/Design/FileResolution/Strategy/View/NotifiableInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/FileResolution/Strategy/ViewInterface.php
+++ b/app/code/Magento/Core/Model/Design/FileResolution/Strategy/ViewInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/FileResolution/StrategyPool.php
+++ b/app/code/Magento/Core/Model/Design/FileResolution/StrategyPool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Design/Source/Design.php
+++ b/app/code/Magento/Core/Model/Design/Source/Design.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Dir.php
+++ b/app/code/Magento/Core/Model/Dir.php
@@ -14,7 +14,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Dir/Verification.php
+++ b/app/code/Magento/Core/Model/Dir/Verification.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email.php
+++ b/app/code/Magento/Core/Model/Email.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email/Info.php
+++ b/app/code/Magento/Core/Model/Email/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email/Template.php
+++ b/app/code/Magento/Core/Model/Email/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email/Template/Config.php
+++ b/app/code/Magento/Core/Model/Email/Template/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email/Template/Config/Converter.php
+++ b/app/code/Magento/Core/Model/Email/Template/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email/Template/Config/Data.php
+++ b/app/code/Magento/Core/Model/Email/Template/Config/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email/Template/Config/Reader.php
+++ b/app/code/Magento/Core/Model/Email/Template/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email/Template/Config/SchemaLocator.php
+++ b/app/code/Magento/Core/Model/Email/Template/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email/Template/Filter.php
+++ b/app/code/Magento/Core/Model/Email/Template/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email/Template/Mailer.php
+++ b/app/code/Magento/Core/Model/Email/Template/Mailer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Email/Transport.php
+++ b/app/code/Magento/Core/Model/Email/Transport.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Encryption.php
+++ b/app/code/Magento/Core/Model/Encryption.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/EncryptionFactory.php
+++ b/app/code/Magento/Core/Model/EncryptionFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/EncryptionInterface.php
+++ b/app/code/Magento/Core/Model/EncryptionInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/EntityFactory.php
+++ b/app/code/Magento/Core/Model/EntityFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/EntryPoint/Cron.php
+++ b/app/code/Magento/Core/Model/EntryPoint/Cron.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/EntryPoint/Http.php
+++ b/app/code/Magento/Core/Model/EntryPoint/Http.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/EntryPoint/Media.php
+++ b/app/code/Magento/Core/Model/EntryPoint/Media.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Event/Config.php
+++ b/app/code/Magento/Core/Model/Event/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Event/Config/Converter.php
+++ b/app/code/Magento/Core/Model/Event/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Event/Config/Data.php
+++ b/app/code/Magento/Core/Model/Event/Config/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Event/Config/Reader.php
+++ b/app/code/Magento/Core/Model/Event/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Event/Config/SchemaLocator.php
+++ b/app/code/Magento/Core/Model/Event/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Event/ConfigInterface.php
+++ b/app/code/Magento/Core/Model/Event/ConfigInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Event/Invoker/InvokerDefault.php
+++ b/app/code/Magento/Core/Model/Event/Invoker/InvokerDefault.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Event/InvokerInterface.php
+++ b/app/code/Magento/Core/Model/Event/InvokerInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Event/Manager.php
+++ b/app/code/Magento/Core/Model/Event/Manager.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Factory.php
+++ b/app/code/Magento/Core/Model/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Factory/Helper.php
+++ b/app/code/Magento/Core/Model/Factory/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Fieldset/Config.php
+++ b/app/code/Magento/Core/Model/Fieldset/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Fieldset/Config/Converter.php
+++ b/app/code/Magento/Core/Model/Fieldset/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Fieldset/Config/Data.php
+++ b/app/code/Magento/Core/Model/Fieldset/Config/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Fieldset/Config/Reader.php
+++ b/app/code/Magento/Core/Model/Fieldset/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Fieldset/Config/SchemaLocator.php
+++ b/app/code/Magento/Core/Model/Fieldset/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage.php
+++ b/app/code/Magento/Core/Model/File/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage/AbstractStorage.php
+++ b/app/code/Magento/Core/Model/File/Storage/AbstractStorage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage/Config.php
+++ b/app/code/Magento/Core/Model/File/Storage/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage/Database.php
+++ b/app/code/Magento/Core/Model/File/Storage/Database.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage/Database/AbstractDatabase.php
+++ b/app/code/Magento/Core/Model/File/Storage/Database/AbstractDatabase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage/Directory/Database.php
+++ b/app/code/Magento/Core/Model/File/Storage/Directory/Database.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage/File.php
+++ b/app/code/Magento/Core/Model/File/Storage/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage/Flag.php
+++ b/app/code/Magento/Core/Model/File/Storage/Flag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage/Request.php
+++ b/app/code/Magento/Core/Model/File/Storage/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage/Response.php
+++ b/app/code/Magento/Core/Model/File/Storage/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Storage/Synchronization.php
+++ b/app/code/Magento/Core/Model/File/Storage/Synchronization.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Uploader.php
+++ b/app/code/Magento/Core/Model/File/Uploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Validator/AvailablePath.php
+++ b/app/code/Magento/Core/Model/File/Validator/AvailablePath.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/File/Validator/NotProtectedExtension.php
+++ b/app/code/Magento/Core/Model/File/Validator/NotProtectedExtension.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Flag.php
+++ b/app/code/Magento/Core/Model/Flag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Image/AdapterFactory.php
+++ b/app/code/Magento/Core/Model/Image/AdapterFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Image/Factory.php
+++ b/app/code/Magento/Core/Model/Image/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Input/Filter.php
+++ b/app/code/Magento/Core/Model/Input/Filter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Input/Filter/MaliciousCode.php
+++ b/app/code/Magento/Core/Model/Input/Filter/MaliciousCode.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout.php
+++ b/app/code/Magento/Core/Model/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/AbstractHandler.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/AbstractHandler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/Handler/ArrayHandler.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/Handler/ArrayHandler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/Handler/Boolean.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/Handler/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/Handler/Helper.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/Handler/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/Handler/Number.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/Handler/Number.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/Handler/Object.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/Handler/Object.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/Handler/Options.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/Handler/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/Handler/String.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/Handler/String.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/Handler/Url.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/Handler/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/HandlerFactory.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/HandlerFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/HandlerFactoryInterface.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/HandlerFactoryInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/HandlerInterface.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/HandlerInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/Processor.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/Processor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/Updater.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/Updater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Argument/UpdaterInterface.php
+++ b/app/code/Magento/Core/Model/Layout/Argument/UpdaterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Element.php
+++ b/app/code/Magento/Core/Model/Layout/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Factory.php
+++ b/app/code/Magento/Core/Model/Layout/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File.php
+++ b/app/code/Magento/Core/Model/Layout/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/Factory.php
+++ b/app/code/Magento/Core/Model/Layout/File/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/FileList/Factory.php
+++ b/app/code/Magento/Core/Model/Layout/File/FileList/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/ListFile.php
+++ b/app/code/Magento/Core/Model/Layout/File/ListFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/Source/Aggregated.php
+++ b/app/code/Magento/Core/Model/Layout/File/Source/Aggregated.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/Source/Base.php
+++ b/app/code/Magento/Core/Model/Layout/File/Source/Base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/Source/Decorator/ModuleDependency.php
+++ b/app/code/Magento/Core/Model/Layout/File/Source/Decorator/ModuleDependency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/Source/Decorator/ModuleOutput.php
+++ b/app/code/Magento/Core/Model/Layout/File/Source/Decorator/ModuleOutput.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/Source/Override/Base.php
+++ b/app/code/Magento/Core/Model/Layout/File/Source/Override/Base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/Source/Override/Theme.php
+++ b/app/code/Magento/Core/Model/Layout/File/Source/Override/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/Source/Theme.php
+++ b/app/code/Magento/Core/Model/Layout/File/Source/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/File/SourceInterface.php
+++ b/app/code/Magento/Core/Model/Layout/File/SourceInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Filter/Acl.php
+++ b/app/code/Magento/Core/Model/Layout/Filter/Acl.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Link.php
+++ b/app/code/Magento/Core/Model/Layout/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Merge.php
+++ b/app/code/Magento/Core/Model/Layout/Merge.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/ScheduledStructure.php
+++ b/app/code/Magento/Core/Model/Layout/ScheduledStructure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Translator.php
+++ b/app/code/Magento/Core/Model/Layout/Translator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Layout/Update.php
+++ b/app/code/Magento/Core/Model/Layout/Update.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Locale.php
+++ b/app/code/Magento/Core/Model/Locale.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Locale/Config.php
+++ b/app/code/Magento/Core/Model/Locale/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Locale/Hierarchy/Config.php
+++ b/app/code/Magento/Core/Model/Locale/Hierarchy/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Locale/Hierarchy/Config/Converter.php
+++ b/app/code/Magento/Core/Model/Locale/Hierarchy/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Locale/Hierarchy/Config/FileResolver.php
+++ b/app/code/Magento/Core/Model/Locale/Hierarchy/Config/FileResolver.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Locale/Hierarchy/Config/Reader.php
+++ b/app/code/Magento/Core/Model/Locale/Hierarchy/Config/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Locale/Hierarchy/Config/SchemaLocator.php
+++ b/app/code/Magento/Core/Model/Locale/Hierarchy/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Locale/Validator.php
+++ b/app/code/Magento/Core/Model/Locale/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/LocaleInterface.php
+++ b/app/code/Magento/Core/Model/LocaleInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Log/Adapter.php
+++ b/app/code/Magento/Core/Model/Log/Adapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Logger.php
+++ b/app/code/Magento/Core/Model/Logger.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Message.php
+++ b/app/code/Magento/Core/Model/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Message/AbstractMessage.php
+++ b/app/code/Magento/Core/Model/Message/AbstractMessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Message/Collection.php
+++ b/app/code/Magento/Core/Model/Message/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Message/Error.php
+++ b/app/code/Magento/Core/Model/Message/Error.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Message/Notice.php
+++ b/app/code/Magento/Core/Model/Message/Notice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Message/Success.php
+++ b/app/code/Magento/Core/Model/Message/Success.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Message/Warning.php
+++ b/app/code/Magento/Core/Model/Message/Warning.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Module/Declaration/Converter/Dom.php
+++ b/app/code/Magento/Core/Model/Module/Declaration/Converter/Dom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Module/Declaration/FileResolver.php
+++ b/app/code/Magento/Core/Model/Module/Declaration/FileResolver.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Module/Declaration/Reader/Filesystem.php
+++ b/app/code/Magento/Core/Model/Module/Declaration/Reader/Filesystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Module/Declaration/SchemaLocator.php
+++ b/app/code/Magento/Core/Model/Module/Declaration/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Module/Dir.php
+++ b/app/code/Magento/Core/Model/Module/Dir.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Module/Dir/ReverseResolver.php
+++ b/app/code/Magento/Core/Model/Module/Dir/ReverseResolver.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Module/ResourceResolver.php
+++ b/app/code/Magento/Core/Model/Module/ResourceResolver.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Module/ResourceResolverInterface.php
+++ b/app/code/Magento/Core/Model/Module/ResourceResolverInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ModuleList.php
+++ b/app/code/Magento/Core/Model/ModuleList.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ModuleListInterface.php
+++ b/app/code/Magento/Core/Model/ModuleListInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ModuleManager.php
+++ b/app/code/Magento/Core/Model/ModuleManager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/NoRouteHandlerList.php
+++ b/app/code/Magento/Core/Model/NoRouteHandlerList.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ObjectManager.php
+++ b/app/code/Magento/Core/Model/ObjectManager.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ObjectManager/ConfigCache.php
+++ b/app/code/Magento/Core/Model/ObjectManager/ConfigCache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ObjectManager/ConfigLoader.php
+++ b/app/code/Magento/Core/Model/ObjectManager/ConfigLoader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ObjectManager/ConfigLoader/Primary.php
+++ b/app/code/Magento/Core/Model/ObjectManager/ConfigLoader/Primary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ObjectManager/DefinitionFactory.php
+++ b/app/code/Magento/Core/Model/ObjectManager/DefinitionFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ObjectManager/DynamicConfigInterface.php
+++ b/app/code/Magento/Core/Model/ObjectManager/DynamicConfigInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ObjectManager/Relations.php
+++ b/app/code/Magento/Core/Model/ObjectManager/Relations.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Observer.php
+++ b/app/code/Magento/Core/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ObserverFactory.php
+++ b/app/code/Magento/Core/Model/ObserverFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Option/ArrayInterface.php
+++ b/app/code/Magento/Core/Model/Option/ArrayInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Option/ArrayPool.php
+++ b/app/code/Magento/Core/Model/Option/ArrayPool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page.php
+++ b/app/code/Magento/Core/Model/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/AssetInterface.php
+++ b/app/code/Magento/Core/Model/Page/Asset/AssetInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/Collection.php
+++ b/app/code/Magento/Core/Model/Page/Asset/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/LocalInterface.php
+++ b/app/code/Magento/Core/Model/Page/Asset/LocalInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/MergeService.php
+++ b/app/code/Magento/Core/Model/Page/Asset/MergeService.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/MergeStrategy/Checksum.php
+++ b/app/code/Magento/Core/Model/Page/Asset/MergeStrategy/Checksum.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/MergeStrategy/Direct.php
+++ b/app/code/Magento/Core/Model/Page/Asset/MergeStrategy/Direct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/MergeStrategy/FileExists.php
+++ b/app/code/Magento/Core/Model/Page/Asset/MergeStrategy/FileExists.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/MergeStrategyInterface.php
+++ b/app/code/Magento/Core/Model/Page/Asset/MergeStrategyInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/MergeableInterface.php
+++ b/app/code/Magento/Core/Model/Page/Asset/MergeableInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/Merged.php
+++ b/app/code/Magento/Core/Model/Page/Asset/Merged.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/Minified.php
+++ b/app/code/Magento/Core/Model/Page/Asset/Minified.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/MinifyService.php
+++ b/app/code/Magento/Core/Model/Page/Asset/MinifyService.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/PublicFile.php
+++ b/app/code/Magento/Core/Model/Page/Asset/PublicFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/Remote.php
+++ b/app/code/Magento/Core/Model/Page/Asset/Remote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Page/Asset/ViewFile.php
+++ b/app/code/Magento/Core/Model/Page/Asset/ViewFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Registry.php
+++ b/app/code/Magento/Core/Model/Registry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource.php
+++ b/app/code/Magento/Core/Model/Resource.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/AbstractResource.php
+++ b/app/code/Magento/Core/Model/Resource/AbstractResource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Cache.php
+++ b/app/code/Magento/Core/Model/Resource/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Config.php
+++ b/app/code/Magento/Core/Model/Resource/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Config/Converter.php
+++ b/app/code/Magento/Core/Model/Resource/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Config/Data.php
+++ b/app/code/Magento/Core/Model/Resource/Config/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Config/Data/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Config/Data/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Config/Reader.php
+++ b/app/code/Magento/Core/Model/Resource/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Config/SchemaLocator.php
+++ b/app/code/Magento/Core/Model/Resource/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Config/Value/Collection/Scoped.php
+++ b/app/code/Magento/Core/Model/Resource/Config/Value/Collection/Scoped.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/ConnectionAdapterInterface.php
+++ b/app/code/Magento/Core/Model/Resource/ConnectionAdapterInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/ConnectionFactory.php
+++ b/app/code/Magento/Core/Model/Resource/ConnectionFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Db/AbstractDb.php
+++ b/app/code/Magento/Core/Model/Resource/Db/AbstractDb.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Db/Collection/AbstractCollection.php
+++ b/app/code/Magento/Core/Model/Resource/Db/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Db/Profiler.php
+++ b/app/code/Magento/Core/Model/Resource/Db/Profiler.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Design.php
+++ b/app/code/Magento/Core/Model/Resource/Design.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Design/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Design/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Email/Template.php
+++ b/app/code/Magento/Core/Model/Resource/Email/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Email/Template/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Email/Template/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Entity/AbstractEntity.php
+++ b/app/code/Magento/Core/Model/Resource/Entity/AbstractEntity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Entity/Table.php
+++ b/app/code/Magento/Core/Model/Resource/Entity/Table.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/File/Storage/AbstractStorage.php
+++ b/app/code/Magento/Core/Model/Resource/File/Storage/AbstractStorage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/File/Storage/Database.php
+++ b/app/code/Magento/Core/Model/Resource/File/Storage/Database.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/File/Storage/Directory/Database.php
+++ b/app/code/Magento/Core/Model/Resource/File/Storage/Directory/Database.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/File/Storage/File.php
+++ b/app/code/Magento/Core/Model/Resource/File/Storage/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Flag.php
+++ b/app/code/Magento/Core/Model/Resource/Flag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Helper.php
+++ b/app/code/Magento/Core/Model/Resource/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Helper/AbstractHelper.php
+++ b/app/code/Magento/Core/Model/Resource/Helper/AbstractHelper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/HelperFactory.php
+++ b/app/code/Magento/Core/Model/Resource/HelperFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/HelperPool.php
+++ b/app/code/Magento/Core/Model/Resource/HelperPool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Iterator.php
+++ b/app/code/Magento/Core/Model/Resource/Iterator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Layout/Link.php
+++ b/app/code/Magento/Core/Model/Resource/Layout/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Layout/Link/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Layout/Link/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Layout/Update.php
+++ b/app/code/Magento/Core/Model/Resource/Layout/Update.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Layout/Update/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Layout/Update/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Resource.php
+++ b/app/code/Magento/Core/Model/Resource/Resource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Session.php
+++ b/app/code/Magento/Core/Model/Resource/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Setup.php
+++ b/app/code/Magento/Core/Model/Resource/Setup.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Setup/Context.php
+++ b/app/code/Magento/Core/Model/Resource/Setup/Context.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Setup/Generic.php
+++ b/app/code/Magento/Core/Model/Resource/Setup/Generic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Setup/Migration.php
+++ b/app/code/Magento/Core/Model/Resource/Setup/Migration.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/SetupFactory.php
+++ b/app/code/Magento/Core/Model/Resource/SetupFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/SetupInterface.php
+++ b/app/code/Magento/Core/Model/Resource/SetupInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Store.php
+++ b/app/code/Magento/Core/Model/Resource/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Store/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Store/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Store/Group.php
+++ b/app/code/Magento/Core/Model/Resource/Store/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Store/Group/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Store/Group/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Theme.php
+++ b/app/code/Magento/Core/Model/Resource/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Theme/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Theme/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Theme/Customization/Update.php
+++ b/app/code/Magento/Core/Model/Resource/Theme/Customization/Update.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Theme/File.php
+++ b/app/code/Magento/Core/Model/Resource/Theme/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Theme/File/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Theme/File/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Theme/Grid/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Theme/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Transaction.php
+++ b/app/code/Magento/Core/Model/Resource/Transaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Translate.php
+++ b/app/code/Magento/Core/Model/Resource/Translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Translate/String.php
+++ b/app/code/Magento/Core/Model/Resource/Translate/String.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Type/AbstractType.php
+++ b/app/code/Magento/Core/Model/Resource/Type/AbstractType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Type/Db.php
+++ b/app/code/Magento/Core/Model/Resource/Type/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Type/Db/Pdo/Mysql.php
+++ b/app/code/Magento/Core/Model/Resource/Type/Db/Pdo/Mysql.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Url/Rewrite.php
+++ b/app/code/Magento/Core/Model/Resource/Url/Rewrite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Url/Rewrite/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Url/Rewrite/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Variable.php
+++ b/app/code/Magento/Core/Model/Resource/Variable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Variable/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Variable/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Website.php
+++ b/app/code/Magento/Core/Model/Resource/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Website/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Website/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Resource/Website/Grid/Collection.php
+++ b/app/code/Magento/Core/Model/Resource/Website/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Route/Config.php
+++ b/app/code/Magento/Core/Model/Route/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Route/Config/Converter.php
+++ b/app/code/Magento/Core/Model/Route/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Route/Config/Reader.php
+++ b/app/code/Magento/Core/Model/Route/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Route/Config/SchemaLocator.php
+++ b/app/code/Magento/Core/Model/Route/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Route/ConfigInterface.php
+++ b/app/code/Magento/Core/Model/Route/ConfigInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Router/NoRouteHandler.php
+++ b/app/code/Magento/Core/Model/Router/NoRouteHandler.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Router/NoRouteHandlerInterface.php
+++ b/app/code/Magento/Core/Model/Router/NoRouteHandlerInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/RouterList.php
+++ b/app/code/Magento/Core/Model/RouterList.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Sender.php
+++ b/app/code/Magento/Core/Model/Sender.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Session.php
+++ b/app/code/Magento/Core/Model/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Session/AbstractSession.php
+++ b/app/code/Magento/Core/Model/Session/AbstractSession.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Session/Context.php
+++ b/app/code/Magento/Core/Model/Session/Context.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Session/Exception.php
+++ b/app/code/Magento/Core/Model/Session/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Session/Generic.php
+++ b/app/code/Magento/Core/Model/Session/Generic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Session/Pool.php
+++ b/app/code/Magento/Core/Model/Session/Pool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Session/Validator.php
+++ b/app/code/Magento/Core/Model/Session/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Source/Email/Variables.php
+++ b/app/code/Magento/Core/Model/Source/Email/Variables.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Source/Urlrewrite/Options.php
+++ b/app/code/Magento/Core/Model/Source/Urlrewrite/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Source/Urlrewrite/Types.php
+++ b/app/code/Magento/Core/Model/Source/Urlrewrite/Types.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store.php
+++ b/app/code/Magento/Core/Model/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store/Config.php
+++ b/app/code/Magento/Core/Model/Store/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store/ConfigInterface.php
+++ b/app/code/Magento/Core/Model/Store/ConfigInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store/Exception.php
+++ b/app/code/Magento/Core/Model/Store/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store/Group.php
+++ b/app/code/Magento/Core/Model/Store/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store/Group/Factory.php
+++ b/app/code/Magento/Core/Model/Store/Group/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store/ListInterface.php
+++ b/app/code/Magento/Core/Model/Store/ListInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store/Storage/Db.php
+++ b/app/code/Magento/Core/Model/Store/Storage/Db.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store/Storage/DefaultStorage.php
+++ b/app/code/Magento/Core/Model/Store/Storage/DefaultStorage.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store/StorageFactory.php
+++ b/app/code/Magento/Core/Model/Store/StorageFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Store/StorageInterface.php
+++ b/app/code/Magento/Core/Model/Store/StorageInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/StoreFactory.php
+++ b/app/code/Magento/Core/Model/StoreFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/StoreManager.php
+++ b/app/code/Magento/Core/Model/StoreManager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/StoreManagerInterface.php
+++ b/app/code/Magento/Core/Model/StoreManagerInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/System/Store.php
+++ b/app/code/Magento/Core/Model/System/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Template.php
+++ b/app/code/Magento/Core/Model/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/TemplateEngine/BlockTrackerInterface.php
+++ b/app/code/Magento/Core/Model/TemplateEngine/BlockTrackerInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/TemplateEngine/EngineInterface.php
+++ b/app/code/Magento/Core/Model/TemplateEngine/EngineInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/TemplateEngine/Factory.php
+++ b/app/code/Magento/Core/Model/TemplateEngine/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/TemplateEngine/Php.php
+++ b/app/code/Magento/Core/Model/TemplateEngine/Php.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/TemplateEngine/Twig.php
+++ b/app/code/Magento/Core/Model/TemplateEngine/Twig.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/TemplateEngine/Twig/CommonFunctions.php
+++ b/app/code/Magento/Core/Model/TemplateEngine/Twig/CommonFunctions.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/TemplateEngine/Twig/EnvironmentFactory.php
+++ b/app/code/Magento/Core/Model/TemplateEngine/Twig/EnvironmentFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/TemplateEngine/Twig/Extension.php
+++ b/app/code/Magento/Core/Model/TemplateEngine/Twig/Extension.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/TemplateEngine/Twig/FullFileName.php
+++ b/app/code/Magento/Core/Model/TemplateEngine/Twig/FullFileName.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/TemplateEngine/Twig/LayoutFunctions.php
+++ b/app/code/Magento/Core/Model/TemplateEngine/Twig/LayoutFunctions.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme.php
+++ b/app/code/Magento/Core/Model/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Collection.php
+++ b/app/code/Magento/Core/Model/Theme/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/CopyService.php
+++ b/app/code/Magento/Core/Model/Theme/CopyService.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Customization.php
+++ b/app/code/Magento/Core/Model/Theme/Customization.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Customization/AbstractFile.php
+++ b/app/code/Magento/Core/Model/Theme/Customization/AbstractFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Customization/File/Css.php
+++ b/app/code/Magento/Core/Model/Theme/Customization/File/Css.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Customization/File/Js.php
+++ b/app/code/Magento/Core/Model/Theme/Customization/File/Js.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Customization/FileAssetInterface.php
+++ b/app/code/Magento/Core/Model/Theme/Customization/FileAssetInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Customization/FileInterface.php
+++ b/app/code/Magento/Core/Model/Theme/Customization/FileInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Customization/FileServiceFactory.php
+++ b/app/code/Magento/Core/Model/Theme/Customization/FileServiceFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Customization/Path.php
+++ b/app/code/Magento/Core/Model/Theme/Customization/Path.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/CustomizationInterface.php
+++ b/app/code/Magento/Core/Model/Theme/CustomizationInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Domain/Factory.php
+++ b/app/code/Magento/Core/Model/Theme/Domain/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Domain/Physical.php
+++ b/app/code/Magento/Core/Model/Theme/Domain/Physical.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Domain/Staging.php
+++ b/app/code/Magento/Core/Model/Theme/Domain/Staging.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Domain/Virtual.php
+++ b/app/code/Magento/Core/Model/Theme/Domain/Virtual.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/File.php
+++ b/app/code/Magento/Core/Model/Theme/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/FileFactory.php
+++ b/app/code/Magento/Core/Model/Theme/FileFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/FileInterface.php
+++ b/app/code/Magento/Core/Model/Theme/FileInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/FlyweightFactory.php
+++ b/app/code/Magento/Core/Model/Theme/FlyweightFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Image.php
+++ b/app/code/Magento/Core/Model/Theme/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Image/Path.php
+++ b/app/code/Magento/Core/Model/Theme/Image/Path.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Image/Uploader.php
+++ b/app/code/Magento/Core/Model/Theme/Image/Uploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Label.php
+++ b/app/code/Magento/Core/Model/Theme/Label.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Observer.php
+++ b/app/code/Magento/Core/Model/Theme/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Registration.php
+++ b/app/code/Magento/Core/Model/Theme/Registration.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Theme/Validator.php
+++ b/app/code/Magento/Core/Model/Theme/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/ThemeInterface.php
+++ b/app/code/Magento/Core/Model/ThemeInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Translate.php
+++ b/app/code/Magento/Core/Model/Translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Translate/Factory.php
+++ b/app/code/Magento/Core/Model/Translate/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Translate/Inline.php
+++ b/app/code/Magento/Core/Model/Translate/Inline.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Translate/InlineInterface.php
+++ b/app/code/Magento/Core/Model/Translate/InlineInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Translate/InlineParser.php
+++ b/app/code/Magento/Core/Model/Translate/InlineParser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Translate/String.php
+++ b/app/code/Magento/Core/Model/Translate/String.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Url.php
+++ b/app/code/Magento/Core/Model/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Url/Rewrite.php
+++ b/app/code/Magento/Core/Model/Url/Rewrite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Url/SecurityInfo.php
+++ b/app/code/Magento/Core/Model/Url/SecurityInfo.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Url/SecurityInfoInterface.php
+++ b/app/code/Magento/Core/Model/Url/SecurityInfoInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Url/Validator.php
+++ b/app/code/Magento/Core/Model/Url/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/UrlInterface.php
+++ b/app/code/Magento/Core/Model/UrlInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Validator/Factory.php
+++ b/app/code/Magento/Core/Model/Validator/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Variable.php
+++ b/app/code/Magento/Core/Model/Variable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Variable/Config.php
+++ b/app/code/Magento/Core/Model/Variable/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/View/Config.php
+++ b/app/code/Magento/Core/Model/View/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/View/DeployedFilesManager.php
+++ b/app/code/Magento/Core/Model/View/DeployedFilesManager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/View/Design.php
+++ b/app/code/Magento/Core/Model/View/Design.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/View/Design/Proxy.php
+++ b/app/code/Magento/Core/Model/View/Design/Proxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/View/DesignInterface.php
+++ b/app/code/Magento/Core/Model/View/DesignInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/View/FileSystem.php
+++ b/app/code/Magento/Core/Model/View/FileSystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/View/PublicFilesManagerInterface.php
+++ b/app/code/Magento/Core/Model/View/PublicFilesManagerInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/View/Publisher.php
+++ b/app/code/Magento/Core/Model/View/Publisher.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/View/Service.php
+++ b/app/code/Magento/Core/Model/View/Service.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/View/Url.php
+++ b/app/code/Magento/Core/Model/View/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Website.php
+++ b/app/code/Magento/Core/Model/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/Model/Website/Factory.php
+++ b/app/code/Magento/Core/Model/Website/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.10-1.6.0.11.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.12-1.6.0.13.php
+++ b/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.12-1.6.0.13.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.2-1.6.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.3-1.6.0.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.4-1.6.0.5.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/Magento/Core/data/core_setup/data-upgrade-1.6.0.5-1.6.0.6.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/cache.xml
+++ b/app/code/Magento/Core/etc/cache.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/cache.xsd
+++ b/app/code/Magento/Core/etc/cache.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/config.xml
+++ b/app/code/Magento/Core/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/crontab.xml
+++ b/app/code/Magento/Core/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/di.xml
+++ b/app/code/Magento/Core/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/email_templates.xsd
+++ b/app/code/Magento/Core/etc/email_templates.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/email_templates_file.xsd
+++ b/app/code/Magento/Core/etc/email_templates_file.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/email_templates_types.xsd
+++ b/app/code/Magento/Core/etc/email_templates_types.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/events.xml
+++ b/app/code/Magento/Core/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/events.xsd
+++ b/app/code/Magento/Core/etc/events.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/fieldset.xsd
+++ b/app/code/Magento/Core/etc/fieldset.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/fieldset_file.xsd
+++ b/app/code/Magento/Core/etc/fieldset_file.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/frontend/di.xml
+++ b/app/code/Magento/Core/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/frontend/events.xml
+++ b/app/code/Magento/Core/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/frontend/routes.xml
+++ b/app/code/Magento/Core/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/layout_merged.xsd
+++ b/app/code/Magento/Core/etc/layout_merged.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/layout_single.xsd
+++ b/app/code/Magento/Core/etc/layout_single.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/layouts.xsd
+++ b/app/code/Magento/Core/etc/layouts.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/locale.xsd
+++ b/app/code/Magento/Core/etc/locale.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/module.xml
+++ b/app/code/Magento/Core/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/module.xsd
+++ b/app/code/Magento/Core/etc/module.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/resources.xml
+++ b/app/code/Magento/Core/etc/resources.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/resources.xsd
+++ b/app/code/Magento/Core/etc/resources.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/routes.xsd
+++ b/app/code/Magento/Core/etc/routes.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/routes_merged.xsd
+++ b/app/code/Magento/Core/etc/routes_merged.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/service_calls.xsd
+++ b/app/code/Magento/Core/etc/service_calls.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/etc/types.xsd
+++ b/app/code/Magento/Core/etc/types.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/functions.php
+++ b/app/code/Magento/Core/functions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Core/sql/core_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/oracle-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/Core/sql/core_setup/oracle-upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.10-1.6.0.11.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.11-1.6.0.12.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.11-1.6.0.12.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.12-1.6.0.13.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.12-1.6.0.13.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.13-1.6.0.14.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.13-1.6.0.14.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.14-1.6.0.15.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.14-1.6.0.15.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.5-1.6.0.6.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.6-1.6.0.7.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.6-1.6.0.7.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.7-1.6.0.8.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.7-1.6.0.8.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.8-1.6.0.9.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.8-1.6.0.9.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.9-1.6.0.10.php
+++ b/app/code/Magento/Core/sql/core_setup/upgrade-1.6.0.9-1.6.0.10.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/view/adminhtml/prototype/magento.css
+++ b/app/code/Magento/Core/view/adminhtml/prototype/magento.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/view/adminhtml/translate_inline.phtml
+++ b/app/code/Magento/Core/view/adminhtml/translate_inline.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/view/frontend/formkey.phtml
+++ b/app/code/Magento/Core/view/frontend/formkey.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/view/frontend/layout/default.xml
+++ b/app/code/Magento/Core/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/view/frontend/link.phtml
+++ b/app/code/Magento/Core/view/frontend/link.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/view/frontend/messages.phtml
+++ b/app/code/Magento/Core/view/frontend/messages.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/view/frontend/prototype/magento.css
+++ b/app/code/Magento/Core/view/frontend/prototype/magento.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Core/view/frontend/translate_inline.phtml
+++ b/app/code/Magento/Core/view/frontend/translate_inline.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Exception.php
+++ b/app/code/Magento/Cron/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Helper/Data.php
+++ b/app/code/Magento/Cron/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Config.php
+++ b/app/code/Magento/Cron/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Config/Backend/Product/Alert.php
+++ b/app/code/Magento/Cron/Model/Config/Backend/Product/Alert.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Config/Backend/Sitemap.php
+++ b/app/code/Magento/Cron/Model/Config/Backend/Sitemap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Config/Converter/Db.php
+++ b/app/code/Magento/Cron/Model/Config/Converter/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Config/Converter/Xml.php
+++ b/app/code/Magento/Cron/Model/Config/Converter/Xml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Config/Data.php
+++ b/app/code/Magento/Cron/Model/Config/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Config/Reader/Db.php
+++ b/app/code/Magento/Cron/Model/Config/Reader/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Config/Reader/Xml.php
+++ b/app/code/Magento/Cron/Model/Config/Reader/Xml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Config/SchemaLocator.php
+++ b/app/code/Magento/Cron/Model/Config/SchemaLocator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Config/Source/Frequency.php
+++ b/app/code/Magento/Cron/Model/Config/Source/Frequency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/ConfigInterface.php
+++ b/app/code/Magento/Cron/Model/ConfigInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Observer.php
+++ b/app/code/Magento/Cron/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Resource/Schedule.php
+++ b/app/code/Magento/Cron/Model/Resource/Schedule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Resource/Schedule/Collection.php
+++ b/app/code/Magento/Cron/Model/Resource/Schedule/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/Model/Schedule.php
+++ b/app/code/Magento/Cron/Model/Schedule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/etc/adminhtml/system.xml
+++ b/app/code/Magento/Cron/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/etc/config.xml
+++ b/app/code/Magento/Cron/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/etc/crontab.xsd
+++ b/app/code/Magento/Cron/etc/crontab.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/etc/crontab/events.xml
+++ b/app/code/Magento/Cron/etc/crontab/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/etc/di.xml
+++ b/app/code/Magento/Cron/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/etc/module.xml
+++ b/app/code/Magento/Cron/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Cron/sql/cron_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Cron/sql/cron_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Matrix.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Matrix.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Services.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Services.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currencysymbol.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/Helper/Data.php
+++ b/app/code/Magento/CurrencySymbol/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/Model/Observer.php
+++ b/app/code/Magento/CurrencySymbol/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/Model/System/Currencysymbol.php
+++ b/app/code/Magento/CurrencySymbol/Model/System/Currencysymbol.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/etc/adminhtml/acl.xml
+++ b/app/code/Magento/CurrencySymbol/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/etc/adminhtml/menu.xml
+++ b/app/code/Magento/CurrencySymbol/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/etc/adminhtml/routes.xml
+++ b/app/code/Magento/CurrencySymbol/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/etc/di.xml
+++ b/app/code/Magento/CurrencySymbol/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/etc/events.xml
+++ b/app/code/Magento/CurrencySymbol/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/etc/module.xml
+++ b/app/code/Magento/CurrencySymbol/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/grid.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/grid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/layout/adminhtml_system_currencysymbol_index.xml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/layout/adminhtml_system_currencysymbol_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/system/currency/rate/matrix.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/system/currency/rate/matrix.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/system/currency/rate/services.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/system/currency/rate/services.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/system/currency/rates.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/system/currency/rates.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/AuthorizationLink.php
+++ b/app/code/Magento/Customer/Block/Account/AuthorizationLink.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/Dashboard.php
+++ b/app/code/Magento/Customer/Block/Account/Dashboard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/Dashboard/Address.php
+++ b/app/code/Magento/Customer/Block/Account/Dashboard/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/Dashboard/Block.php
+++ b/app/code/Magento/Customer/Block/Account/Dashboard/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/Dashboard/Hello.php
+++ b/app/code/Magento/Customer/Block/Account/Dashboard/Hello.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/Dashboard/Info.php
+++ b/app/code/Magento/Customer/Block/Account/Dashboard/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/Dashboard/Newsletter.php
+++ b/app/code/Magento/Customer/Block/Account/Dashboard/Newsletter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/Dashboard/Sidebar.php
+++ b/app/code/Magento/Customer/Block/Account/Dashboard/Sidebar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/Forgotpassword.php
+++ b/app/code/Magento/Customer/Block/Account/Forgotpassword.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/Link.php
+++ b/app/code/Magento/Customer/Block/Account/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/RegisterLink.php
+++ b/app/code/Magento/Customer/Block/Account/RegisterLink.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Account/Resetpassword.php
+++ b/app/code/Magento/Customer/Block/Account/Resetpassword.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Address/Book.php
+++ b/app/code/Magento/Customer/Block/Address/Book.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Address/Edit.php
+++ b/app/code/Magento/Customer/Block/Address/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Address/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/Customer/Block/Address/Renderer/DefaultRenderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Address/Renderer/RendererInterface.php
+++ b/app/code/Magento/Customer/Block/Address/Renderer/RendererInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Form/Edit.php
+++ b/app/code/Magento/Customer/Block/Form/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Form/Login.php
+++ b/app/code/Magento/Customer/Block/Form/Login.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Form/Register.php
+++ b/app/code/Magento/Customer/Block/Form/Register.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Newsletter.php
+++ b/app/code/Magento/Customer/Block/Newsletter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Widget/AbstractWidget.php
+++ b/app/code/Magento/Customer/Block/Widget/AbstractWidget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Widget/Dob.php
+++ b/app/code/Magento/Customer/Block/Widget/Dob.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Widget/Gender.php
+++ b/app/code/Magento/Customer/Block/Widget/Gender.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Widget/Name.php
+++ b/app/code/Magento/Customer/Block/Widget/Name.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Block/Widget/Taxvat.php
+++ b/app/code/Magento/Customer/Block/Widget/Taxvat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Controller/Account.php
+++ b/app/code/Magento/Customer/Controller/Account.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Controller/Address.php
+++ b/app/code/Magento/Customer/Controller/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Controller/Review.php
+++ b/app/code/Magento/Customer/Controller/Review.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Exception.php
+++ b/app/code/Magento/Customer/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Helper/Address.php
+++ b/app/code/Magento/Customer/Helper/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Helper/Data.php
+++ b/app/code/Magento/Customer/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Address.php
+++ b/app/code/Magento/Customer/Model/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Address/Config.php
+++ b/app/code/Magento/Customer/Model/Address/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Address/Config/Converter.php
+++ b/app/code/Magento/Customer/Model/Address/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Address/Config/Reader.php
+++ b/app/code/Magento/Customer/Model/Address/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Address/Config/SchemaLocator.php
+++ b/app/code/Magento/Customer/Model/Address/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Address/Form.php
+++ b/app/code/Magento/Customer/Model/Address/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute.php
+++ b/app/code/Magento/Customer/Model/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Backend/Data/Boolean.php
+++ b/app/code/Magento/Customer/Model/Attribute/Backend/Data/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/AbstractData.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/AbstractData.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/Boolean.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/Date.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/File.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/Hidden.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/Hidden.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/Image.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/Multiline.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/Multiline.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/Multiselect.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/Multiselect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/Postcode.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/Postcode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/Select.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/Text.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Attribute/Data/Textarea.php
+++ b/app/code/Magento/Customer/Model/Attribute/Data/Textarea.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Config/Backend/Address/Street.php
+++ b/app/code/Magento/Customer/Model/Config/Backend/Address/Street.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Config/Backend/Password/Link/Expirationperiod.php
+++ b/app/code/Magento/Customer/Model/Config/Backend/Password/Link/Expirationperiod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Config/Backend/Show/Address.php
+++ b/app/code/Magento/Customer/Model/Config/Backend/Show/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Config/Backend/Show/Customer.php
+++ b/app/code/Magento/Customer/Model/Config/Backend/Show/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Config/Share.php
+++ b/app/code/Magento/Customer/Model/Config/Share.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Config/Source/Address/Type.php
+++ b/app/code/Magento/Customer/Model/Config/Source/Address/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Config/Source/Group.php
+++ b/app/code/Magento/Customer/Model/Config/Source/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Config/Source/Group/Multiselect.php
+++ b/app/code/Magento/Customer/Model/Config/Source/Group/Multiselect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Customer.php
+++ b/app/code/Magento/Customer/Model/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Billing.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Billing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Password.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Password.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Shipping.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Store.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Website.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Customer/Attribute/Source/Group.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Source/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Customer/Attribute/Source/Store.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Source/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Customer/Attribute/Source/Website.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Source/Website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Form.php
+++ b/app/code/Magento/Customer/Model/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Group.php
+++ b/app/code/Magento/Customer/Model/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Observer.php
+++ b/app/code/Magento/Customer/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Address.php
+++ b/app/code/Magento/Customer/Model/Resource/Address.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Address/Attribute/Backend/Region.php
+++ b/app/code/Magento/Customer/Model/Resource/Address/Attribute/Backend/Region.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Address/Attribute/Collection.php
+++ b/app/code/Magento/Customer/Model/Resource/Address/Attribute/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Address/Attribute/Source/Country.php
+++ b/app/code/Magento/Customer/Model/Resource/Address/Attribute/Source/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Address/Attribute/Source/Region.php
+++ b/app/code/Magento/Customer/Model/Resource/Address/Attribute/Source/Region.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Address/Collection.php
+++ b/app/code/Magento/Customer/Model/Resource/Address/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Attribute.php
+++ b/app/code/Magento/Customer/Model/Resource/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Attribute/Collection.php
+++ b/app/code/Magento/Customer/Model/Resource/Attribute/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Customer.php
+++ b/app/code/Magento/Customer/Model/Resource/Customer.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Customer/Collection.php
+++ b/app/code/Magento/Customer/Model/Resource/Customer/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Customer/CustomersTypeOptions.php
+++ b/app/code/Magento/Customer/Model/Resource/Customer/CustomersTypeOptions.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Form/Attribute.php
+++ b/app/code/Magento/Customer/Model/Resource/Form/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Form/Attribute/Collection.php
+++ b/app/code/Magento/Customer/Model/Resource/Form/Attribute/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Group.php
+++ b/app/code/Magento/Customer/Model/Resource/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Group/Collection.php
+++ b/app/code/Magento/Customer/Model/Resource/Group/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Group/Grid/Collection.php
+++ b/app/code/Magento/Customer/Model/Resource/Group/Grid/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Resource/Setup.php
+++ b/app/code/Magento/Customer/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Model/Session.php
+++ b/app/code/Magento/Customer/Model/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/Service/Customer.php
+++ b/app/code/Magento/Customer/Service/Customer.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/data/customer_setup/data-upgrade-1.6.1.0-1.6.2.0.php
+++ b/app/code/Magento/Customer/data/customer_setup/data-upgrade-1.6.1.0-1.6.2.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/data/customer_setup/data-upgrade-1.6.2.0.1-1.6.2.0.2.php
+++ b/app/code/Magento/Customer/data/customer_setup/data-upgrade-1.6.2.0.1-1.6.2.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/address_formats.xml
+++ b/app/code/Magento/Customer/etc/address_formats.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/address_formats.xsd
+++ b/app/code/Magento/Customer/etc/address_formats.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/adminhtml/di.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/adminhtml/system.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/config.xml
+++ b/app/code/Magento/Customer/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/di.xml
+++ b/app/code/Magento/Customer/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/email_templates.xml
+++ b/app/code/Magento/Customer/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/events.xml
+++ b/app/code/Magento/Customer/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/fieldset.xml
+++ b/app/code/Magento/Customer/etc/fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/frontend/di.xml
+++ b/app/code/Magento/Customer/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/frontend/events.xml
+++ b/app/code/Magento/Customer/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/frontend/routes.xml
+++ b/app/code/Magento/Customer/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/module.xml
+++ b/app/code/Magento/Customer/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/etc/validation.xml
+++ b/app/code/Magento/Customer/etc/validation.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/sql/customer_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Customer/sql/customer_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/sql/customer_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/Magento/Customer/sql/customer_setup/mysql4-upgrade-1.6.0.0-1.6.1.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/sql/customer_setup/upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/Magento/Customer/sql/customer_setup/upgrade-1.6.0.0-1.6.1.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/sql/customer_setup/upgrade-1.6.1.0-1.6.2.0.php
+++ b/app/code/Magento/Customer/sql/customer_setup/upgrade-1.6.1.0-1.6.2.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/sql/customer_setup/upgrade-1.6.2.0-1.6.2.0.1.php
+++ b/app/code/Magento/Customer/sql/customer_setup/upgrade-1.6.2.0-1.6.2.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/sql/customer_setup/upgrade-1.6.2.0.1-1.6.2.0.3.php
+++ b/app/code/Magento/Customer/sql/customer_setup/upgrade-1.6.2.0.1-1.6.2.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/sql/customer_setup/upgrade-1.6.2.0.3-1.6.2.0.4.php
+++ b/app/code/Magento/Customer/sql/customer_setup/upgrade-1.6.2.0.3-1.6.2.0.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/account/dashboard.phtml
+++ b/app/code/Magento/Customer/view/frontend/account/dashboard.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/account/dashboard/address.phtml
+++ b/app/code/Magento/Customer/view/frontend/account/dashboard/address.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/account/dashboard/hello.phtml
+++ b/app/code/Magento/Customer/view/frontend/account/dashboard/hello.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/account/dashboard/info.phtml
+++ b/app/code/Magento/Customer/view/frontend/account/dashboard/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/account/dashboard/newsletter.phtml
+++ b/app/code/Magento/Customer/view/frontend/account/dashboard/newsletter.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/account/link/back.phtml
+++ b/app/code/Magento/Customer/view/frontend/account/link/back.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/account/navigation.phtml
+++ b/app/code/Magento/Customer/view/frontend/account/navigation.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/address.js
+++ b/app/code/Magento/Customer/view/frontend/address.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/address.phtml
+++ b/app/code/Magento/Customer/view/frontend/address.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/address/book.phtml
+++ b/app/code/Magento/Customer/view/frontend/address/book.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/address/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/address/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/balance.phtml
+++ b/app/code/Magento/Customer/view/frontend/balance.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/form/address.phtml
+++ b/app/code/Magento/Customer/view/frontend/form/address.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/form/changepassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/form/changepassword.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/form/confirmation.phtml
+++ b/app/code/Magento/Customer/view/frontend/form/confirmation.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/form/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/form/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/form/forgotpassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/form/forgotpassword.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/form/login.phtml
+++ b/app/code/Magento/Customer/view/frontend/form/login.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/form/mini.login.phtml
+++ b/app/code/Magento/Customer/view/frontend/form/mini.login.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/form/newsletter.phtml
+++ b/app/code/Magento/Customer/view/frontend/form/newsletter.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/form/register.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/form/resetforgottenpassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/form/resetforgottenpassword.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/js/checkout-balance.js
+++ b/app/code/Magento/Customer/view/frontend/js/checkout-balance.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_confirmation.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_confirmation.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_create.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_create.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_createpassword.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_createpassword.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_edit.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_forgotpassword.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_forgotpassword.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_index.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_login.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_login.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_logoutsuccess.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_logoutsuccess.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_address_form.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_address_form.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/customer_address_index.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_address_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/layout/default.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/logout.phtml
+++ b/app/code/Magento/Customer/view/frontend/logout.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/set-password.js
+++ b/app/code/Magento/Customer/view/frontend/set-password.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/widget/dob.phtml
+++ b/app/code/Magento/Customer/view/frontend/widget/dob.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/widget/gender.phtml
+++ b/app/code/Magento/Customer/view/frontend/widget/gender.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/widget/name.phtml
+++ b/app/code/Magento/Customer/view/frontend/widget/name.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Customer/view/frontend/widget/taxvat.phtml
+++ b/app/code/Magento/Customer/view/frontend/widget/taxvat.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Container.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Background.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Background.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/BackgroundUploader.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/BackgroundUploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Button.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Button.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/ColorPicker.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/ColorPicker.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Column.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Column.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Composite/AbstractComposite.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Composite/AbstractComposite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/ContainerInterface.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/ContainerInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Font.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Font.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/FontPicker.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/FontPicker.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/ImageUploader.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/ImageUploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Logo.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Logo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/LogoUploader.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/LogoUploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Uploader.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Element/Uploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/BackgroundUploader.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/BackgroundUploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Checkbox.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/ColorPicker.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/ColorPicker.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Column.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Column.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Composite.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Composite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Font.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Font.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/ImageUploader.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/ImageUploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/LogoUploader.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/LogoUploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Recursive.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Recursive.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Uploader.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Form/Renderer/Uploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/AbstractBlock.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/AbstractBlock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/Buttons.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/Buttons.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/Buttons/Edit.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/Buttons/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/Buttons/Save.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/Buttons/Save.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Block.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/Css.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/Css.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/Css/Group.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/Css/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/Custom.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/Custom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/ImageSizing.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/ImageSizing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/Js.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/Js.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/Content.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/Content.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/Content/Files.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/Content/Files.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/Content/Uploader.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/Content/Uploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/Tree.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/Tree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/AbstractTab.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/AbstractTab.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/Backgrounds.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/Backgrounds.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/Buttons.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/Buttons.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/Fonts.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/Fonts.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/Header.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/Tips.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/QuickStyles/Tips.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Settings.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Settings.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Tabs/AbstractTabs.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Tabs/AbstractTabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Tabs/Body.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Tabs/Body.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Button.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Button.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/SelectorList/AbstractSelectorList.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/SelectorList/AbstractSelectorList.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/SelectorList/Assigned.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/SelectorList/Assigned.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/SelectorList/Available.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/SelectorList/Available.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/SelectorList/Unassigned.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/SelectorList/Unassigned.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/StoreView.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/StoreView.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/Tab/AbstractTab.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/Tab/AbstractTab.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/Tab/Available.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/Tab/Available.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/Tab/Customizations.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/Tab/Customizations.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/Tabs.php
+++ b/app/code/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Controller/Adminhtml/System/Design/Editor.php
+++ b/app/code/Magento/DesignEditor/Controller/Adminhtml/System/Design/Editor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Controller/Adminhtml/System/Design/Editor/Files.php
+++ b/app/code/Magento/DesignEditor/Controller/Adminhtml/System/Design/Editor/Files.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Controller/Adminhtml/System/Design/Editor/Tools.php
+++ b/app/code/Magento/DesignEditor/Controller/Adminhtml/System/Design/Editor/Tools.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Controller/Varien/Router/Standard.php
+++ b/app/code/Magento/DesignEditor/Controller/Varien/Router/Standard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Helper/Data.php
+++ b/app/code/Magento/DesignEditor/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Area.php
+++ b/app/code/Magento/DesignEditor/Model/Area.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Config/Backend/File/RequestData.php
+++ b/app/code/Magento/DesignEditor/Model/Config/Backend/File/RequestData.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Config/Control/AbstractControl.php
+++ b/app/code/Magento/DesignEditor/Model/Config/Control/AbstractControl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Config/Control/ImageSizing.php
+++ b/app/code/Magento/DesignEditor/Model/Config/Control/ImageSizing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Config/Control/QuickStyles.php
+++ b/app/code/Magento/DesignEditor/Model/Config/Control/QuickStyles.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/Controls/Configuration.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/Controls/Configuration.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/Controls/Factory.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/Controls/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/ImageSizing/Validator.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/ImageSizing/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Form/Builder.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Form/Builder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Form/Element/Factory.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Form/Element/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Form/Renderer/Factory.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Form/Renderer/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/ImageUploader.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/ImageUploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/LogoUploader.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/LogoUploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Renderer.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Renderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Renderer/AbstractRenderer.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Renderer/AbstractRenderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Renderer/BackgroundImage.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Renderer/BackgroundImage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Renderer/DefaultRenderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Renderer/Factory.php
+++ b/app/code/Magento/DesignEditor/Model/Editor/Tools/QuickStyles/Renderer/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Observer.php
+++ b/app/code/Magento/DesignEditor/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Plugin/ThemeCopyService.php
+++ b/app/code/Magento/DesignEditor/Model/Plugin/ThemeCopyService.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/State.php
+++ b/app/code/Magento/DesignEditor/Model/State.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Theme/Change.php
+++ b/app/code/Magento/DesignEditor/Model/Theme/Change.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Theme/Context.php
+++ b/app/code/Magento/DesignEditor/Model/Theme/Context.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Theme/Customization/File/QuickStyleCss.php
+++ b/app/code/Magento/DesignEditor/Model/Theme/Customization/File/QuickStyleCss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Theme/Resource/Change.php
+++ b/app/code/Magento/DesignEditor/Model/Theme/Resource/Change.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Translate/InlineVde.php
+++ b/app/code/Magento/DesignEditor/Model/Translate/InlineVde.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Url/Factory.php
+++ b/app/code/Magento/DesignEditor/Model/Url/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/Model/Url/NavigationMode.php
+++ b/app/code/Magento/DesignEditor/Model/Url/NavigationMode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/adminhtml/acl.xml
+++ b/app/code/Magento/DesignEditor/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/adminhtml/menu.xml
+++ b/app/code/Magento/DesignEditor/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/adminhtml/routes.xml
+++ b/app/code/Magento/DesignEditor/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/config.xml
+++ b/app/code/Magento/DesignEditor/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/di.xml
+++ b/app/code/Magento/DesignEditor/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/events.xml
+++ b/app/code/Magento/DesignEditor/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/frontend/routes.xml
+++ b/app/code/Magento/DesignEditor/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/image_sizing.xsd
+++ b/app/code/Magento/DesignEditor/etc/image_sizing.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/module.xml
+++ b/app/code/Magento/DesignEditor/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/quick_styles.xsd
+++ b/app/code/Magento/DesignEditor/etc/quick_styles.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/etc/vde/events.xml
+++ b/app/code/Magento/DesignEditor/etc/vde/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/sql/designeditor_setup/install-1.0.0.1.php
+++ b/app/code/Magento/DesignEditor/sql/designeditor_setup/install-1.0.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/sql/designeditor_setup/upgrade-1.0.0.1-1.0.0.2.php
+++ b/app/code/Magento/DesignEditor/sql/designeditor_setup/upgrade-1.0.0.1-1.0.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/sql/designeditor_setup/upgrade-1.0.0.2-1.0.0.3.php
+++ b/app/code/Magento/DesignEditor/sql/designeditor_setup/upgrade-1.0.0.2-1.0.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/css/styles.css
+++ b/app/code/Magento/DesignEditor/view/adminhtml/css/styles.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/dialog.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/dialog.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/container.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/container.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/background-uploader.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/background-uploader.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/checkbox-utility.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/checkbox-utility.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/color-picker.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/color-picker.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/composite.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/composite.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/composite/children.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/composite/children.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/composite/wrapper.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/composite/wrapper.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/element/input.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/element/input.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/element/wrapper.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/element/wrapper.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/font.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/font.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/logo-uploader.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/logo-uploader.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/simple.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/simple.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/template.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/form/renderer/template.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/toolbar.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/toolbar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/toolbar/buttons.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/toolbar/buttons.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/toolbar/buttons/edit.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/toolbar/buttons/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/block.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/block.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/code/css.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/code/css.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/code/css/group.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/code/css/group.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/code/custom.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/code/custom.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/code/image-sizing.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/code/image-sizing.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/code/js.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/code/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/files/content.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/files/content.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/files/content/files.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/files/content/files.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/files/content/uploader.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/files/content/uploader.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/files/js.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/files/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/files/tree.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/files/tree.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/quick-styles/form.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/quick-styles/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/settings.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/settings.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/tabs.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/tabs.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/tabs/body.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/tabs/body.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/tabs/handle.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/tabs/handle.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/tabs/super-handle.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/editor/tools/tabs/super-handle.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/custom-css.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/custom-css.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/dialog.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/dialog.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/image-sizing.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/image-sizing.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/infinitescroll.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/infinitescroll.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/message.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/message.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/quick-style-element.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/quick-style-element.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/quick-style-uploader.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/quick-style-uploader.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/theme-assign.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/theme-assign.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/theme-delete.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/theme-delete.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/theme-edit.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/theme-edit.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/theme-revert.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/theme-revert.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/theme-save.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/theme-save.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/theme-selector.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/theme-selector.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/tools-files.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/tools-files.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/tools-panel.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/tools-panel.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/tools.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/tools.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/js/vde-frame.js
+++ b/app/code/Magento/DesignEditor/view/adminhtml/js/vde-frame.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_files_contents.xml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_files_contents.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_files_index.xml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_files_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_firstentrance.xml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_firstentrance.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_index.xml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_launch.xml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_launch.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_loadthemelist.xml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/layout/adminhtml_system_design_editor_loadthemelist.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/theme/available.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/theme/available.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/theme/button.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/theme/button.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/theme/customized.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/theme/customized.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/theme/list/available.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/theme/list/available.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/theme/list/available_ajax.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/theme/list/available_ajax.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/theme/list/customized.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/theme/list/customized.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/theme/selector/first_entrance.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/theme/selector/first_entrance.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/theme/selector/my_customizations_tab.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/theme/selector/my_customizations_tab.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/theme/selector/storeview.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/theme/selector/storeview.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/adminhtml/theme/selector/theme_edit.phtml
+++ b/app/code/Magento/DesignEditor/view/adminhtml/theme/selector/theme_edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/DesignEditor/view/frontend/translate_inline.phtml
+++ b/app/code/Magento/DesignEditor/view/frontend/translate_inline.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Block/Adminhtml/Frontend/Currency/Base.php
+++ b/app/code/Magento/Directory/Block/Adminhtml/Frontend/Currency/Base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/Magento/Directory/Block/Adminhtml/Frontend/Region/Updater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Block/Currency.php
+++ b/app/code/Magento/Directory/Block/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Controller/Currency.php
+++ b/app/code/Magento/Directory/Controller/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Exception.php
+++ b/app/code/Magento/Directory/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Helper/Data.php
+++ b/app/code/Magento/Directory/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Helper/Url.php
+++ b/app/code/Magento/Directory/Helper/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Config/Source/Allregion.php
+++ b/app/code/Magento/Directory/Model/Config/Source/Allregion.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Config/Source/Country.php
+++ b/app/code/Magento/Directory/Model/Config/Source/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Config/Source/Country/Full.php
+++ b/app/code/Magento/Directory/Model/Config/Source/Country/Full.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Country.php
+++ b/app/code/Magento/Directory/Model/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Country/Format.php
+++ b/app/code/Magento/Directory/Model/Country/Format.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/CountryFactory.php
+++ b/app/code/Magento/Directory/Model/CountryFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Currency.php
+++ b/app/code/Magento/Directory/Model/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Currency/DefaultLocator.php
+++ b/app/code/Magento/Directory/Model/Currency/DefaultLocator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Currency/Filter.php
+++ b/app/code/Magento/Directory/Model/Currency/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Currency/Import/AbstractImport.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/AbstractImport.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Currency/Import/Config.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Currency/Import/Factory.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Currency/Import/ImportInterface.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/ImportInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Currency/Import/Source/Service.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/Source/Service.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Currency/Import/Webservicex.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/Webservicex.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Observer.php
+++ b/app/code/Magento/Directory/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Region.php
+++ b/app/code/Magento/Directory/Model/Region.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/RegionFactory.php
+++ b/app/code/Magento/Directory/Model/RegionFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Resource/Country.php
+++ b/app/code/Magento/Directory/Model/Resource/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Resource/Country/Collection.php
+++ b/app/code/Magento/Directory/Model/Resource/Country/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Resource/Country/Format.php
+++ b/app/code/Magento/Directory/Model/Resource/Country/Format.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Resource/Country/Format/Collection.php
+++ b/app/code/Magento/Directory/Model/Resource/Country/Format/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Resource/Currency.php
+++ b/app/code/Magento/Directory/Model/Resource/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Resource/Region.php
+++ b/app/code/Magento/Directory/Model/Resource/Region.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Resource/Region/Collection.php
+++ b/app/code/Magento/Directory/Model/Resource/Region/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/Model/Resource/Setup.php
+++ b/app/code/Magento/Directory/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/data/directory_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Directory/data/directory_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/Directory/data/directory_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/etc/adminhtml/di.xml
+++ b/app/code/Magento/Directory/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/etc/adminhtml/system.xml
+++ b/app/code/Magento/Directory/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/etc/config.xml
+++ b/app/code/Magento/Directory/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/etc/crontab.xml
+++ b/app/code/Magento/Directory/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/etc/di.xml
+++ b/app/code/Magento/Directory/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/etc/email_templates.xml
+++ b/app/code/Magento/Directory/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/etc/frontend/routes.xml
+++ b/app/code/Magento/Directory/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/etc/module.xml
+++ b/app/code/Magento/Directory/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/sql/directory_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Directory/sql/directory_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/view/adminhtml/js/optional_zip_countries.phtml
+++ b/app/code/Magento/Directory/view/adminhtml/js/optional_zip_countries.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/view/frontend/currency.phtml
+++ b/app/code/Magento/Directory/view/frontend/currency.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/view/frontend/currency/switch.phtml
+++ b/app/code/Magento/Directory/view/frontend/currency/switch.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/view/frontend/js/optional_zip_countries.phtml
+++ b/app/code/Magento/Directory/view/frontend/js/optional_zip_countries.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/Directory/view/frontend/layout/catalog_category_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/view/frontend/layout/catalogsearch_advanced_index.xml
+++ b/app/code/Magento/Directory/view/frontend/layout/catalogsearch_advanced_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/view/frontend/layout/catalogsearch_advanced_result.xml
+++ b/app/code/Magento/Directory/view/frontend/layout/catalogsearch_advanced_result.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/Directory/view/frontend/layout/catalogsearch_result_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Directory/view/frontend/layout/default.xml
+++ b/app/code/Magento/Directory/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Downloadable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Sales/Items/Column/Downloadable/Name.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Sales/Items/Column/Downloadable/Name.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Catalog/Product/Links.php
+++ b/app/code/Magento/Downloadable/Block/Catalog/Product/Links.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Catalog/Product/View/Type.php
+++ b/app/code/Magento/Downloadable/Block/Catalog/Product/View/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Checkout/Cart/Item/Renderer.php
+++ b/app/code/Magento/Downloadable/Block/Checkout/Cart/Item/Renderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Checkout/Success.php
+++ b/app/code/Magento/Downloadable/Block/Checkout/Success.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Customer/Products/ListProducts.php
+++ b/app/code/Magento/Downloadable/Block/Customer/Products/ListProducts.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Sales/Order/Email/Items/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Sales/Order/Email/Items/Downloadable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Sales/Order/Email/Items/Order/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Sales/Order/Email/Items/Order/Downloadable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Block/Sales/Order/Item/Renderer/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Sales/Order/Item/Renderer/Downloadable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/File.php
+++ b/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit.php
+++ b/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Controller/Customer.php
+++ b/app/code/Magento/Downloadable/Controller/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Controller/Download.php
+++ b/app/code/Magento/Downloadable/Controller/Download.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Helper/Catalog/Product/Configuration.php
+++ b/app/code/Magento/Downloadable/Helper/Catalog/Product/Configuration.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Helper/Data.php
+++ b/app/code/Magento/Downloadable/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Helper/Download.php
+++ b/app/code/Magento/Downloadable/Helper/Download.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Helper/File.php
+++ b/app/code/Magento/Downloadable/Helper/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Link.php
+++ b/app/code/Magento/Downloadable/Model/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Link/Purchased.php
+++ b/app/code/Magento/Downloadable/Model/Link/Purchased.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Link/Purchased/Item.php
+++ b/app/code/Magento/Downloadable/Model/Link/Purchased/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Observer.php
+++ b/app/code/Magento/Downloadable/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Product/Price.php
+++ b/app/code/Magento/Downloadable/Model/Product/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Product/Type.php
+++ b/app/code/Magento/Downloadable/Model/Product/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Resource/Indexer/Price.php
+++ b/app/code/Magento/Downloadable/Model/Resource/Indexer/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Resource/Link.php
+++ b/app/code/Magento/Downloadable/Model/Resource/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Resource/Link/Collection.php
+++ b/app/code/Magento/Downloadable/Model/Resource/Link/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Resource/Link/Purchased.php
+++ b/app/code/Magento/Downloadable/Model/Resource/Link/Purchased.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Resource/Link/Purchased/Collection.php
+++ b/app/code/Magento/Downloadable/Model/Resource/Link/Purchased/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Resource/Link/Purchased/Item.php
+++ b/app/code/Magento/Downloadable/Model/Resource/Link/Purchased/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Resource/Link/Purchased/Item/Collection.php
+++ b/app/code/Magento/Downloadable/Model/Resource/Link/Purchased/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Resource/Sample.php
+++ b/app/code/Magento/Downloadable/Model/Resource/Sample.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Resource/Sample/Collection.php
+++ b/app/code/Magento/Downloadable/Model/Resource/Sample/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Sales/Order/Pdf/Items/AbstractItems.php
+++ b/app/code/Magento/Downloadable/Model/Sales/Order/Pdf/Items/AbstractItems.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Sales/Order/Pdf/Items/Creditmemo.php
+++ b/app/code/Magento/Downloadable/Model/Sales/Order/Pdf/Items/Creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Sales/Order/Pdf/Items/Invoice.php
+++ b/app/code/Magento/Downloadable/Model/Sales/Order/Pdf/Items/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/Sample.php
+++ b/app/code/Magento/Downloadable/Model/Sample.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/System/Config/Source/Contentdisposition.php
+++ b/app/code/Magento/Downloadable/Model/System/Config/Source/Contentdisposition.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/Model/System/Config/Source/Orderitemstatus.php
+++ b/app/code/Magento/Downloadable/Model/System/Config/Source/Orderitemstatus.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/data/downloadable_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Downloadable/data/downloadable_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/data/downloadable_setup/data-upgrade-1.6.0.0.2-1.6.0.0.3.php
+++ b/app/code/Magento/Downloadable/data/downloadable_setup/data-upgrade-1.6.0.0.2-1.6.0.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Downloadable/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/adminhtml/events.xml
+++ b/app/code/Magento/Downloadable/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Downloadable/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Downloadable/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/adminhtml/system.xml
+++ b/app/code/Magento/Downloadable/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/catalog_attributes.xml
+++ b/app/code/Magento/Downloadable/etc/catalog_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/config.xml
+++ b/app/code/Magento/Downloadable/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/di.xml
+++ b/app/code/Magento/Downloadable/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/fieldset.xml
+++ b/app/code/Magento/Downloadable/etc/fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/frontend/di.xml
+++ b/app/code/Magento/Downloadable/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/frontend/events.xml
+++ b/app/code/Magento/Downloadable/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/frontend/routes.xml
+++ b/app/code/Magento/Downloadable/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/module.xml
+++ b/app/code/Magento/Downloadable/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/pdf.xml
+++ b/app/code/Magento/Downloadable/etc/pdf.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/product_types.xml
+++ b/app/code/Magento/Downloadable/etc/product_types.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/etc/sales.xml
+++ b/app/code/Magento/Downloadable/etc/sales.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/sql/downloadable_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Downloadable/sql/downloadable_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/Magento/Downloadable/sql/downloadable_setup/mysql4-upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/Magento/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/Magento/Downloadable/sql/downloadable_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_catalog_product_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_catalog_product_downloadable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_catalog_product_simple.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_catalog_product_simple.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_catalog_product_virtual.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_catalog_product_virtual.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_customer_wishlist.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_customer_wishlist.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_creditmemo_new.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_creditmemo_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_creditmemo_updateqty.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_creditmemo_updateqty.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_creditmemo_view.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_creditmemo_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_invoice_new.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_invoice_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_invoice_updateqty.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_invoice_updateqty.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_invoice_view.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_invoice_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_view.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/adminhtml_sales_order_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_view_type_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_view_type_downloadable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/product/composite/fieldset/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/product/composite/fieldset/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/product/edit/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/product/edit/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/product/edit/downloadable/links.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/product/edit/downloadable/links.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/product/edit/downloadable/samples.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/product/edit/downloadable/samples.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/product/validation-rules.js
+++ b/app/code/Magento/Downloadable/view/adminhtml/product/validation-rules.js
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/sales/items/column/downloadable/creditmemo/name.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/sales/items/column/downloadable/creditmemo/name.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/sales/items/column/downloadable/invoice/name.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/sales/items/column/downloadable/invoice/name.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/sales/items/column/downloadable/name.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/sales/items/column/downloadable/name.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/sales/order/creditmemo/create/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/sales/order/creditmemo/create/items/renderer/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/sales/order/creditmemo/view/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/sales/order/creditmemo/view/items/renderer/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/sales/order/invoice/create/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/sales/order/invoice/create/items/renderer/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/sales/order/invoice/view/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/sales/order/invoice/view/items/renderer/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/adminhtml/sales/order/view/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/sales/order/view/items/renderer/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/catalog/product/links.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/catalog/product/links.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/catalog/product/samples.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/catalog/product/samples.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/catalog/product/type.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/catalog/product/type.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/checkout/cart/item/default.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/checkout/cart/item/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/checkout/multishipping/item/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/checkout/multishipping/item/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/checkout/onepage/review/item.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/checkout/onepage/review/item.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/checkout/success.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/checkout/success.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/customer/products/list.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/customer/products/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/downloadable.js
+++ b/app/code/Magento/Downloadable/view/frontend/downloadable.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/email/order/items/creditmemo/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/email/order/items/creditmemo/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/email/order/items/invoice/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/email/order/items/invoice/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/email/order/items/order/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/email/order/items/order/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/catalog_product_view_type_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/catalog_product_view_type_downloadable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_cart_configure_type_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_cart_configure_type_downloadable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_cart_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_multishipping_addresses.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_multishipping_addresses.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_multishipping_overview.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_multishipping_overview.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_multishipping_shipping.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_multishipping_shipping.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_multishipping_success.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_multishipping_success.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_onepage_review.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_onepage_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/checkout_onepage_success.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/checkout_onepage_success.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/customer_account.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/downloadable_customer_products.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/downloadable_customer_products.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/paypal_express_review.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/paypal_express_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/paypal_express_review_details.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/paypal_express_review_details.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/paypaluk_express_review.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/paypaluk_express_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/paypaluk_express_review_details.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/paypaluk_express_review_details.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_creditmemo_items.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_creditmemo_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_invoice_items.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_invoice_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_items.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_email_order_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_creditmemo.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_creditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_invoice.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_invoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_printorder.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_printorder.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_printordercreditmemo.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_printordercreditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_printorderinvoice.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_printorderinvoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_view.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_guest_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_creditmemo.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_creditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_invoice.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_invoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_printorder.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_printorder.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_printordercreditmemo.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_printordercreditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_printorderinvoice.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_printorderinvoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/layout/sales_order_view.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/sales_order_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/sales/order/creditmemo/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/sales/order/creditmemo/items/renderer/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/sales/order/invoice/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/sales/order/invoice/items/renderer/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Downloadable/view/frontend/sales/order/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/sales/order/items/renderer/downloadable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Js.php
+++ b/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Js.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Main/AbstractMain.php
+++ b/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Main/AbstractMain.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Options/AbstractOptions.php
+++ b/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Options/AbstractOptions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Options/Labels.php
+++ b/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Options/Labels.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Options/Options.php
+++ b/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Options/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Block/Adminhtml/Attribute/Grid/AbstractGrid.php
+++ b/app/code/Magento/Eav/Block/Adminhtml/Attribute/Grid/AbstractGrid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Exception.php
+++ b/app/code/Magento/Eav/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Helper/Data.php
+++ b/app/code/Magento/Eav/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Adminhtml/System/Config/Source/Inputtype.php
+++ b/app/code/Magento/Eav/Model/Adminhtml/System/Config/Source/Inputtype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Adminhtml/System/Config/Source/Inputtype/Validator.php
+++ b/app/code/Magento/Eav/Model/Adminhtml/System/Config/Source/Inputtype/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute.php
+++ b/app/code/Magento/Eav/Model/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/AbstractData.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/AbstractData.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/Boolean.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/Date.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/File.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/Hidden.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Hidden.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/Image.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/Multiline.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Multiline.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/Multiselect.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Multiselect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/Select.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Attribute/Data/Textarea.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Textarea.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/AttributeDataFactory.php
+++ b/app/code/Magento/Eav/Model/AttributeDataFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/AttributeFactory.php
+++ b/app/code/Magento/Eav/Model/AttributeFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Cache/Type.php
+++ b/app/code/Magento/Eav/Model/Cache/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Config.php
+++ b/app/code/Magento/Eav/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity.php
+++ b/app/code/Magento/Eav/Model/Entity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/AttributeInterface.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/AttributeInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/AbstractBackend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/AbstractBackend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/ArrayBackend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/ArrayBackend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/BackendInterface.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/BackendInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Datetime.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Datetime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/DefaultBackend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/DefaultBackend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Increment.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Increment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Serialized.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Serialized.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Store.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Time/Created.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Time/Created.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Time/Updated.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/Time/Updated.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Config.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Config/Converter.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Config/Reader.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Config/SchemaLocator.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Exception.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/AbstractFrontend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/AbstractFrontend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/Datetime.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/Datetime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/DefaultFrontend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/DefaultFrontend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/FrontendInterface.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/FrontendInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Group.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Option.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Set.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Set.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Boolean.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Config.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/SourceInterface.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/SourceInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Store.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/EntityInterface.php
+++ b/app/code/Magento/Eav/Model/Entity/EntityInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Increment/AbstractIncrement.php
+++ b/app/code/Magento/Eav/Model/Entity/Increment/AbstractIncrement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Increment/Alphanum.php
+++ b/app/code/Magento/Eav/Model/Entity/Increment/Alphanum.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Increment/IncrementInterface.php
+++ b/app/code/Magento/Eav/Model/Entity/Increment/IncrementInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Increment/Numeric.php
+++ b/app/code/Magento/Eav/Model/Entity/Increment/Numeric.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Setup.php
+++ b/app/code/Magento/Eav/Model/Entity/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Store.php
+++ b/app/code/Magento/Eav/Model/Entity/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Entity/Type.php
+++ b/app/code/Magento/Eav/Model/Entity/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Form.php
+++ b/app/code/Magento/Eav/Model/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Form/Element.php
+++ b/app/code/Magento/Eav/Model/Form/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Form/Factory.php
+++ b/app/code/Magento/Eav/Model/Form/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Form/Fieldset.php
+++ b/app/code/Magento/Eav/Model/Form/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Form/Type.php
+++ b/app/code/Magento/Eav/Model/Form/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Attribute.php
+++ b/app/code/Magento/Eav/Model/Resource/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Attribute/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Attribute/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Config.php
+++ b/app/code/Magento/Eav/Model/Resource/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Attribute.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Grid/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Group.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Group/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Group/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Option.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Option/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Option/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Set.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Set.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Set/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Attribute/Set/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Store.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Type.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Entity/Type/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Type/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Form/Attribute.php
+++ b/app/code/Magento/Eav/Model/Resource/Form/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Form/Attribute/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Form/Attribute/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Form/Element.php
+++ b/app/code/Magento/Eav/Model/Resource/Form/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Form/Element/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Form/Element/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Form/Fieldset.php
+++ b/app/code/Magento/Eav/Model/Resource/Form/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Form/Fieldset/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Form/Fieldset/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Form/Type.php
+++ b/app/code/Magento/Eav/Model/Resource/Form/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Form/Type/Collection.php
+++ b/app/code/Magento/Eav/Model/Resource/Form/Type/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Resource/Helper.php
+++ b/app/code/Magento/Eav/Model/Resource/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Validator/Attribute/Backend.php
+++ b/app/code/Magento/Eav/Model/Validator/Attribute/Backend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/Model/Validator/Attribute/Data.php
+++ b/app/code/Magento/Eav/Model/Validator/Attribute/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/data/eav_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/Eav/data/eav_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/etc/cache.xml
+++ b/app/code/Magento/Eav/etc/cache.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/etc/config.xml
+++ b/app/code/Magento/Eav/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/etc/di.xml
+++ b/app/code/Magento/Eav/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/etc/eav_attributes.xsd
+++ b/app/code/Magento/Eav/etc/eav_attributes.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/etc/module.xml
+++ b/app/code/Magento/Eav/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/etc/validation.xml
+++ b/app/code/Magento/Eav/etc/validation.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/sql/eav_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Eav/sql/eav_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/sql/eav_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/Magento/Eav/sql/eav_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Eav/view/adminhtml/attribute/edit/js.phtml
+++ b/app/code/Magento/Eav/view/adminhtml/attribute/edit/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Product/Helper/Form/Config.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Product/Helper/Form/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Form.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Giftoptions.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Giftoptions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Form.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Giftoptions.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Giftoptions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Items.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Helper/Data.php
+++ b/app/code/Magento/GiftMessage/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Helper/Message.php
+++ b/app/code/Magento/GiftMessage/Helper/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Helper/Url.php
+++ b/app/code/Magento/GiftMessage/Helper/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Model/Message.php
+++ b/app/code/Magento/GiftMessage/Model/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Model/Observer.php
+++ b/app/code/Magento/GiftMessage/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Model/Plugin/QuoteItem.php
+++ b/app/code/Magento/GiftMessage/Model/Plugin/QuoteItem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Model/Resource/Message.php
+++ b/app/code/Magento/GiftMessage/Model/Resource/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Model/Resource/Message/Collection.php
+++ b/app/code/Magento/GiftMessage/Model/Resource/Message/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Model/Resource/Setup.php
+++ b/app/code/Magento/GiftMessage/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/Model/TypeFactory.php
+++ b/app/code/Magento/GiftMessage/Model/TypeFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/data/giftmessage_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/GiftMessage/data/giftmessage_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/etc/adminhtml/di.xml
+++ b/app/code/Magento/GiftMessage/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/etc/adminhtml/events.xml
+++ b/app/code/Magento/GiftMessage/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/etc/adminhtml/system.xml
+++ b/app/code/Magento/GiftMessage/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/etc/catalog_attributes.xml
+++ b/app/code/Magento/GiftMessage/etc/catalog_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/etc/config.xml
+++ b/app/code/Magento/GiftMessage/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/etc/di.xml
+++ b/app/code/Magento/GiftMessage/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/etc/frontend/di.xml
+++ b/app/code/Magento/GiftMessage/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/etc/frontend/events.xml
+++ b/app/code/Magento/GiftMessage/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/etc/frontend/routes.xml
+++ b/app/code/Magento/GiftMessage/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/etc/module.xml
+++ b/app/code/Magento/GiftMessage/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/sql/giftmessage_setup/install-1.6.0.0.php
+++ b/app/code/Magento/GiftMessage/sql/giftmessage_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/form.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/giftoptionsform.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/giftoptionsform.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/helper.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/helper.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/layout/adminhtml_sales_order_create_index.xml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/layout/adminhtml_sales_order_create_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/layout/adminhtml_sales_order_create_load_block_data.xml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/layout/adminhtml_sales_order_create_load_block_data.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/layout/adminhtml_sales_order_create_load_block_items.xml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/layout/adminhtml_sales_order_create_load_block_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/layout/adminhtml_sales_order_view.xml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/layout/adminhtml_sales_order_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/popup.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/popup.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/sales/order/create/giftoptions.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/sales/order/create/giftoptions.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/sales/order/create/items.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/sales/order/create/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/sales/order/view/giftoptions.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/sales/order/view/giftoptions.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/adminhtml/sales/order/view/items.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/sales/order/view/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/frontend/gift-options.js
+++ b/app/code/Magento/GiftMessage/view/frontend/gift-options.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GiftMessage/view/frontend/inline.phtml
+++ b/app/code/Magento/GiftMessage/view/frontend/inline.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/Block/Code.php
+++ b/app/code/Magento/GoogleAdwords/Block/Code.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/Helper/Data.php
+++ b/app/code/Magento/GoogleAdwords/Helper/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/Model/Config/Backend/AbstractConversion.php
+++ b/app/code/Magento/GoogleAdwords/Model/Config/Backend/AbstractConversion.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/Model/Config/Backend/Color.php
+++ b/app/code/Magento/GoogleAdwords/Model/Config/Backend/Color.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/Model/Config/Backend/ConversionId.php
+++ b/app/code/Magento/GoogleAdwords/Model/Config/Backend/ConversionId.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/Model/Config/Source/Language.php
+++ b/app/code/Magento/GoogleAdwords/Model/Config/Source/Language.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/Model/Config/Source/ValueType.php
+++ b/app/code/Magento/GoogleAdwords/Model/Config/Source/ValueType.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/Model/Filter/UppercaseTitle.php
+++ b/app/code/Magento/GoogleAdwords/Model/Filter/UppercaseTitle.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/Model/Observer.php
+++ b/app/code/Magento/GoogleAdwords/Model/Observer.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/Model/Validator/Factory.php
+++ b/app/code/Magento/GoogleAdwords/Model/Validator/Factory.php
@@ -14,7 +14,7 @@ namespace Magento\GoogleAdwords\Model\Validator;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/etc/adminhtml/system.xml
+++ b/app/code/Magento/GoogleAdwords/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/etc/config.xml
+++ b/app/code/Magento/GoogleAdwords/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/etc/frontend/events.xml
+++ b/app/code/Magento/GoogleAdwords/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/etc/module.xml
+++ b/app/code/Magento/GoogleAdwords/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/view/frontend/code.phtml
+++ b/app/code/Magento/GoogleAdwords/view/frontend/code.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAdwords/view/frontend/layout/checkout_onepage_success.xml
+++ b/app/code/Magento/GoogleAdwords/view/frontend/layout/checkout_onepage_success.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAnalytics/Helper/Data.php
+++ b/app/code/Magento/GoogleAnalytics/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAnalytics/Model/Observer.php
+++ b/app/code/Magento/GoogleAnalytics/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAnalytics/etc/adminhtml/acl.xml
+++ b/app/code/Magento/GoogleAnalytics/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAnalytics/etc/adminhtml/system.xml
+++ b/app/code/Magento/GoogleAnalytics/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAnalytics/etc/frontend/events.xml
+++ b/app/code/Magento/GoogleAnalytics/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAnalytics/etc/module.xml
+++ b/app/code/Magento/GoogleAnalytics/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAnalytics/view/frontend/ga.phtml
+++ b/app/code/Magento/GoogleAnalytics/view/frontend/ga.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleAnalytics/view/frontend/layout/default.xml
+++ b/app/code/Magento/GoogleAnalytics/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Block/Adminhtml/Shipping/Applicable/Countries.php
+++ b/app/code/Magento/GoogleCheckout/Block/Adminhtml/Shipping/Applicable/Countries.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Block/Adminhtml/Shipping/Merchant.php
+++ b/app/code/Magento/GoogleCheckout/Block/Adminhtml/Shipping/Merchant.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Block/Form.php
+++ b/app/code/Magento/GoogleCheckout/Block/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Block/Link.php
+++ b/app/code/Magento/GoogleCheckout/Block/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Block/Redirect.php
+++ b/app/code/Magento/GoogleCheckout/Block/Redirect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Controller/Api.php
+++ b/app/code/Magento/GoogleCheckout/Controller/Api.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Controller/Redirect.php
+++ b/app/code/Magento/GoogleCheckout/Controller/Redirect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Exception.php
+++ b/app/code/Magento/GoogleCheckout/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Helper/Data.php
+++ b/app/code/Magento/GoogleCheckout/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Api.php
+++ b/app/code/Magento/GoogleCheckout/Model/Api.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Api/Debug.php
+++ b/app/code/Magento/GoogleCheckout/Model/Api/Debug.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Api/Xml/AbstractXml.php
+++ b/app/code/Magento/GoogleCheckout/Model/Api/Xml/AbstractXml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Api/Xml/Calculate.php
+++ b/app/code/Magento/GoogleCheckout/Model/Api/Xml/Calculate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Api/Xml/Callback.php
+++ b/app/code/Magento/GoogleCheckout/Model/Api/Xml/Callback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Api/Xml/Checkout.php
+++ b/app/code/Magento/GoogleCheckout/Model/Api/Xml/Checkout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Api/Xml/Order.php
+++ b/app/code/Magento/GoogleCheckout/Model/Api/Xml/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Notification.php
+++ b/app/code/Magento/GoogleCheckout/Model/Notification.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Observer.php
+++ b/app/code/Magento/GoogleCheckout/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Payment.php
+++ b/app/code/Magento/GoogleCheckout/Model/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Resource/Api/Debug.php
+++ b/app/code/Magento/GoogleCheckout/Model/Resource/Api/Debug.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Resource/Api/Debug/Collection.php
+++ b/app/code/Magento/GoogleCheckout/Model/Resource/Api/Debug/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Resource/Notification.php
+++ b/app/code/Magento/GoogleCheckout/Model/Resource/Notification.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Shipping.php
+++ b/app/code/Magento/GoogleCheckout/Model/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Source/Checkout/Image.php
+++ b/app/code/Magento/GoogleCheckout/Model/Source/Checkout/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Source/Locale.php
+++ b/app/code/Magento/GoogleCheckout/Model/Source/Locale.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Source/Shipping/Carrier.php
+++ b/app/code/Magento/GoogleCheckout/Model/Source/Shipping/Carrier.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Source/Shipping/Category.php
+++ b/app/code/Magento/GoogleCheckout/Model/Source/Shipping/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Source/Shipping/Units.php
+++ b/app/code/Magento/GoogleCheckout/Model/Source/Shipping/Units.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Source/Shipping/Virtual/Method.php
+++ b/app/code/Magento/GoogleCheckout/Model/Source/Shipping/Virtual/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/Model/Source/Shipping/Virtual/Schedule.php
+++ b/app/code/Magento/GoogleCheckout/Model/Source/Shipping/Virtual/Schedule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/etc/adminhtml/acl.xml
+++ b/app/code/Magento/GoogleCheckout/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/etc/adminhtml/events.xml
+++ b/app/code/Magento/GoogleCheckout/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/etc/adminhtml/system.xml
+++ b/app/code/Magento/GoogleCheckout/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/etc/catalog_attributes.xml
+++ b/app/code/Magento/GoogleCheckout/etc/catalog_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/etc/config.xml
+++ b/app/code/Magento/GoogleCheckout/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/etc/di.xml
+++ b/app/code/Magento/GoogleCheckout/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/etc/frontend/di.xml
+++ b/app/code/Magento/GoogleCheckout/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/etc/frontend/routes.xml
+++ b/app/code/Magento/GoogleCheckout/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/etc/module.xml
+++ b/app/code/Magento/GoogleCheckout/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/sql/googlecheckout_setup/install-1.6.0.0.php
+++ b/app/code/Magento/GoogleCheckout/sql/googlecheckout_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/sql/googlecheckout_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/GoogleCheckout/sql/googlecheckout_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/view/frontend/form.phtml
+++ b/app/code/Magento/GoogleCheckout/view/frontend/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/GoogleCheckout/view/frontend/layout/checkout_cart_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/view/frontend/layout/googlecheckout_redirect_redirect.xml
+++ b/app/code/Magento/GoogleCheckout/view/frontend/layout/googlecheckout_redirect_redirect.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleCheckout/view/frontend/link.phtml
+++ b/app/code/Magento/GoogleCheckout/view/frontend/link.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Block/AbstractCode.php
+++ b/app/code/Magento/GoogleOptimizer/Block/AbstractCode.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Block/Adminhtml/AbstractTab.php
+++ b/app/code/Magento/GoogleOptimizer/Block/Adminhtml/AbstractTab.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Block/Adminhtml/Catalog/Category/Edit/Tab/Googleoptimizer.php
+++ b/app/code/Magento/GoogleOptimizer/Block/Adminhtml/Catalog/Category/Edit/Tab/Googleoptimizer.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Block/Adminhtml/Catalog/Product/Edit/Tab/Googleoptimizer.php
+++ b/app/code/Magento/GoogleOptimizer/Block/Adminhtml/Catalog/Product/Edit/Tab/Googleoptimizer.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Block/Adminhtml/Cms/Page/Edit/Tab/Googleoptimizer.php
+++ b/app/code/Magento/GoogleOptimizer/Block/Adminhtml/Cms/Page/Edit/Tab/Googleoptimizer.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Block/Code/Category.php
+++ b/app/code/Magento/GoogleOptimizer/Block/Code/Category.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Block/Code/Page.php
+++ b/app/code/Magento/GoogleOptimizer/Block/Code/Page.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Block/Code/Product.php
+++ b/app/code/Magento/GoogleOptimizer/Block/Code/Product.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Helper/Code.php
+++ b/app/code/Magento/GoogleOptimizer/Helper/Code.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Helper/Data.php
+++ b/app/code/Magento/GoogleOptimizer/Helper/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Helper/Form.php
+++ b/app/code/Magento/GoogleOptimizer/Helper/Form.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Model/Code.php
+++ b/app/code/Magento/GoogleOptimizer/Model/Code.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Model/Observer/AbstractSave.php
+++ b/app/code/Magento/GoogleOptimizer/Model/Observer/AbstractSave.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Model/Observer/Block/Category/Tab.php
+++ b/app/code/Magento/GoogleOptimizer/Model/Observer/Block/Category/Tab.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Model/Observer/Category/Delete.php
+++ b/app/code/Magento/GoogleOptimizer/Model/Observer/Category/Delete.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Model/Observer/Category/Save.php
+++ b/app/code/Magento/GoogleOptimizer/Model/Observer/Category/Save.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Model/Observer/CmsPage/Delete.php
+++ b/app/code/Magento/GoogleOptimizer/Model/Observer/CmsPage/Delete.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Model/Observer/CmsPage/Save.php
+++ b/app/code/Magento/GoogleOptimizer/Model/Observer/CmsPage/Save.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Model/Observer/Product/Delete.php
+++ b/app/code/Magento/GoogleOptimizer/Model/Observer/Product/Delete.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Model/Observer/Product/Save.php
+++ b/app/code/Magento/GoogleOptimizer/Model/Observer/Product/Save.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/Model/Resource/Code.php
+++ b/app/code/Magento/GoogleOptimizer/Model/Resource/Code.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/etc/adminhtml/system.xml
+++ b/app/code/Magento/GoogleOptimizer/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/etc/config.xml
+++ b/app/code/Magento/GoogleOptimizer/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/etc/events.xml
+++ b/app/code/Magento/GoogleOptimizer/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/etc/module.xml
+++ b/app/code/Magento/GoogleOptimizer/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/sql/googleoptimizer_setup/install-2.0.0.0.php
+++ b/app/code/Magento/GoogleOptimizer/sql/googleoptimizer_setup/install-2.0.0.0.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/view/adminhtml/layout/adminhtml_catalog_product_new.xml
+++ b/app/code/Magento/GoogleOptimizer/view/adminhtml/layout/adminhtml_catalog_product_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/view/adminhtml/layout/adminhtml_cms_page_edit.xml
+++ b/app/code/Magento/GoogleOptimizer/view/adminhtml/layout/adminhtml_cms_page_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/GoogleOptimizer/view/frontend/layout/catalog_category_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/GoogleOptimizer/view/frontend/layout/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleOptimizer/view/frontend/layout/cms_page_view.xml
+++ b/app/code/Magento/GoogleOptimizer/view/frontend/layout/cms_page_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Captcha.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Captcha.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Items.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Items/Item.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Items/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Items/Product.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Items/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Items/Renderer/Id.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Items/Renderer/Id.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Store/Switcher.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Store/Switcher.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Types.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Types.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Types/Edit.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Types/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Types/Edit/Attributes.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Types/Edit/Attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Types/Edit/Form.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Types/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Types/Edit/Select.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Types/Edit/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/Adminhtml/Types/Renderer/Country.php
+++ b/app/code/Magento/GoogleShopping/Block/Adminhtml/Types/Renderer/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Block/SiteVerification.php
+++ b/app/code/Magento/GoogleShopping/Block/SiteVerification.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Controller/Adminhtml/Googleshopping/Items.php
+++ b/app/code/Magento/GoogleShopping/Controller/Adminhtml/Googleshopping/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Controller/Adminhtml/Googleshopping/Selection.php
+++ b/app/code/Magento/GoogleShopping/Controller/Adminhtml/Googleshopping/Selection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Controller/Adminhtml/Googleshopping/Types.php
+++ b/app/code/Magento/GoogleShopping/Controller/Adminhtml/Googleshopping/Types.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Helper/Category.php
+++ b/app/code/Magento/GoogleShopping/Helper/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Helper/Data.php
+++ b/app/code/Magento/GoogleShopping/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Helper/Price.php
+++ b/app/code/Magento/GoogleShopping/Helper/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Helper/Product.php
+++ b/app/code/Magento/GoogleShopping/Helper/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/Availability.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/Availability.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/Condition.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/Condition.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/Content.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/Content.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/ContentLanguage.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/ContentLanguage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/DefaultAttribute.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/DefaultAttribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/Destinations.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/Destinations.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/GoogleProductCategory.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/GoogleProductCategory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/Id.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/Id.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/ImageLink.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/ImageLink.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/Link.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/Price.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/ProductType.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/ProductType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/Quantity.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/Quantity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/SalePriceEffectiveDate.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/SalePriceEffectiveDate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/ShippingWeight.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/ShippingWeight.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/TargetCountry.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/TargetCountry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/Tax.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Attribute/Title.php
+++ b/app/code/Magento/GoogleShopping/Model/Attribute/Title.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/AttributeFactory.php
+++ b/app/code/Magento/GoogleShopping/Model/AttributeFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Config.php
+++ b/app/code/Magento/GoogleShopping/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Flag.php
+++ b/app/code/Magento/GoogleShopping/Model/Flag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Item.php
+++ b/app/code/Magento/GoogleShopping/Model/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/MassOperations.php
+++ b/app/code/Magento/GoogleShopping/Model/MassOperations.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Observer.php
+++ b/app/code/Magento/GoogleShopping/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Resource/Attribute.php
+++ b/app/code/Magento/GoogleShopping/Model/Resource/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Resource/Attribute/Collection.php
+++ b/app/code/Magento/GoogleShopping/Model/Resource/Attribute/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Resource/Grid/Collection.php
+++ b/app/code/Magento/GoogleShopping/Model/Resource/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Resource/Item.php
+++ b/app/code/Magento/GoogleShopping/Model/Resource/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Resource/Item/Collection.php
+++ b/app/code/Magento/GoogleShopping/Model/Resource/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Resource/Setup.php
+++ b/app/code/Magento/GoogleShopping/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Resource/Type.php
+++ b/app/code/Magento/GoogleShopping/Model/Resource/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Resource/Type/Collection.php
+++ b/app/code/Magento/GoogleShopping/Model/Resource/Type/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Service.php
+++ b/app/code/Magento/GoogleShopping/Model/Service.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Service/Item.php
+++ b/app/code/Magento/GoogleShopping/Model/Service/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Source/Accounttype.php
+++ b/app/code/Magento/GoogleShopping/Model/Source/Accounttype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Source/Authtype.php
+++ b/app/code/Magento/GoogleShopping/Model/Source/Authtype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Source/Country.php
+++ b/app/code/Magento/GoogleShopping/Model/Source/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Source/Destinationstates.php
+++ b/app/code/Magento/GoogleShopping/Model/Source/Destinationstates.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Source/Statuses.php
+++ b/app/code/Magento/GoogleShopping/Model/Source/Statuses.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/Model/Type.php
+++ b/app/code/Magento/GoogleShopping/Model/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/data/googleshopping_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/GoogleShopping/data/googleshopping_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/etc/adminhtml/acl.xml
+++ b/app/code/Magento/GoogleShopping/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/etc/adminhtml/di.xml
+++ b/app/code/Magento/GoogleShopping/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/etc/adminhtml/events.xml
+++ b/app/code/Magento/GoogleShopping/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/etc/adminhtml/menu.xml
+++ b/app/code/Magento/GoogleShopping/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/etc/adminhtml/routes.xml
+++ b/app/code/Magento/GoogleShopping/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/etc/adminhtml/system.xml
+++ b/app/code/Magento/GoogleShopping/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/etc/config.xml
+++ b/app/code/Magento/GoogleShopping/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/etc/di.xml
+++ b/app/code/Magento/GoogleShopping/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/etc/module.xml
+++ b/app/code/Magento/GoogleShopping/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/sql/googleshopping_setup/install-1.6.0.0.php
+++ b/app/code/Magento/GoogleShopping/sql/googleshopping_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/sql/googleshopping_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/Magento/GoogleShopping/sql/googleshopping_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/adminhtml/captcha.phtml
+++ b/app/code/Magento/GoogleShopping/view/adminhtml/captcha.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/adminhtml/googleshopping.js
+++ b/app/code/Magento/GoogleShopping/view/adminhtml/googleshopping.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/adminhtml/items.phtml
+++ b/app/code/Magento/GoogleShopping/view/adminhtml/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/adminhtml/layout/adminhtml_googleshopping_items_index.xml
+++ b/app/code/Magento/GoogleShopping/view/adminhtml/layout/adminhtml_googleshopping_items_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/adminhtml/layout/adminhtml_googleshopping_types_block.xml
+++ b/app/code/Magento/GoogleShopping/view/adminhtml/layout/adminhtml_googleshopping_types_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/adminhtml/layout/adminhtml_googleshopping_types_grid.xml
+++ b/app/code/Magento/GoogleShopping/view/adminhtml/layout/adminhtml_googleshopping_types_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/adminhtml/layout/adminhtml_googleshopping_types_index.xml
+++ b/app/code/Magento/GoogleShopping/view/adminhtml/layout/adminhtml_googleshopping_types_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/adminhtml/types/edit.phtml
+++ b/app/code/Magento/GoogleShopping/view/adminhtml/types/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/adminhtml/types/edit/attributes.phtml
+++ b/app/code/Magento/GoogleShopping/view/adminhtml/types/edit/attributes.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/adminhtml/types/edit/select.phtml
+++ b/app/code/Magento/GoogleShopping/view/adminhtml/types/edit/select.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/GoogleShopping/view/frontend/layout/cms_index_index.xml
+++ b/app/code/Magento/GoogleShopping/view/frontend/layout/cms_index_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Export/Edit.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Export/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Export/Edit/Form.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Export/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Export/Filter.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Export/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Form/After.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Form/After.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Before.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Before.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Form.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Import/Frame/Result.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Import/Frame/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Helper/Data.php
+++ b/app/code/Magento/ImportExport/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/AbstractModel.php
+++ b/app/code/Magento/ImportExport/Model/AbstractModel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export.php
+++ b/app/code/Magento/ImportExport/Model/Export.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Export/AbstractEntity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Adapter/AbstractAdapter.php
+++ b/app/code/Magento/ImportExport/Model/Export/Adapter/AbstractAdapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Adapter/Csv.php
+++ b/app/code/Magento/ImportExport/Model/Export/Adapter/Csv.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Adapter/Factory.php
+++ b/app/code/Magento/ImportExport/Model/Export/Adapter/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Config.php
+++ b/app/code/Magento/ImportExport/Model/Export/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Config/Converter.php
+++ b/app/code/Magento/ImportExport/Model/Export/Config/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Config/Reader.php
+++ b/app/code/Magento/ImportExport/Model/Export/Config/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Config/SchemaLocator.php
+++ b/app/code/Magento/ImportExport/Model/Export/Config/SchemaLocator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/ConfigInterface.php
+++ b/app/code/Magento/ImportExport/Model/Export/ConfigInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEav.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEav.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/Eav/Customer.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/Eav/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/Eav/Customer/Address.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/Eav/Customer/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/Factory.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/Product.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/Product/Type/AbstractType.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/Product/Type/AbstractType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/Product/Type/Configurable.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/Product/Type/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/Product/Type/Factory.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/Product/Type/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/Product/Type/Grouped.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/Product/Type/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Entity/Product/Type/Simple.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/Product/Type/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Export/Factory.php
+++ b/app/code/Magento/ImportExport/Model/Export/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import.php
+++ b/app/code/Magento/ImportExport/Model/Import.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/AbstractEntity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/AbstractSource.php
+++ b/app/code/Magento/ImportExport/Model/Import/AbstractSource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Adapter.php
+++ b/app/code/Magento/ImportExport/Model/Import/Adapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Config.php
+++ b/app/code/Magento/ImportExport/Model/Import/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Config/Converter.php
+++ b/app/code/Magento/ImportExport/Model/Import/Config/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Config/Reader.php
+++ b/app/code/Magento/ImportExport/Model/Import/Config/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Config/SchemaLocator.php
+++ b/app/code/Magento/ImportExport/Model/Import/Config/SchemaLocator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/ConfigInterface.php
+++ b/app/code/Magento/ImportExport/Model/Import/ConfigInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEav.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEav.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/CustomerComposite.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/CustomerComposite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Eav/AbstractCustomer.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Eav/AbstractCustomer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Eav/Customer.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Eav/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Eav/Customer/Address.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Eav/Customer/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Factory.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Product.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Product/Option.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Product/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Product/Type/AbstractType.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Product/Type/AbstractType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Product/Type/Configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Product/Type/Factory.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Product/Type/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Product/Type/Grouped.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Product/Type/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Product/Type/Simple.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Product/Type/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Proxy/Product.php
+++ b/app/code/Magento/ImportExport/Model/Import/Proxy/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Proxy/Product/Resource.php
+++ b/app/code/Magento/ImportExport/Model/Import/Proxy/Product/Resource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Source/Csv.php
+++ b/app/code/Magento/ImportExport/Model/Import/Source/Csv.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Import/Uploader.php
+++ b/app/code/Magento/ImportExport/Model/Import/Uploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Resource/CollectionByPagesIterator.php
+++ b/app/code/Magento/ImportExport/Model/Resource/CollectionByPagesIterator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Resource/Customer/Storage.php
+++ b/app/code/Magento/ImportExport/Model/Resource/Customer/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Resource/Helper.php
+++ b/app/code/Magento/ImportExport/Model/Resource/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Resource/Import/CustomerComposite/Data.php
+++ b/app/code/Magento/ImportExport/Model/Resource/Import/CustomerComposite/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Resource/Import/Data.php
+++ b/app/code/Magento/ImportExport/Model/Resource/Import/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Source/Export/Entity.php
+++ b/app/code/Magento/ImportExport/Model/Source/Export/Entity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Source/Export/Format.php
+++ b/app/code/Magento/ImportExport/Model/Source/Export/Format.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Source/Import/AbstractBehavior.php
+++ b/app/code/Magento/ImportExport/Model/Source/Import/AbstractBehavior.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Source/Import/Behavior/Basic.php
+++ b/app/code/Magento/ImportExport/Model/Source/Import/Behavior/Basic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Source/Import/Behavior/Custom.php
+++ b/app/code/Magento/ImportExport/Model/Source/Import/Behavior/Custom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Source/Import/Behavior/Factory.php
+++ b/app/code/Magento/ImportExport/Model/Source/Import/Behavior/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/Model/Source/Import/Entity.php
+++ b/app/code/Magento/ImportExport/Model/Source/Import/Entity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/adminhtml/acl.xml
+++ b/app/code/Magento/ImportExport/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/adminhtml/menu.xml
+++ b/app/code/Magento/ImportExport/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/adminhtml/routes.xml
+++ b/app/code/Magento/ImportExport/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/config.xml
+++ b/app/code/Magento/ImportExport/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/di.xml
+++ b/app/code/Magento/ImportExport/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/export.xml
+++ b/app/code/Magento/ImportExport/etc/export.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/export.xsd
+++ b/app/code/Magento/ImportExport/etc/export.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/export_merged.xsd
+++ b/app/code/Magento/ImportExport/etc/export_merged.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/import.xml
+++ b/app/code/Magento/ImportExport/etc/import.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/import.xsd
+++ b/app/code/Magento/ImportExport/etc/import.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/import_merged.xsd
+++ b/app/code/Magento/ImportExport/etc/import_merged.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/etc/module.xml
+++ b/app/code/Magento/ImportExport/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/sql/importexport_setup/install-1.6.0.0.php
+++ b/app/code/Magento/ImportExport/sql/importexport_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/sql/importexport_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/Magento/ImportExport/sql/importexport_setup/mysql4-upgrade-1.6.0.1-1.6.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/sql/importexport_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/Magento/ImportExport/sql/importexport_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/sql/importexport_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/Magento/ImportExport/sql/importexport_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/busy.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/busy.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/export/form/after.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/export/form/after.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/export/form/before.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/export/form/before.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/export/form/filter/after.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/export/form/filter/after.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/import/form/after.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/import/form/after.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/import/form/before.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/import/form/before.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/import/frame/result.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/import/frame/result.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_export_getfilter.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_export_getfilter.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_export_index.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_export_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_busy.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_busy.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_index.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_start.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_start.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_validate.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/layout/adminhtml_import_validate.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Block/Adminhtml/Process.php
+++ b/app/code/Magento/Index/Block/Adminhtml/Process.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Block/Adminhtml/Process/Edit.php
+++ b/app/code/Magento/Index/Block/Adminhtml/Process/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Block/Adminhtml/Process/Edit/Form.php
+++ b/app/code/Magento/Index/Block/Adminhtml/Process/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Block/Adminhtml/Process/Edit/Tab/Main.php
+++ b/app/code/Magento/Index/Block/Adminhtml/Process/Edit/Tab/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Block/Adminhtml/Process/Edit/Tabs.php
+++ b/app/code/Magento/Index/Block/Adminhtml/Process/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Block/Adminhtml/Process/Grid.php
+++ b/app/code/Magento/Index/Block/Adminhtml/Process/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Block/Adminhtml/Process/Grid/Massaction.php
+++ b/app/code/Magento/Index/Block/Adminhtml/Process/Grid/Massaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Controller/Adminhtml/Process.php
+++ b/app/code/Magento/Index/Controller/Adminhtml/Process.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Helper/Data.php
+++ b/app/code/Magento/Index/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/EntryPoint/Indexer.php
+++ b/app/code/Magento/Index/Model/EntryPoint/Indexer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/EntryPoint/Shell.php
+++ b/app/code/Magento/Index/Model/EntryPoint/Shell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/EntryPoint/Shell/ErrorHandler.php
+++ b/app/code/Magento/Index/Model/EntryPoint/Shell/ErrorHandler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Event.php
+++ b/app/code/Magento/Index/Model/Event.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/EventRepository.php
+++ b/app/code/Magento/Index/Model/EventRepository.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Indexer.php
+++ b/app/code/Magento/Index/Model/Indexer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Indexer/AbstractIndexer.php
+++ b/app/code/Magento/Index/Model/Indexer/AbstractIndexer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Indexer/Config.php
+++ b/app/code/Magento/Index/Model/Indexer/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Indexer/Config/Converter.php
+++ b/app/code/Magento/Index/Model/Indexer/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Indexer/Config/Reader.php
+++ b/app/code/Magento/Index/Model/Indexer/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Indexer/Config/SchemaLocator.php
+++ b/app/code/Magento/Index/Model/Indexer/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Indexer/ConfigInterface.php
+++ b/app/code/Magento/Index/Model/Indexer/ConfigInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Indexer/Factory.php
+++ b/app/code/Magento/Index/Model/Indexer/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/IndexerInterface.php
+++ b/app/code/Magento/Index/Model/IndexerInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Lock/Storage.php
+++ b/app/code/Magento/Index/Model/Lock/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Observer.php
+++ b/app/code/Magento/Index/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Process.php
+++ b/app/code/Magento/Index/Model/Process.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Process/File.php
+++ b/app/code/Magento/Index/Model/Process/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Process/FileFactory.php
+++ b/app/code/Magento/Index/Model/Process/FileFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Resource/AbstractResource.php
+++ b/app/code/Magento/Index/Model/Resource/AbstractResource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Resource/Event.php
+++ b/app/code/Magento/Index/Model/Resource/Event.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Resource/Event/Collection.php
+++ b/app/code/Magento/Index/Model/Resource/Event/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Resource/Process.php
+++ b/app/code/Magento/Index/Model/Resource/Process.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Resource/Process/Collection.php
+++ b/app/code/Magento/Index/Model/Resource/Process/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Resource/Setup.php
+++ b/app/code/Magento/Index/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/Shell.php
+++ b/app/code/Magento/Index/Model/Shell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/Model/System/Message/IndexOutdated.php
+++ b/app/code/Magento/Index/Model/System/Message/IndexOutdated.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Index/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/etc/adminhtml/di.xml
+++ b/app/code/Magento/Index/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Index/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Index/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/etc/di.xml
+++ b/app/code/Magento/Index/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/etc/events.xml
+++ b/app/code/Magento/Index/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/etc/indexers.xsd
+++ b/app/code/Magento/Index/etc/indexers.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/etc/indexers_merged.xsd
+++ b/app/code/Magento/Index/etc/indexers_merged.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/etc/module.xml
+++ b/app/code/Magento/Index/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/sql/index_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Index/sql/index_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Index/view/adminhtml/layout/adminhtml_process_edit.xml
+++ b/app/code/Magento/Index/view/adminhtml/layout/adminhtml_process_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/AbstractBlock.php
+++ b/app/code/Magento/Install/Block/AbstractBlock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/Admin.php
+++ b/app/code/Magento/Install/Block/Admin.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/Begin.php
+++ b/app/code/Magento/Install/Block/Begin.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/Config.php
+++ b/app/code/Magento/Install/Block/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/Db/Main.php
+++ b/app/code/Magento/Install/Block/Db/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/Db/Type.php
+++ b/app/code/Magento/Install/Block/Db/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/Db/Type/Mysql4.php
+++ b/app/code/Magento/Install/Block/Db/Type/Mysql4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/Download.php
+++ b/app/code/Magento/Install/Block/Download.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/End.php
+++ b/app/code/Magento/Install/Block/End.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/Locale.php
+++ b/app/code/Magento/Install/Block/Locale.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Block/State.php
+++ b/app/code/Magento/Install/Block/State.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Controller/Action.php
+++ b/app/code/Magento/Install/Controller/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Controller/Index.php
+++ b/app/code/Magento/Install/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Controller/Wizard.php
+++ b/app/code/Magento/Install/Controller/Wizard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Helper/Data.php
+++ b/app/code/Magento/Install/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Config.php
+++ b/app/code/Magento/Install/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Config/Converter.php
+++ b/app/code/Magento/Install/Model/Config/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Config/Data.php
+++ b/app/code/Magento/Install/Model/Config/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Config/Reader.php
+++ b/app/code/Magento/Install/Model/Config/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Config/SchemaLocator.php
+++ b/app/code/Magento/Install/Model/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/EntryPoint/Console.php
+++ b/app/code/Magento/Install/Model/EntryPoint/Console.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/EntryPoint/Output.php
+++ b/app/code/Magento/Install/Model/EntryPoint/Output.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/EntryPoint/Upgrade.php
+++ b/app/code/Magento/Install/Model/EntryPoint/Upgrade.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer.php
+++ b/app/code/Magento/Install/Model/Installer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer/AbstractInstaller.php
+++ b/app/code/Magento/Install/Model/Installer/AbstractInstaller.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer/Config.php
+++ b/app/code/Magento/Install/Model/Installer/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer/Console.php
+++ b/app/code/Magento/Install/Model/Installer/Console.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer/Data.php
+++ b/app/code/Magento/Install/Model/Installer/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer/Db.php
+++ b/app/code/Magento/Install/Model/Installer/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer/Db/AbstractDb.php
+++ b/app/code/Magento/Install/Model/Installer/Db/AbstractDb.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer/Db/Factory.php
+++ b/app/code/Magento/Install/Model/Installer/Db/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer/Db/Mysql4.php
+++ b/app/code/Magento/Install/Model/Installer/Db/Mysql4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer/Filesystem.php
+++ b/app/code/Magento/Install/Model/Installer/Filesystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Installer/Pear.php
+++ b/app/code/Magento/Install/Model/Installer/Pear.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Observer.php
+++ b/app/code/Magento/Install/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/Model/Wizard.php
+++ b/app/code/Magento/Install/Model/Wizard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/etc/di.xml
+++ b/app/code/Magento/Install/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/etc/frontend/di.xml
+++ b/app/code/Magento/Install/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/etc/frontend/routes.xml
+++ b/app/code/Magento/Install/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/etc/install/events.xml
+++ b/app/code/Magento/Install/etc/install/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/etc/install_wizard.xml
+++ b/app/code/Magento/Install/etc/install_wizard.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/etc/install_wizard.xsd
+++ b/app/code/Magento/Install/etc/install_wizard.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/etc/install_wizard_file.xsd
+++ b/app/code/Magento/Install/etc/install_wizard_file.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/etc/module.xml
+++ b/app/code/Magento/Install/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/begin.phtml
+++ b/app/code/Magento/Install/view/install/begin.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/config.phtml
+++ b/app/code/Magento/Install/view/install/config.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/create_admin.phtml
+++ b/app/code/Magento/Install/view/install/create_admin.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/css/mage-js-ee-style.css
+++ b/app/code/Magento/Install/view/install/css/mage-js-ee-style.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/css/mage-js-style.css
+++ b/app/code/Magento/Install/view/install/css/mage-js-style.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/css/validate.css
+++ b/app/code/Magento/Install/view/install/css/validate.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/db/main.phtml
+++ b/app/code/Magento/Install/view/install/db/main.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/db/mysql4.phtml
+++ b/app/code/Magento/Install/view/install/db/mysql4.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/download.phtml
+++ b/app/code/Magento/Install/view/install/download.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/end.phtml
+++ b/app/code/Magento/Install/view/install/end.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/js/install.js
+++ b/app/code/Magento/Install/view/install/js/install.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/layout/install_wizard.xml
+++ b/app/code/Magento/Install/view/install/layout/install_wizard.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/layout/install_wizard_config.xml
+++ b/app/code/Magento/Install/view/install/layout/install_wizard_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/locale.phtml
+++ b/app/code/Magento/Install/view/install/locale.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/page.phtml
+++ b/app/code/Magento/Install/view/install/page.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Install/view/install/state.phtml
+++ b/app/code/Magento/Install/view/install/state.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Helper/Data.php
+++ b/app/code/Magento/Log/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Aggregation.php
+++ b/app/code/Magento/Log/Model/Aggregation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Cron.php
+++ b/app/code/Magento/Log/Model/Cron.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Customer.php
+++ b/app/code/Magento/Log/Model/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/EntryPoint/Shell.php
+++ b/app/code/Magento/Log/Model/EntryPoint/Shell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Log.php
+++ b/app/code/Magento/Log/Model/Log.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Aggregation.php
+++ b/app/code/Magento/Log/Model/Resource/Aggregation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Customer.php
+++ b/app/code/Magento/Log/Model/Resource/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Helper.php
+++ b/app/code/Magento/Log/Model/Resource/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Log.php
+++ b/app/code/Magento/Log/Model/Resource/Log.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Shell.php
+++ b/app/code/Magento/Log/Model/Resource/Shell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Visitor.php
+++ b/app/code/Magento/Log/Model/Resource/Visitor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Visitor/Collection.php
+++ b/app/code/Magento/Log/Model/Resource/Visitor/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Visitor/Online.php
+++ b/app/code/Magento/Log/Model/Resource/Visitor/Online.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Visitor/Online/Collection.php
+++ b/app/code/Magento/Log/Model/Resource/Visitor/Online/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Visitor/Online/Grid/Collection.php
+++ b/app/code/Magento/Log/Model/Resource/Visitor/Online/Grid/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Resource/Visitor/Online/Grid/Row/UrlGenerator.php
+++ b/app/code/Magento/Log/Model/Resource/Visitor/Online/Grid/Row/UrlGenerator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Shell.php
+++ b/app/code/Magento/Log/Model/Shell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Shell/Command/Clean.php
+++ b/app/code/Magento/Log/Model/Shell/Command/Clean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Shell/Command/Factory.php
+++ b/app/code/Magento/Log/Model/Shell/Command/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Shell/Command/Status.php
+++ b/app/code/Magento/Log/Model/Shell/Command/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Shell/CommandInterface.php
+++ b/app/code/Magento/Log/Model/Shell/CommandInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Visitor.php
+++ b/app/code/Magento/Log/Model/Visitor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/Model/Visitor/Online.php
+++ b/app/code/Magento/Log/Model/Visitor/Online.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/data/log_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Log/data/log_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/etc/adminhtml/system.xml
+++ b/app/code/Magento/Log/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/etc/config.xml
+++ b/app/code/Magento/Log/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/etc/crontab.xml
+++ b/app/code/Magento/Log/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/etc/di.xml
+++ b/app/code/Magento/Log/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/etc/email_templates.xml
+++ b/app/code/Magento/Log/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/etc/frontend/events.xml
+++ b/app/code/Magento/Log/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/etc/module.xml
+++ b/app/code/Magento/Log/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Log/sql/log_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Log/sql/log_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Media/Helper/Data.php
+++ b/app/code/Magento/Media/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Media/Model/File/Image.php
+++ b/app/code/Magento/Media/Model/File/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Media/Model/Image.php
+++ b/app/code/Magento/Media/Model/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Media/Model/Image/Config/ConfigInterface.php
+++ b/app/code/Magento/Media/Model/Image/Config/ConfigInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Media/etc/frontend/routes.xml
+++ b/app/code/Magento/Media/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Media/etc/module.xml
+++ b/app/code/Magento/Media/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Block/Subscribe.php
+++ b/app/code/Magento/Newsletter/Block/Subscribe.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Block/Subscribe/Grid/Options/GroupOptionHash.php
+++ b/app/code/Magento/Newsletter/Block/Subscribe/Grid/Options/GroupOptionHash.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Block/Subscribe/Grid/Options/StoreOptionHash.php
+++ b/app/code/Magento/Newsletter/Block/Subscribe/Grid/Options/StoreOptionHash.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Controller/Manage.php
+++ b/app/code/Magento/Newsletter/Controller/Manage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Controller/Subscriber.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Helper/Data.php
+++ b/app/code/Magento/Newsletter/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Message.php
+++ b/app/code/Magento/Newsletter/Model/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Observer.php
+++ b/app/code/Magento/Newsletter/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Problem.php
+++ b/app/code/Magento/Newsletter/Model/Problem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Queue.php
+++ b/app/code/Magento/Newsletter/Model/Queue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Queue/Options/Status.php
+++ b/app/code/Magento/Newsletter/Model/Queue/Options/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Grid/Collection.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Problem.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Problem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Problem/Collection.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Problem/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Queue.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Queue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Queue/Collection.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Queue/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Queue/Grid/Collection.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Queue/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Setup.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Subscriber.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Subscriber/Collection.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Subscriber/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Subscriber/Grid/Collection.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Subscriber/Grid/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Template.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Resource/Template/Collection.php
+++ b/app/code/Magento/Newsletter/Model/Resource/Template/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Session.php
+++ b/app/code/Magento/Newsletter/Model/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Template.php
+++ b/app/code/Magento/Newsletter/Model/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/Model/Template/Filter.php
+++ b/app/code/Magento/Newsletter/Model/Template/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/Magento/Newsletter/data/newsletter_setup/data-upgrade-1.6.0.1-1.6.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Newsletter/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/adminhtml/di.xml
+++ b/app/code/Magento/Newsletter/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/adminhtml/events.xml
+++ b/app/code/Magento/Newsletter/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Newsletter/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/adminhtml/system.xml
+++ b/app/code/Magento/Newsletter/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/config.xml
+++ b/app/code/Magento/Newsletter/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/crontab.xml
+++ b/app/code/Magento/Newsletter/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/di.xml
+++ b/app/code/Magento/Newsletter/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/email_templates.xml
+++ b/app/code/Magento/Newsletter/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/frontend/di.xml
+++ b/app/code/Magento/Newsletter/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/frontend/events.xml
+++ b/app/code/Magento/Newsletter/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/frontend/routes.xml
+++ b/app/code/Magento/Newsletter/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/etc/module.xml
+++ b/app/code/Magento/Newsletter/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/sql/newsletter_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Newsletter/sql/newsletter_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/view/adminhtml/layout/adminhtml_newsletter_queue_grid.xml
+++ b/app/code/Magento/Newsletter/view/adminhtml/layout/adminhtml_newsletter_queue_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/view/adminhtml/layout/adminhtml_newsletter_queue_grid_block.xml
+++ b/app/code/Magento/Newsletter/view/adminhtml/layout/adminhtml_newsletter_queue_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/view/adminhtml/layout/adminhtml_newsletter_queue_index.xml
+++ b/app/code/Magento/Newsletter/view/adminhtml/layout/adminhtml_newsletter_queue_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/view/adminhtml/queue/list.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/queue/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Newsletter/view/frontend/layout/customer_account.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/view/frontend/layout/default.xml
+++ b/app/code/Magento/Newsletter/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/view/frontend/layout/newsletter_manage_index.xml
+++ b/app/code/Magento/Newsletter/view/frontend/layout/newsletter_manage_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/view/frontend/newsletter.js
+++ b/app/code/Magento/Newsletter/view/frontend/newsletter.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Newsletter/view/frontend/subscribe.phtml
+++ b/app/code/Magento/Newsletter/view/frontend/subscribe.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Block/Adminhtml/Oauth/Consumer.php
+++ b/app/code/Magento/Oauth/Block/Adminhtml/Oauth/Consumer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
+++ b/app/code/Magento/Oauth/Block/Adminhtml/Oauth/Consumer/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
+++ b/app/code/Magento/Oauth/Block/Adminhtml/Oauth/Consumer/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Block/Adminhtml/Oauth/Consumer/Grid.php
+++ b/app/code/Magento/Oauth/Block/Adminhtml/Oauth/Consumer/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Block/Authorize/AbstractAuthorize.php
+++ b/app/code/Magento/Oauth/Block/Authorize/AbstractAuthorize.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Block/Customer/Token/ListToken.php
+++ b/app/code/Magento/Oauth/Block/Customer/Token/ListToken.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Controller/Adminhtml/Oauth/Consumer.php
+++ b/app/code/Magento/Oauth/Controller/Adminhtml/Oauth/Consumer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Controller/Token.php
+++ b/app/code/Magento/Oauth/Controller/Token.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Exception.php
+++ b/app/code/Magento/Oauth/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Helper/Data.php
+++ b/app/code/Magento/Oauth/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Helper/Service.php
+++ b/app/code/Magento/Oauth/Helper/Service.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Consumer.php
+++ b/app/code/Magento/Oauth/Model/Consumer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Consumer/Factory.php
+++ b/app/code/Magento/Oauth/Model/Consumer/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Consumer/Validator/KeyLength.php
+++ b/app/code/Magento/Oauth/Model/Consumer/Validator/KeyLength.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Nonce.php
+++ b/app/code/Magento/Oauth/Model/Nonce.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Resource/Consumer.php
+++ b/app/code/Magento/Oauth/Model/Resource/Consumer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Resource/Consumer/Collection.php
+++ b/app/code/Magento/Oauth/Model/Resource/Consumer/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Resource/Nonce.php
+++ b/app/code/Magento/Oauth/Model/Resource/Nonce.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Resource/Nonce/Collection.php
+++ b/app/code/Magento/Oauth/Model/Resource/Nonce/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Resource/Token.php
+++ b/app/code/Magento/Oauth/Model/Resource/Token.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Resource/Token/Collection.php
+++ b/app/code/Magento/Oauth/Model/Resource/Token/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Model/Token.php
+++ b/app/code/Magento/Oauth/Model/Token.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Service/OauthV1.php
+++ b/app/code/Magento/Oauth/Service/OauthV1.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/Service/OauthV1Interface.php
+++ b/app/code/Magento/Oauth/Service/OauthV1Interface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Oauth/etc/adminhtml/acl.xml
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Oauth/etc/adminhtml/menu.xml
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Oauth/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/etc/adminhtml/system.xml
+++ b/app/code/Magento/Oauth/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/etc/config.xml
+++ b/app/code/Magento/Oauth/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/etc/di.xml
+++ b/app/code/Magento/Oauth/etc/di.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/etc/frontend/routes.xml
+++ b/app/code/Magento/Oauth/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/etc/module.xml
+++ b/app/code/Magento/Oauth/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/etc/schema/OauthV1.xsd
+++ b/app/code/Magento/Oauth/etc/schema/OauthV1.xsd
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/sql/oauth_setup/install-1.0.0.0.php
+++ b/app/code/Magento/Oauth/sql/oauth_setup/install-1.0.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/sql/oauth_setup/upgrade-1.0.0.0-1.0.0.1.php
+++ b/app/code/Magento/Oauth/sql/oauth_setup/upgrade-1.0.0.0-1.0.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/view/adminhtml/layout/adminhtml_oauth_consumer_edit.xml
+++ b/app/code/Magento/Oauth/view/adminhtml/layout/adminhtml_oauth_consumer_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/view/adminhtml/layout/adminhtml_oauth_consumer_grid.xml
+++ b/app/code/Magento/Oauth/view/adminhtml/layout/adminhtml_oauth_consumer_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/view/adminhtml/layout/adminhtml_oauth_consumer_index.xml
+++ b/app/code/Magento/Oauth/view/adminhtml/layout/adminhtml_oauth_consumer_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Oauth/view/adminhtml/layout/adminhtml_oauth_consumer_new.xml
+++ b/app/code/Magento/Oauth/view/adminhtml/layout/adminhtml_oauth_consumer_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Block/Form.php
+++ b/app/code/Magento/Ogone/Block/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Block/Info.php
+++ b/app/code/Magento/Ogone/Block/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Block/Paypage.php
+++ b/app/code/Magento/Ogone/Block/Paypage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Block/Placeform.php
+++ b/app/code/Magento/Ogone/Block/Placeform.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Controller/Api.php
+++ b/app/code/Magento/Ogone/Controller/Api.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Helper/Data.php
+++ b/app/code/Magento/Ogone/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Model/Api.php
+++ b/app/code/Magento/Ogone/Model/Api.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Model/Config.php
+++ b/app/code/Magento/Ogone/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Model/Source/PaymentAction.php
+++ b/app/code/Magento/Ogone/Model/Source/PaymentAction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Model/Source/Pmlist.php
+++ b/app/code/Magento/Ogone/Model/Source/Pmlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/Model/Source/Template.php
+++ b/app/code/Magento/Ogone/Model/Source/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/etc/adminhtml/system.xml
+++ b/app/code/Magento/Ogone/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/etc/config.xml
+++ b/app/code/Magento/Ogone/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/etc/frontend/di.xml
+++ b/app/code/Magento/Ogone/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/etc/frontend/routes.xml
+++ b/app/code/Magento/Ogone/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/etc/module.xml
+++ b/app/code/Magento/Ogone/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/etc/resources.xml
+++ b/app/code/Magento/Ogone/etc/resources.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/sql/ogone_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Ogone/sql/ogone_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/view/adminhtml/info.phtml
+++ b/app/code/Magento/Ogone/view/adminhtml/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/view/frontend/form.phtml
+++ b/app/code/Magento/Ogone/view/frontend/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/view/frontend/info.phtml
+++ b/app/code/Magento/Ogone/view/frontend/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/view/frontend/layout/ogone_api_paypage.xml
+++ b/app/code/Magento/Ogone/view/frontend/layout/ogone_api_paypage.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/view/frontend/layout/ogone_api_placeform.xml
+++ b/app/code/Magento/Ogone/view/frontend/layout/ogone_api_placeform.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/view/frontend/paypage.phtml
+++ b/app/code/Magento/Ogone/view/frontend/paypage.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Ogone/view/frontend/placeform.phtml
+++ b/app/code/Magento/Ogone/view/frontend/placeform.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html.php
+++ b/app/code/Magento/Page/Block/Html.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Breadcrumbs.php
+++ b/app/code/Magento/Page/Block/Html/Breadcrumbs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Footer.php
+++ b/app/code/Magento/Page/Block/Html/Footer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Head.php
+++ b/app/code/Magento/Page/Block/Html/Head.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Head/AssetBlock.php
+++ b/app/code/Magento/Page/Block/Html/Head/AssetBlock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Head/Css.php
+++ b/app/code/Magento/Page/Block/Html/Head/Css.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Head/Link.php
+++ b/app/code/Magento/Page/Block/Html/Head/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Head/Script.php
+++ b/app/code/Magento/Page/Block/Html/Head/Script.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Header.php
+++ b/app/code/Magento/Page/Block/Html/Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Notices.php
+++ b/app/code/Magento/Page/Block/Html/Notices.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Pager.php
+++ b/app/code/Magento/Page/Block/Html/Pager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Title.php
+++ b/app/code/Magento/Page/Block/Html/Title.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Topmenu.php
+++ b/app/code/Magento/Page/Block/Html/Topmenu.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Html/Welcome.php
+++ b/app/code/Magento/Page/Block/Html/Welcome.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Js/Components.php
+++ b/app/code/Magento/Page/Block/Js/Components.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Js/Cookie.php
+++ b/app/code/Magento/Page/Block/Js/Cookie.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Js/Translate.php
+++ b/app/code/Magento/Page/Block/Js/Translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Link.php
+++ b/app/code/Magento/Page/Block/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Link/Current.php
+++ b/app/code/Magento/Page/Block/Link/Current.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Links.php
+++ b/app/code/Magento/Page/Block/Links.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Redirect.php
+++ b/app/code/Magento/Page/Block/Redirect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Switcher.php
+++ b/app/code/Magento/Page/Block/Switcher.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Template/Container.php
+++ b/app/code/Magento/Page/Block/Template/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Block/Template/Links/Block.php
+++ b/app/code/Magento/Page/Block/Template/Links/Block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Helper/Data.php
+++ b/app/code/Magento/Page/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Helper/Html.php
+++ b/app/code/Magento/Page/Helper/Html.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Helper/Layout.php
+++ b/app/code/Magento/Page/Helper/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Helper/Robots.php
+++ b/app/code/Magento/Page/Helper/Robots.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Model/Asset/GroupedCollection.php
+++ b/app/code/Magento/Page/Model/Asset/GroupedCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Model/Asset/PropertyGroup.php
+++ b/app/code/Magento/Page/Model/Asset/PropertyGroup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Model/Config.php
+++ b/app/code/Magento/Page/Model/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Model/Config/Converter.php
+++ b/app/code/Magento/Page/Model/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Model/Config/Reader.php
+++ b/app/code/Magento/Page/Model/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Model/Config/SchemaLocator.php
+++ b/app/code/Magento/Page/Model/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/Model/Source/Layout.php
+++ b/app/code/Magento/Page/Model/Source/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/etc/adminhtml/system.xml
+++ b/app/code/Magento/Page/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/etc/config.xml
+++ b/app/code/Magento/Page/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/etc/di.xml
+++ b/app/code/Magento/Page/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/etc/module.xml
+++ b/app/code/Magento/Page/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/etc/page_layouts.xml
+++ b/app/code/Magento/Page/etc/page_layouts.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/etc/page_layouts.xsd
+++ b/app/code/Magento/Page/etc/page_layouts.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/etc/page_layouts_file.xsd
+++ b/app/code/Magento/Page/etc/page_layouts_file.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/adminhtml/empty.phtml
+++ b/app/code/Magento/Page/view/adminhtml/empty.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/adminhtml/title.phtml
+++ b/app/code/Magento/Page/view/adminhtml/title.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/1column.phtml
+++ b/app/code/Magento/Page/view/frontend/1column.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/2columns-left.phtml
+++ b/app/code/Magento/Page/view/frontend/2columns-left.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/2columns-right.phtml
+++ b/app/code/Magento/Page/view/frontend/2columns-right.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/3columns.phtml
+++ b/app/code/Magento/Page/view/frontend/3columns.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/callouts/left_col.phtml
+++ b/app/code/Magento/Page/view/frontend/callouts/left_col.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/callouts/right_col.phtml
+++ b/app/code/Magento/Page/view/frontend/callouts/right_col.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/css/tabs.css
+++ b/app/code/Magento/Page/view/frontend/css/tabs.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/css/validate.css
+++ b/app/code/Magento/Page/view/frontend/css/validate.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/empty.phtml
+++ b/app/code/Magento/Page/view/frontend/empty.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/html/breadcrumbs.phtml
+++ b/app/code/Magento/Page/view/frontend/html/breadcrumbs.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/html/footer.phtml
+++ b/app/code/Magento/Page/view/frontend/html/footer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/html/head.phtml
+++ b/app/code/Magento/Page/view/frontend/html/head.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/html/header.phtml
+++ b/app/code/Magento/Page/view/frontend/html/header.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/html/notices.phtml
+++ b/app/code/Magento/Page/view/frontend/html/notices.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/html/pager.phtml
+++ b/app/code/Magento/Page/view/frontend/html/pager.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/html/topmenu.phtml
+++ b/app/code/Magento/Page/view/frontend/html/topmenu.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/js/calendar.phtml
+++ b/app/code/Magento/Page/view/frontend/js/calendar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/js/components.phtml
+++ b/app/code/Magento/Page/view/frontend/js/components.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/js/cookie.phtml
+++ b/app/code/Magento/Page/view/frontend/js/cookie.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/js/menu.js
+++ b/app/code/Magento/Page/view/frontend/js/menu.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/js/notices.js
+++ b/app/code/Magento/Page/view/frontend/js/notices.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/js/popup-menu.js
+++ b/app/code/Magento/Page/view/frontend/js/popup-menu.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/js/row-builder.js
+++ b/app/code/Magento/Page/view/frontend/js/row-builder.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/js/truncate.js
+++ b/app/code/Magento/Page/view/frontend/js/truncate.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/layout/default.xml
+++ b/app/code/Magento/Page/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/layout/page_calendar.xml
+++ b/app/code/Magento/Page/view/frontend/layout/page_calendar.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/layout/page_empty.xml
+++ b/app/code/Magento/Page/view/frontend/layout/page_empty.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/layout/page_one_column.xml
+++ b/app/code/Magento/Page/view/frontend/layout/page_one_column.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/layout/page_three_columns.xml
+++ b/app/code/Magento/Page/view/frontend/layout/page_three_columns.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/layout/page_two_columns_left.xml
+++ b/app/code/Magento/Page/view/frontend/layout/page_two_columns_left.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/layout/page_two_columns_right.xml
+++ b/app/code/Magento/Page/view/frontend/layout/page_two_columns_right.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/layout/print.xml
+++ b/app/code/Magento/Page/view/frontend/layout/print.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/link.phtml
+++ b/app/code/Magento/Page/view/frontend/link.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/link/current.phtml
+++ b/app/code/Magento/Page/view/frontend/link/current.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/links.phtml
+++ b/app/code/Magento/Page/view/frontend/links.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/menu.js
+++ b/app/code/Magento/Page/view/frontend/menu.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/page_fragment.phtml
+++ b/app/code/Magento/Page/view/frontend/page_fragment.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/popup.phtml
+++ b/app/code/Magento/Page/view/frontend/popup.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/print.phtml
+++ b/app/code/Magento/Page/view/frontend/print.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/redirect.phtml
+++ b/app/code/Magento/Page/view/frontend/redirect.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/switch/flags.phtml
+++ b/app/code/Magento/Page/view/frontend/switch/flags.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/switch/languages.phtml
+++ b/app/code/Magento/Page/view/frontend/switch/languages.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/switch/stores.phtml
+++ b/app/code/Magento/Page/view/frontend/switch/stores.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/template/container.phtml
+++ b/app/code/Magento/Page/view/frontend/template/container.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Page/view/frontend/template/linksblock.phtml
+++ b/app/code/Magento/Page/view/frontend/template/linksblock.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/Block/Adminhtml/Cache/Additional.php
+++ b/app/code/Magento/PageCache/Block/Adminhtml/Cache/Additional.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/Controller/Adminhtml/PageCache.php
+++ b/app/code/Magento/PageCache/Controller/Adminhtml/PageCache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/Helper/Data.php
+++ b/app/code/Magento/PageCache/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/Model/CacheControlFactory.php
+++ b/app/code/Magento/PageCache/Model/CacheControlFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/Model/Control/ControlInterface.php
+++ b/app/code/Magento/PageCache/Model/Control/ControlInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/Model/Control/Zend.php
+++ b/app/code/Magento/PageCache/Model/Control/Zend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/Model/Observer.php
+++ b/app/code/Magento/PageCache/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/Model/System/Config/Source/Controls.php
+++ b/app/code/Magento/PageCache/Model/System/Config/Source/Controls.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/etc/adminhtml/acl.xml
+++ b/app/code/Magento/PageCache/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/etc/adminhtml/routes.xml
+++ b/app/code/Magento/PageCache/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/etc/adminhtml/system.xml
+++ b/app/code/Magento/PageCache/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/etc/config.xml
+++ b/app/code/Magento/PageCache/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/etc/di.xml
+++ b/app/code/Magento/PageCache/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/etc/events.xml
+++ b/app/code/Magento/PageCache/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/etc/frontend/events.xml
+++ b/app/code/Magento/PageCache/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/etc/module.xml
+++ b/app/code/Magento/PageCache/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/view/adminhtml/cache/additional.phtml
+++ b/app/code/Magento/PageCache/view/adminhtml/cache/additional.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/view/adminhtml/layout/adminhtml_cache_index.xml
+++ b/app/code/Magento/PageCache/view/adminhtml/layout/adminhtml_cache_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/view/frontend/cookie.phtml
+++ b/app/code/Magento/PageCache/view/frontend/cookie.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PageCache/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/PageCache/view/frontend/layout/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Block/Authorizenet/Form/Cc.php
+++ b/app/code/Magento/Paygate/Block/Authorizenet/Form/Cc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Block/Authorizenet/Info/Cc.php
+++ b/app/code/Magento/Paygate/Block/Authorizenet/Info/Cc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Controller/Adminhtml/Paygate/Authorizenet/Payment.php
+++ b/app/code/Magento/Paygate/Controller/Adminhtml/Paygate/Authorizenet/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Controller/Authorizenet/Payment.php
+++ b/app/code/Magento/Paygate/Controller/Authorizenet/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Helper/Data.php
+++ b/app/code/Magento/Paygate/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Model/Authorizenet.php
+++ b/app/code/Magento/Paygate/Model/Authorizenet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Model/Authorizenet/Cards.php
+++ b/app/code/Magento/Paygate/Model/Authorizenet/Cards.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Model/Authorizenet/Debug.php
+++ b/app/code/Magento/Paygate/Model/Authorizenet/Debug.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Model/Authorizenet/Request.php
+++ b/app/code/Magento/Paygate/Model/Authorizenet/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Model/Authorizenet/Result.php
+++ b/app/code/Magento/Paygate/Model/Authorizenet/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Model/Authorizenet/Source/Cctype.php
+++ b/app/code/Magento/Paygate/Model/Authorizenet/Source/Cctype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Model/Authorizenet/Source/PaymentAction.php
+++ b/app/code/Magento/Paygate/Model/Authorizenet/Source/PaymentAction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Model/Resource/Authorizenet/Debug.php
+++ b/app/code/Magento/Paygate/Model/Resource/Authorizenet/Debug.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/Model/Resource/Authorizenet/Debug/Collection.php
+++ b/app/code/Magento/Paygate/Model/Resource/Authorizenet/Debug/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/etc/adminhtml/di.xml
+++ b/app/code/Magento/Paygate/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Paygate/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/etc/adminhtml/system.xml
+++ b/app/code/Magento/Paygate/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/etc/config.xml
+++ b/app/code/Magento/Paygate/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/etc/frontend/di.xml
+++ b/app/code/Magento/Paygate/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/etc/frontend/routes.xml
+++ b/app/code/Magento/Paygate/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/etc/module.xml
+++ b/app/code/Magento/Paygate/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/sql/paygate_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Paygate/sql/paygate_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/view/adminhtml/form/cc.phtml
+++ b/app/code/Magento/Paygate/view/adminhtml/form/cc.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/view/adminhtml/info/cc.phtml
+++ b/app/code/Magento/Paygate/view/adminhtml/info/cc.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/view/adminhtml/info/pdf.phtml
+++ b/app/code/Magento/Paygate/view/adminhtml/info/pdf.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/view/frontend/form/cc.phtml
+++ b/app/code/Magento/Paygate/view/frontend/form/cc.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/view/frontend/info/cc.phtml
+++ b/app/code/Magento/Paygate/view/frontend/info/cc.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paygate/view/frontend/paygate-authenticate.js
+++ b/app/code/Magento/Paygate/view/frontend/paygate-authenticate.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Catalog/Product/View/Profile.php
+++ b/app/code/Magento/Payment/Block/Catalog/Product/View/Profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Form.php
+++ b/app/code/Magento/Payment/Block/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Form/Banktransfer.php
+++ b/app/code/Magento/Payment/Block/Form/Banktransfer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Form/Cashondelivery.php
+++ b/app/code/Magento/Payment/Block/Form/Cashondelivery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Form/Cc.php
+++ b/app/code/Magento/Payment/Block/Form/Cc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Form/Ccsave.php
+++ b/app/code/Magento/Payment/Block/Form/Ccsave.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Form/Checkmo.php
+++ b/app/code/Magento/Payment/Block/Form/Checkmo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Form/Container.php
+++ b/app/code/Magento/Payment/Block/Form/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Form/Purchaseorder.php
+++ b/app/code/Magento/Payment/Block/Form/Purchaseorder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Info.php
+++ b/app/code/Magento/Payment/Block/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Info/AbstractContainer.php
+++ b/app/code/Magento/Payment/Block/Info/AbstractContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Info/Cc.php
+++ b/app/code/Magento/Payment/Block/Info/Cc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Info/Ccsave.php
+++ b/app/code/Magento/Payment/Block/Info/Ccsave.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Info/Checkmo.php
+++ b/app/code/Magento/Payment/Block/Info/Checkmo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Info/Instructions.php
+++ b/app/code/Magento/Payment/Block/Info/Instructions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Block/Info/Purchaseorder.php
+++ b/app/code/Magento/Payment/Block/Info/Purchaseorder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Exception.php
+++ b/app/code/Magento/Payment/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Helper/Data.php
+++ b/app/code/Magento/Payment/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Billing/AbstractAgreement.php
+++ b/app/code/Magento/Payment/Model/Billing/AbstractAgreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Billing/Agreement/MethodInterface.php
+++ b/app/code/Magento/Payment/Model/Billing/Agreement/MethodInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Config.php
+++ b/app/code/Magento/Payment/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Config/Converter.php
+++ b/app/code/Magento/Payment/Model/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Config/Reader.php
+++ b/app/code/Magento/Payment/Model/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Config/SchemaLocator.php
+++ b/app/code/Magento/Payment/Model/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Config/Source/Allmethods.php
+++ b/app/code/Magento/Payment/Model/Config/Source/Allmethods.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Config/Source/Allowedmethods.php
+++ b/app/code/Magento/Payment/Model/Config/Source/Allowedmethods.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Config/Source/Allspecificcountries.php
+++ b/app/code/Magento/Payment/Model/Config/Source/Allspecificcountries.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Config/Source/Cctype.php
+++ b/app/code/Magento/Payment/Model/Config/Source/Cctype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Info.php
+++ b/app/code/Magento/Payment/Model/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Info/Exception.php
+++ b/app/code/Magento/Payment/Model/Info/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Method/AbstractMethod.php
+++ b/app/code/Magento/Payment/Model/Method/AbstractMethod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Method/Banktransfer.php
+++ b/app/code/Magento/Payment/Model/Method/Banktransfer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Method/Cashondelivery.php
+++ b/app/code/Magento/Payment/Model/Method/Cashondelivery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Method/Cc.php
+++ b/app/code/Magento/Payment/Model/Method/Cc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Method/Ccsave.php
+++ b/app/code/Magento/Payment/Model/Method/Ccsave.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Method/Checkmo.php
+++ b/app/code/Magento/Payment/Model/Method/Checkmo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Method/Factory.php
+++ b/app/code/Magento/Payment/Model/Method/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Method/Free.php
+++ b/app/code/Magento/Payment/Model/Method/Free.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Method/Purchaseorder.php
+++ b/app/code/Magento/Payment/Model/Method/Purchaseorder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Observer.php
+++ b/app/code/Magento/Payment/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Paygate/Result.php
+++ b/app/code/Magento/Payment/Model/Paygate/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Recurring/Profile.php
+++ b/app/code/Magento/Payment/Model/Recurring/Profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Recurring/Profile/MethodInterface.php
+++ b/app/code/Magento/Payment/Model/Recurring/Profile/MethodInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Source/Cctype.php
+++ b/app/code/Magento/Payment/Model/Source/Cctype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/Model/Source/Invoice.php
+++ b/app/code/Magento/Payment/Model/Source/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Payment/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/etc/adminhtml/system.xml
+++ b/app/code/Magento/Payment/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/etc/config.xml
+++ b/app/code/Magento/Payment/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/etc/di.xml
+++ b/app/code/Magento/Payment/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/etc/events.xml
+++ b/app/code/Magento/Payment/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/etc/frontend/events.xml
+++ b/app/code/Magento/Payment/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/etc/module.xml
+++ b/app/code/Magento/Payment/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/etc/payment.xml
+++ b/app/code/Magento/Payment/etc/payment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/etc/payment.xsd
+++ b/app/code/Magento/Payment/etc/payment.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/etc/payment_file.xsd
+++ b/app/code/Magento/Payment/etc/payment_file.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/form/banktransfer.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/form/banktransfer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/form/cashondelivery.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/form/cashondelivery.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/form/cc.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/form/cc.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/form/ccsave.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/form/ccsave.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/form/checkmo.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/form/checkmo.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/form/purchaseorder.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/form/purchaseorder.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/info/checkmo.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/info/checkmo.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/info/default.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/info/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/info/instructions.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/info/instructions.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/info/pdf/checkmo.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/info/pdf/checkmo.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/info/pdf/default.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/info/pdf/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/info/pdf/purchaseorder.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/info/pdf/purchaseorder.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/adminhtml/info/purchaseorder.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/info/purchaseorder.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/catalog/product/view/profile/options.phtml
+++ b/app/code/Magento/Payment/view/frontend/catalog/product/view/profile/options.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/catalog/product/view/profile/schedule.phtml
+++ b/app/code/Magento/Payment/view/frontend/catalog/product/view/profile/schedule.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/cc-type.js
+++ b/app/code/Magento/Payment/view/frontend/cc-type.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/form/banktransfer.phtml
+++ b/app/code/Magento/Payment/view/frontend/form/banktransfer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/form/cashondelivery.phtml
+++ b/app/code/Magento/Payment/view/frontend/form/cashondelivery.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/form/cc.phtml
+++ b/app/code/Magento/Payment/view/frontend/form/cc.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/form/ccsave.phtml
+++ b/app/code/Magento/Payment/view/frontend/form/ccsave.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/form/checkmo.phtml
+++ b/app/code/Magento/Payment/view/frontend/form/checkmo.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/form/purchaseorder.phtml
+++ b/app/code/Magento/Payment/view/frontend/form/purchaseorder.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/info/checkmo.phtml
+++ b/app/code/Magento/Payment/view/frontend/info/checkmo.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/info/default.phtml
+++ b/app/code/Magento/Payment/view/frontend/info/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/info/instructions.phtml
+++ b/app/code/Magento/Payment/view/frontend/info/instructions.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/info/purchaseorder.phtml
+++ b/app/code/Magento/Payment/view/frontend/info/purchaseorder.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Payment/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Payment/view/frontend/layout/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/Settlement/Details.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/Settlement/Details.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/Settlement/Details/Form.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/Settlement/Details/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/Settlement/Report.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/Settlement/Report.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/ApiWizard.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/ApiWizard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Field/Hidden.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Field/Hidden.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Expanded.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Expanded.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Group.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Hint.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Hint.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Location.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Location.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Store.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Fieldset/Store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Express/Form.php
+++ b/app/code/Magento/Paypal/Block/Express/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Express/Review.php
+++ b/app/code/Magento/Paypal/Block/Express/Review.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Express/Review/Billing.php
+++ b/app/code/Magento/Paypal/Block/Express/Review/Billing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Express/Review/Details.php
+++ b/app/code/Magento/Paypal/Block/Express/Review/Details.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Express/Review/Shipping.php
+++ b/app/code/Magento/Paypal/Block/Express/Review/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Express/Shortcut.php
+++ b/app/code/Magento/Paypal/Block/Express/Shortcut.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Hosted/Pro/Form.php
+++ b/app/code/Magento/Paypal/Block/Hosted/Pro/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Hosted/Pro/Iframe.php
+++ b/app/code/Magento/Paypal/Block/Hosted/Pro/Iframe.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Hosted/Pro/Info.php
+++ b/app/code/Magento/Paypal/Block/Hosted/Pro/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Iframe.php
+++ b/app/code/Magento/Paypal/Block/Iframe.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Logo.php
+++ b/app/code/Magento/Paypal/Block/Logo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Payflow/Advanced/Form.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Advanced/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Payflow/Advanced/Iframe.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Advanced/Iframe.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Payflow/Advanced/Info.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Advanced/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Payflow/Advanced/Review.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Advanced/Review.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Payflow/Link/Form.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Link/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Payflow/Link/Iframe.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Link/Iframe.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Payflow/Link/Info.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Link/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Payflow/Link/Review.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Link/Review.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Payment/Info.php
+++ b/app/code/Magento/Paypal/Block/Payment/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Standard/Form.php
+++ b/app/code/Magento/Paypal/Block/Standard/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Block/Standard/Redirect.php
+++ b/app/code/Magento/Paypal/Block/Standard/Redirect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Paypal/Reports.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Paypal/Reports.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Controller/Express.php
+++ b/app/code/Magento/Paypal/Controller/Express.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Controller/Express/AbstractExpress.php
+++ b/app/code/Magento/Paypal/Controller/Express/AbstractExpress.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Controller/Hostedpro.php
+++ b/app/code/Magento/Paypal/Controller/Hostedpro.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Controller/Ipn.php
+++ b/app/code/Magento/Paypal/Controller/Ipn.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Controller/Payflow.php
+++ b/app/code/Magento/Paypal/Controller/Payflow.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Controller/Payflowadvanced.php
+++ b/app/code/Magento/Paypal/Controller/Payflowadvanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Controller/Standard.php
+++ b/app/code/Magento/Paypal/Controller/Standard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Exception.php
+++ b/app/code/Magento/Paypal/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Helper/Checkout.php
+++ b/app/code/Magento/Paypal/Helper/Checkout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Helper/Data.php
+++ b/app/code/Magento/Paypal/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Helper/Hss.php
+++ b/app/code/Magento/Paypal/Helper/Hss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Api/AbstractApi.php
+++ b/app/code/Magento/Paypal/Model/Api/AbstractApi.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Api/Nvp.php
+++ b/app/code/Magento/Paypal/Model/Api/Nvp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Api/Standard.php
+++ b/app/code/Magento/Paypal/Model/Api/Standard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Api/Type/Factory.php
+++ b/app/code/Magento/Paypal/Model/Api/Type/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Cart.php
+++ b/app/code/Magento/Paypal/Model/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Cert.php
+++ b/app/code/Magento/Paypal/Model/Cert.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Config.php
+++ b/app/code/Magento/Paypal/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Config/Factory.php
+++ b/app/code/Magento/Paypal/Model/Config/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Direct.php
+++ b/app/code/Magento/Paypal/Model/Direct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Express.php
+++ b/app/code/Magento/Paypal/Model/Express.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Express/Checkout.php
+++ b/app/code/Magento/Paypal/Model/Express/Checkout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Express/Checkout/Factory.php
+++ b/app/code/Magento/Paypal/Model/Express/Checkout/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Hostedpro.php
+++ b/app/code/Magento/Paypal/Model/Hostedpro.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Hostedpro/Request.php
+++ b/app/code/Magento/Paypal/Model/Hostedpro/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Info.php
+++ b/app/code/Magento/Paypal/Model/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Ipn.php
+++ b/app/code/Magento/Paypal/Model/Ipn.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Method/Agreement.php
+++ b/app/code/Magento/Paypal/Model/Method/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Method/ProTypeFactory.php
+++ b/app/code/Magento/Paypal/Model/Method/ProTypeFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Observer.php
+++ b/app/code/Magento/Paypal/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Payflow/Request.php
+++ b/app/code/Magento/Paypal/Model/Payflow/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Payflowadvanced.php
+++ b/app/code/Magento/Paypal/Model/Payflowadvanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Payflowlink.php
+++ b/app/code/Magento/Paypal/Model/Payflowlink.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Payflowpro.php
+++ b/app/code/Magento/Paypal/Model/Payflowpro.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Payment/Transaction.php
+++ b/app/code/Magento/Paypal/Model/Payment/Transaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Pro.php
+++ b/app/code/Magento/Paypal/Model/Pro.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Report/Settlement.php
+++ b/app/code/Magento/Paypal/Model/Report/Settlement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Report/Settlement/Row.php
+++ b/app/code/Magento/Paypal/Model/Report/Settlement/Row.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Resource/Cert.php
+++ b/app/code/Magento/Paypal/Model/Resource/Cert.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Resource/Payment/Transaction.php
+++ b/app/code/Magento/Paypal/Model/Resource/Payment/Transaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Resource/Payment/Transaction/Collection.php
+++ b/app/code/Magento/Paypal/Model/Resource/Payment/Transaction/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Resource/Report/Settlement.php
+++ b/app/code/Magento/Paypal/Model/Resource/Report/Settlement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Resource/Report/Settlement/Options/TransactionEvents.php
+++ b/app/code/Magento/Paypal/Model/Resource/Report/Settlement/Options/TransactionEvents.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Resource/Report/Settlement/Row.php
+++ b/app/code/Magento/Paypal/Model/Resource/Report/Settlement/Row.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Resource/Report/Settlement/Row/Collection.php
+++ b/app/code/Magento/Paypal/Model/Resource/Report/Settlement/Row/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/Standard.php
+++ b/app/code/Magento/Paypal/Model/Standard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Backend/Cert.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Backend/Cert.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Backend/Cron.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Backend/Cron.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Backend/MerchantCountry.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Backend/MerchantCountry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Source/AuthorizationAmounts.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/AuthorizationAmounts.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Source/BuyerCountry.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/BuyerCountry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Source/FetchingSchedule.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/FetchingSchedule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Source/Logo.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/Logo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Source/MerchantCountry.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/MerchantCountry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Source/PaymentActions.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/PaymentActions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Source/PaymentActions/Express.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/PaymentActions/Express.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Source/RequireBillingAddress.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/RequireBillingAddress.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/Model/System/Config/Source/UrlMethod.php
+++ b/app/code/Magento/Paypal/Model/System/Config/Source/UrlMethod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Paypal/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/adminhtml/di.xml
+++ b/app/code/Magento/Paypal/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Paypal/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Paypal/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/adminhtml/system.xml
+++ b/app/code/Magento/Paypal/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/config.xml
+++ b/app/code/Magento/Paypal/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/crontab.xml
+++ b/app/code/Magento/Paypal/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/di.xml
+++ b/app/code/Magento/Paypal/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/frontend/di.xml
+++ b/app/code/Magento/Paypal/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/frontend/events.xml
+++ b/app/code/Magento/Paypal/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/frontend/routes.xml
+++ b/app/code/Magento/Paypal/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/module.xml
+++ b/app/code/Magento/Paypal/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/etc/payment.xml
+++ b/app/code/Magento/Paypal/etc/payment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/sql/paypal_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Paypal/sql/paypal_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/sql/paypal_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/Paypal/sql/paypal_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/sql/paypal_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/Magento/Paypal/sql/paypal_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/sql/paypal_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/Magento/Paypal/sql/paypal_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_paypal_reports_block.xml
+++ b/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_paypal_reports_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_paypal_reports_grid.xml
+++ b/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_paypal_reports_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_paypal_reports_index.xml
+++ b/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_paypal_reports_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/app/code/Magento/Paypal/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/adminhtml/styles.css
+++ b/app/code/Magento/Paypal/view/adminhtml/styles.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/adminhtml/system/config/api_wizard.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/system/config/api_wizard.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/adminhtml/system/config/fieldset/hint.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/system/config/fieldset/hint.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/adminhtml/system/config/fieldset/store.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/system/config/fieldset/store.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/adminhtml/system/config/payflowlink/advanced.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/system/config/payflowlink/advanced.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/adminhtml/system/config/payflowlink/info.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/system/config/payflowlink/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/express/review.phtml
+++ b/app/code/Magento/Paypal/view/frontend/express/review.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/express/review/address.phtml
+++ b/app/code/Magento/Paypal/view/frontend/express/review/address.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/express/review/details.phtml
+++ b/app/code/Magento/Paypal/view/frontend/express/review/details.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/express/review/shipping/method.phtml
+++ b/app/code/Magento/Paypal/view/frontend/express/review/shipping/method.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/express/shortcut.phtml
+++ b/app/code/Magento/Paypal/view/frontend/express/shortcut.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/hss/form.phtml
+++ b/app/code/Magento/Paypal/view/frontend/hss/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/hss/iframe.phtml
+++ b/app/code/Magento/Paypal/view/frontend/hss/iframe.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/hss/info.phtml
+++ b/app/code/Magento/Paypal/view/frontend/hss/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/hss/js.phtml
+++ b/app/code/Magento/Paypal/view/frontend/hss/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/hss/redirect.phtml
+++ b/app/code/Magento/Paypal/view/frontend/hss/redirect.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/hss/review/button.phtml
+++ b/app/code/Magento/Paypal/view/frontend/hss/review/button.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/js/paypal-checkout.js
+++ b/app/code/Magento/Paypal/view/frontend/js/paypal-checkout.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/SHORTCUT_popup.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/SHORTCUT_popup.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/catalog_category_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/catalog_product_compare_index.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/catalog_product_compare_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/catalogsearch_advanced_result.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/catalogsearch_advanced_result.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/catalogsearch_result_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/checkout_cart_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/checkout_onepage_failure.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/checkout_onepage_failure.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/checkout_onepage_review.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/checkout_onepage_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/checkout_onepage_success.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/checkout_onepage_success.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/cms_index_index.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/cms_index_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/default.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_express_review.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_express_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_express_review_details.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_express_review_details.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_hostedpro_cancel.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_hostedpro_cancel.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_cancelpayment.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_cancelpayment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_form.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_form.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_returnurl.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflow_returnurl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_cancelpayment.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_cancelpayment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_form.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_form.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_returnurl.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_payflowadvanced_returnurl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/paypal_standard_redirect.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/paypal_standard_redirect.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/review_product_list.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/review_product_list.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/tag_customer_view.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/tag_customer_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/tag_product_list.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/tag_product_list.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/layout/wishlist_index_index.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/wishlist_index_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/order-review.js
+++ b/app/code/Magento/Paypal/view/frontend/order-review.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/partner/logo.phtml
+++ b/app/code/Magento/Paypal/view/frontend/partner/logo.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/payflowadvanced/form.phtml
+++ b/app/code/Magento/Paypal/view/frontend/payflowadvanced/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/payflowadvanced/iframe.phtml
+++ b/app/code/Magento/Paypal/view/frontend/payflowadvanced/iframe.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/payflowadvanced/info.phtml
+++ b/app/code/Magento/Paypal/view/frontend/payflowadvanced/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/payflowadvanced/redirect.phtml
+++ b/app/code/Magento/Paypal/view/frontend/payflowadvanced/redirect.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/payflowlink/form.phtml
+++ b/app/code/Magento/Paypal/view/frontend/payflowlink/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/payflowlink/iframe.phtml
+++ b/app/code/Magento/Paypal/view/frontend/payflowlink/iframe.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/payflowlink/info.phtml
+++ b/app/code/Magento/Paypal/view/frontend/payflowlink/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/payflowlink/redirect.phtml
+++ b/app/code/Magento/Paypal/view/frontend/payflowlink/redirect.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/payment/mark.phtml
+++ b/app/code/Magento/Paypal/view/frontend/payment/mark.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Paypal/view/frontend/payment/redirect.phtml
+++ b/app/code/Magento/Paypal/view/frontend/payment/redirect.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/Block/Express/Form.php
+++ b/app/code/Magento/PaypalUk/Block/Express/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/Block/Express/Shortcut.php
+++ b/app/code/Magento/PaypalUk/Block/Express/Shortcut.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/Controller/Express.php
+++ b/app/code/Magento/PaypalUk/Controller/Express.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/Helper/Data.php
+++ b/app/code/Magento/PaypalUk/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/Model/Api/Nvp.php
+++ b/app/code/Magento/PaypalUk/Model/Api/Nvp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/Model/Direct.php
+++ b/app/code/Magento/PaypalUk/Model/Direct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/Model/Express.php
+++ b/app/code/Magento/PaypalUk/Model/Express.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/Model/Express/Checkout.php
+++ b/app/code/Magento/PaypalUk/Model/Express/Checkout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/Model/Pro.php
+++ b/app/code/Magento/PaypalUk/Model/Pro.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/etc/adminhtml/di.xml
+++ b/app/code/Magento/PaypalUk/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/etc/config.xml
+++ b/app/code/Magento/PaypalUk/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/etc/frontend/di.xml
+++ b/app/code/Magento/PaypalUk/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/etc/frontend/routes.xml
+++ b/app/code/Magento/PaypalUk/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/etc/module.xml
+++ b/app/code/Magento/PaypalUk/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/sql/paypaluk_setup/install-1.6.0.0.php
+++ b/app/code/Magento/PaypalUk/sql/paypaluk_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/express/review.phtml
+++ b/app/code/Magento/PaypalUk/view/frontend/express/review.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/SHORTCUT_uk_popup.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/SHORTCUT_uk_popup.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/catalog_category_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/catalog_product_compare_index.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/catalog_product_compare_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/catalogsearch_advanced_result.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/catalogsearch_advanced_result.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/catalogsearch_result_index.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/catalogsearch_result_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/checkout_cart_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/checkout_onepage_failure.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/checkout_onepage_failure.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/checkout_onepage_success.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/checkout_onepage_success.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/default.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/paypal_express_review_details.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/paypal_express_review_details.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/paypaluk_express_review.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/paypaluk_express_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/paypaluk_express_review_details.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/paypaluk_express_review_details.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/review_product_list.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/review_product_list.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/tag_customer_view.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/tag_customer_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/tag_product_list.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/tag_product_list.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/PaypalUk/view/frontend/layout/wishlist_index_index.xml
+++ b/app/code/Magento/PaypalUk/view/frontend/layout/wishlist_index_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Block/Form/Remember.php
+++ b/app/code/Magento/Persistent/Block/Form/Remember.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Block/Header/Additional.php
+++ b/app/code/Magento/Persistent/Block/Header/Additional.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Controller/Index.php
+++ b/app/code/Magento/Persistent/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Helper/Data.php
+++ b/app/code/Magento/Persistent/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Helper/Session.php
+++ b/app/code/Magento/Persistent/Helper/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Model/Factory.php
+++ b/app/code/Magento/Persistent/Model/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Model/Observer.php
+++ b/app/code/Magento/Persistent/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Model/Observer/Session.php
+++ b/app/code/Magento/Persistent/Model/Observer/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Model/Persistent/Config.php
+++ b/app/code/Magento/Persistent/Model/Persistent/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Model/Resource/Session.php
+++ b/app/code/Magento/Persistent/Model/Resource/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/Model/Session.php
+++ b/app/code/Magento/Persistent/Model/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Persistent/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/adminhtml/system.xml
+++ b/app/code/Magento/Persistent/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/config.xml
+++ b/app/code/Magento/Persistent/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/crontab.xml
+++ b/app/code/Magento/Persistent/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/di.xml
+++ b/app/code/Magento/Persistent/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/frontend/di.xml
+++ b/app/code/Magento/Persistent/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/frontend/events.xml
+++ b/app/code/Magento/Persistent/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/frontend/routes.xml
+++ b/app/code/Magento/Persistent/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/module.xml
+++ b/app/code/Magento/Persistent/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/persistent.xml
+++ b/app/code/Magento/Persistent/etc/persistent.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/etc/persistent.xsd
+++ b/app/code/Magento/Persistent/etc/persistent.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/sql/persistent_setup/install-1.0.0.0.php
+++ b/app/code/Magento/Persistent/sql/persistent_setup/install-1.0.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/checkout/onepage/billing.phtml
+++ b/app/code/Magento/Persistent/view/frontend/checkout/onepage/billing.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/checkout/onepage/login.phtml
+++ b/app/code/Magento/Persistent/view/frontend/checkout/onepage/login.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/customer/form/login.phtml
+++ b/app/code/Magento/Persistent/view/frontend/customer/form/login.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/customer/form/register.phtml
+++ b/app/code/Magento/Persistent/view/frontend/customer/form/register.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/layout/checkout_onepage_index.xml
+++ b/app/code/Magento/Persistent/view/frontend/layout/checkout_onepage_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/layout/customer_account_create.xml
+++ b/app/code/Magento/Persistent/view/frontend/layout/customer_account_create.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/layout/customer_account_login.xml
+++ b/app/code/Magento/Persistent/view/frontend/layout/customer_account_login.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/remember-me-popup.js
+++ b/app/code/Magento/Persistent/view/frontend/remember-me-popup.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/remember_me.phtml
+++ b/app/code/Magento/Persistent/view/frontend/remember_me.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/remember_me_tooltip.phtml
+++ b/app/code/Magento/Persistent/view/frontend/remember_me_tooltip.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Persistent/view/frontend/splitbutton.js
+++ b/app/code/Magento/Persistent/view/frontend/splitbutton.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Block/Email/AbstractEmail.php
+++ b/app/code/Magento/ProductAlert/Block/Email/AbstractEmail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Block/Email/Price.php
+++ b/app/code/Magento/ProductAlert/Block/Email/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Block/Email/Stock.php
+++ b/app/code/Magento/ProductAlert/Block/Email/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Block/Product/View.php
+++ b/app/code/Magento/ProductAlert/Block/Product/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Block/Product/View/Price.php
+++ b/app/code/Magento/ProductAlert/Block/Product/View/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Block/Product/View/Stock.php
+++ b/app/code/Magento/ProductAlert/Block/Product/View/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Controller/Add.php
+++ b/app/code/Magento/ProductAlert/Controller/Add.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Helper/Data.php
+++ b/app/code/Magento/ProductAlert/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Email.php
+++ b/app/code/Magento/ProductAlert/Model/Email.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Observer.php
+++ b/app/code/Magento/ProductAlert/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Price.php
+++ b/app/code/Magento/ProductAlert/Model/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Resource/AbstractResource.php
+++ b/app/code/Magento/ProductAlert/Model/Resource/AbstractResource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Resource/Price.php
+++ b/app/code/Magento/ProductAlert/Model/Resource/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Resource/Price/Collection.php
+++ b/app/code/Magento/ProductAlert/Model/Resource/Price/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Resource/Price/Customer/Collection.php
+++ b/app/code/Magento/ProductAlert/Model/Resource/Price/Customer/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Resource/Stock.php
+++ b/app/code/Magento/ProductAlert/Model/Resource/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Resource/Stock/Collection.php
+++ b/app/code/Magento/ProductAlert/Model/Resource/Stock/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Resource/Stock/Customer/Collection.php
+++ b/app/code/Magento/ProductAlert/Model/Resource/Stock/Customer/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/Model/Stock.php
+++ b/app/code/Magento/ProductAlert/Model/Stock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/etc/adminhtml/system.xml
+++ b/app/code/Magento/ProductAlert/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/etc/config.xml
+++ b/app/code/Magento/ProductAlert/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/etc/crontab.xml
+++ b/app/code/Magento/ProductAlert/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/etc/email_templates.xml
+++ b/app/code/Magento/ProductAlert/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/etc/frontend/routes.xml
+++ b/app/code/Magento/ProductAlert/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/etc/module.xml
+++ b/app/code/Magento/ProductAlert/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/sql/productalert_setup/install-1.6.0.0.php
+++ b/app/code/Magento/ProductAlert/sql/productalert_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/view/frontend/email/price.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/email/price.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/view/frontend/email/stock.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/email/stock.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/ProductAlert/view/frontend/layout/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/ProductAlert/view/frontend/product/view.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/product/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Block/Entity/Detailed.php
+++ b/app/code/Magento/Rating/Block/Entity/Detailed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Helper/Data.php
+++ b/app/code/Magento/Rating/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Observer.php
+++ b/app/code/Magento/Rating/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Rating.php
+++ b/app/code/Magento/Rating/Model/Rating.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Rating/Entity.php
+++ b/app/code/Magento/Rating/Model/Rating/Entity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Rating/Option.php
+++ b/app/code/Magento/Rating/Model/Rating/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Rating/Option/Vote.php
+++ b/app/code/Magento/Rating/Model/Rating/Option/Vote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Resource/Rating.php
+++ b/app/code/Magento/Rating/Model/Resource/Rating.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Resource/Rating/Collection.php
+++ b/app/code/Magento/Rating/Model/Resource/Rating/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Resource/Rating/Entity.php
+++ b/app/code/Magento/Rating/Model/Resource/Rating/Entity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Resource/Rating/Grid/Collection.php
+++ b/app/code/Magento/Rating/Model/Resource/Rating/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Resource/Rating/Option.php
+++ b/app/code/Magento/Rating/Model/Resource/Rating/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Resource/Rating/Option/Collection.php
+++ b/app/code/Magento/Rating/Model/Resource/Rating/Option/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Resource/Rating/Option/Vote.php
+++ b/app/code/Magento/Rating/Model/Resource/Rating/Option/Vote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/Model/Resource/Rating/Option/Vote/Collection.php
+++ b/app/code/Magento/Rating/Model/Resource/Rating/Option/Vote/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/data/rating_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Rating/data/rating_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Rating/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/etc/adminhtml/events.xml
+++ b/app/code/Magento/Rating/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/etc/module.xml
+++ b/app/code/Magento/Rating/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/sql/rating_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Rating/sql/rating_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/sql/rating_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/Rating/sql/rating_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/view/frontend/detailed.phtml
+++ b/app/code/Magento/Rating/view/frontend/detailed.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rating/view/frontend/empty.phtml
+++ b/app/code/Magento/Rating/view/frontend/empty.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Adminhtml/Customer/Accounts.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Customer/Accounts.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Adminhtml/Customer/Orders.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Customer/Orders.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Adminhtml/Customer/Totals.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Customer/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Adminhtml/Grid.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Adminhtml/Product/Sold.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Product/Sold.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Adminhtml/Refresh/Statistics.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Refresh/Statistics.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Product/AbstractProduct.php
+++ b/app/code/Magento/Reports/Block/Product/AbstractProduct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Product/Compared.php
+++ b/app/code/Magento/Reports/Block/Product/Compared.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Product/Viewed.php
+++ b/app/code/Magento/Reports/Block/Product/Viewed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Product/Widget/Compared.php
+++ b/app/code/Magento/Reports/Block/Product/Widget/Compared.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Block/Product/Widget/Viewed.php
+++ b/app/code/Magento/Reports/Block/Product/Widget/Viewed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Exception.php
+++ b/app/code/Magento/Reports/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Helper/Data.php
+++ b/app/code/Magento/Reports/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Config.php
+++ b/app/code/Magento/Reports/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Event.php
+++ b/app/code/Magento/Reports/Model/Event.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Event/Observer.php
+++ b/app/code/Magento/Reports/Model/Event/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Event/Type.php
+++ b/app/code/Magento/Reports/Model/Event/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Flag.php
+++ b/app/code/Magento/Reports/Model/Flag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Grouped/Collection.php
+++ b/app/code/Magento/Reports/Model/Grouped/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Plugin/Log.php
+++ b/app/code/Magento/Reports/Model/Plugin/Log.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Product/Index/AbstractIndex.php
+++ b/app/code/Magento/Reports/Model/Product/Index/AbstractIndex.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Product/Index/Compared.php
+++ b/app/code/Magento/Reports/Model/Product/Index/Compared.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Product/Index/Factory.php
+++ b/app/code/Magento/Reports/Model/Product/Index/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Product/Index/Viewed.php
+++ b/app/code/Magento/Reports/Model/Product/Index/Viewed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Accounts/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Accounts/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Accounts/Collection/Initial.php
+++ b/app/code/Magento/Reports/Model/Resource/Accounts/Collection/Initial.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Customer/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Customer/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Customer/Orders/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Customer/Orders/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Customer/Orders/Collection/Initial.php
+++ b/app/code/Magento/Reports/Model/Resource/Customer/Orders/Collection/Initial.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Customer/Totals/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Customer/Totals/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Customer/Totals/Collection/Initial.php
+++ b/app/code/Magento/Reports/Model/Resource/Customer/Totals/Collection/Initial.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Entity/Summary/Collection/AbstractCollection.php
+++ b/app/code/Magento/Reports/Model/Resource/Entity/Summary/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Event.php
+++ b/app/code/Magento/Reports/Model/Resource/Event.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Event/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Event/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Event/Type.php
+++ b/app/code/Magento/Reports/Model/Resource/Event/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Event/Type/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Event/Type/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Helper.php
+++ b/app/code/Magento/Reports/Model/Resource/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/HelperFactory.php
+++ b/app/code/Magento/Reports/Model/Resource/HelperFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/HelperInterface.php
+++ b/app/code/Magento/Reports/Model/Resource/HelperInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Order/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Downloads/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Downloads/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Index/AbstractIndex.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Index/AbstractIndex.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Index/Collection/AbstractCollection.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Index/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Index/Compared.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Index/Compared.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Index/Compared/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Index/Compared/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Index/Viewed.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Index/Viewed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Index/Viewed/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Index/Viewed/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Lowstock/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Lowstock/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Sold/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Sold/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Product/Sold/Collection/Initial.php
+++ b/app/code/Magento/Reports/Model/Resource/Product/Sold/Collection/Initial.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Quote/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Quote/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Refresh/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Refresh/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Report/AbstractReport.php
+++ b/app/code/Magento/Reports/Model/Resource/Report/AbstractReport.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Report/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Report/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Report/Collection/AbstractCollection.php
+++ b/app/code/Magento/Reports/Model/Resource/Report/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Report/Collection/Factory.php
+++ b/app/code/Magento/Reports/Model/Resource/Report/Collection/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Report/Product/Viewed.php
+++ b/app/code/Magento/Reports/Model/Resource/Report/Product/Viewed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Report/Product/Viewed/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Report/Product/Viewed/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Review/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Review/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Review/Customer/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Review/Customer/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Review/Product/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Review/Product/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Setup.php
+++ b/app/code/Magento/Reports/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Shopcart/Product/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Shopcart/Product/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Wishlist/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Wishlist/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Resource/Wishlist/Product/Collection.php
+++ b/app/code/Magento/Reports/Model/Resource/Wishlist/Product/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/Model/Totals.php
+++ b/app/code/Magento/Reports/Model/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/data/reports_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Reports/data/reports_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Reports/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/etc/adminhtml/di.xml
+++ b/app/code/Magento/Reports/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Reports/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/etc/adminhtml/system.xml
+++ b/app/code/Magento/Reports/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/etc/config.xml
+++ b/app/code/Magento/Reports/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/etc/di.xml
+++ b/app/code/Magento/Reports/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/etc/frontend/di.xml
+++ b/app/code/Magento/Reports/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/etc/frontend/events.xml
+++ b/app/code/Magento/Reports/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/etc/module.xml
+++ b/app/code/Magento/Reports/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/etc/widget.xml
+++ b/app/code/Magento/Reports/etc/widget.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/sql/reports_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Reports/sql/reports_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/sql/reports_setup/mysql4-install-1.6.0.0.php
+++ b/app/code/Magento/Reports/sql/reports_setup/mysql4-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/sql/reports_setup/upgrade-1.6.0.0-1.6.0.0.1.php
+++ b/app/code/Magento/Reports/sql/reports_setup/upgrade-1.6.0.0-1.6.0.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/sql/reports_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
+++ b/app/code/Magento/Reports/sql/reports_setup/upgrade-1.6.0.0.1-1.6.0.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/grid.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/grid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_accounts.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_accounts.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_accounts_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_accounts_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exportaccountscsv.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exportaccountscsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exportaccountsexcel.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exportaccountsexcel.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exportorderscsv.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exportorderscsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exportordersexcel.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exportordersexcel.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exporttotalscsv.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exporttotalscsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exporttotalsexcel.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_exporttotalsexcel.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_orders.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_orders.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_orders_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_orders_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_totals.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_totals.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_totals_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_customer_totals_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_exportlowstockcsv.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_exportlowstockcsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_exportlowstockexcel.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_exportlowstockexcel.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_exportsoldcsv.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_exportsoldcsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_exportsoldexcel.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_exportsoldexcel.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_lowstock.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_lowstock.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_lowstock_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_lowstock_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_sold.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_sold.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_sold_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_product_sold_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_customer.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_customer.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_customer_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_customer_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_exportcustomercsv.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_exportcustomercsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_exportcustomerexcel.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_exportcustomerexcel.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_exportproductcsv.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_exportproductcsv.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_exportproductexcel.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_exportproductexcel.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_product.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_product.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_product_grid.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_review_product_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_statistics_index.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/adminhtml_report_statistics_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/store/switcher.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/store/switcher.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/adminhtml/store/switcher/enhanced.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/store/switcher/enhanced.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/home_product_compared.phtml
+++ b/app/code/Magento/Reports/view/frontend/home_product_compared.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/home_product_viewed.phtml
+++ b/app/code/Magento/Reports/view/frontend/home_product_viewed.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/layout/catalog_category_view_type_default_without_children.xml
+++ b/app/code/Magento/Reports/view/frontend/layout/catalog_category_view_type_default_without_children.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/layout/catalog_category_view_type_layered_without_children.xml
+++ b/app/code/Magento/Reports/view/frontend/layout/catalog_category_view_type_layered_without_children.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/layout/default.xml
+++ b/app/code/Magento/Reports/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/layout/print.xml
+++ b/app/code/Magento/Reports/view/frontend/layout/print.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/product_compared.phtml
+++ b/app/code/Magento/Reports/view/frontend/product_compared.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/product_viewed.phtml
+++ b/app/code/Magento/Reports/view/frontend/product_viewed.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widget/compared/column/compared_default_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/widget/compared/column/compared_default_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widget/compared/column/compared_images_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/widget/compared/column/compared_images_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widget/compared/column/compared_names_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/widget/compared/column/compared_names_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widget/compared/content/compared_grid.phtml
+++ b/app/code/Magento/Reports/view/frontend/widget/compared/content/compared_grid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widget/compared/content/compared_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/widget/compared/content/compared_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widget/viewed/column/viewed_default_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/widget/viewed/column/viewed_default_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widget/viewed/column/viewed_images_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/widget/viewed/column/viewed_images_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widget/viewed/column/viewed_names_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/widget/viewed/column/viewed_names_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widget/viewed/content/viewed_grid.phtml
+++ b/app/code/Magento/Reports/view/frontend/widget/viewed/content/viewed_grid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widget/viewed/content/viewed_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/widget/viewed/content/viewed_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Reports/view/frontend/widgets.css
+++ b/app/code/Magento/Reports/view/frontend/widgets.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Block/Customer/ListCustomer.php
+++ b/app/code/Magento/Review/Block/Customer/ListCustomer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Block/Customer/Recent.php
+++ b/app/code/Magento/Review/Block/Customer/Recent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Block/Customer/View.php
+++ b/app/code/Magento/Review/Block/Customer/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Block/Form.php
+++ b/app/code/Magento/Review/Block/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Block/Helper.php
+++ b/app/code/Magento/Review/Block/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Block/Product/View.php
+++ b/app/code/Magento/Review/Block/Product/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Block/Product/View/ListView.php
+++ b/app/code/Magento/Review/Block/Product/View/ListView.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Block/Product/View/Other.php
+++ b/app/code/Magento/Review/Block/Product/View/Other.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Block/View.php
+++ b/app/code/Magento/Review/Block/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Controller/Customer.php
+++ b/app/code/Magento/Review/Controller/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Controller/Product.php
+++ b/app/code/Magento/Review/Controller/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Helper/Action/Pager.php
+++ b/app/code/Magento/Review/Helper/Action/Pager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Helper/Data.php
+++ b/app/code/Magento/Review/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Observer.php
+++ b/app/code/Magento/Review/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Resource/Review.php
+++ b/app/code/Magento/Review/Model/Resource/Review.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Resource/Review/Collection.php
+++ b/app/code/Magento/Review/Model/Resource/Review/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Resource/Review/Product/Collection.php
+++ b/app/code/Magento/Review/Model/Resource/Review/Product/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Resource/Review/Status.php
+++ b/app/code/Magento/Review/Model/Resource/Review/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Resource/Review/Status/Collection.php
+++ b/app/code/Magento/Review/Model/Resource/Review/Status/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Resource/Review/Summary.php
+++ b/app/code/Magento/Review/Model/Resource/Review/Summary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Resource/Review/Summary/Collection.php
+++ b/app/code/Magento/Review/Model/Resource/Review/Summary/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Review.php
+++ b/app/code/Magento/Review/Model/Review.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Review/Status.php
+++ b/app/code/Magento/Review/Model/Review/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/Model/Review/Summary.php
+++ b/app/code/Magento/Review/Model/Review/Summary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/data/review_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Review/data/review_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Review/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/etc/adminhtml/di.xml
+++ b/app/code/Magento/Review/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/etc/adminhtml/events.xml
+++ b/app/code/Magento/Review/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Review/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/etc/adminhtml/system.xml
+++ b/app/code/Magento/Review/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/etc/config.xml
+++ b/app/code/Magento/Review/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/etc/frontend/di.xml
+++ b/app/code/Magento/Review/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/etc/frontend/events.xml
+++ b/app/code/Magento/Review/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/etc/frontend/routes.xml
+++ b/app/code/Magento/Review/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/etc/module.xml
+++ b/app/code/Magento/Review/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/sql/review_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Review/sql/review_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/customer/list.phtml
+++ b/app/code/Magento/Review/view/frontend/customer/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/customer/recent.phtml
+++ b/app/code/Magento/Review/view/frontend/customer/recent.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/customer/view.phtml
+++ b/app/code/Magento/Review/view/frontend/customer/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/form.phtml
+++ b/app/code/Magento/Review/view/frontend/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/helper/summary.phtml
+++ b/app/code/Magento/Review/view/frontend/helper/summary.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/helper/summary_short.phtml
+++ b/app/code/Magento/Review/view/frontend/helper/summary_short.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Review/view/frontend/layout/customer_account.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/layout/customer_account_index.xml
+++ b/app/code/Magento/Review/view/frontend/layout/customer_account_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/layout/review_customer_index.xml
+++ b/app/code/Magento/Review/view/frontend/layout/review_customer_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/layout/review_customer_view.xml
+++ b/app/code/Magento/Review/view/frontend/layout/review_customer_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/layout/review_product_list.xml
+++ b/app/code/Magento/Review/view/frontend/layout/review_product_list.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/layout/review_product_view.xml
+++ b/app/code/Magento/Review/view/frontend/layout/review_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/product/view/count.phtml
+++ b/app/code/Magento/Review/view/frontend/product/view/count.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/product/view/list.phtml
+++ b/app/code/Magento/Review/view/frontend/product/view/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/product/view/other.phtml
+++ b/app/code/Magento/Review/view/frontend/product/view/other.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Review/view/frontend/view.phtml
+++ b/app/code/Magento/Review/view/frontend/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/AbstractBlock.php
+++ b/app/code/Magento/Rss/Block/AbstractBlock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Catalog/AbstractCatalog.php
+++ b/app/code/Magento/Rss/Block/Catalog/AbstractCatalog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Catalog/Category.php
+++ b/app/code/Magento/Rss/Block/Catalog/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Catalog/NewCatalog.php
+++ b/app/code/Magento/Rss/Block/Catalog/NewCatalog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Catalog/NotifyStock.php
+++ b/app/code/Magento/Rss/Block/Catalog/NotifyStock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Catalog/Review.php
+++ b/app/code/Magento/Rss/Block/Catalog/Review.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Catalog/Salesrule.php
+++ b/app/code/Magento/Rss/Block/Catalog/Salesrule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Catalog/Special.php
+++ b/app/code/Magento/Rss/Block/Catalog/Special.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/ListBlock.php
+++ b/app/code/Magento/Rss/Block/ListBlock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Order/Details.php
+++ b/app/code/Magento/Rss/Block/Order/Details.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Order/NewOrder.php
+++ b/app/code/Magento/Rss/Block/Order/NewOrder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Order/Status.php
+++ b/app/code/Magento/Rss/Block/Order/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Block/Wishlist.php
+++ b/app/code/Magento/Rss/Block/Wishlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Controller/Catalog.php
+++ b/app/code/Magento/Rss/Controller/Catalog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Controller/Index.php
+++ b/app/code/Magento/Rss/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Controller/Order.php
+++ b/app/code/Magento/Rss/Controller/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Helper/Data.php
+++ b/app/code/Magento/Rss/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Helper/Order.php
+++ b/app/code/Magento/Rss/Helper/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Model/Resource/Order.php
+++ b/app/code/Magento/Rss/Model/Resource/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Model/Rss.php
+++ b/app/code/Magento/Rss/Model/Rss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/Model/System/Config/Backend/Links.php
+++ b/app/code/Magento/Rss/Model/System/Config/Backend/Links.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Rss/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/etc/adminhtml/system.xml
+++ b/app/code/Magento/Rss/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/etc/frontend/di.xml
+++ b/app/code/Magento/Rss/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/etc/frontend/routes.xml
+++ b/app/code/Magento/Rss/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/etc/module.xml
+++ b/app/code/Magento/Rss/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/adminhtml/layout/rss_catalog_notifystock.xml
+++ b/app/code/Magento/Rss/view/adminhtml/layout/rss_catalog_notifystock.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/adminhtml/layout/rss_catalog_review.xml
+++ b/app/code/Magento/Rss/view/adminhtml/layout/rss_catalog_review.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/adminhtml/layout/rss_order_new.xml
+++ b/app/code/Magento/Rss/view/adminhtml/layout/rss_order_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/frontend/layout/default.xml
+++ b/app/code/Magento/Rss/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/frontend/layout/rss_catalog_category.xml
+++ b/app/code/Magento/Rss/view/frontend/layout/rss_catalog_category.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/frontend/layout/rss_catalog_new.xml
+++ b/app/code/Magento/Rss/view/frontend/layout/rss_catalog_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/frontend/layout/rss_catalog_salesrule.xml
+++ b/app/code/Magento/Rss/view/frontend/layout/rss_catalog_salesrule.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/frontend/layout/rss_catalog_special.xml
+++ b/app/code/Magento/Rss/view/frontend/layout/rss_catalog_special.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/frontend/layout/rss_index_index.xml
+++ b/app/code/Magento/Rss/view/frontend/layout/rss_index_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/frontend/layout/rss_index_wishlist.xml
+++ b/app/code/Magento/Rss/view/frontend/layout/rss_index_wishlist.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/frontend/layout/rss_order_status.xml
+++ b/app/code/Magento/Rss/view/frontend/layout/rss_order_status.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/frontend/list.phtml
+++ b/app/code/Magento/Rss/view/frontend/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rss/view/frontend/order/details.phtml
+++ b/app/code/Magento/Rss/view/frontend/order/details.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Block/Actions.php
+++ b/app/code/Magento/Rule/Block/Actions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Block/Conditions.php
+++ b/app/code/Magento/Rule/Block/Conditions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Block/Editable.php
+++ b/app/code/Magento/Rule/Block/Editable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Block/Newchild.php
+++ b/app/code/Magento/Rule/Block/Newchild.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Block/Rule.php
+++ b/app/code/Magento/Rule/Block/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Helper/Data.php
+++ b/app/code/Magento/Rule/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/AbstractModel.php
+++ b/app/code/Magento/Rule/Model/AbstractModel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Action/AbstractAction.php
+++ b/app/code/Magento/Rule/Model/Action/AbstractAction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Action/ActionInterface.php
+++ b/app/code/Magento/Rule/Model/Action/ActionInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Action/Collection.php
+++ b/app/code/Magento/Rule/Model/Action/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/ActionFactory.php
+++ b/app/code/Magento/Rule/Model/ActionFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Condition/AbstractCondition.php
+++ b/app/code/Magento/Rule/Model/Condition/AbstractCondition.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Condition/Combine.php
+++ b/app/code/Magento/Rule/Model/Condition/Combine.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Condition/ConditionInterface.php
+++ b/app/code/Magento/Rule/Model/Condition/ConditionInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Condition/Context.php
+++ b/app/code/Magento/Rule/Model/Condition/Context.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php
+++ b/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/ConditionFactory.php
+++ b/app/code/Magento/Rule/Model/ConditionFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Renderer/Actions.php
+++ b/app/code/Magento/Rule/Model/Renderer/Actions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Renderer/Conditions.php
+++ b/app/code/Magento/Rule/Model/Renderer/Conditions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Resource/AbstractResource.php
+++ b/app/code/Magento/Rule/Model/Resource/AbstractResource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Resource/Rule/Collection/AbstractCollection.php
+++ b/app/code/Magento/Rule/Model/Resource/Rule/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/Model/Rule.php
+++ b/app/code/Magento/Rule/Model/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Rule/etc/module.xml
+++ b/app/code/Magento/Rule/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/View/Form.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/View/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Orders.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/View/Tab/Orders.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/View/Tabs.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Billing/Agreement/View/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Customer/Edit/Tab/Agreement.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Customer/Edit/Tab/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Customer/Edit/Tab/Recurring/Profile.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Customer/Edit/Tab/Recurring/Profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/Edit/Form.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/Grid.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View/Getawayinfo.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View/Getawayinfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View/Info.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Info.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Orders.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Recurring/Profile/View/Tab/Orders.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Report/Filter/Form.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Report/Filter/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Report/Filter/Form/Coupon.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Report/Filter/Form/Coupon.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/Report/Filter/Form/Order.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Report/Filter/Form/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Adminhtml/System/Config/Form/Fieldset/Order/Statuses.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/System/Config/Form/Fieldset/Order/Statuses.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Billing/Agreement/View.php
+++ b/app/code/Magento/Sales/Block/Billing/Agreement/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Billing/Agreements.php
+++ b/app/code/Magento/Sales/Block/Billing/Agreements.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Guest/Link.php
+++ b/app/code/Magento/Sales/Block/Guest/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Items/AbstractItems.php
+++ b/app/code/Magento/Sales/Block/Items/AbstractItems.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Comments.php
+++ b/app/code/Magento/Sales/Block/Order/Comments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Creditmemo.php
+++ b/app/code/Magento/Sales/Block/Order/Creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Creditmemo/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Creditmemo/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Creditmemo/Totals.php
+++ b/app/code/Magento/Sales/Block/Order/Creditmemo/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Email/Creditmemo/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Creditmemo/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Email/Invoice/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Invoice/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Email/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Email/Items/DefaultItems.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items/DefaultItems.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Email/Items/Order/Grouped.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items/Order/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Email/Shipment/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Shipment/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/History.php
+++ b/app/code/Magento/Sales/Block/Order/History.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Info.php
+++ b/app/code/Magento/Sales/Block/Order/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Info/Buttons.php
+++ b/app/code/Magento/Sales/Block/Order/Info/Buttons.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Invoice.php
+++ b/app/code/Magento/Sales/Block/Order/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Invoice/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Invoice/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Invoice/Totals.php
+++ b/app/code/Magento/Sales/Block/Order/Invoice/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Item/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/Sales/Block/Order/Item/Renderer/DefaultRenderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Item/Renderer/Grouped.php
+++ b/app/code/Magento/Sales/Block/Order/Item/Renderer/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Link.php
+++ b/app/code/Magento/Sales/Block/Order/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/PrintOrder/Creditmemo.php
+++ b/app/code/Magento/Sales/Block/Order/PrintOrder/Creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/PrintOrder/Invoice.php
+++ b/app/code/Magento/Sales/Block/Order/PrintOrder/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/PrintOrder/Shipment.php
+++ b/app/code/Magento/Sales/Block/Order/PrintOrder/Shipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/PrintShipment.php
+++ b/app/code/Magento/Sales/Block/Order/PrintShipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Recent.php
+++ b/app/code/Magento/Sales/Block/Order/Recent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Shipment.php
+++ b/app/code/Magento/Sales/Block/Order/Shipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Shipment/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Shipment/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/Totals.php
+++ b/app/code/Magento/Sales/Block/Order/Totals.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Order/View.php
+++ b/app/code/Magento/Sales/Block/Order/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Payment/Form/Billing/Agreement.php
+++ b/app/code/Magento/Sales/Block/Payment/Form/Billing/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Payment/Info/Billing/Agreement.php
+++ b/app/code/Magento/Sales/Block/Payment/Info/Billing/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Recurring/Profile/Grid.php
+++ b/app/code/Magento/Sales/Block/Recurring/Profile/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Recurring/Profile/Related/Orders/Grid.php
+++ b/app/code/Magento/Sales/Block/Recurring/Profile/Related/Orders/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Recurring/Profile/View.php
+++ b/app/code/Magento/Sales/Block/Recurring/Profile/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Recurring/Profile/View/Address.php
+++ b/app/code/Magento/Sales/Block/Recurring/Profile/View/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Recurring/Profile/View/Data.php
+++ b/app/code/Magento/Sales/Block/Recurring/Profile/View/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Recurring/Profile/View/Fees.php
+++ b/app/code/Magento/Sales/Block/Recurring/Profile/View/Fees.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Recurring/Profile/View/Item.php
+++ b/app/code/Magento/Sales/Block/Recurring/Profile/View/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Recurring/Profile/View/Reference.php
+++ b/app/code/Magento/Sales/Block/Recurring/Profile/View/Reference.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Recurring/Profile/View/Schedule.php
+++ b/app/code/Magento/Sales/Block/Recurring/Profile/View/Schedule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Recurring/Profiles.php
+++ b/app/code/Magento/Sales/Block/Recurring/Profiles.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Reorder/Sidebar.php
+++ b/app/code/Magento/Sales/Block/Reorder/Sidebar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Status/Grid/Column/State.php
+++ b/app/code/Magento/Sales/Block/Status/Grid/Column/State.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Status/Grid/Column/Unassign.php
+++ b/app/code/Magento/Sales/Block/Status/Grid/Column/Unassign.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Block/Widget/Guest/Form.php
+++ b/app/code/Magento/Sales/Block/Widget/Guest/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Controller/AbstractController.php
+++ b/app/code/Magento/Sales/Controller/AbstractController.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Controller/Billing/Agreement.php
+++ b/app/code/Magento/Sales/Controller/Billing/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Controller/Download.php
+++ b/app/code/Magento/Sales/Controller/Download.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Controller/Guest.php
+++ b/app/code/Magento/Sales/Controller/Guest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Controller/Order.php
+++ b/app/code/Magento/Sales/Controller/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Controller/Recurring/Profile.php
+++ b/app/code/Magento/Sales/Controller/Recurring/Profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Exception.php
+++ b/app/code/Magento/Sales/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Helper/Data.php
+++ b/app/code/Magento/Sales/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Helper/Guest.php
+++ b/app/code/Magento/Sales/Helper/Guest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Helper/Reorder.php
+++ b/app/code/Magento/Sales/Helper/Reorder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/AbstractModel.php
+++ b/app/code/Magento/Sales/Model/AbstractModel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Billing/Agreement.php
+++ b/app/code/Magento/Sales/Model/Billing/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Billing/Agreement/OrdersUpdater.php
+++ b/app/code/Magento/Sales/Model/Billing/Agreement/OrdersUpdater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/CarrierFactory.php
+++ b/app/code/Magento/Sales/Model/CarrierFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Config.php
+++ b/app/code/Magento/Sales/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Config/Converter.php
+++ b/app/code/Magento/Sales/Model/Config/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Config/Data.php
+++ b/app/code/Magento/Sales/Model/Config/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Config/Ordered.php
+++ b/app/code/Magento/Sales/Model/Config/Ordered.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Config/Reader.php
+++ b/app/code/Magento/Sales/Model/Config/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Config/SchemaLocator.php
+++ b/app/code/Magento/Sales/Model/Config/SchemaLocator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Config/Source/Order/Status.php
+++ b/app/code/Magento/Sales/Model/Config/Source/Order/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Config/Source/Order/Status/NewStatus.php
+++ b/app/code/Magento/Sales/Model/Config/Source/Order/Status/NewStatus.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Config/Source/Order/Status/Newprocessing.php
+++ b/app/code/Magento/Sales/Model/Config/Source/Order/Status/Newprocessing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Config/Source/Order/Status/Processing.php
+++ b/app/code/Magento/Sales/Model/Config/Source/Order/Status/Processing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/ConfigInterface.php
+++ b/app/code/Magento/Sales/Model/ConfigInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Convert/Order.php
+++ b/app/code/Magento/Sales/Model/Convert/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Convert/Quote.php
+++ b/app/code/Magento/Sales/Model/Convert/Quote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/ConverterInterface.php
+++ b/app/code/Magento/Sales/Model/ConverterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Email/Template.php
+++ b/app/code/Magento/Sales/Model/Email/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Observer.php
+++ b/app/code/Magento/Sales/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Observer/Backend/BillingAgreement.php
+++ b/app/code/Magento/Sales/Model/Observer/Backend/BillingAgreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Observer/Backend/CatalogPriceRule.php
+++ b/app/code/Magento/Sales/Model/Observer/Backend/CatalogPriceRule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Observer/Backend/CatalogProductQuote.php
+++ b/app/code/Magento/Sales/Model/Observer/Backend/CatalogProductQuote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Observer/Backend/CustomerQuote.php
+++ b/app/code/Magento/Sales/Model/Observer/Backend/CustomerQuote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Observer/Backend/RecurringProfile/FormRenderer.php
+++ b/app/code/Magento/Sales/Model/Observer/Backend/RecurringProfile/FormRenderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Address.php
+++ b/app/code/Magento/Sales/Model/Order/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Comment.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Comment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/AbstractTotal.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/AbstractTotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Cost.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Cost.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Grand.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Grand.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Shipping.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Subtotal.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Subtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Grid/Massaction/ItemsUpdater.php
+++ b/app/code/Magento/Sales/Model/Order/Grid/Massaction/ItemsUpdater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Grid/Row/UrlGenerator.php
+++ b/app/code/Magento/Sales/Model/Order/Grid/Row/UrlGenerator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice/Comment.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Comment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice/Total/AbstractTotal.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Total/AbstractTotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice/Total/Cost.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Total/Cost.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Total/Discount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice/Total/Grand.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Total/Grand.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice/Total/Shipping.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Total/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice/Total/Subtotal.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Total/Subtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Invoice/Total/Tax.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Total/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Payment.php
+++ b/app/code/Magento/Sales/Model/Order/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Payment/Transaction.php
+++ b/app/code/Magento/Sales/Model/Order/Payment/Transaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Config/Converter.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Config/Converter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Config/Reader.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Config/SchemaLocator.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Creditmemo.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/AbstractItems.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/AbstractItems.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Creditmemo/DefaultCreditmemo.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Creditmemo/DefaultCreditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Creditmemo/Grouped.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Creditmemo/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/Grouped.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/Grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Shipment/DefaultShipment.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Shipment/DefaultShipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/ItemsFactory.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/ItemsFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Shipment.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Shipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Shipment/Packaging.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Shipment/Packaging.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Total/DefaultTotal.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Total/DefaultTotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Pdf/Total/Factory.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Total/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Shipment.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Shipment/Comment.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Comment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Shipment/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Shipment/Track.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Track.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Status.php
+++ b/app/code/Magento/Sales/Model/Order/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Status/History.php
+++ b/app/code/Magento/Sales/Model/Order/Status/History.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Tax.php
+++ b/app/code/Magento/Sales/Model/Order/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Total.php
+++ b/app/code/Magento/Sales/Model/Order/Total.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Total/AbstractTotal.php
+++ b/app/code/Magento/Sales/Model/Order/Total/AbstractTotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/Total/Config/Base.php
+++ b/app/code/Magento/Sales/Model/Order/Total/Config/Base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Order/TotalFactory.php
+++ b/app/code/Magento/Sales/Model/Order/TotalFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Payment/Method/Billing/AbstractAgreement.php
+++ b/app/code/Magento/Sales/Model/Payment/Method/Billing/AbstractAgreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Payment/Method/Converter.php
+++ b/app/code/Magento/Sales/Model/Payment/Method/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote.php
+++ b/app/code/Magento/Sales/Model/Quote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address.php
+++ b/app/code/Magento/Sales/Model/Quote/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Item.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Rate.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Rate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/AbstractTotal.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/AbstractTotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Collector.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Collector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Custbalance.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Custbalance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Discount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Grand.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Grand.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Msrp.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Msrp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/AbstractRecurring.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/AbstractRecurring.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/Collector.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/Collector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/Recurring/Initial.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/Recurring/Initial.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/Recurring/Trial.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/Recurring/Trial.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Nominal/Subtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Shipping.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Subtotal.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Subtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Tax.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Address/TotalFactory.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/TotalFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Config.php
+++ b/app/code/Magento/Sales/Model/Quote/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Item.php
+++ b/app/code/Magento/Sales/Model/Quote/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Item/AbstractItem.php
+++ b/app/code/Magento/Sales/Model/Quote/Item/AbstractItem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Item/Option.php
+++ b/app/code/Magento/Sales/Model/Quote/Item/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Quote/Payment.php
+++ b/app/code/Magento/Sales/Model/Quote/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Recurring/Profile.php
+++ b/app/code/Magento/Sales/Model/Recurring/Profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/AbstractResource.php
+++ b/app/code/Magento/Sales/Model/Resource/AbstractResource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Billing/Agreement.php
+++ b/app/code/Magento/Sales/Model/Resource/Billing/Agreement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Billing/Agreement/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Billing/Agreement/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Collection/AbstractCollection.php
+++ b/app/code/Magento/Sales/Model/Resource/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Factory.php
+++ b/app/code/Magento/Sales/Model/Resource/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Helper.php
+++ b/app/code/Magento/Sales/Model/Resource/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/HelperInterface.php
+++ b/app/code/Magento/Sales/Model/Resource/HelperInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order.php
+++ b/app/code/Magento/Sales/Model/Resource/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/AbstractOrder.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/AbstractOrder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Address.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Address/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Address/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Attribute/Backend/Billing.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Attribute/Backend/Billing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Attribute/Backend/Child.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Attribute/Backend/Child.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Attribute/Backend/Parent.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Attribute/Backend/Parent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Attribute/Backend/Shipping.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Attribute/Backend/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Collection/AbstractCollection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Collection/Factory.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Collection/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Comment/Collection/AbstractCollection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Comment/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Creditmemo.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Child.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Child.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Parent.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Attribute/Backend/Parent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Comment.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Comment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Comment/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Comment/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Item.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Item/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Creditmemo/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Customer/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Customer/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Grid/StatusesArray.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Grid/StatusesArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Child.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Child.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Item.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Order.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Parent.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice/Attribute/Backend/Parent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice/Comment.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice/Comment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice/Comment/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice/Comment/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice/Item.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Invoice/Item/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Invoice/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Item/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Payment.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Payment/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Payment/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Payment/Transaction.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Payment/Transaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Payment/Transaction/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Payment/Transaction/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Child.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Child.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Parent.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment/Attribute/Backend/Parent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment/Comment.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment/Comment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment/Comment/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment/Comment/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment/Item.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment/Item/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment/Track.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment/Track.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Shipment/Track/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Shipment/Track/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Status.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Status/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Status/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Status/History.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Status/History.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Status/History/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Status/History/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Tax.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Order/Tax/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Order/Tax/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Backend.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Backend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Backend/Child.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Backend/Child.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Backend/Parent.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Backend/Parent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Backend/Region.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Backend/Region.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Custbalance.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Custbalance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Discount.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Discount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Grand.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Grand.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Shipping.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Subtotal.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Subtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Tax.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Attribute/Frontend/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Item.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Item/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Rate.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Rate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Address/Rate/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Address/Rate/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Item.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Item/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Item/Option.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Item/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Item/Option/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Item/Option/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Payment.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Quote/Payment/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Quote/Payment/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Recurring/Profile.php
+++ b/app/code/Magento/Sales/Model/Resource/Recurring/Profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Recurring/Profile/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Recurring/Profile/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report.php
+++ b/app/code/Magento/Sales/Model/Resource/Report.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/AbstractReport.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/AbstractReport.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Bestsellers.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Bestsellers.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Bestsellers/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Bestsellers/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Collection/AbstractCollection.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Collection/AbstractCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Invoiced.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Invoiced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Invoiced/Collection/Invoiced.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Invoiced/Collection/Invoiced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Invoiced/Collection/Order.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Invoiced/Collection/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Order.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Order/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Order/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Order/Createdat.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Order/Createdat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Order/Updatedat.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Order/Updatedat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Order/Updatedat/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Order/Updatedat/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Refunded.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Refunded.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Refunded/Collection/Order.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Refunded/Collection/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Refunded/Collection/Refunded.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Refunded/Collection/Refunded.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Shipping.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Shipping/Collection/Order.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Shipping/Collection/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Report/Shipping/Collection/Shipment.php
+++ b/app/code/Magento/Sales/Model/Resource/Report/Shipping/Collection/Shipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Sale/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Sale/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Setup.php
+++ b/app/code/Magento/Sales/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Resource/Status/Collection.php
+++ b/app/code/Magento/Sales/Model/Resource/Status/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/ResourceFactory.php
+++ b/app/code/Magento/Sales/Model/ResourceFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Service/Order.php
+++ b/app/code/Magento/Sales/Model/Service/Order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Service/Quote.php
+++ b/app/code/Magento/Sales/Model/Service/Quote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Status/ListFactory.php
+++ b/app/code/Magento/Sales/Model/Status/ListFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/Model/Status/ListStatus.php
+++ b/app/code/Magento/Sales/Model/Status/ListStatus.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/data/sales_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Sales/data/sales_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/data/sales_setup/data-upgrade-1.6.0.10-1.6.0.11.php
+++ b/app/code/Magento/Sales/data/sales_setup/data-upgrade-1.6.0.10-1.6.0.11.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/data/sales_setup/data-upgrade-1.6.0.11-1.6.0.12.php
+++ b/app/code/Magento/Sales/data/sales_setup/data-upgrade-1.6.0.11-1.6.0.12.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/data/sales_setup/data-upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/Magento/Sales/data/sales_setup/data-upgrade-1.6.0.4-1.6.0.5.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/data/sales_setup/data-upgrade-1.6.0.8-1.6.0.9.php
+++ b/app/code/Magento/Sales/data/sales_setup/data-upgrade-1.6.0.8-1.6.0.9.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/adminhtml/events.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/adminhtml/system.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/catalog_attributes.xml
+++ b/app/code/Magento/Sales/etc/catalog_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/config.xml
+++ b/app/code/Magento/Sales/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/crontab.xml
+++ b/app/code/Magento/Sales/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/email_templates.xml
+++ b/app/code/Magento/Sales/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/events.xml
+++ b/app/code/Magento/Sales/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/fieldset.xml
+++ b/app/code/Magento/Sales/etc/fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/frontend/di.xml
+++ b/app/code/Magento/Sales/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/frontend/events.xml
+++ b/app/code/Magento/Sales/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/frontend/routes.xml
+++ b/app/code/Magento/Sales/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/module.xml
+++ b/app/code/Magento/Sales/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/pdf.xml
+++ b/app/code/Magento/Sales/etc/pdf.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/pdf.xsd
+++ b/app/code/Magento/Sales/etc/pdf.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/pdf_file.xsd
+++ b/app/code/Magento/Sales/etc/pdf_file.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/sales.xml
+++ b/app/code/Magento/Sales/etc/sales.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/sales.xsd
+++ b/app/code/Magento/Sales/etc/sales.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/etc/widget.xml
+++ b/app/code/Magento/Sales/etc/widget.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Sales/sql/sales_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.11-1.6.0.12.php
+++ b/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.11-1.6.0.12.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.3-1.6.0.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.4-1.6.0.5.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.5-1.6.0.6.php
+++ b/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.5-1.6.0.6.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.6-1.6.0.7.php
+++ b/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.6-1.6.0.7.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.7-1.6.0.8.php
+++ b/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.7-1.6.0.8.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.8-1.6.0.9.php
+++ b/app/code/Magento/Sales/sql/sales_setup/upgrade-1.6.0.8-1.6.0.9.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/adminhtml/billing/agreement/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/billing/agreement/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/adminhtml/billing/agreement/view/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/billing/agreement/view/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/adminhtml/billing/agreement/view/tab/info.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/billing/agreement/view/tab/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/adminhtml/payment/form/billing/agreement.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/payment/form/billing/agreement.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/adminhtml/recurring/profile/view.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/recurring/profile/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/adminhtml/recurring/profile/view/info.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/recurring/profile/view/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/billing/agreement/view.phtml
+++ b/app/code/Magento/Sales/view/frontend/billing/agreement/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/billing/agreements.phtml
+++ b/app/code/Magento/Sales/view/frontend/billing/agreements.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/email/creditmemo/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/email/creditmemo/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/email/invoice/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/email/invoice/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/email/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/email/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/email/items/creditmemo/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/email/items/creditmemo/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/email/items/invoice/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/email/items/invoice/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/email/items/order/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/email/items/order/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/email/items/shipment/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/email/items/shipment/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/email/shipment/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/email/shipment/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/email/shipment/track.phtml
+++ b/app/code/Magento/Sales/view/frontend/email/shipment/track.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/gift-message.js
+++ b/app/code/Magento/Sales/view/frontend/gift-message.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/guest/form.phtml
+++ b/app/code/Magento/Sales/view/frontend/guest/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/checkout_onepage_index.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/checkout_onepage_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/customer_account.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/customer_account_index.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/customer_account_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/default.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_billing_agreement_index.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_billing_agreement_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_billing_agreement_view.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_billing_agreement_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_creditmemo_items.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_creditmemo_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_invoice_items.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_invoice_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_items.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_items.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_items.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_creditmemo.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_creditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_form.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_form.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_invoice.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_invoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_printorder.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_printorder.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_printordercreditmemo.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_printordercreditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_printorderinvoice.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_printorderinvoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_printshipment.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_printshipment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_reorder.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_reorder.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_shipment.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_shipment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_guest_view.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_guest_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_creditmemo.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_creditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_guest_info_links.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_guest_info_links.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_history.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_history.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_info_links.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_info_links.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_invoice.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_invoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_printorder.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_printorder.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_printordercreditmemo.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_printordercreditmemo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_printorderinvoice.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_printorderinvoice.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_printshipment.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_printshipment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_reorder.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_reorder.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_shipment.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_shipment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_order_view.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_order_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_recurring_profile_index.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_recurring_profile_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_recurring_profile_orders.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_recurring_profile_orders.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_recurring_profile_view.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_recurring_profile_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/layout/sales_recurring_profile_view__tabs.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_recurring_profile_view__tabs.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/comments.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/comments.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/creditmemo.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/creditmemo.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/creditmemo/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/creditmemo/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/creditmemo/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/creditmemo/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/history.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/history.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/info.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/info/buttons.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/info/buttons.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/invoice.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/invoice.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/invoice/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/invoice/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/invoice/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/invoice/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/print.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/print.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/print/creditmemo.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/print/creditmemo.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/print/invoice.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/print/invoice.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/print/shipment.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/print/shipment.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/recent.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/recent.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/shipment.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/shipment.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/shipment/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/shipment/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/shipment/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/shipment/items/renderer/default.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/totals.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/totals.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/trackinginfo.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/trackinginfo.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/order/view.phtml
+++ b/app/code/Magento/Sales/view/frontend/order/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/orders-returns.js
+++ b/app/code/Magento/Sales/view/frontend/orders-returns.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/payment/form/billing/agreement.phtml
+++ b/app/code/Magento/Sales/view/frontend/payment/form/billing/agreement.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/recurring/grid.phtml
+++ b/app/code/Magento/Sales/view/frontend/recurring/grid.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/recurring/profile/view.phtml
+++ b/app/code/Magento/Sales/view/frontend/recurring/profile/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/recurring/profile/view/info.phtml
+++ b/app/code/Magento/Sales/view/frontend/recurring/profile/view/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/recurring/profiles.phtml
+++ b/app/code/Magento/Sales/view/frontend/recurring/profiles.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/reorder/sidebar.phtml
+++ b/app/code/Magento/Sales/view/frontend/reorder/sidebar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sales/view/frontend/widget/guest/form.phtml
+++ b/app/code/Magento/Sales/view/frontend/widget/guest/form.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Exception.php
+++ b/app/code/Magento/SalesRule/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Helper/Coupon.php
+++ b/app/code/Magento/SalesRule/Helper/Coupon.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Helper/Data.php
+++ b/app/code/Magento/SalesRule/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Coupon.php
+++ b/app/code/Magento/SalesRule/Model/Coupon.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Coupon/Codegenerator.php
+++ b/app/code/Magento/SalesRule/Model/Coupon/Codegenerator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Coupon/CodegeneratorInterface.php
+++ b/app/code/Magento/SalesRule/Model/Coupon/CodegeneratorInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Coupon/Massgenerator.php
+++ b/app/code/Magento/SalesRule/Model/Coupon/Massgenerator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Observer.php
+++ b/app/code/Magento/SalesRule/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Plugin/QuoteConfigProductAttributes.php
+++ b/app/code/Magento/SalesRule/Model/Plugin/QuoteConfigProductAttributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Quote/Discount.php
+++ b/app/code/Magento/SalesRule/Model/Quote/Discount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Quote/Freeshipping.php
+++ b/app/code/Magento/SalesRule/Model/Quote/Freeshipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Quote/Nominal/Discount.php
+++ b/app/code/Magento/SalesRule/Model/Quote/Nominal/Discount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Coupon.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Coupon.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Coupon/Collection.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Coupon/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Coupon/Usage.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Coupon/Usage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Report/Collection.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Report/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Report/Rule.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Report/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Report/Rule/Createdat.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Report/Rule/Createdat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Report/Rule/Updatedat.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Report/Rule/Updatedat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Report/Updatedat/Collection.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Report/Updatedat/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Rule.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Rule/Collection.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Rule/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Rule/Customer.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Rule/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Rule/Customer/Collection.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Rule/Customer/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Rule/Quote/Collection.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Rule/Quote/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Resource/Setup.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Rule.php
+++ b/app/code/Magento/SalesRule/Model/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Rule/Action/Collection.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Action/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Rule/Action/Product.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Action/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Address.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Combine.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Combine.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Product.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Product/Combine.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Product/Combine.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Product/Found.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Product/Found.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Product/Subselect.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Product/Subselect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Rule/Customer.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/System/Config/Source/Coupon/Format.php
+++ b/app/code/Magento/SalesRule/Model/System/Config/Source/Coupon/Format.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/Model/Validator.php
+++ b/app/code/Magento/SalesRule/Model/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/data/salesrule_setup/data-upgrade-1.6.0.3-1.6.0.4.php
+++ b/app/code/Magento/SalesRule/data/salesrule_setup/data-upgrade-1.6.0.3-1.6.0.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/adminhtml/acl.xml
+++ b/app/code/Magento/SalesRule/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/adminhtml/di.xml
+++ b/app/code/Magento/SalesRule/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/adminhtml/events.xml
+++ b/app/code/Magento/SalesRule/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/adminhtml/menu.xml
+++ b/app/code/Magento/SalesRule/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/adminhtml/system.xml
+++ b/app/code/Magento/SalesRule/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/config.xml
+++ b/app/code/Magento/SalesRule/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/crontab.xml
+++ b/app/code/Magento/SalesRule/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/di.xml
+++ b/app/code/Magento/SalesRule/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/events.xml
+++ b/app/code/Magento/SalesRule/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/fieldset.xml
+++ b/app/code/Magento/SalesRule/etc/fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/module.xml
+++ b/app/code/Magento/SalesRule/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/etc/sales.xml
+++ b/app/code/Magento/SalesRule/etc/sales.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/sql/salesrule_setup/install-1.6.0.0.php
+++ b/app/code/Magento/SalesRule/sql/salesrule_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/sql/salesrule_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/SalesRule/sql/salesrule_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/sql/salesrule_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/Magento/SalesRule/sql/salesrule_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/SalesRule/sql/salesrule_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/Magento/SalesRule/sql/salesrule_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/Block/Send.php
+++ b/app/code/Magento/Sendfriend/Block/Send.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/Controller/Product.php
+++ b/app/code/Magento/Sendfriend/Controller/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/Helper/Data.php
+++ b/app/code/Magento/Sendfriend/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/Model/Observer.php
+++ b/app/code/Magento/Sendfriend/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/Model/Resource/Sendfriend.php
+++ b/app/code/Magento/Sendfriend/Model/Resource/Sendfriend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/Model/Resource/Sendfriend/Collection.php
+++ b/app/code/Magento/Sendfriend/Model/Resource/Sendfriend/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/Model/Sendfriend.php
+++ b/app/code/Magento/Sendfriend/Model/Sendfriend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Sendfriend/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/etc/config.xml
+++ b/app/code/Magento/Sendfriend/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/etc/email_templates.xml
+++ b/app/code/Magento/Sendfriend/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/etc/frontend/events.xml
+++ b/app/code/Magento/Sendfriend/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/etc/frontend/routes.xml
+++ b/app/code/Magento/Sendfriend/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/etc/module.xml
+++ b/app/code/Magento/Sendfriend/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/sql/sendfriend_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Sendfriend/sql/sendfriend_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/view/frontend/layout/sendfriend_product_send.xml
+++ b/app/code/Magento/Sendfriend/view/frontend/layout/sendfriend_product_send.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sendfriend/view/frontend/send.phtml
+++ b/app/code/Magento/Sendfriend/view/frontend/send.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Service/AuthorizationException.php
+++ b/app/code/Magento/Service/AuthorizationException.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Service/Exception.php
+++ b/app/code/Magento/Service/Exception.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Service/ResourceNotFoundException.php
+++ b/app/code/Magento/Service/ResourceNotFoundException.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Service/etc/module.xml
+++ b/app/code/Magento/Service/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Block/Tracking/Ajax.php
+++ b/app/code/Magento/Shipping/Block/Tracking/Ajax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Block/Tracking/Popup.php
+++ b/app/code/Magento/Shipping/Block/Tracking/Popup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Controller/Tracking.php
+++ b/app/code/Magento/Shipping/Controller/Tracking.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Exception.php
+++ b/app/code/Magento/Shipping/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Helper/Data.php
+++ b/app/code/Magento/Shipping/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Carrier/CarrierInterface.php
+++ b/app/code/Magento/Shipping/Model/Carrier/CarrierInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Carrier/Factory.php
+++ b/app/code/Magento/Shipping/Model/Carrier/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Carrier/Flatrate.php
+++ b/app/code/Magento/Shipping/Model/Carrier/Flatrate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Carrier/Freeshipping.php
+++ b/app/code/Magento/Shipping/Model/Carrier/Freeshipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Carrier/Pickup.php
+++ b/app/code/Magento/Shipping/Model/Carrier/Pickup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Carrier/Tablerate.php
+++ b/app/code/Magento/Shipping/Model/Carrier/Tablerate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Config.php
+++ b/app/code/Magento/Shipping/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Config/Backend/Tablerate.php
+++ b/app/code/Magento/Shipping/Model/Config/Backend/Tablerate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Config/Source/Allmethods.php
+++ b/app/code/Magento/Shipping/Model/Config/Source/Allmethods.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Config/Source/Allspecificcountries.php
+++ b/app/code/Magento/Shipping/Model/Config/Source/Allspecificcountries.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Config/Source/Flatrate.php
+++ b/app/code/Magento/Shipping/Model/Config/Source/Flatrate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Config/Source/Tablerate.php
+++ b/app/code/Magento/Shipping/Model/Config/Source/Tablerate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Info.php
+++ b/app/code/Magento/Shipping/Model/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Rate/AbstractRate.php
+++ b/app/code/Magento/Shipping/Model/Rate/AbstractRate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Rate/Request.php
+++ b/app/code/Magento/Shipping/Model/Rate/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Rate/Result.php
+++ b/app/code/Magento/Shipping/Model/Rate/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Rate/Result/AbstractResult.php
+++ b/app/code/Magento/Shipping/Model/Rate/Result/AbstractResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Rate/Result/Error.php
+++ b/app/code/Magento/Shipping/Model/Rate/Result/Error.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Rate/Result/Method.php
+++ b/app/code/Magento/Shipping/Model/Rate/Result/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Resource/Carrier/Tablerate.php
+++ b/app/code/Magento/Shipping/Model/Resource/Carrier/Tablerate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Resource/Carrier/Tablerate/Collection.php
+++ b/app/code/Magento/Shipping/Model/Resource/Carrier/Tablerate/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Shipment/Request.php
+++ b/app/code/Magento/Shipping/Model/Shipment/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Shipment/ReturnShipment.php
+++ b/app/code/Magento/Shipping/Model/Shipment/ReturnShipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Shipping.php
+++ b/app/code/Magento/Shipping/Model/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Source/HandlingAction.php
+++ b/app/code/Magento/Shipping/Model/Source/HandlingAction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Source/HandlingType.php
+++ b/app/code/Magento/Shipping/Model/Source/HandlingType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Tracking/Result.php
+++ b/app/code/Magento/Shipping/Model/Tracking/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Tracking/Result/AbstractResult.php
+++ b/app/code/Magento/Shipping/Model/Tracking/Result/AbstractResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Tracking/Result/Error.php
+++ b/app/code/Magento/Shipping/Model/Tracking/Result/Error.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/Model/Tracking/Result/Status.php
+++ b/app/code/Magento/Shipping/Model/Tracking/Result/Status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Shipping/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/etc/adminhtml/system.xml
+++ b/app/code/Magento/Shipping/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/etc/config.xml
+++ b/app/code/Magento/Shipping/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/etc/frontend/routes.xml
+++ b/app/code/Magento/Shipping/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/etc/module.xml
+++ b/app/code/Magento/Shipping/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/sql/shipping_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Shipping/sql/shipping_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/view/frontend/layout/shipping_tracking_popup.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/shipping_tracking_popup.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Shipping/view/frontend/tracking/popup.phtml
+++ b/app/code/Magento/Shipping/view/frontend/tracking/popup.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Helper/Data.php
+++ b/app/code/Magento/Sitemap/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Model/Config/Backend/Priority.php
+++ b/app/code/Magento/Sitemap/Model/Config/Backend/Priority.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Model/Config/Source/Frequency.php
+++ b/app/code/Magento/Sitemap/Model/Config/Source/Frequency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Model/Observer.php
+++ b/app/code/Magento/Sitemap/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Model/Resource/Catalog/Category.php
+++ b/app/code/Magento/Sitemap/Model/Resource/Catalog/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Model/Resource/Catalog/Product.php
+++ b/app/code/Magento/Sitemap/Model/Resource/Catalog/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Model/Resource/Cms/Page.php
+++ b/app/code/Magento/Sitemap/Model/Resource/Cms/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Model/Resource/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Resource/Sitemap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Model/Resource/Sitemap/Collection.php
+++ b/app/code/Magento/Sitemap/Model/Resource/Sitemap/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/Model/Source/Product/Image/IncludeImage.php
+++ b/app/code/Magento/Sitemap/Model/Source/Product/Image/IncludeImage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Sitemap/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Sitemap/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/etc/adminhtml/system.xml
+++ b/app/code/Magento/Sitemap/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/etc/config.xml
+++ b/app/code/Magento/Sitemap/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/etc/crontab.xml
+++ b/app/code/Magento/Sitemap/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/etc/di.xml
+++ b/app/code/Magento/Sitemap/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/etc/email_templates.xml
+++ b/app/code/Magento/Sitemap/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/etc/module.xml
+++ b/app/code/Magento/Sitemap/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/sql/sitemap_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Sitemap/sql/sitemap_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/view/adminhtml/layout/adminhtml_sitemap_index.xml
+++ b/app/code/Magento/Sitemap/view/adminhtml/layout/adminhtml_sitemap_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Sitemap/view/adminhtml/layout/adminhtml_sitemap_index_grid_block.xml
+++ b/app/code/Magento/Sitemap/view/adminhtml/layout/adminhtml_sitemap_index_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Block/Adminhtml/Frontend/Region/Updater.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Frontend/Region/Updater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Block/Checkout/Discount.php
+++ b/app/code/Magento/Tax/Block/Checkout/Discount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Block/Checkout/Grandtotal.php
+++ b/app/code/Magento/Tax/Block/Checkout/Grandtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Block/Checkout/Shipping.php
+++ b/app/code/Magento/Tax/Block/Checkout/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Block/Checkout/Subtotal.php
+++ b/app/code/Magento/Tax/Block/Checkout/Subtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Block/Checkout/Tax.php
+++ b/app/code/Magento/Tax/Block/Checkout/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Block/Sales/Order/Tax.php
+++ b/app/code/Magento/Tax/Block/Sales/Order/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Exception.php
+++ b/app/code/Magento/Tax/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Helper/Data.php
+++ b/app/code/Magento/Tax/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Calculation.php
+++ b/app/code/Magento/Tax/Model/Calculation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Calculation/Rate.php
+++ b/app/code/Magento/Tax/Model/Calculation/Rate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Calculation/Rate/Title.php
+++ b/app/code/Magento/Tax/Model/Calculation/Rate/Title.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Calculation/RateFactory.php
+++ b/app/code/Magento/Tax/Model/Calculation/RateFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Calculation/Rule.php
+++ b/app/code/Magento/Tax/Model/Calculation/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/ClassModel.php
+++ b/app/code/Magento/Tax/Model/ClassModel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Config.php
+++ b/app/code/Magento/Tax/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Config/Price/IncludePrice.php
+++ b/app/code/Magento/Tax/Model/Config/Price/IncludePrice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Config/Source/Apply/On.php
+++ b/app/code/Magento/Tax/Model/Config/Source/Apply/On.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Config/Source/Basedon.php
+++ b/app/code/Magento/Tax/Model/Config/Source/Basedon.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Config/Source/Catalog.php
+++ b/app/code/Magento/Tax/Model/Config/Source/Catalog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Config/Source/TaxClass/Customer.php
+++ b/app/code/Magento/Tax/Model/Config/Source/TaxClass/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Config/Source/TaxClass/Product.php
+++ b/app/code/Magento/Tax/Model/Config/Source/TaxClass/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Observer.php
+++ b/app/code/Magento/Tax/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Rate/CsvImportHandler.php
+++ b/app/code/Magento/Tax/Model/Rate/CsvImportHandler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Calculation.php
+++ b/app/code/Magento/Tax/Model/Resource/Calculation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Calculation/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/Calculation/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Calculation/Grid/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/Calculation/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Calculation/Rate.php
+++ b/app/code/Magento/Tax/Model/Resource/Calculation/Rate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Calculation/Rate/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/Calculation/Rate/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Calculation/Rate/Title.php
+++ b/app/code/Magento/Tax/Model/Resource/Calculation/Rate/Title.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Calculation/Rate/Title/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/Calculation/Rate/Title/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Calculation/Rule.php
+++ b/app/code/Magento/Tax/Model/Resource/Calculation/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Calculation/Rule/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/Calculation/Rule/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Report/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/Report/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Report/Tax.php
+++ b/app/code/Magento/Tax/Model/Resource/Report/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Report/Tax/Createdat.php
+++ b/app/code/Magento/Tax/Model/Resource/Report/Tax/Createdat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Report/Tax/Updatedat.php
+++ b/app/code/Magento/Tax/Model/Resource/Report/Tax/Updatedat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Report/Updatedat/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/Report/Updatedat/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Rule/Grid/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/Rule/Grid/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Rule/Grid/Options/CustomerTaxClass.php
+++ b/app/code/Magento/Tax/Model/Resource/Rule/Grid/Options/CustomerTaxClass.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Rule/Grid/Options/HashOptimized.php
+++ b/app/code/Magento/Tax/Model/Resource/Rule/Grid/Options/HashOptimized.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Rule/Grid/Options/ProductTaxClass.php
+++ b/app/code/Magento/Tax/Model/Resource/Rule/Grid/Options/ProductTaxClass.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Sales/Order/Tax.php
+++ b/app/code/Magento/Tax/Model/Resource/Sales/Order/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Sales/Order/Tax/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/Sales/Order/Tax/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Sales/Order/Tax/Item.php
+++ b/app/code/Magento/Tax/Model/Resource/Sales/Order/Tax/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Sales/Order/Tax/Item/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/Sales/Order/Tax/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/Setup.php
+++ b/app/code/Magento/Tax/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/TaxClass.php
+++ b/app/code/Magento/Tax/Model/Resource/TaxClass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Resource/TaxClass/Collection.php
+++ b/app/code/Magento/Tax/Model/Resource/TaxClass/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Order/Tax.php
+++ b/app/code/Magento/Tax/Model/Sales/Order/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Order/Tax/Item.php
+++ b/app/code/Magento/Tax/Model/Sales/Order/Tax/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Pdf/Grandtotal.php
+++ b/app/code/Magento/Tax/Model/Sales/Pdf/Grandtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Pdf/Shipping.php
+++ b/app/code/Magento/Tax/Model/Sales/Pdf/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Pdf/Subtotal.php
+++ b/app/code/Magento/Tax/Model/Sales/Pdf/Subtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Pdf/Tax.php
+++ b/app/code/Magento/Tax/Model/Sales/Pdf/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Discount.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Discount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Nominal/Subtotal.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Nominal/Subtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Nominal/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Shipping.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Subtotal.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Subtotal.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/System/Config/Source/Algorithm.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/Algorithm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/System/Config/Source/Apply.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/Apply.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/System/Config/Source/PriceType.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/PriceType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/System/Config/Source/Tax/Country.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/Tax/Country.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/System/Config/Source/Tax/Display/Type.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/Tax/Display/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/System/Config/Source/Tax/Region.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/Tax/Region.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/TaxClass/AbstractType.php
+++ b/app/code/Magento/Tax/Model/TaxClass/AbstractType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/TaxClass/Factory.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/TaxClass/Source/Customer.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Source/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/TaxClass/Source/Product.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Source/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/TaxClass/Type/Customer.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Type/Customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/TaxClass/Type/Product.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Type/Product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/Model/TaxClass/Type/TypeInterface.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Type/TypeInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/data/tax_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/Tax/data/tax_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Tax/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Tax/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/adminhtml/system.xml
+++ b/app/code/Magento/Tax/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/catalog_attributes.xml
+++ b/app/code/Magento/Tax/etc/catalog_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/config.xml
+++ b/app/code/Magento/Tax/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/crontab.xml
+++ b/app/code/Magento/Tax/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/di.xml
+++ b/app/code/Magento/Tax/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/events.xml
+++ b/app/code/Magento/Tax/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/fieldset.xml
+++ b/app/code/Magento/Tax/etc/fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/module.xml
+++ b/app/code/Magento/Tax/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/pdf.xml
+++ b/app/code/Magento/Tax/etc/pdf.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/etc/sales.xml
+++ b/app/code/Magento/Tax/etc/sales.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/sql/tax_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Tax/sql/tax_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/sql/tax_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/Tax/sql/tax_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/sql/tax_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/Magento/Tax/sql/tax_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/sql/tax_setup/upgrade-1.6.0.2-1.6.0.3.php
+++ b/app/code/Magento/Tax/sql/tax_setup/upgrade-1.6.0.2-1.6.0.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/sql/tax_setup/upgrade-1.6.0.4-1.6.0.5.php
+++ b/app/code/Magento/Tax/sql/tax_setup/upgrade-1.6.0.4-1.6.0.5.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/view/frontend/checkout/discount.phtml
+++ b/app/code/Magento/Tax/view/frontend/checkout/discount.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/view/frontend/checkout/grandtotal.phtml
+++ b/app/code/Magento/Tax/view/frontend/checkout/grandtotal.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/view/frontend/checkout/shipping.phtml
+++ b/app/code/Magento/Tax/view/frontend/checkout/shipping.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/view/frontend/checkout/subtotal.phtml
+++ b/app/code/Magento/Tax/view/frontend/checkout/subtotal.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/view/frontend/checkout/tax.phtml
+++ b/app/code/Magento/Tax/view/frontend/checkout/tax.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Tax/view/frontend/order/tax.phtml
+++ b/app/code/Magento/Tax/view/frontend/order/tax.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/AbstractTab.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/AbstractTab.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Form.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Form/Element/File.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Form/Element/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Form/Element/Image.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Form/Element/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Form/Element/Links.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Form/Element/Links.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Tab/Css.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Tab/Css.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Tab/General.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Tab/General.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Tab/Js.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Tab/Js.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Tabs.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content/Files.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content/Files.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content/Uploader.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content/Uploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Tree.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Tree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Wysiwyg/Files.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Wysiwyg/Files.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Helper/Data.php
+++ b/app/code/Magento/Theme/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Helper/Storage.php
+++ b/app/code/Magento/Theme/Helper/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Model/Config.php
+++ b/app/code/Magento/Theme/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Model/Config/Customization.php
+++ b/app/code/Magento/Theme/Model/Config/Customization.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Model/Theme/Customization/File/CustomCss.php
+++ b/app/code/Magento/Theme/Model/Theme/Customization/File/CustomCss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Model/Theme/SingleFile.php
+++ b/app/code/Magento/Theme/Model/Theme/SingleFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Model/Uploader/Service.php
+++ b/app/code/Magento/Theme/Model/Uploader/Service.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/Model/Wysiwyg/Storage.php
+++ b/app/code/Magento/Theme/Model/Wysiwyg/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Theme/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Theme/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Theme/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/etc/config.xml
+++ b/app/code/Magento/Theme/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/etc/di.xml
+++ b/app/code/Magento/Theme/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/etc/module.xml
+++ b/app/code/Magento/Theme/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/browser/content.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/browser/content.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/browser/content/files.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/browser/content/files.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/browser/content/uploader.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/browser/content/uploader.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/css/theme.css
+++ b/app/code/Magento/Theme/view/adminhtml/css/theme.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/js/custom-js-list.js
+++ b/app/code/Magento/Theme/view/adminhtml/js/custom-js-list.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/js/form.js
+++ b/app/code/Magento/Theme/view/adminhtml/js/form.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/js/sortable.js
+++ b/app/code/Magento/Theme/view/adminhtml/js/sortable.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_block.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_edit.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_grid.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_index.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_theme_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_wysiwyg_files_contents.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_wysiwyg_files_contents.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_wysiwyg_files_index.xml
+++ b/app/code/Magento/Theme/view/adminhtml/layout/adminhtml_system_design_wysiwyg_files_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/tabs/css.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/tabs/css.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/tabs/fieldset/js.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/tabs/fieldset/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Theme/view/adminhtml/tabs/js.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/tabs/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Block/Adminhtml/Dhl/Unitofmeasure.php
+++ b/app/code/Magento/Usa/Block/Adminhtml/Dhl/Unitofmeasure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Helper/Data.php
+++ b/app/code/Magento/Usa/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/AbstractCarrier.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/AbstractCarrier/Source/Mode.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/AbstractCarrier/Source/Mode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/AbstractCarrier/Source/Requesttype.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/AbstractCarrier/Source/Requesttype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Contenttype.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Contenttype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/AbstractMethod.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/AbstractMethod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Doc.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Doc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freedoc.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freedoc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freenondoc.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Freenondoc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Generic.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Generic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Nondoc.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Nondoc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Size.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Size.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Unitofmeasure.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/International/Source/Method/Unitofmeasure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/Page.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/PageBuilder.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Label/Pdf/PageBuilder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Dutypaymenttype.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Dutypaymenttype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Freemethod.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Freemethod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Generic.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Generic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Method.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Rounding.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Rounding.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Value.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Protection/Value.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Shipmenttype.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Dhl/Source/Shipmenttype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex/Source/Dropoff.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex/Source/Dropoff.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex/Source/Freemethod.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex/Source/Freemethod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex/Source/Generic.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex/Source/Generic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex/Source/Method.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex/Source/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex/Source/Packaging.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Fedex/Source/Packaging.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Container.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/DestType.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/DestType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Freemethod.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Freemethod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Generic.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Generic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Method.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Mode.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Mode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/OriginShipment.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/OriginShipment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Pickup.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Pickup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Type.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Unitofmeasure.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Ups/Source/Unitofmeasure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Usps.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Usps.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Container.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Freemethod.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Freemethod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Generic.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Generic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Machinable.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Machinable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Method.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Size.php
+++ b/app/code/Magento/Usa/Model/Shipping/Carrier/Usps/Source/Size.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/Model/Simplexml/Element.php
+++ b/app/code/Magento/Usa/Model/Simplexml/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/etc/adminhtml/system.xml
+++ b/app/code/Magento/Usa/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/etc/config.xml
+++ b/app/code/Magento/Usa/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/etc/dhl/international/countries.xml
+++ b/app/code/Magento/Usa/etc/dhl/international/countries.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/etc/module.xml
+++ b/app/code/Magento/Usa/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/sql/usa_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Usa/sql/usa_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/sql/usa_setup/upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/Usa/sql/usa_setup/upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Usa/view/adminhtml/dhl/unitofmeasure.phtml
+++ b/app/code/Magento/Usa/view/adminhtml/dhl/unitofmeasure.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/Buttons.php
+++ b/app/code/Magento/User/Block/Buttons.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/Role.php
+++ b/app/code/Magento/User/Block/Role.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/Role/Edit.php
+++ b/app/code/Magento/User/Block/Role/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/Role/Grid/User.php
+++ b/app/code/Magento/User/Block/Role/Grid/User.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/Role/Tab/Edit.php
+++ b/app/code/Magento/User/Block/Role/Tab/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/Role/Tab/Info.php
+++ b/app/code/Magento/User/Block/Role/Tab/Info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/Role/Tab/Users.php
+++ b/app/code/Magento/User/Block/Role/Tab/Users.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/User.php
+++ b/app/code/Magento/User/Block/User.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/User/Edit.php
+++ b/app/code/Magento/User/Block/User/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/User/Edit/Form.php
+++ b/app/code/Magento/User/Block/User/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/User/Edit/Tab/Main.php
+++ b/app/code/Magento/User/Block/User/Edit/Tab/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/User/Edit/Tab/Roles.php
+++ b/app/code/Magento/User/Block/User/Edit/Tab/Roles.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Block/User/Edit/Tabs.php
+++ b/app/code/Magento/User/Block/User/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Controller/Adminhtml/Auth.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Controller/Adminhtml/User.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Controller/Adminhtml/User/Role.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Role.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Helper/Data.php
+++ b/app/code/Magento/User/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Acl/Loader/Role.php
+++ b/app/code/Magento/User/Model/Acl/Loader/Role.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Acl/Loader/Rule.php
+++ b/app/code/Magento/User/Model/Acl/Loader/Rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Acl/Role/Generic.php
+++ b/app/code/Magento/User/Model/Acl/Role/Generic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Acl/Role/Group.php
+++ b/app/code/Magento/User/Model/Acl/Role/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Acl/Role/User.php
+++ b/app/code/Magento/User/Model/Acl/Role/User.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/Permissions/Collection.php
+++ b/app/code/Magento/User/Model/Resource/Permissions/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/Role.php
+++ b/app/code/Magento/User/Model/Resource/Role.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/Role/Collection.php
+++ b/app/code/Magento/User/Model/Resource/Role/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/Role/Grid/Collection.php
+++ b/app/code/Magento/User/Model/Resource/Role/Grid/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/Role/User/Collection.php
+++ b/app/code/Magento/User/Model/Resource/Role/User/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/Rules.php
+++ b/app/code/Magento/User/Model/Resource/Rules.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/Rules/Collection.php
+++ b/app/code/Magento/User/Model/Resource/Rules/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/Setup.php
+++ b/app/code/Magento/User/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/User.php
+++ b/app/code/Magento/User/Model/Resource/User.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/User/Collection.php
+++ b/app/code/Magento/User/Model/Resource/User/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Resource/User/Locked/Collection.php
+++ b/app/code/Magento/User/Model/Resource/User/Locked/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Role.php
+++ b/app/code/Magento/User/Model/Role.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/Rules.php
+++ b/app/code/Magento/User/Model/Rules.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/Model/User.php
+++ b/app/code/Magento/User/Model/User.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/data/user_setup/data-install-1.6.0.0.php
+++ b/app/code/Magento/User/data/user_setup/data-install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/data/user_setup/data-upgrade-1.6.1.1-1.6.1.2.php
+++ b/app/code/Magento/User/data/user_setup/data-upgrade-1.6.1.1-1.6.1.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/data/user_setup/data-upgrade-1.6.1.3-1.6.1.4.php
+++ b/app/code/Magento/User/data/user_setup/data-upgrade-1.6.1.3-1.6.1.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/etc/adminhtml/acl.xml
+++ b/app/code/Magento/User/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/etc/adminhtml/di.xml
+++ b/app/code/Magento/User/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/etc/adminhtml/menu.xml
+++ b/app/code/Magento/User/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/etc/adminhtml/routes.xml
+++ b/app/code/Magento/User/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/etc/adminhtml/system.xml
+++ b/app/code/Magento/User/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/etc/config.xml
+++ b/app/code/Magento/User/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/etc/di.xml
+++ b/app/code/Magento/User/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/etc/email_templates.xml
+++ b/app/code/Magento/User/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/etc/module.xml
+++ b/app/code/Magento/User/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/sql/user_setup/install-1.6.0.0.php
+++ b/app/code/Magento/User/sql/user_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/sql/user_setup/upgrade-1.6.0.0-1.6.1.0.php
+++ b/app/code/Magento/User/sql/user_setup/upgrade-1.6.0.0-1.6.1.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/sql/user_setup/upgrade-1.6.1.0-1.6.1.1.php
+++ b/app/code/Magento/User/sql/user_setup/upgrade-1.6.1.0-1.6.1.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/sql/user_setup/upgrade-1.6.1.2-1.6.1.3.php
+++ b/app/code/Magento/User/sql/user_setup/upgrade-1.6.1.2-1.6.1.3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/sql/user_setup/upgrade-1.6.1.3-1.6.1.4.php
+++ b/app/code/Magento/User/sql/user_setup/upgrade-1.6.1.3-1.6.1.4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/admin/forgotpassword.phtml
+++ b/app/code/Magento/User/view/adminhtml/admin/forgotpassword.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/admin/forgotpassword_url.phtml
+++ b/app/code/Magento/User/view/adminhtml/admin/forgotpassword_url.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/admin/resetforgottenpassword.phtml
+++ b/app/code/Magento/User/view/adminhtml/admin/resetforgottenpassword.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/js/roles-tree.js
+++ b/app/code/Magento/User/view/adminhtml/js/roles-tree.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_auth_forgotpassword.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_auth_forgotpassword.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_auth_login.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_auth_login.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_auth_resetpassword.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_auth_resetpassword.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_edit.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_grid_block.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_index.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_editrole.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_editrole.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_editrolegrid.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_editrolegrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_grid_block.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_index.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_rolegrid.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_role_rolegrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_rolegrid.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_rolegrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_rolesgrid.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_rolesgrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/role/edit.phtml
+++ b/app/code/Magento/User/view/adminhtml/role/edit.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/role/info.phtml
+++ b/app/code/Magento/User/view/adminhtml/role/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/role/users.phtml
+++ b/app/code/Magento/User/view/adminhtml/role/users.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/role/users_grid_js.phtml
+++ b/app/code/Magento/User/view/adminhtml/role/users_grid_js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/User/view/adminhtml/user/roles_grid_js.phtml
+++ b/app/code/Magento/User/view/adminhtml/user/roles_grid_js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/Role.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/Role.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/Role/Edit.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/Role/Edit.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/Role/Edit/Form.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/Role/Edit/Form.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/Role/Edit/Tab/Main.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/Role/Edit/Tab/Main.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/Role/Edit/Tab/Resource.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/Role/Edit/Tab/Resource.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/Role/Edit/Tabs.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/Role/Edit/Tabs.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/User.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/User.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/User/Edit.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/User/Edit.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/User/Edit/Form.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/User/Edit/Form.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/User/Edit/Tab/Main.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/User/Edit/Tab/Main.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Block/Adminhtml/User/Edit/Tabs.php
+++ b/app/code/Magento/Webapi/Block/Adminhtml/User/Edit/Tabs.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Adminhtml/Webapi/Role.php
+++ b/app/code/Magento/Webapi/Controller/Adminhtml/Webapi/Role.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Adminhtml/Webapi/User.php
+++ b/app/code/Magento/Webapi/Controller/Adminhtml/Webapi/User.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/ErrorProcessor.php
+++ b/app/code/Magento/Webapi/Controller/ErrorProcessor.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Request.php
+++ b/app/code/Magento/Webapi/Controller/Request.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Response.php
+++ b/app/code/Magento/Webapi/Controller/Response.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest.php
+++ b/app/code/Magento/Webapi/Controller/Rest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Request.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Request.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Request/Deserializer/Factory.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Request/Deserializer/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Request/Deserializer/Json.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Request/Deserializer/Json.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Request/Deserializer/Xml.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Request/Deserializer/Xml.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Request/DeserializerInterface.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Request/DeserializerInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Response.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Response.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Response/Renderer/Factory.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Response/Renderer/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Response/Renderer/Json.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Response/Renderer/Json.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Response/Renderer/Xml.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Response/Renderer/Xml.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Response/RendererInterface.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Response/RendererInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Router.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Router.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Rest/Router/Route.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Router/Route.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Soap.php
+++ b/app/code/Magento/Webapi/Controller/Soap.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Soap/Handler.php
+++ b/app/code/Magento/Webapi/Controller/Soap/Handler.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Controller/Soap/Request.php
+++ b/app/code/Magento/Webapi/Controller/Soap/Request.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Exception.php
+++ b/app/code/Magento/Webapi/Exception.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Helper/Data.php
+++ b/app/code/Magento/Webapi/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Builder.php
+++ b/app/code/Magento/Webapi/Model/Acl/Builder.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Cache.php
+++ b/app/code/Magento/Webapi/Model/Acl/Cache.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Resource/Config/Converter/Dom.php
+++ b/app/code/Magento/Webapi/Model/Acl/Resource/Config/Converter/Dom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Resource/Config/Reader/Filesystem.php
+++ b/app/code/Magento/Webapi/Model/Acl/Resource/Config/Reader/Filesystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Resource/Config/SchemaLocator.php
+++ b/app/code/Magento/Webapi/Model/Acl/Resource/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Resource/Provider.php
+++ b/app/code/Magento/Webapi/Model/Acl/Resource/Provider.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Resource/ProviderInterface.php
+++ b/app/code/Magento/Webapi/Model/Acl/Resource/ProviderInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Role.php
+++ b/app/code/Magento/Webapi/Model/Acl/Role.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Role/Factory.php
+++ b/app/code/Magento/Webapi/Model/Acl/Role/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Role/InRoleUserUpdater.php
+++ b/app/code/Magento/Webapi/Model/Acl/Role/InRoleUserUpdater.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Role/UsersUpdater.php
+++ b/app/code/Magento/Webapi/Model/Acl/Role/UsersUpdater.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Rule.php
+++ b/app/code/Magento/Webapi/Model/Acl/Rule.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/Rule/Factory.php
+++ b/app/code/Magento/Webapi/Model/Acl/Rule/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/User.php
+++ b/app/code/Magento/Webapi/Model/Acl/User.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/User/Factory.php
+++ b/app/code/Magento/Webapi/Model/Acl/User/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Acl/User/RoleUpdater.php
+++ b/app/code/Magento/Webapi/Model/Acl/User/RoleUpdater.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Authorization/Loader/Resource.php
+++ b/app/code/Magento/Webapi/Model/Authorization/Loader/Resource.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Authorization/Loader/Role.php
+++ b/app/code/Magento/Webapi/Model/Authorization/Loader/Role.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Authorization/Loader/Rule.php
+++ b/app/code/Magento/Webapi/Model/Authorization/Loader/Rule.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Authorization/Policy/Acl.php
+++ b/app/code/Magento/Webapi/Model/Authorization/Policy/Acl.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Authorization/Role.php
+++ b/app/code/Magento/Webapi/Model/Authorization/Role.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Authorization/Role/Factory.php
+++ b/app/code/Magento/Webapi/Model/Authorization/Role/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Authorization/Role/Locator/Factory.php
+++ b/app/code/Magento/Webapi/Model/Authorization/Role/Locator/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Authorization/RoleLocator.php
+++ b/app/code/Magento/Webapi/Model/Authorization/RoleLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Cache/Type.php
+++ b/app/code/Magento/Webapi/Model/Cache/Type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Config.php
+++ b/app/code/Magento/Webapi/Model/Config.php
@@ -14,7 +14,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Config/Dom.php
+++ b/app/code/Magento/Webapi/Model/Config/Dom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Config/Reader.php
+++ b/app/code/Magento/Webapi/Model/Config/Reader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Resource/Acl/Role.php
+++ b/app/code/Magento/Webapi/Model/Resource/Acl/Role.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Resource/Acl/Role/Collection.php
+++ b/app/code/Magento/Webapi/Model/Resource/Acl/Role/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Resource/Acl/Rule.php
+++ b/app/code/Magento/Webapi/Model/Resource/Acl/Rule.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Resource/Acl/Rule/Collection.php
+++ b/app/code/Magento/Webapi/Model/Resource/Acl/Rule/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Resource/Acl/User.php
+++ b/app/code/Magento/Webapi/Model/Resource/Acl/User.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Resource/Acl/User/Collection.php
+++ b/app/code/Magento/Webapi/Model/Resource/Acl/User/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Rest/Config.php
+++ b/app/code/Magento/Webapi/Model/Rest/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Soap/Config.php
+++ b/app/code/Magento/Webapi/Model/Soap/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Soap/Fault.php
+++ b/app/code/Magento/Webapi/Model/Soap/Fault.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Soap/Server.php
+++ b/app/code/Magento/Webapi/Model/Soap/Server.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Soap/Server/Factory.php
+++ b/app/code/Magento/Webapi/Model/Soap/Server/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Soap/Wsdl.php
+++ b/app/code/Magento/Webapi/Model/Soap/Wsdl.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Soap/Wsdl/ComplexTypeStrategy/AnyComplexType.php
+++ b/app/code/Magento/Webapi/Model/Soap/Wsdl/ComplexTypeStrategy/AnyComplexType.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Soap/Wsdl/Factory.php
+++ b/app/code/Magento/Webapi/Model/Soap/Wsdl/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Soap/Wsdl/Generator.php
+++ b/app/code/Magento/Webapi/Model/Soap/Wsdl/Generator.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/Model/Source/Acl/Role.php
+++ b/app/code/Magento/Webapi/Model/Source/Acl/Role.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/acl.xsd
+++ b/app/code/Magento/Webapi/etc/acl.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Webapi/etc/adminhtml/acl.xml
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Webapi/etc/adminhtml/menu.xml
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Webapi/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/adminhtml/system.xml
+++ b/app/code/Magento/Webapi/etc/adminhtml/system.xml
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/cache.xml
+++ b/app/code/Magento/Webapi/etc/cache.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/config.xml
+++ b/app/code/Magento/Webapi/etc/config.xml
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/di.xml
+++ b/app/code/Magento/Webapi/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/module.xml
+++ b/app/code/Magento/Webapi/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/validation.xml
+++ b/app/code/Magento/Webapi/etc/validation.xml
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/etc/webapi.xsd
+++ b/app/code/Magento/Webapi/etc/webapi.xsd
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/sql/webapi_setup/install-1.0.0.0.php
+++ b/app/code/Magento/Webapi/sql/webapi_setup/install-1.0.0.0.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/sql/webapi_setup/upgrade-1.0.0.0-1.0.0.1.php
+++ b/app/code/Magento/Webapi/sql/webapi_setup/upgrade-1.0.0.0-1.0.0.1.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/sql/webapi_setup/upgrade-1.0.0.1-1.0.0.2.php
+++ b/app/code/Magento/Webapi/sql/webapi_setup/upgrade-1.0.0.1-1.0.0.2.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/sql/webapi_setup/upgrade-1.0.0.2-1.0.0.3.php
+++ b/app/code/Magento/Webapi/sql/webapi_setup/upgrade-1.0.0.2-1.0.0.3.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_edit.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_edit_tab_users_grid_block.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_edit_tab_users_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_grid_block.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_index.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_rolegrid.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_rolegrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_usersgrid.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_role_usersgrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_edit.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_edit_tab_roles_grid_block.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_edit_tab_roles_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_grid.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_grid_block.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_grid_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_index.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_rolesgrid.xml
+++ b/app/code/Magento/Webapi/view/adminhtml/layout/adminhtml_webapi_user_rolesgrid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/rolesedit.phtml
+++ b/app/code/Magento/Webapi/view/adminhtml/rolesedit.phtml
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webapi/view/adminhtml/rolesusersgridjs.phtml
+++ b/app/code/Magento/Webapi/view/adminhtml/rolesusersgridjs.phtml
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Block/Adminhtml/Registration/Activate.php
+++ b/app/code/Magento/Webhook/Block/Adminhtml/Registration/Activate.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Block/Adminhtml/Registration/Create/Form.php
+++ b/app/code/Magento/Webhook/Block/Adminhtml/Registration/Create/Form.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Block/Adminhtml/Registration/Create/Form/Container.php
+++ b/app/code/Magento/Webhook/Block/Adminhtml/Registration/Create/Form/Container.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Block/Adminhtml/Registration/Failed.php
+++ b/app/code/Magento/Webhook/Block/Adminhtml/Registration/Failed.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Block/Adminhtml/Subscription.php
+++ b/app/code/Magento/Webhook/Block/Adminhtml/Subscription.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Block/Adminhtml/Subscription/Edit.php
+++ b/app/code/Magento/Webhook/Block/Adminhtml/Subscription/Edit.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Block/Adminhtml/Subscription/Edit/Form.php
+++ b/app/code/Magento/Webhook/Block/Adminhtml/Subscription/Edit/Form.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Block/Adminhtml/Subscription/Grid/Renderer/Action.php
+++ b/app/code/Magento/Webhook/Block/Adminhtml/Subscription/Grid/Renderer/Action.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Controller/Adminhtml/Webhook/Registration.php
+++ b/app/code/Magento/Webhook/Controller/Adminhtml/Webhook/Registration.php
@@ -14,7 +14,7 @@ namespace Magento\Webhook\Controller\Adminhtml\Webhook;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Controller/Adminhtml/Webhook/Subscription.php
+++ b/app/code/Magento/Webhook/Controller/Adminhtml/Webhook/Subscription.php
@@ -13,7 +13,7 @@ namespace Magento\Webhook\Controller\Adminhtml\Webhook;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Exception.php
+++ b/app/code/Magento/Webhook/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Helper/Data.php
+++ b/app/code/Magento/Webhook/Helper/Data.php
@@ -15,7 +15,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Endpoint.php
+++ b/app/code/Magento/Webhook/Model/Endpoint.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Event.php
+++ b/app/code/Magento/Webhook/Model/Event.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Event/Factory.php
+++ b/app/code/Magento/Webhook/Model/Event/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Event/QueueReader.php
+++ b/app/code/Magento/Webhook/Model/Event/QueueReader.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Event/QueueWriter.php
+++ b/app/code/Magento/Webhook/Model/Event/QueueWriter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Job.php
+++ b/app/code/Magento/Webhook/Model/Job.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Job/Factory.php
+++ b/app/code/Magento/Webhook/Model/Job/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Job/QueueReader.php
+++ b/app/code/Magento/Webhook/Model/Job/QueueReader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Job/QueueWriter.php
+++ b/app/code/Magento/Webhook/Model/Job/QueueWriter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Observer.php
+++ b/app/code/Magento/Webhook/Model/Observer.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Resource/Endpoint.php
+++ b/app/code/Magento/Webhook/Model/Resource/Endpoint.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Resource/Event.php
+++ b/app/code/Magento/Webhook/Model/Resource/Event.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Resource/Event/Collection.php
+++ b/app/code/Magento/Webhook/Model/Resource/Event/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Resource/Job.php
+++ b/app/code/Magento/Webhook/Model/Resource/Job.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Resource/Job/Collection.php
+++ b/app/code/Magento/Webhook/Model/Resource/Job/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Resource/Subscription.php
+++ b/app/code/Magento/Webhook/Model/Resource/Subscription.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Resource/Subscription/Collection.php
+++ b/app/code/Magento/Webhook/Model/Resource/Subscription/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Resource/Subscription/Grid/Collection.php
+++ b/app/code/Magento/Webhook/Model/Resource/Subscription/Grid/Collection.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Source/Authentication.php
+++ b/app/code/Magento/Webhook/Model/Source/Authentication.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Source/Format.php
+++ b/app/code/Magento/Webhook/Model/Source/Format.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Source/Hook.php
+++ b/app/code/Magento/Webhook/Model/Source/Hook.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Subscription.php
+++ b/app/code/Magento/Webhook/Model/Subscription.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Subscription/Config.php
+++ b/app/code/Magento/Webhook/Model/Subscription/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Subscription/Factory.php
+++ b/app/code/Magento/Webhook/Model/Subscription/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Subscription/Options/Status.php
+++ b/app/code/Magento/Webhook/Model/Subscription/Options/Status.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/User.php
+++ b/app/code/Magento/Webhook/Model/User.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/User/Factory.php
+++ b/app/code/Magento/Webhook/Model/User/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Webapi/EventHandler.php
+++ b/app/code/Magento/Webhook/Model/Webapi/EventHandler.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Webapi/EventHandler/Factory.php
+++ b/app/code/Magento/Webhook/Model/Webapi/EventHandler/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Model/Webapi/User/Factory.php
+++ b/app/code/Magento/Webhook/Model/Webapi/User/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Service/SubscriptionV1.php
+++ b/app/code/Magento/Webhook/Service/SubscriptionV1.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/Service/SubscriptionV1Interface.php
+++ b/app/code/Magento/Webhook/Service/SubscriptionV1Interface.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Webhook/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Webhook/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Webhook/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/etc/crontab.xml
+++ b/app/code/Magento/Webhook/etc/crontab.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/etc/di.xml
+++ b/app/code/Magento/Webhook/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/etc/events.xml
+++ b/app/code/Magento/Webhook/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/etc/frontend/routes.xml
+++ b/app/code/Magento/Webhook/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/etc/module.xml
+++ b/app/code/Magento/Webhook/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/etc/webapi.xml
+++ b/app/code/Magento/Webhook/etc/webapi.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/etc/webapi/acl.xml
+++ b/app/code/Magento/Webhook/etc/webapi/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/schema/service/SubscriptionV1.xsd
+++ b/app/code/Magento/Webhook/schema/service/SubscriptionV1.xsd
@@ -14,7 +14,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/sql/webhook_setup/install-1.0.0.0.php
+++ b/app/code/Magento/Webhook/sql/webhook_setup/install-1.0.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/css/boxes.css
+++ b/app/code/Magento/Webhook/view/adminhtml/css/boxes.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/css/modal.css
+++ b/app/code/Magento/Webhook/view/adminhtml/css/modal.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/css/webhook.css
+++ b/app/code/Magento/Webhook/view/adminhtml/css/webhook.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/js/validate_form.js
+++ b/app/code/Magento/Webhook/view/adminhtml/js/validate_form.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/js/webhook.js
+++ b/app/code/Magento/Webhook/view/adminhtml/js/webhook.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_registration_activate.xml
+++ b/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_registration_activate.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_registration_failed.xml
+++ b/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_registration_failed.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_registration_succeeded.xml
+++ b/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_registration_succeeded.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_registration_user.xml
+++ b/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_registration_user.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_subscription_edit.xml
+++ b/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_subscription_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_subscription_grid.xml
+++ b/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_subscription_grid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_subscription_index.xml
+++ b/app/code/Magento/Webhook/view/adminhtml/layout/adminhtml_webhook_subscription_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/registration/activate.phtml
+++ b/app/code/Magento/Webhook/view/adminhtml/registration/activate.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/registration/create/container.phtml
+++ b/app/code/Magento/Webhook/view/adminhtml/registration/create/container.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/registration/failed.phtml
+++ b/app/code/Magento/Webhook/view/adminhtml/registration/failed.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Webhook/view/adminhtml/registration/succeeded.phtml
+++ b/app/code/Magento/Webhook/view/adminhtml/registration/succeeded.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Block/Element/Weee/Tax.php
+++ b/app/code/Magento/Weee/Block/Element/Weee/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Block/Renderer/Weee/Tax.php
+++ b/app/code/Magento/Weee/Block/Renderer/Weee/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Helper/Data.php
+++ b/app/code/Magento/Weee/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Model/Attribute/Backend/Weee/Tax.php
+++ b/app/code/Magento/Weee/Model/Attribute/Backend/Weee/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Model/Config/Source/Display.php
+++ b/app/code/Magento/Weee/Model/Config/Source/Display.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Model/Observer.php
+++ b/app/code/Magento/Weee/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Model/Resource/Attribute/Backend/Weee/Tax.php
+++ b/app/code/Magento/Weee/Model/Resource/Attribute/Backend/Weee/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Model/Resource/Tax.php
+++ b/app/code/Magento/Weee/Model/Resource/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Model/Tax.php
+++ b/app/code/Magento/Weee/Model/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Model/Total/Creditmemo/Weee.php
+++ b/app/code/Magento/Weee/Model/Total/Creditmemo/Weee.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Model/Total/Invoice/Weee.php
+++ b/app/code/Magento/Weee/Model/Total/Invoice/Weee.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Model/Total/Quote/Nominal/Weee.php
+++ b/app/code/Magento/Weee/Model/Total/Quote/Nominal/Weee.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/Model/Total/Quote/Weee.php
+++ b/app/code/Magento/Weee/Model/Total/Quote/Weee.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/etc/adminhtml/events.xml
+++ b/app/code/Magento/Weee/etc/adminhtml/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/etc/adminhtml/system.xml
+++ b/app/code/Magento/Weee/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/etc/config.xml
+++ b/app/code/Magento/Weee/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/etc/di.xml
+++ b/app/code/Magento/Weee/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/etc/events.xml
+++ b/app/code/Magento/Weee/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/etc/fieldset.xml
+++ b/app/code/Magento/Weee/etc/fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/etc/module.xml
+++ b/app/code/Magento/Weee/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/etc/sales.xml
+++ b/app/code/Magento/Weee/etc/sales.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/sql/weee_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Weee/sql/weee_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/view/adminhtml/js/fpt-attribute.js
+++ b/app/code/Magento/Weee/view/adminhtml/js/fpt-attribute.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/view/adminhtml/layout/adminhtml_catalog_product_new.xml
+++ b/app/code/Magento/Weee/view/adminhtml/layout/adminhtml_catalog_product_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/view/adminhtml/renderer/tax.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/renderer/tax.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/view/frontend/layout/default.xml
+++ b/app/code/Magento/Weee/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Weee/view/frontend/tax-toggle.js
+++ b/app/code/Magento/Weee/view/frontend/tax-toggle.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Chooser.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Chooser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Form.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Container.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Layout.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Template.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Form.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Properties.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Properties.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tabs.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tabs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Block/BlockInterface.php
+++ b/app/code/Magento/Widget/Block/BlockInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Helper/Data.php
+++ b/app/code/Magento/Widget/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Config/Converter.php
+++ b/app/code/Magento/Widget/Model/Config/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Config/Data.php
+++ b/app/code/Magento/Widget/Model/Config/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Config/FileResolver.php
+++ b/app/code/Magento/Widget/Model/Config/FileResolver.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Config/Reader.php
+++ b/app/code/Magento/Widget/Model/Config/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Config/SchemaLocator.php
+++ b/app/code/Magento/Widget/Model/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Resource/Widget.php
+++ b/app/code/Magento/Widget/Model/Resource/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Resource/Widget/Instance.php
+++ b/app/code/Magento/Widget/Model/Resource/Widget/Instance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Resource/Widget/Instance/Collection.php
+++ b/app/code/Magento/Widget/Model/Resource/Widget/Instance/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Resource/Widget/Instance/Options/ThemeId.php
+++ b/app/code/Magento/Widget/Model/Resource/Widget/Instance/Options/ThemeId.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Resource/Widget/Instance/Options/Types.php
+++ b/app/code/Magento/Widget/Model/Resource/Widget/Instance/Options/Types.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Template/Filter.php
+++ b/app/code/Magento/Widget/Model/Template/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Widget.php
+++ b/app/code/Magento/Widget/Model/Widget.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Widget/Config.php
+++ b/app/code/Magento/Widget/Model/Widget/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Widget/Instance.php
+++ b/app/code/Magento/Widget/Model/Widget/Instance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/Model/Widget/Instance/OptionsFactory.php
+++ b/app/code/Magento/Widget/Model/Widget/Instance/OptionsFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/data/widget_setup/data-upgrade-1.6.0.0-1.6.0.1.php
+++ b/app/code/Magento/Widget/data/widget_setup/data-upgrade-1.6.0.0-1.6.0.1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Widget/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/etc/adminhtml/di.xml
+++ b/app/code/Magento/Widget/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Widget/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/etc/adminhtml/routes.xml
+++ b/app/code/Magento/Widget/etc/adminhtml/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/etc/di.xml
+++ b/app/code/Magento/Widget/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/etc/module.xml
+++ b/app/code/Magento/Widget/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/etc/types.xsd
+++ b/app/code/Magento/Widget/etc/types.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/etc/widget.xsd
+++ b/app/code/Magento/Widget/etc/widget.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/etc/widget_file.xsd
+++ b/app/code/Magento/Widget/etc/widget_file.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/sql/widget_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Widget/sql/widget_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/sql/widget_setup/upgrade-1.6.0.1-1.6.0.2.php
+++ b/app/code/Magento/Widget/sql/widget_setup/upgrade-1.6.0.1-1.6.0.2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/adminhtml/css/styles.css
+++ b/app/code/Magento/Widget/view/adminhtml/css/styles.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/adminhtml/instance/edit/layout.phtml
+++ b/app/code/Magento/Widget/view/adminhtml/instance/edit/layout.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/adminhtml/instance/js.phtml
+++ b/app/code/Magento/Widget/view/adminhtml/instance/js.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_index.xml
+++ b/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_instance_block.xml
+++ b/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_instance_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_instance_edit.xml
+++ b/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_instance_edit.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_instance_index.xml
+++ b/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_instance_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_loadoptions.xml
+++ b/app/code/Magento/Widget/view/adminhtml/layout/adminhtml_widget_loadoptions.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/frontend/layout/default.xml
+++ b/app/code/Magento/Widget/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/frontend/layout/print.xml
+++ b/app/code/Magento/Widget/view/frontend/layout/print.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Widget/view/frontend/widgets.css
+++ b/app/code/Magento/Widget/view/frontend/widgets.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/AbstractBlock.php
+++ b/app/code/Magento/Wishlist/Block/AbstractBlock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Sharing.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Sharing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Sidebar.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Sidebar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Wishlist.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Wishlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Wishlist/Button.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Wishlist/Button.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Column.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Column.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Column/Cart.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Column/Cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Column/Comment.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Column/Comment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Column/Image.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Column/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Column/Remove.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Column/Remove.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Options.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Wishlist/Item/Options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Customer/Wishlist/Items.php
+++ b/app/code/Magento/Wishlist/Block/Customer/Wishlist/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Item/Configure.php
+++ b/app/code/Magento/Wishlist/Block/Item/Configure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Link.php
+++ b/app/code/Magento/Wishlist/Block/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Render/Item/Price.php
+++ b/app/code/Magento/Wishlist/Block/Render/Item/Price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Share/Email/Items.php
+++ b/app/code/Magento/Wishlist/Block/Share/Email/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Share/Email/Rss.php
+++ b/app/code/Magento/Wishlist/Block/Share/Email/Rss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Block/Share/Wishlist.php
+++ b/app/code/Magento/Wishlist/Block/Share/Wishlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Controller/AbstractController.php
+++ b/app/code/Magento/Wishlist/Controller/AbstractController.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Controller/Index.php
+++ b/app/code/Magento/Wishlist/Controller/Index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Controller/Shared.php
+++ b/app/code/Magento/Wishlist/Controller/Shared.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Helper/Data.php
+++ b/app/code/Magento/Wishlist/Helper/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Config.php
+++ b/app/code/Magento/Wishlist/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Config/Source/Summary.php
+++ b/app/code/Magento/Wishlist/Model/Config/Source/Summary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Item.php
+++ b/app/code/Magento/Wishlist/Model/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Item/Option.php
+++ b/app/code/Magento/Wishlist/Model/Item/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Observer.php
+++ b/app/code/Magento/Wishlist/Model/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Resource/Item.php
+++ b/app/code/Magento/Wishlist/Model/Resource/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Resource/Item/Collection.php
+++ b/app/code/Magento/Wishlist/Model/Resource/Item/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Resource/Item/Collection/Grid.php
+++ b/app/code/Magento/Wishlist/Model/Resource/Item/Collection/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Resource/Item/Option.php
+++ b/app/code/Magento/Wishlist/Model/Resource/Item/Option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Resource/Item/Option/Collection.php
+++ b/app/code/Magento/Wishlist/Model/Resource/Item/Option/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Resource/Wishlist.php
+++ b/app/code/Magento/Wishlist/Model/Resource/Wishlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Resource/Wishlist/Collection.php
+++ b/app/code/Magento/Wishlist/Model/Resource/Wishlist/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/Model/Wishlist.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/adminhtml/acl.xml
+++ b/app/code/Magento/Wishlist/etc/adminhtml/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/adminhtml/di.xml
+++ b/app/code/Magento/Wishlist/etc/adminhtml/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/adminhtml/system.xml
+++ b/app/code/Magento/Wishlist/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/catalog_attributes.xml
+++ b/app/code/Magento/Wishlist/etc/catalog_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/config.xml
+++ b/app/code/Magento/Wishlist/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/di.xml
+++ b/app/code/Magento/Wishlist/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/email_templates.xml
+++ b/app/code/Magento/Wishlist/etc/email_templates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/events.xml
+++ b/app/code/Magento/Wishlist/etc/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/frontend/di.xml
+++ b/app/code/Magento/Wishlist/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/frontend/events.xml
+++ b/app/code/Magento/Wishlist/etc/frontend/events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/frontend/routes.xml
+++ b/app/code/Magento/Wishlist/etc/frontend/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/module.xml
+++ b/app/code/Magento/Wishlist/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/etc/view.xml
+++ b/app/code/Magento/Wishlist/etc/view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/sql/wishlist_setup/install-1.6.0.0.php
+++ b/app/code/Magento/Wishlist/sql/wishlist_setup/install-1.6.0.0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/adminhtml/customer/edit/tab/wishlist.phtml
+++ b/app/code/Magento/Wishlist/view/adminhtml/customer/edit/tab/wishlist.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/adminhtml/layout/adminhtml_customer_wishlist.xml
+++ b/app/code/Magento/Wishlist/view/adminhtml/layout/adminhtml_customer_wishlist.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/button/share.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/button/share.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/button/tocart.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/button/tocart.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/button/update.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/button/update.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/email/items.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/email/items.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/email/rss.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/email/rss.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/item/column/cart.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/item/column/cart.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/item/column/image.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/item/column/image.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/item/column/info.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/item/column/info.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/item/column/remove.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/item/column/remove.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/item/configure/addto.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/item/configure/addto.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/item/list.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/item/list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/js/add-to-wishlist.js
+++ b/app/code/Magento/Wishlist/view/frontend/js/add-to-wishlist.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/js/search.js
+++ b/app/code/Magento/Wishlist/view/frontend/js/search.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/customer_account.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/layout/default.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_bundle.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_bundle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_configurable.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_configurable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_grouped.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_grouped.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_simple.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_simple.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_index.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_share.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_share.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_shared_index.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_shared_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/options_list.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/options_list.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/render/item/price.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/render/item/price.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/render/item/price_msrp_item.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/render/item/price_msrp_item.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/render/item/price_msrp_rss.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/render/item/price_msrp_rss.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/shared.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/shared.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/sharing.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/sharing.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/sidebar.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/sidebar.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/view.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/view.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Magento/Wishlist/view/frontend/wishlist.js
+++ b/app/code/Magento/Wishlist/view/frontend/wishlist.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/code/Zend/Date.php
+++ b/app/code/Zend/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/app/code/Zend/Mime.php
+++ b/app/code/Zend/Mime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/app/design/adminhtml/magento_backend/Magento_Adminhtml/layout/default.xml
+++ b/app/design/adminhtml/magento_backend/Magento_Adminhtml/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/css/admin.css
+++ b/app/design/adminhtml/magento_backend/css/admin.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/css/antiscroll.css
+++ b/app/design/adminhtml/magento_backend/css/antiscroll.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/css/debug.css
+++ b/app/design/adminhtml/magento_backend/css/debug.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/css/header.css
+++ b/app/design/adminhtml/magento_backend/css/header.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/css/pages.css
+++ b/app/design/adminhtml/magento_backend/css/pages.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/js/antiscroll.js
+++ b/app/design/adminhtml/magento_backend/js/antiscroll.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/js/head.js
+++ b/app/design/adminhtml/magento_backend/js/head.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/js/jquery.details.js
+++ b/app/design/adminhtml/magento_backend/js/jquery.details.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/js/jquery.details.min.js
+++ b/app/design/adminhtml/magento_backend/js/jquery.details.min.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/js/jquery.mousewheel.js
+++ b/app/design/adminhtml/magento_backend/js/jquery.mousewheel.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/js/theme.js
+++ b/app/design/adminhtml/magento_backend/js/theme.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/mui/base.css
+++ b/app/design/adminhtml/magento_backend/mui/base.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/mui/components.css
+++ b/app/design/adminhtml/magento_backend/mui/components.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/mui/elements.css
+++ b/app/design/adminhtml/magento_backend/mui/elements.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/mui/form.css
+++ b/app/design/adminhtml/magento_backend/mui/form.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/mui/grid.css
+++ b/app/design/adminhtml/magento_backend/mui/grid.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/mui/icons.css
+++ b/app/design/adminhtml/magento_backend/mui/icons.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/mui/print.css
+++ b/app/design/adminhtml/magento_backend/mui/print.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/mui/reset.css
+++ b/app/design/adminhtml/magento_backend/mui/reset.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/mui/utils.css
+++ b/app/design/adminhtml/magento_backend/mui/utils.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_backend/theme.xml
+++ b/app/design/adminhtml/magento_backend/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_basic/Magento_Adminhtml/layout/default.xml
+++ b/app/design/adminhtml/magento_basic/Magento_Adminhtml/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_basic/below_ie7.css
+++ b/app/design/adminhtml/magento_basic/below_ie7.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_basic/boxes.css
+++ b/app/design/adminhtml/magento_basic/boxes.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_basic/custom.css
+++ b/app/design/adminhtml/magento_basic/custom.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_basic/ie7.css
+++ b/app/design/adminhtml/magento_basic/ie7.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_basic/iestyles.css
+++ b/app/design/adminhtml/magento_basic/iestyles.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_basic/menu.css
+++ b/app/design/adminhtml/magento_basic/menu.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_basic/print.css
+++ b/app/design/adminhtml/magento_basic/print.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_basic/reset.css
+++ b/app/design/adminhtml/magento_basic/reset.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/adminhtml/magento_basic/theme.xml
+++ b/app/design/adminhtml/magento_basic/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/frontend/magento_blank/css/print.css
+++ b/app/design/frontend/magento_blank/css/print.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/frontend/magento_blank/css/styles-ie.css
+++ b/app/design/frontend/magento_blank/css/styles-ie.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/frontend/magento_blank/css/styles.css
+++ b/app/design/frontend/magento_blank/css/styles.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/frontend/magento_blank/theme.xml
+++ b/app/design/frontend/magento_blank/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/frontend/magento_demo/Magento_Page/layout/default.xml
+++ b/app/design/frontend/magento_demo/Magento_Page/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/frontend/magento_demo/Magento_Page/layout/print.xml
+++ b/app/design/frontend/magento_demo/Magento_Page/layout/print.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/frontend/magento_demo/css/print.css
+++ b/app/design/frontend/magento_demo/css/print.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/frontend/magento_demo/css/styles-ie.css
+++ b/app/design/frontend/magento_demo/css/styles-ie.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/frontend/magento_demo/css/styles.css
+++ b/app/design/frontend/magento_demo/css/styles.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/frontend/magento_demo/theme.xml
+++ b/app/design/frontend/magento_demo/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/install/magento_basic/css/boxes.css
+++ b/app/design/install/magento_basic/css/boxes.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/install/magento_basic/css/clears.css
+++ b/app/design/install/magento_basic/css/clears.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/install/magento_basic/css/ie7minus.css
+++ b/app/design/install/magento_basic/css/ie7minus.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/install/magento_basic/css/iestyles.css
+++ b/app/design/install/magento_basic/css/iestyles.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/install/magento_basic/css/reset.css
+++ b/app/design/install/magento_basic/css/reset.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/design/install/magento_basic/theme.xml
+++ b/app/design/install/magento_basic/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/etc/config.xml
+++ b/app/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/app/etc/local.xml.template
+++ b/app/etc/local.xml.template
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/shell/indexer.php
+++ b/dev/shell/indexer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/shell/install.php
+++ b/dev/shell/install.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/shell/log.php
+++ b/dev/shell/log.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/etc/integration-tests-config.xml
+++ b/dev/tests/integration/etc/integration-tests-config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/etc/local-mysql.xml.dist
+++ b/dev/tests/integration/etc/local-mysql.xml.dist
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Annotation/AppArea.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Annotation/AppArea.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Annotation/AppIsolation.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Annotation/AppIsolation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Annotation/ConfigFixture.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Annotation/ConfigFixture.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Annotation/DataFixture.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Annotation/DataFixture.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Annotation/DbIsolation.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Annotation/DbIsolation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Bootstrap.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/DocBlock.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/DocBlock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Environment.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Environment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Memory.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Memory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Profiler.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Profiler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Settings.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Settings.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Cookie.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Cookie.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Db/AbstractDb.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/AbstractDb.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Db/Adapter/Mysql.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/Adapter/Mysql.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Db/Adapter/TransactionInterface.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/Adapter/TransactionInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Db/ConnectionAdapter.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/ConnectionAdapter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Entity.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Entity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Event/Magento.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Event/Magento.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Event/Param/Transaction.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Event/Param/Transaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Event/PhpUnit.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Event/PhpUnit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Event/Transaction.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Event/Transaction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/EventManager.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/EventManager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Api.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Api.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Bootstrap.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Config.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Eav.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Eav.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Factory.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Memory.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Memory.php
@@ -14,7 +14,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Isolation/WorkingDirectory.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Isolation/WorkingDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/MemoryLimit.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/MemoryLimit.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/ObjectManager.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/ObjectManager.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/ObjectManager/Config.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/ObjectManager/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/ObjectManager/Configurator.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/ObjectManager/Configurator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Profiler/OutputBamboo.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Profiler/OutputBamboo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Request.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Response.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractConfigFiles.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractConfigFiles.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractIntegrity.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractIntegrity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Workaround/Cleanup/StaticProperties.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Workaround/Cleanup/StaticProperties.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Workaround/Cleanup/TestCaseProperties.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Workaround/Cleanup/TestCaseProperties.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/Magento/TestFramework/Workaround/Segfault.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Workaround/Segfault.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/bootstrap.php
+++ b/dev/tests/integration/framework/bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/framework/bootstrap.php
+++ b/dev/tests/integration/framework/tests/unit/framework/bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/phpunit.xml.dist
+++ b/dev/tests/integration/framework/tests/unit/phpunit.xml.dist
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/AppAreaTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/AppAreaTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/AppIsolationTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/AppIsolationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/ConfigFixtureTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/ConfigFixtureTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/DataFixtureTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/DataFixtureTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/DbIsolationTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/DbIsolationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/_files/sample_fixture_two_rollback.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/_files/sample_fixture_two_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/ApplicationTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/ApplicationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/DocBlockTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/DocBlockTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/EnvironmentTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/EnvironmentTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/MemoryTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/MemoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/ProfilerTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/ProfilerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/SettingsTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/SettingsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/1.xml
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/1.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/1.xml.dist
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/1.xml.dist
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/2.xml
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/3.xml.dist
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/3.xml.dist
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/4.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/4.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/metrics.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Bootstrap/_files/metrics.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/BootstrapTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/BootstrapTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/CookieTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/CookieTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Db/Adapter/TransactionInterfaceTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Db/Adapter/TransactionInterfaceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/EntityTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/EntityTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Event/MagentoTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Event/MagentoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Event/Param/TransactionTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Event/Param/TransactionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Event/PhpUnitTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Event/PhpUnitTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Event/TransactionTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Event/TransactionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/EventManagerTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/EventManagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Helper/BootstrapTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Helper/BootstrapTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Helper/FactoryTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Helper/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Helper/MemoryTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Helper/MemoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Isolation/WorkingDirectoryTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Isolation/WorkingDirectoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/MemoryLimitTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/MemoryLimitTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/ObjectManagerTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/ObjectManagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Profiler/OutputBambooTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Profiler/OutputBambooTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Profiler/OutputBambooTestFilter.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Profiler/OutputBambooTestFilter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/RequestTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/RequestTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/ResponseTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/ResponseTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/TestCase/ControllerAbstractTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/TestCase/ControllerAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Workaround/Cleanup/TestCasePropertiesTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Workaround/Cleanup/TestCasePropertiesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Workaround/Cleanup/TestCasePropertiesTest/DummyTestCase.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Workaround/Cleanup/TestCasePropertiesTest/DummyTestCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/phpunit.xml.dist
+++ b/dev/tests/integration/phpunit.xml.dist
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/AdminNotification/Model/Resource/Inbox/Collection/CriticalTest.php
+++ b/dev/tests/integration/testsuite/Magento/AdminNotification/Model/Resource/Inbox/Collection/CriticalTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/AdminNotification/_files/notifications.php
+++ b/dev/tests/integration/testsuite/Magento/AdminNotification/_files/notifications.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Category/TreeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Category/TreeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/AddTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Attribute/Set/Toolbar/AddTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/OptionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/OptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/SelectTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Options/Type/SelectTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/MatrixTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/MatrixTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/SettingsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/SettingsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/TabsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/TabsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/CategoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/CategoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery/ContentTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/Gallery/ContentTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/WeightTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/WeightTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Options/AjaxTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Catalog/Product/Options/AjaxTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Cms/Page/Edit/Tab/DesignTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Cms/Page/Edit/Tab/DesignTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Customer/Edit/Tab/View/AccordionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Customer/Edit/Tab/View/AccordionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Customer/OnlineTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Customer/OnlineTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Dashboard/GraphTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Dashboard/GraphTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Newsletter/Queue/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Newsletter/Queue/Edit/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Newsletter/SubscriberTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Newsletter/SubscriberTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Page/HeadTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Page/HeadTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Page/HeaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Page/HeaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Promo/Catalog/Edit/Tab/MainTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Promo/Catalog/Edit/Tab/MainTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/LabelsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/LabelsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/MainTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Promo/Quote/Edit/Tab/MainTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Rating/Edit/Tab/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Rating/Edit/Tab/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Filter/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Filter/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Bestsellers/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Bestsellers/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Coupons/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Coupons/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Invoiced/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Invoiced/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Refunded/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Refunded/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Sales/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Sales/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Shipping/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Shipping/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Tax/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Report/Sales/Tax/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Sales/Items/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Sales/Items/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Sales/Order/Create/Form/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Sales/Order/Create/Form/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Account/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Account/Edit/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Design/Edit/Tab/GeneralTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Design/Edit/Tab/GeneralTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Store/DeleteTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Store/DeleteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Store/Edit/Form/GroupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Store/Edit/Form/GroupTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Store/Edit/Form/StoreTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Store/Edit/Form/StoreTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Store/Edit/Form/WebsiteTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Store/Edit/Form/WebsiteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Store/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Store/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Variable/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/System/Variable/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Tax/Rate/ImportExportTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Tax/Rate/ImportExportTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/TemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Catalog/Category/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Catalog/Category/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Catalog/Category/TreeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Catalog/Category/TreeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Catalog/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Catalog/Edit/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Catalog/Product/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Catalog/Product/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Catalog/Product/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Catalog/Product/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/Edit/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Cms/Page/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/Edit/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Urlrewrite/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Widget/ContainerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Widget/ContainerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Widget/Form/ContainerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Widget/Form/ContainerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Widget/Grid/Massaction/ItemTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Widget/Grid/Massaction/ItemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Widget/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Widget/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Widget/TabsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Block/Widget/TabsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/CacheTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/CacheTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Catalog/CategoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Catalog/CategoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Catalog/Product/Action/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Catalog/Product/Action/AttributeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Catalog/Product/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Catalog/Product/AttributeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Catalog/Product/ReviewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Catalog/Product/ReviewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Catalog/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Catalog/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Customer/GroupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Customer/GroupTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/CustomerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/CustomerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/IndexTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/NewsletterQueueTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/NewsletterQueueTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/NewsletterTemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/NewsletterTemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Sales/Order/CreateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Sales/Order/CreateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Sales/Order/CreditmemoTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Sales/Order/CreditmemoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Sales/OrderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Sales/OrderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/System/DesignTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/System/DesignTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/System/StoreTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/System/StoreTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/System/VariableTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/System/VariableTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Tax/RateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Tax/RateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Tax/TaxTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Controller/Tax/TaxTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/DashboardTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/DashboardTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Model/Sales/Order/CreateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Model/Sales/Order/CreateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/Model/SessionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/Model/SessionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/System/AccountTest.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/System/AccountTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/_files/form_key_disabled.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/_files/form_key_disabled.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/_files/form_key_disabled_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/_files/form_key_disabled_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/_files/order_shipping_address_different_to_billing.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/_files/order_shipping_address_different_to_billing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/_files/order_shipping_address_same_as_billing.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/_files/order_shipping_address_same_as_billing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/Sales/_files/address.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/Sales/_files/address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/Sales/_files/address_data.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/Sales/_files/address_data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/Sales/_files/order_info.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/Sales/_files/order_info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_disabled.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_disabled.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_disabled_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_disabled_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_enabled.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_enabled.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_enabled_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_enabled_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_invalidated.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_invalidated.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_invalidated_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/all_types_invalidated_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/application_cache.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/application_cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/application_cache_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/application_cache_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/empty_storage.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/empty_storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/non_application_cache.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/non_application_cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/non_application_cache_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/cache/non_application_cache_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/customer_sample.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/customer_sample.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/newsletter_sample.php
+++ b/dev/tests/integration/testsuite/Magento/Adminhtml/controllers/_files/newsletter_sample.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Authorizenet/Block/Directpost/IframeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Authorizenet/Block/Directpost/IframeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Authorizenet/Controller/Directpost/PaymentTest.php
+++ b/dev/tests/integration/testsuite/Magento/Authorizenet/Controller/Directpost/PaymentTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/System/Config/FormStub.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/System/Config/FormStub.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/System/Config/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/System/Config/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/System/Config/_files/test_section_config.xml
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/System/Config/_files/test_section_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/TemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/ContainerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/ContainerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/Grid/ColumnSetTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/Grid/ColumnSetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/Grid/ContainerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/Grid/ContainerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/Grid/ExtendedTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/Grid/ExtendedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/Grid/MassactionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/Grid/MassactionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/WidgetTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/WidgetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/_files/backend_theme.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/_files/backend_theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/_files/design/adminhtml/test_default/Magento_Backend/layout_test_grid_handle.xml
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/_files/design/adminhtml/test_default/Magento_Backend/layout_test_grid_handle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Controller/AbstractActionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Controller/AbstractActionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Controller/Adminhtml/AuthTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Controller/Adminhtml/AuthTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Controller/Adminhtml/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Controller/Adminhtml/IndexTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Controller/Adminhtml/System/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Controller/Adminhtml/System/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Controller/Router/DefaultRouterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Controller/Router/DefaultRouterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Controller/Router/Validator/DefaultTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Controller/Router/Validator/DefaultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/Auth/SessionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/Auth/SessionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/AuthTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/AuthTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/Config/Backend/Admin/RobotsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/Config/Backend/Admin/RobotsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/Config/Backend/BaseurlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/Config/Backend/BaseurlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/Config/Backend/Image/AdapterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/Config/Backend/Image/AdapterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/LocaleTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/LocaleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/MenuTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/MenuTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/SessionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/SessionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/UrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/_files/config_groups.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/_files/config_groups.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/_files/config_section.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/_files/config_section.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/_files/no_robots_txt.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/_files/no_robots_txt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Model/_files/robots_txt.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Model/_files/robots_txt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Backend/Utility/Controller.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Utility/Controller.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/SearchTest.php
+++ b/dev/tests/integration/testsuite/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/SearchTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Bundle/Controller/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Bundle/Controller/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Bundle/Model/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Bundle/Model/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Bundle/_files/product.php
+++ b/dev/tests/integration/testsuite/Magento/Bundle/_files/product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cache/Backend/MongoDbTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cache/Backend/MongoDbTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cache/CoreTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cache/CoreTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Captcha/Block/Captcha/DefaultTest.php
+++ b/dev/tests/integration/testsuite/Magento/Captcha/Block/Captcha/DefaultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Captcha/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Captcha/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Captcha/_files/dummy_user.php
+++ b/dev/tests/integration/testsuite/Magento/Captcha/_files/dummy_user.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Layer/ViewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Layer/ViewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/Configurable/AssociatedSelector/Backend/Grid/ColumnSetTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/Configurable/AssociatedSelector/Backend/Grid/ColumnSetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ListTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ListTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/NewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/NewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ProductList/CrosssellTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ProductList/CrosssellTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ProductList/RelatedTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ProductList/RelatedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ProductList/ToolbarTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ProductList/ToolbarTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/View/AdditionalTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/View/AdditionalTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/View/OptionsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/View/OptionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/View/Type/ConfigurableTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/View/Type/ConfigurableTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ViewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ViewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/CategoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/CategoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/IndexTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Product/CompareTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Product/CompareTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/Category/FlatTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/Category/FlatTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/CategoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/CategoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/ImageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/ImageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/OutputTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/OutputTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/CompareTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/CompareTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/FlatTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/FlatTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/UrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/ViewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/ViewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/IndexerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/IndexerTest.php
@@ -15,7 +15,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Category/CategoryImageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Category/CategoryImageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Category/CategoryImageTest/StubZendLogWriterStreamTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Category/CategoryImageTest/StubZendLogWriterStreamTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Category/_files/category_without_image.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Category/_files/category_without_image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/DesignTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/DesignTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/AttributeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/CategoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/CategoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/DecimalTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/DecimalTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/ItemTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/ItemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/AlgorithmAdvancedTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/AlgorithmAdvancedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/AlgorithmBaseTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/AlgorithmBaseTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/_files/_algorithm_base_data.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/_files/_algorithm_base_data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/_files/products_advanced.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/_files/products_advanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/_files/products_base.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/Price/_files/products_base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/PriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/PriceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/_files/attribute_weight_filterable.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/_files/attribute_weight_filterable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/_files/attribute_with_option.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/_files/attribute_with_option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/LayerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/LayerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/MediaTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/MediaTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/PriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/PriceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/TierpriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/TierpriceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/_files/select_attribute.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/_files/select_attribute.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/ImageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/ImageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/Configurable/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/Configurable/AttributeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/Configurable/PriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/Configurable/PriceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/ConfigurableTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/ConfigurableTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/PriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/PriceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/VirtualTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Type/VirtualTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/TypeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/TypeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/UrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductExternalTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductExternalTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductGettersTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductGettersTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductPriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductPriceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/Eav/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/Eav/AttributeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/Product/Collection/AssociatedProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/Product/Collection/AssociatedProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/Product/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/Product/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/Product/Flat/IndexerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/Product/Flat/IndexerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/Product/Type/Grouped/AssociatedProductsCollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/Product/Type/Grouped/AssociatedProductsCollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/UrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/_files/url_rewrites.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Resource/_files/url_rewrites.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/UrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/WidgetTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/WidgetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/categories.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/categories.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/filterable_attributes.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/filterable_attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/multiple_products.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/multiple_products.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_associated.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_associated.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_configurable.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_configurable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_grouped.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_grouped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_image.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_image_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_image_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_duplicated.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_duplicated.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_xss.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_xss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_special_price.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_special_price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_virtual.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_virtual.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_with_image.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_with_image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_with_image_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_with_image_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_with_options.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_with_options.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/products.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/products.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/products_crosssell.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/products_crosssell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/products_new.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/products_new.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/products_related.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/products_related.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/url_rewrites.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/url_rewrites.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/url_rewrites_invalid.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/url_rewrites_invalid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/controllers/_files/attribute_system.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/controllers/_files/attribute_system.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/controllers/_files/attribute_system_with_applyto_data.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/controllers/_files/attribute_system_with_applyto_data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/controllers/_files/attribute_user_defined.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/controllers/_files/attribute_user_defined.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Catalog/controllers/_files/products.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/controllers/_files/products.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/CatalogInventory/Model/Stock/ItemTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogInventory/Model/Stock/ItemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/CatalogRule/Model/RuleTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogRule/Model/RuleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/CatalogRule/_files/catalog_rule_10_off_not_logged.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogRule/_files/catalog_rule_10_off_not_logged.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Block/Advanced/ResultTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Block/Advanced/ResultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Block/ResultTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Block/ResultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Block/TermTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Block/TermTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/AjaxTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/AjaxTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/ResultTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/ResultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/_files/query.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/_files/query.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Centinel/CreateOrderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Centinel/CreateOrderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Centinel/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Centinel/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/Block/Cart/Item/RendererTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Block/Cart/Item/RendererTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/Block/Cart/SidebarTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Block/Cart/SidebarTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/Block/CartTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Block/CartTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/Block/Multishipping/OverviewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Block/Multishipping/OverviewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/Block/Onepage/Payment/MethodsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Block/Onepage/Payment/MethodsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/Controller/CartTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Controller/CartTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/Controller/MultishippingTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Controller/MultishippingTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/Controller/OnepageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Controller/OnepageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/Model/Type/OnepageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Model/Type/OnepageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/cart.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/cart.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/discount_10percent.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/discount_10percent.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/product_bundle.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/product_bundle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/product_with_custom_option.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/product_with_custom_option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_address.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_address.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_address_saved.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_address_saved.php
@@ -14,7 +14,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_bundle_product.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_bundle_product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_ccsave_payment.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_ccsave_payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_check_payment.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_check_payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_check_payment_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_check_payment_rollback.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_configurable_product.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_configurable_product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_downloadable_product.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_downloadable_product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_product_and_payment.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_product_and_payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_simple_product.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_simple_product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_simple_product_and_custom_option.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/quote_with_simple_product_and_custom_option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/simple_product.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/simple_product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cms/Block/BlockTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Block/BlockTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cms/Block/Widget/BlockTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Block/Widget/BlockTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cms/Controller/PageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Controller/PageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cms/Controller/RouterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Controller/RouterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cms/Helper/PageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Helper/PageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cms/Helper/Wysiwyg/ImagesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Helper/Wysiwyg/ImagesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cms/Model/Wysiwyg/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Model/Wysiwyg/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cms/Model/Wysiwyg/Images/StorageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Model/Wysiwyg/Images/StorageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cms/_files/block.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/_files/block.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cms/_files/pages.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/_files/pages.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/ParentClassWithNamespace.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/ParentClassWithNamespace.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/ParentClassWithoutNamespace.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/ParentClassWithoutNamespace.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/ParentInterfaceWithoutNamespace.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/ParentInterfaceWithoutNamespace.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithNamespace.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithNamespace.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithNamespaceFactory.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithNamespaceFactory.php
@@ -13,7 +13,7 @@ namespace Magento\Code\GeneratorTest;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithNamespaceInterceptor.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithNamespaceInterceptor.php
@@ -13,7 +13,7 @@ namespace Magento\Code\GeneratorTest;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithNamespaceProxy.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithNamespaceProxy.php
@@ -13,7 +13,7 @@ namespace Magento\Code\GeneratorTest;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithoutNamespace.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithoutNamespace.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithoutNamespaceFactory.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithoutNamespaceFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithoutNamespaceInterceptor.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithoutNamespaceInterceptor.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithoutNamespaceProxy.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceClassWithoutNamespaceProxy.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceInterfaceWithoutNamespace.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceInterfaceWithoutNamespace.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceInterfaceWithoutNamespaceInterceptor.php
+++ b/dev/tests/integration/testsuite/Magento/Code/GeneratorTest/SourceInterfaceWithoutNamespaceInterceptor.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Connect/Controller/Adminhtml/Extension/LocalTest.php
+++ b/dev/tests/integration/testsuite/Magento/Connect/Controller/Adminhtml/Extension/LocalTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Block/AbstractBlockTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Block/AbstractBlockTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Block/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Block/TemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Block/Text/ListTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Block/Text/ListTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Block/TextTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Block/TextTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Block/_files/frontend/magento_demo/css/wrong.css
+++ b/dev/tests/integration/testsuite/Magento/Core/Block/_files/frontend/magento_demo/css/wrong.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Controller/AjaxTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Controller/AjaxTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Controller/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Controller/IndexTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Controller/Request/HttpTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Controller/Request/HttpTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Controller/Varien/ActionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Controller/Varien/ActionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Controller/Varien/FrontTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Controller/Varien/FrontTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Controller/Varien/Router/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Controller/Varien/Router/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Controller/Varien/Router/BaseTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Controller/Varien/Router/BaseTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Helper/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Helper/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Helper/HttpTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Helper/HttpTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Helper/JsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Helper/JsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Helper/StringTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Helper/StringTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Helper/Url/RewriteTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Helper/Url/RewriteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Helper/UrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Helper/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/App/AreaTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/App/AreaTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/App/EmulationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/App/EmulationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/AppTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/AppTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Cache/Frontend/PoolTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Cache/Frontend/PoolTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Config/BaseTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Config/BaseTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Config/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Config/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Config/ElementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Config/ElementTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Catalog/Service/TestProduct.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Catalog/Service/TestProduct.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Catalog/etc/module.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Catalog/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Catalog/etc/service_calls.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Catalog/etc/service_calls.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/First/etc/module.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/First/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/First/etc/service_calls.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/First/etc/service_calls.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Last/etc/module.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Last/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Last/etc/service_calls.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Last/etc/service_calls.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Test/etc/module.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Test/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Test/etc/service_calls.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/Magento/Test/etc/service_calls.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/layout_update.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataService/LayoutTest/layout_update.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DataSource.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DataSource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Design/Backend/ExceptionsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Design/Backend/ExceptionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Design/FileResolution/Strategy/FallbackTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Design/FileResolution/Strategy/FallbackTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Design/Source/DesignTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Design/Source/DesignTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Design/Source/_files/design/frontend/a_d/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Design/Source/_files/design/frontend/a_d/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Design/Source/_files/design/frontend/b_e/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Design/Source/_files/design/frontend/b_e/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Design/Source/_files/design/frontend/magento_default/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Design/Source/_files/design/frontend/magento_default/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Design/Source/_files/design/frontend/magento_g/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Design/Source/_files/design/frontend/magento_g/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/DesignTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/DesignTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Email/Template/FilterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Email/Template/FilterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Email/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Email/TemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/adminhtml/test_default/Magento_Core/layout/email_template_test_handle.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/adminhtml/test_default/Magento_Core/layout/email_template_test_handle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/adminhtml/test_default/Magento_Core/sample_email_content.phtml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/adminhtml/test_default/Magento_Core/sample_email_content.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/adminhtml/test_default/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/adminhtml/test_default/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/frontend/test_default/Magento_Core/layout/email_template_test_handle.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/frontend/test_default/Magento_Core/layout/email_template_test_handle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/frontend/test_default/Magento_Core/sample_email_content.phtml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/frontend/test_default/Magento_Core/sample_email_content.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/frontend/test_default/Magento_Core/sample_email_content_custom.phtml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/frontend/test_default/Magento_Core/sample_email_content_custom.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/frontend/test_default/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/design/frontend/test_default/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/themes.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Email/_files/themes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/EncryptionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/EncryptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/EntryPoint/HttpTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/EntryPoint/HttpTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/ReaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/ReaderTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/_files/Magento/Test/etc/fieldset.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/_files/Magento/Test/etc/fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/_files/Magento/Test/etc/module.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/_files/Magento/Test/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/_files/expectedArray.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/_files/expectedArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/_files/partialFieldsetFirst.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/_files/partialFieldsetFirst.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/_files/partialFieldsetSecond.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Fieldset/Config/_files/partialFieldsetSecond.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/File/StorageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/File/StorageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Image/AdapterFactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Image/AdapterFactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Layout/ElementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Layout/ElementTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Layout/UpdateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Layout/UpdateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/LayoutArgumentObjectUpdater.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/LayoutArgumentObjectUpdater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/LayoutArgumentSimpleUpdater.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/LayoutArgumentSimpleUpdater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/LayoutDirectivesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/LayoutDirectivesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/LayoutTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/LayoutTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/LocaleTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/LocaleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Page/Asset/MergedTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Page/Asset/MergedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/CacheTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/CacheTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Db/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Db/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Db/Collection/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Db/Collection/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Db/ProfilerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Db/ProfilerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Entity/TableTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Entity/TableTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/HelperTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/HelperTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/IteratorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/IteratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Layout/UpdateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Layout/UpdateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/SessionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/SessionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/SetupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/SetupTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Store/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Store/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/StoreTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/StoreTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Theme/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/Theme/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/TransactionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/TransactionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Resource/WebsiteTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Resource/WebsiteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/ResourceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/ResourceTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/RouterListTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/RouterListTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Session/AbstractSession/VarienTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Session/AbstractSession/VarienTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Session/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Session/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Store/GroupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Store/GroupTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/StoreTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/StoreTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/TemplateEngine/TwigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/TemplateEngine/TwigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/TemplateEngine/_files/simple.twig
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/TemplateEngine/_files/simple.twig
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/TemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Theme/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Theme/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Theme/Domain/VirtualTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Theme/Domain/VirtualTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Theme/FileTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Theme/FileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Theme/LabelTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Theme/LabelTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Theme/RegistrationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Theme/RegistrationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Theme/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Theme/ValidatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/ThemeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/ThemeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Translate/InlineParserTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Translate/InlineParserTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Translate/InlineTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Translate/InlineTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Translate/StringTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Translate/StringTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Translate/_files/_inline_page_expected.html
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Translate/_files/_inline_page_expected.html
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Translate/_files/_inline_page_original.html
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Translate/_files/_inline_page_original.html
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Translate/_files/_translation_data.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Translate/_files/_translation_data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/TranslateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/TranslateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Url/RewriteTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Url/RewriteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/UrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Validator/FactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Validator/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/Variable/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/Variable/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/VariableTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/VariableTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/View/DesignTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/View/DesignTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/View/FileSystemTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/View/FileSystemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/View/PublicationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/View/PublicationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/WebsiteTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/WebsiteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/_layout_update.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/_layout_update.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/adminhtml/vendor_test/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/adminhtml/vendor_test/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/area_two/vendor_theme_one/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/area_two/vendor_theme_one/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/design_area/vendor_theme_one/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/design_area/vendor_theme_one/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/access_violation.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/access_violation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/magento_default/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/magento_default/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/magento_default_iphone/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/magento_default_iphone/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_cache_test_theme/layout_test_handle.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_cache_test_theme/layout_test_handle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_cache_test_theme/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_cache_test_theme/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Catalog/catalog_category_view.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Catalog/catalog_category_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Catalog/catalog_category_view_type_default.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Catalog/catalog_category_view_type_default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Catalog/catalog_product_view.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Catalog/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Catalog/catalog_product_view_type_simple.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Catalog/catalog_product_view_type_simple.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Catalog/theme_template.phtml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Catalog/theme_template.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Cms/layout_test_handle_extra.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Cms/layout_test_handle_extra.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Core/layout_test_handle_main.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Core/layout_test_handle_main.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Core/layout_test_handle_sample.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Core/layout_test_handle_sample.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Core/test.phtml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/Magento_Core/test.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/css/styles.css
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/css/styles.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/js/tabs.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/js/tabs.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/view.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_default/view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_publication/style.css
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_publication/style.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_publication/sub.css
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_publication/sub.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_publication/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_publication/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_test_theme/layout_test_handle.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_test_theme/layout_test_handle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_test_theme/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/test_test_theme/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_custom_theme/Fixture_Module/fixture_script.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_custom_theme/Fixture_Module/fixture_script.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_custom_theme/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_custom_theme/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/access_violation.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/access_violation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/css/base64.css
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/css/base64.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/css/deep/recursive.css
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/css/deep/recursive.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/css/exception.css
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/css/exception.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/css/file.css
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/css/file.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/recursive.css
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/recursive.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/scripts.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/scripts.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/frontend/vendor_default/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/themes.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/design/themes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/Fixture_Module/fixture_script_two.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/Fixture_Module/fixture_script_two.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/Fixture_Module/fixture_template_two.phtml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/Fixture_Module/fixture_template_two.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/fixture_script_two.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/fixture_script_two.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/fixture_template_two.phtml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/fixture_template_two.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/mage/script.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/mage/script.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme2/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_custom_theme2/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/Fixture_Module/fixture_script.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/Fixture_Module/fixture_script.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/Fixture_Module/fixture_template.phtml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/Fixture_Module/fixture_template.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/fixture_script.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/fixture_script.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/fixture_template.phtml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/fixture_template.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/i18n/ru_RU/Fixture_Module/fixture_script.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/i18n/ru_RU/Fixture_Module/fixture_script.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/i18n/ru_RU/fixture_script.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/i18n/ru_RU/fixture_script.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_default/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_standalone_theme/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/design/frontend/vendor_standalone_theme/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/pub/lib/mage/script.js
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/fallback/pub/lib/mage/script.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout/container_attributes.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout/container_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/action_for_anonymous_parent_block.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/action_for_anonymous_parent_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/arguments.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/arguments.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/arguments_complex_values.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/arguments_complex_values.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/arguments_object_type.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/arguments_object_type.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/arguments_object_type_updaters.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/arguments_object_type_updaters.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/arguments_url_type.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/arguments_url_type.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/get_block.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/get_block.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/get_block_exception.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/get_block_exception.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/ifconfig.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/ifconfig.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/move.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/move.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/move_alias_broken.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/move_alias_broken.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/move_broken.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/move_broken.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/move_new_alias.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/move_new_alias.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/move_the_same_alias.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/move_the_same_alias.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/remove.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/remove.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/remove_broken.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/remove_broken.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/render.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/render.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/sort_after_after.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/sort_after_after.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/sort_after_previous.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/sort_after_previous.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/sort_before_after.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/sort_before_after.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/sort_before_before.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/layout_directives_test/sort_before_before.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/local_config/custom/local.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/local_config/custom/local.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/local_config/custom/prohibited.filename.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/local_config/custom/prohibited.filename.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/local_config/local.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/local_config/local.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/local_config/z.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/local_config/z.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/no_local_config/a.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/no_local_config/a.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/no_local_config/b.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/no_local_config/b.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/no_local_config/custom/local.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/local_config/no_local_config/custom/local.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Model/_files/locale/en_AU/config.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Model/_files/locale/en_AU/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Utility/Layout.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Utility/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Utility/LayoutTest.php
+++ b/dev/tests/integration/testsuite/Magento/Core/Utility/LayoutTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Utility/_files/layout/handle_one.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Utility/_files/layout/handle_one.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Utility/_files/layout/handle_three.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Utility/_files/layout/handle_three.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Utility/_files/layout/handle_two.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Utility/_files/layout/handle_two.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Utility/_files/layout_merged/multiple_handles.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Utility/_files/layout_merged/multiple_handles.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/Utility/_files/layout_merged/single_handle.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/Utility/_files/layout_merged/single_handle.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/config_cache.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/config_cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/db_translate.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/db_translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/db_translate_admin_store.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/db_translate_admin_store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/design_change.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/design_change.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/design_change_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/design_change_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/design_change_timezone.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/design_change_timezone.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/design_change_timezone_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/design_change_timezone_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/etc/config.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/etc/module.xml
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/layout_cache.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/layout_cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/layout_update.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/layout_update.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/media_for_change.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/media_for_change.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/media_for_change_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/media_for_change_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/store.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/url_rewrite.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/url_rewrite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Core/_files/variable.php
+++ b/dev/tests/integration/testsuite/Magento/Core/_files/variable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Cron/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cron/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Account/Dashboard/InfoTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Account/Dashboard/InfoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/DobTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/DobTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/GenderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/GenderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/AccountTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/AccountTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/GroupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/GroupTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/Address/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/Address/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/Customer/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/Customer/CollectionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/Service/CustomerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Service/CustomerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/_files/customer.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/_files/customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/_files/customer_address.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/_files/customer_address.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/_files/customer_two_addresses.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/_files/customer_two_addresses.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Customer/_files/two_customers.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/_files/two_customers.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DB/Adapter/InterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/DB/Adapter/InterfaceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DB/Adapter/Pdo/MysqlTest.php
+++ b/dev/tests/integration/testsuite/Magento/DB/Adapter/Pdo/MysqlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Data/Form/Element/FieldsetTest.php
+++ b/dev/tests/integration/testsuite/Magento/Data/Form/Element/FieldsetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Controller/Adminhtml/System/Design/EditorTest.php
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Controller/Adminhtml/System/Design/EditorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/Config/QuickStylesTest.php
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/Config/QuickStylesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/Editor/Tools/Controls/ConfigurationTest.php
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/Editor/Tools/Controls/ConfigurationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/Theme/ChangeTest.php
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/Theme/ChangeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/Translate/InlineVdeTest.php
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/Translate/InlineVdeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/Translate/_files/_inline_page_original.html
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/Translate/_files/_inline_page_original.html
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test/Magento_DesignEditor/controls/image_sizing.xml
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test/Magento_DesignEditor/controls/image_sizing.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test/Magento_DesignEditor/controls/quick_styles.xml
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test/Magento_DesignEditor/controls/quick_styles.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test/view.xml
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test/view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test_child/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test_child/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test_child/view.xml
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/frontend/vendor_test_child/view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/themes.php
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/Model/_files/design/themes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/DesignEditor/_files/design_editor_active.php
+++ b/dev/tests/integration/testsuite/Magento/DesignEditor/_files/design_editor_active.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinksTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinksTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SamplesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SamplesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Controller/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Controller/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Model/Product/TypeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Model/Product/TypeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Downloadable/_files/order_with_downloadable_product.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/_files/order_with_downloadable_product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Downloadable/_files/product.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/_files/product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Downloadable/_files/product_with_files.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/_files/product_with_files.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Eav/Block/Adminhtml/Attribute/Edit/Main/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Block/Adminhtml/Attribute/Edit/Main/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Eav/Model/Resource/Entity/Attribute/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Model/Resource/Entity/Attribute/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Eav/Model/Validator/Attribute/BackendTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Model/Validator/Attribute/BackendTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/File/SizeTest.php
+++ b/dev/tests/integration/testsuite/Magento/File/SizeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Filesystem/Adapter/LocalTest.php
+++ b/dev/tests/integration/testsuite/Magento/Filesystem/Adapter/LocalTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Filesystem/Adapter/ZlibTest.php
+++ b/dev/tests/integration/testsuite/Magento/Filesystem/Adapter/ZlibTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Filesystem/Stream/LocalTest.php
+++ b/dev/tests/integration/testsuite/Magento/Filesystem/Stream/LocalTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Filesystem/Stream/ZlibTest.php
+++ b/dev/tests/integration/testsuite/Magento/Filesystem/Stream/ZlibTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/GiftMessage/Block/Message/InlineTest.php
+++ b/dev/tests/integration/testsuite/Magento/GiftMessage/Block/Message/InlineTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/GoogleShopping/Block/Adminhtml/Items/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/GoogleShopping/Block/Adminhtml/Items/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/GoogleShopping/Controller/Adminhtml/GoogleShopping/ItemsTest.php
+++ b/dev/tests/integration/testsuite/Magento/GoogleShopping/Controller/Adminhtml/GoogleShopping/ItemsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Image/Adapter/InterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Image/Adapter/InterfaceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Block/Adminhtml/Export/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Block/Adminhtml/Export/Edit/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Block/Adminhtml/Export/FilterTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Block/Adminhtml/Export/FilterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Block/Adminhtml/Import/Edit/BeforeTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Block/Adminhtml/Import/Edit/BeforeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Block/Adminhtml/Import/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Block/Adminhtml/Import/Edit/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Controller/Adminhtml/ExportTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Controller/Adminhtml/ExportTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Controller/Adminhtml/ImportTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Controller/Adminhtml/ImportTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/AbstractStubEntity.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/AbstractStubEntity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/Entity/Eav/Customer/AddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/Entity/Eav/Customer/AddressTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/Entity/Eav/CustomerTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/Entity/Eav/CustomerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/Entity/EavAbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/Entity/EavAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/Entity/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/Entity/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/EntityAbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/EntityAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/ExportTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/ExportTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/CustomerCompositeTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/CustomerCompositeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/AddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/AddressTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/CustomerImportTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/CustomerImportTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/CustomerTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/CustomerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/EavAbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/EavAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/Product/Type/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/Product/Type/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/EntityAbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/EntityAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/ImportTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/ImportTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Resource/Import/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Resource/Import/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Source/Import/EntityTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Source/Import/EntityTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/_files/customer.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/_files/customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/_files/customer_with_addresses.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/_files/customer_with_addresses.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/_files/customers.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/_files/customers.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/_files/customers_for_address_import.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/_files/customers_for_address_import.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/_files/import_data.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/_files/import_data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ImportExport/_files/product.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/_files/product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Index/Model/Process/FileTest.php
+++ b/dev/tests/integration/testsuite/Magento/Index/Model/Process/FileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Index/Model/ProcessTest.php
+++ b/dev/tests/integration/testsuite/Magento/Index/Model/ProcessTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Index/Model/ShellTest.php
+++ b/dev/tests/integration/testsuite/Magento/Index/Model/ShellTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Install/Block/AdminTest.php
+++ b/dev/tests/integration/testsuite/Magento/Install/Block/AdminTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Install/Controller/WizardTest.php
+++ b/dev/tests/integration/testsuite/Magento/Install/Controller/WizardTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Install/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Install/IndexTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Install/Model/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Install/Model/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Install/Model/Installer/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Install/Model/Installer/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Install/Model/InstallerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Install/Model/InstallerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Install/Model/_files/Magento/Test/etc/install_wizard.xml
+++ b/dev/tests/integration/testsuite/Magento/Install/Model/_files/Magento/Test/etc/install_wizard.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Install/Model/_files/Magento/Test/etc/module.xml
+++ b/dev/tests/integration/testsuite/Magento/Install/Model/_files/Magento/Test/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Install/Model/_files/install_wizard_complete.xml
+++ b/dev/tests/integration/testsuite/Magento/Install/Model/_files/install_wizard_complete.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Install/Model/_files/install_wizard_partial.xml
+++ b/dev/tests/integration/testsuite/Magento/Install/Model/_files/install_wizard_partial.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Log/Model/Resource/ShellTest.php
+++ b/dev/tests/integration/testsuite/Magento/Log/Model/Resource/ShellTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Log/Model/ShellTest.php
+++ b/dev/tests/integration/testsuite/Magento/Log/Model/ShellTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/MemoryUsageTest.php
+++ b/dev/tests/integration/testsuite/Magento/MemoryUsageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Model/QueueTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Model/QueueTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Model/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Model/TemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Newsletter/_files/queue.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/_files/queue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Newsletter/_files/subscribers.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/_files/subscribers.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Newsletter/_files/template.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/_files/template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/Config/Reader/DomTest.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/Config/Reader/DomTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/ObjectManagerTest.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/ObjectManagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/Basic.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/Basic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/BasicAlias.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/BasicAlias.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/BasicInjection.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/BasicInjection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorEightArguments.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorEightArguments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorFiveArguments.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorFiveArguments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorFourArguments.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorFourArguments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorNineArguments.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorNineArguments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorNoArguments.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorNoArguments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorOneArgument.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorOneArgument.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorSevenArguments.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorSevenArguments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorSixArguments.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorSixArguments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorTenArguments.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorTenArguments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorThreeArguments.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorThreeArguments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorTwoArguments.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/ConstructorTwoArguments.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/InterfaceImplementation.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/InterfaceImplementation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/InterfaceInjection.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/InterfaceInjection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/TestAssetInterface.php
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/TestAsset/TestAssetInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/_files/config_merged.xml
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/_files/config_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/_files/config_one.xml
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/_files/config_one.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ObjectManager/_files/config_two.xml
+++ b/dev/tests/integration/testsuite/Magento/ObjectManager/_files/config_two.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Outbound/Authentication/FactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Outbound/Authentication/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Outbound/Formatter/FactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Outbound/Formatter/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Outbound/Formatter/JsonTest.php
+++ b/dev/tests/integration/testsuite/Magento/Outbound/Formatter/JsonTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Outbound/Formatter/JsonTest/Data.php
+++ b/dev/tests/integration/testsuite/Magento/Outbound/Formatter/JsonTest/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Page/Block/Html/BreadcrumbsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Page/Block/Html/BreadcrumbsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Page/Block/Html/FooterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Page/Block/Html/FooterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Page/Block/Html/HeadTest.php
+++ b/dev/tests/integration/testsuite/Magento/Page/Block/Html/HeadTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Page/Block/HtmlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Page/Block/HtmlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Page/Helper/RobotsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Page/Helper/RobotsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Page/Model/Config/ReaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Page/Model/Config/ReaderTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Page/Model/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Page/Model/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Page/Model/_files/page_layouts.xml
+++ b/dev/tests/integration/testsuite/Magento/Page/Model/_files/page_layouts.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Page/Model/_files/page_layouts2.xml
+++ b/dev/tests/integration/testsuite/Magento/Page/Model/_files/page_layouts2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/PageCache/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/PageCache/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/PageCache/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/PageCache/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Payment/Block/Catalog/Product/View/ProfileTest.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/Block/Catalog/Product/View/ProfileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Payment/Block/InfoTest.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/Block/InfoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Payment/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Payment/Model/Config/ReaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/Model/Config/ReaderTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Payment/Model/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/Model/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Payment/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Payment/Model/_files/payment.xml
+++ b/dev/tests/integration/testsuite/Magento/Payment/Model/_files/payment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Payment/Model/_files/payment2.xml
+++ b/dev/tests/integration/testsuite/Magento/Payment/Model/_files/payment2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Payment/_files/order_status.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/_files/order_status.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/Adminhtml/Paypal/ReportsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Adminhtml/Paypal/ReportsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/Block/Express/ReviewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Block/Express/ReviewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/Controller/ExpressTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Controller/ExpressTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/Controller/HostedproTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Controller/HostedproTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/Controller/PayflowTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Controller/PayflowTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/Controller/PayflowadvancedTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Controller/PayflowadvancedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/Controller/StandardTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Controller/StandardTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/Model/IpnTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Model/IpnTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/Model/Report/SettlementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Model/Report/SettlementTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/Model/VoidTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Model/VoidTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/address_data.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/address_data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/ipn.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/ipn.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/ipn_recurring_profile.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/ipn_recurring_profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/order_express.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/order_express.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/order_payflowpro.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/order_payflowpro.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/order_standard.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/order_standard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/quote_payment.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/quote_payment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/quote_payment_express.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/quote_payment_express.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/quote_payment_payflow.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/quote_payment_payflow.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/quote_payment_standard.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/quote_payment_standard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Paypal/_files/recurring_profile.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/_files/recurring_profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Persistent/Model/Persistent/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Persistent/Model/Persistent/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Persistent/Model/Persistent/_files/expectedArray.php
+++ b/dev/tests/integration/testsuite/Magento/Persistent/Model/Persistent/_files/expectedArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Persistent/Model/Persistent/_files/expectedBlocksArray.php
+++ b/dev/tests/integration/testsuite/Magento/Persistent/Model/Persistent/_files/expectedBlocksArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Persistent/Model/Persistent/_files/persistent.xml
+++ b/dev/tests/integration/testsuite/Magento/Persistent/Model/Persistent/_files/persistent.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ProductAlert/Block/Email/StockTest.php
+++ b/dev/tests/integration/testsuite/Magento/ProductAlert/Block/Email/StockTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Profiler/Driver/Standard/Output/CsvfileTest.php
+++ b/dev/tests/integration/testsuite/Magento/Profiler/Driver/Standard/Output/CsvfileTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Profiler/Driver/Standard/Output/FirebugTest.php
+++ b/dev/tests/integration/testsuite/Magento/Profiler/Driver/Standard/Output/FirebugTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Profiler/Driver/Standard/Output/HtmlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Profiler/Driver/Standard/Output/HtmlTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Profiler/Driver/Standard/Output/_files/output.html
+++ b/dev/tests/integration/testsuite/Magento/Profiler/Driver/Standard/Output/_files/output.html
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Profiler/Driver/Standard/Output/_files/timers.php
+++ b/dev/tests/integration/testsuite/Magento/Profiler/Driver/Standard/Output/_files/timers.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/ProfilerTest.php
+++ b/dev/tests/integration/testsuite/Magento/ProfilerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/PubSub/Event/FactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/PubSub/Event/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/PubSub/Event/QueueHandlerTest.php
+++ b/dev/tests/integration/testsuite/Magento/PubSub/Event/QueueHandlerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/PubSub/Event/QueueWriterTest.php
+++ b/dev/tests/integration/testsuite/Magento/PubSub/Event/QueueWriterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/PubSub/EventTest.php
+++ b/dev/tests/integration/testsuite/Magento/PubSub/EventTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/PubSub/Job/QueueHandlerTest.php
+++ b/dev/tests/integration/testsuite/Magento/PubSub/Job/QueueHandlerTest.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/PubSub/Message/DispatcherAsyncTest.php
+++ b/dev/tests/integration/testsuite/Magento/PubSub/Message/DispatcherAsyncTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/PubSub/_files/config.xml
+++ b/dev/tests/integration/testsuite/Magento/PubSub/_files/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Reports/Block/Adminhtml/GridTest.php
+++ b/dev/tests/integration/testsuite/Magento/Reports/Block/Adminhtml/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Reports/Block/WidgetTest.php
+++ b/dev/tests/integration/testsuite/Magento/Reports/Block/WidgetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Reports/Model/Resource/Report/Product/Viewed/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Reports/Model/Resource/Report/Product/Viewed/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Reports/_files/viewed_products.php
+++ b/dev/tests/integration/testsuite/Magento/Reports/_files/viewed_products.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Review/Controller/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Review/Controller/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Review/Model/Resource/Review/Product/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Review/Model/Resource/Review/Product/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Review/_files/different_reviews.php
+++ b/dev/tests/integration/testsuite/Magento/Review/_files/different_reviews.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Review/_files/review_xss.php
+++ b/dev/tests/integration/testsuite/Magento/Review/_files/review_xss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Review/_files/reviews.php
+++ b/dev/tests/integration/testsuite/Magento/Review/_files/reviews.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Rss/Block/Order/StatusTest.php
+++ b/dev/tests/integration/testsuite/Magento/Rss/Block/Order/StatusTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Rss/Controller/CatalogTest.php
+++ b/dev/tests/integration/testsuite/Magento/Rss/Controller/CatalogTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Rss/Controller/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Rss/Controller/IndexTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Rss/Controller/OrderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Rss/Controller/OrderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Rule/Model/Condition/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Rule/Model/Condition/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Report/Filter/Form/CouponTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Report/Filter/Form/CouponTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Order/CommentsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Order/CommentsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Order/Creditmemo/ItemsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Order/Creditmemo/ItemsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Order/Invoice/ItemsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Order/Invoice/ItemsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Order/PrintOrder/CreditmemoTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Order/PrintOrder/CreditmemoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Order/PrintOrder/InvoiceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Order/PrintOrder/InvoiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Order/Shipment/ItemsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Order/Shipment/ItemsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Order/TotalsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Order/TotalsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Recurring/Profile/ViewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Recurring/Profile/ViewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/AbstractCollectorPositionsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/AbstractCollectorPositionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/CreditmemoTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/CreditmemoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/InvoiceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/InvoiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/OrderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/OrderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/Payment/TransactionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/Payment/TransactionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/ShipmentTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/ShipmentTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/QuoteTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/QuoteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Bestsellers/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Bestsellers/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Invoiced/Collection/InvoicedTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Invoiced/Collection/InvoicedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Invoiced/Collection/OrderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Invoiced/Collection/OrderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Order/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Order/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Refunded/Collection/OrderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Refunded/Collection/OrderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Refunded/Collection/RefundedTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Refunded/Collection/RefundedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Shipping/Collection/OrderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Shipping/Collection/OrderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Shipping/Collection/ShipmentTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Resource/Report/Shipping/Collection/ShipmentTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/address_data.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/address_data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/creditmemo.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/creditmemo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/invoice.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/invoice.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/invoice_verisign.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/invoice_verisign.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_paid_with_saved_cc.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_paid_with_saved_cc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_paid_with_verisign.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_paid_with_verisign.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order_shipping.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order_shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/quote.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/quote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/report_bestsellers.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/report_bestsellers.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/report_invoiced.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/report_invoiced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/report_order.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/report_order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/report_refunded.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/report_refunded.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/report_shipping.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/report_shipping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/transactions.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/transactions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/SalesRule/Model/Resource/Report/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/Model/Resource/Report/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/SalesRule/_files/cart_rule_40_percent_off.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/_files/cart_rule_40_percent_off.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/SalesRule/_files/cart_rule_50_percent_off.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/_files/cart_rule_50_percent_off.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/SalesRule/_files/order_with_coupon.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/_files/order_with_coupon.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/SalesRule/_files/report_coupons.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/_files/report_coupons.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Shipping/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Shipping/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sitemap/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sitemap/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sitemap/Model/Resource/Catalog/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sitemap/Model/Resource/Catalog/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sitemap/_files/sitemap_products.php
+++ b/dev/tests/integration/testsuite/Magento/Sitemap/_files/sitemap_products.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Sitemap/_files/sitemap_products_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Sitemap/_files/sitemap_products_rollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Calculation/RuleTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Calculation/RuleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/ClassTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/ClassTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Rate/CsvImportHandlerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Rate/CsvImportHandlerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Resource/Calculation/Rule/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Resource/Calculation/Rule/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Resource/CalculationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Resource/CalculationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Resource/Report/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Resource/Report/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/_files/order_with_tax.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/_files/order_with_tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/_files/report_tax.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/_files/report_tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Tax/_files/tax_classes.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/_files/tax_classes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/LayoutTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/LayoutTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Magento/Centinel/StateFactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Magento/Centinel/StateFactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Magento/Core/Model/DataService/ServiceCallsConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Magento/Core/Model/DataService/ServiceCallsConfigTest.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Magento/Payment/MethodsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Magento/Payment/MethodsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Magento/Widget/SkinFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Magento/Widget/SkinFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Magento/Widget/TemplateFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Magento/Widget/TemplateFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/AclConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/AclConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/BlockInstantiationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/BlockInstantiationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/CacheFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/CacheFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/CrontabConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/CrontabConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/DiConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/DiConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/EavAttributesConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/EavAttributesConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/EventConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/EventConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ExportConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ExportConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/FieldsetConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/FieldsetConfigFilesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ImportConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ImportConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/IndexerConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/IndexerConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/InstallWizardConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/InstallWizardConfigFilesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/LayoutFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/LayoutFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/LoggingConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/LoggingConfigFilesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/Magento/Catalog/AttributeConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/Magento/Catalog/AttributeConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/Magento/Core/EmailTemplateConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/Magento/Core/EmailTemplateConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/Magento/Customer/AddressFormatsFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/Magento/Customer/AddressFormatsFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/Magento/Sales/PdfConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/Magento/Sales/PdfConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/MenuConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/MenuConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/PageConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/PageConfigFilesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/PaymentConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/PaymentConfigFilesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ProductOptionsConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ProductOptionsConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ProductTypesConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ProductTypesConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ResourcesConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ResourcesConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/RouteConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/RouteConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/SalesConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/SalesConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ServiceCallsConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ServiceCallsConfigFilesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/SystemConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/SystemConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/TemplateFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/TemplateFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ViewConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ViewConfigFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ViewFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ViewFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/WidgetConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/WidgetConfigFilesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/_files/skip_blocks_ce.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/_files/skip_blocks_ce.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/_files/skip_template_blocks_ce.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/_files/skip_template_blocks_ce.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/_files/view_files_ce.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/_files/view_files_ce.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Theme/TemplateFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Theme/TemplateFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Theme/ViewFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Theme/ViewFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Theme/XmlFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Theme/XmlFilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/ViewFileReferenceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/ViewFileReferenceTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/GeneratorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/GeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/FirstModule/Helper/Helper.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/FirstModule/Helper/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/FirstModule/Model/Model.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/FirstModule/Model/Model.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/FirstModule/view/frontend/default.xml
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/FirstModule/view/frontend/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/FirstModule/view/frontend/file.js
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/FirstModule/view/frontend/file.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/FirstModule/view/frontend/template.phtml
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/FirstModule/view/frontend/template.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/SecondModule/Model/Model.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/code/Magento/SecondModule/Model/Model.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/design/adminhtml/default/backend/default.xml
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/design/adminhtml/default/backend/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/design/adminhtml/default/backend/template.phtml
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/app/design/adminhtml/default/backend/template.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/pub/lib/mage/file.js
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/pub/lib/mage/file.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/pub/lib/varien/file.js
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/pub/lib/varien/file.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/unused/Model.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/unused/Model.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/unused/file.js
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/unused/file.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/unused/template.phtml
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/_files/source/unused/template.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Pack/GeneratorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/I18n/Code/Pack/GeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/Layout/Reference/ProcessorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/Layout/Reference/ProcessorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/Layout/Reference/_files/layoutInvalid.xml
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/Layout/Reference/_files/layoutInvalid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/Layout/Reference/_files/layoutValid.xml
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/Layout/Reference/_files/layoutValid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Test/Tools/Layout/Reference/_files/layoutValidExpectUpdated.xml
+++ b/dev/tests/integration/testsuite/Magento/Test/Tools/Layout/Reference/_files/layoutValidExpectUpdated.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Tab/GeneralTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Tab/GeneralTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Theme/Controller/Adminhtml/System/Design/ThemeControllerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Controller/Adminhtml/System/Design/ThemeControllerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Theme/Controller/Adminhtml/System/Design/_files/simple-js-file.js
+++ b/dev/tests/integration/testsuite/Magento/Theme/Controller/Adminhtml/System/Design/_files/simple-js-file.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/Wysiwyg/StorageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/Wysiwyg/StorageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Usa/Block/Adminhtml/Dhl/UnitofmeasureTest.php
+++ b/dev/tests/integration/testsuite/Magento/Usa/Block/Adminhtml/Dhl/UnitofmeasureTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Usa/Model/Shipping/Carrier/UpsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Usa/Model/Shipping/Carrier/UpsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Block/Role/Grid/UserTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Block/Role/Grid/UserTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Block/Role/Tab/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Block/Role/Tab/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Block/User/Edit/Tab/MainTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Block/User/Edit/Tab/MainTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/AuthTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/AuthTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/User/RoleTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/User/RoleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/UserTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/UserTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Model/Resource/Role/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Model/Resource/Role/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Model/Resource/Role/Grid/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Model/Resource/Role/Grid/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Model/Resource/Role/User/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Model/Resource/Role/User/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Model/Resource/RoleTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Model/Resource/RoleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Model/Resource/Rules/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Model/Resource/Rules/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Model/Resource/UserTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Model/Resource/UserTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Model/RoleTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Model/RoleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Model/RulesTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Model/RulesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/Model/UserTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Model/UserTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/User/_files/dummy_user.php
+++ b/dev/tests/integration/testsuite/Magento/User/_files/dummy_user.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/AbstractFormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/AbstractFormTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/Role/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/Role/Edit/FormTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/Role/Edit/Tab/MainTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/Role/Edit/Tab/MainTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/Role/Edit/Tab/ResourceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/Role/Edit/Tab/ResourceTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/User/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/User/Edit/FormTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/User/Edit/Tab/MainTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/User/Edit/Tab/MainTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/User/Edit/TabsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/User/Edit/TabsTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/User/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Block/Adminhtml/User/EditTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Model/Acl/RoleTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Model/Acl/RoleTest.php
@@ -13,7 +13,7 @@ namespace Magento\Webapi\Model\Acl;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Model/Acl/RuleTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Model/Acl/RuleTest.php
@@ -13,7 +13,7 @@ namespace Magento\Webapi\Model\Acl;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Model/Acl/UserTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Model/Acl/UserTest.php
@@ -13,7 +13,7 @@ namespace Magento\Webapi\Model\Acl;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Model/Resource/Acl/RoleTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Model/Resource/Acl/RoleTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Model/Resource/Acl/RuleTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Model/Resource/Acl/RuleTest.php
@@ -14,7 +14,7 @@ namespace Magento\Webapi\Model\Resource\Acl;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/Model/Soap/ServerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/Model/Soap/ServerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/_files/role.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/_files/role.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/_files/role_with_rule.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/_files/role_with_rule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webapi/_files/user_with_role.php
+++ b/dev/tests/integration/testsuite/Magento/Webapi/_files/user_with_role.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Registration/ActivateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Registration/ActivateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Registration/Create/Form/ContainerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Registration/Create/Form/ContainerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Registration/Create/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Registration/Create/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Registration/FailedTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Registration/FailedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/Edit/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/Grid/Renderer/ActionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/Grid/Renderer/ActionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/SubscriptionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Block/Adminhtml/SubscriptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Controller/Adminhtml/Webhook/RegistrationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Controller/Adminhtml/Webhook/RegistrationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Controller/Adminhtml/Webhook/SubscriptionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Controller/Adminhtml/Webhook/SubscriptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/EndpointTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/EndpointTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Event/FactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Event/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Event/QueueReaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Event/QueueReaderTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Event/QueueWriterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Event/QueueWriterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/EventTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/EventTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Job/FactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Job/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Job/QueueReaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Job/QueueReaderTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Job/QueueWriterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Job/QueueWriterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/JobTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/JobTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/ObserverTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/EndpointTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/EndpointTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Event/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Event/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/EventTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/EventTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Job/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Job/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/JobTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/JobTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Subscription/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Subscription/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Subscription/Grid/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Subscription/Grid/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Subscription/Grid/_files/Acme/Subscriber/etc/config.xml
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Subscription/Grid/_files/Acme/Subscriber/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Subscription/Grid/_files/Acme/Subscriber/etc/module.xml
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/Subscription/Grid/_files/Acme/Subscriber/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/SubscriptionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Resource/SubscriptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Subscription/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Subscription/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Subscription/Options/StatusTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Subscription/Options/StatusTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Subscription/_files/Acme/Subscriber/etc/config.xml
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Subscription/_files/Acme/Subscriber/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Subscription/_files/Acme/Subscriber/etc/module.xml
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Subscription/_files/Acme/Subscriber/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/SubscriptionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/SubscriptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/UserTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/UserTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Webapi/EventHandler/FactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Webapi/EventHandler/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Model/Webapi/User/FactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Model/Webapi/User/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Webhook/Service/SubscriptionV1Test.php
+++ b/dev/tests/integration/testsuite/Magento/Webhook/Service/SubscriptionV1Test.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Weee/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Weee/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Weee/_files/product_with_fpt.php
+++ b/dev/tests/integration/testsuite/Magento/Weee/_files/product_with_fpt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/ContainerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/ContainerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/LayoutTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/LayoutTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/catalogsearch_ajax_suggest.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/catalogsearch_ajax_suggest.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/child_page_with_inherited_containers.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/child_page_with_inherited_containers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/child_page_with_inherited_imported_containers.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/child_page_with_inherited_imported_containers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/child_page_with_own_containers.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/child_page_with_own_containers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/child_page_without_containers.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/child_page_without_containers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/non_page_handle_with_own_containers.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/non_page_handle_with_own_containers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/root_page_with_imported_containers.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/root_page_with_imported_containers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/root_page_with_own_containers.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/root_page_with_own_containers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/root_page_without_containers.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/root_page_without_containers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/root_page_without_own_containers.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/layout/root_page_without_own_containers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/page_types_select.html
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/_files/page_types_select.html
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/LayoutTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/LayoutTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/MainTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/MainTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Block/Adminhtml/Widget/Instance/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Controller/Adminhtml/Widget/InstanceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Controller/Adminhtml/Widget/InstanceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Controller/Adminhtml/WidgetTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Controller/Adminhtml/WidgetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/DataTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/FileResolverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/FileResolverTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/ReaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/ReaderTest.php
@@ -12,7 +12,7 @@ namespace Magento\Widget\Model\Config;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/code/Magento/Test/etc/module.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/code/Magento/Test/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/code/Magento/Test/etc/widget.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/code/Magento/Test/etc/widget.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/design/frontend/Test/etc/widget.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/design/frontend/Test/etc/widget.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/expectedGlobalArray.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/expectedGlobalArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/expectedGlobalDesignArray.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/expectedGlobalDesignArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/expectedMergedArray.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/expectedMergedArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/widgetFirst.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/widgetFirst.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/widgetSecond.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Config/_files/widgetSecond.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Widget/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Widget/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Widget/InstanceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Widget/InstanceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/WidgetTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/WidgetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/_files/design/adminhtml/magento_basic/theme.xml
+++ b/dev/tests/integration/testsuite/Magento/Widget/_files/design/adminhtml/magento_basic/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Widget/_files/themes.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/_files/themes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Wishlist/Block/AbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/Wishlist/Block/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Wishlist/Block/Customer/Wishlist/Item/ColumnTest.php
+++ b/dev/tests/integration/testsuite/Magento/Wishlist/Block/Customer/Wishlist/Item/ColumnTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Wishlist/Block/Customer/Wishlist/Item/OptionsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Wishlist/Block/Customer/Wishlist/Item/OptionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Wishlist/Block/Customer/Wishlist/ItemsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Wishlist/Block/Customer/Wishlist/ItemsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Wishlist/Controller/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Wishlist/Controller/IndexTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/integration/testsuite/Magento/Wishlist/_files/wishlist.php
+++ b/dev/tests/integration/testsuite/Magento/Wishlist/_files/wishlist.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/jsTestDriver.php.dist
+++ b/dev/tests/js/jsTestDriver.php.dist
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/jsTestDriverOrder.php
+++ b/dev/tests/js/jsTestDriverOrder.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/run_js_tests.php
+++ b/dev/tests/js/run_js_tests.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/button/button-test.js
+++ b/dev/tests/js/testsuite/mage/button/button-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/calendar/calendar-test.js
+++ b/dev/tests/js/testsuite/mage/calendar/calendar-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/calendar/date-range-test.js
+++ b/dev/tests/js/testsuite/mage/calendar/date-range-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/decorate-test.js
+++ b/dev/tests/js/testsuite/mage/decorate-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/design_editor/adminhtml/js/infinitescroll.js
+++ b/dev/tests/js/testsuite/mage/design_editor/adminhtml/js/infinitescroll.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/edit_trigger/edit-trigger-test.js
+++ b/dev/tests/js/testsuite/mage/edit_trigger/edit-trigger-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/form/form-test.js
+++ b/dev/tests/js/testsuite/mage/form/form-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/loader/loader-test.js
+++ b/dev/tests/js/testsuite/mage/loader/loader-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/mage-test.js
+++ b/dev/tests/js/testsuite/mage/mage-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/suggest/suggest-test.js
+++ b/dev/tests/js/testsuite/mage/suggest/suggest-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/suggest/tree-suggest-test.js
+++ b/dev/tests/js/testsuite/mage/suggest/tree-suggest-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/tabs/tabs-test.js
+++ b/dev/tests/js/testsuite/mage/tabs/tabs-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/translate/translate-test.js
+++ b/dev/tests/js/testsuite/mage/translate/translate-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/translate_inline/translate-inline-test.js
+++ b/dev/tests/js/testsuite/mage/translate_inline/translate-inline-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/translate_inline_vde/translate-inline-vde-dialog-test.js
+++ b/dev/tests/js/testsuite/mage/translate_inline_vde/translate-inline-vde-dialog-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/translate_inline_vde/translate-inline-vde-test.js
+++ b/dev/tests/js/testsuite/mage/translate_inline_vde/translate-inline-vde-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/validation/validate-test.js
+++ b/dev/tests/js/testsuite/mage/validation/validate-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/js/testsuite/mage/webapi-test.js
+++ b/dev/tests/js/testsuite/mage/webapi-test.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/config.php.dist
+++ b/dev/tests/performance/config.php.dist
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Application.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/ImportExport/Fixture/Generator.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/ImportExport/Fixture/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Performance/Bootstrap.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Performance/Bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Performance/Config.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Performance/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario/FailureException.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario/FailureException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario/Handler/FileFormat.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario/Handler/FileFormat.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario/Handler/Jmeter.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario/Handler/Jmeter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario/Handler/Php.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario/Handler/Php.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario/HandlerInterface.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Performance/Scenario/HandlerInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Performance/Testsuite.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Performance/Testsuite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/Magento/TestFramework/Performance/Testsuite/Optimizer.php
+++ b/dev/tests/performance/framework/Magento/TestFramework/Performance/Testsuite/Optimizer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/bootstrap.php
+++ b/dev/tests/performance/framework/bootstrap.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/framework/bootstrap.php
+++ b/dev/tests/performance/framework/tests/unit/framework/bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/phpunit.xml.dist
+++ b/dev/tests/performance/framework/tests/unit/phpunit.xml.dist
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/ApplicationTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/ApplicationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/ImportExport/Fixture/GeneratorTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/ImportExport/Fixture/GeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/BootstrapTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/BootstrapTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/ConfigTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/Scenario/FailureExceptionTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/Scenario/FailureExceptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/Scenario/Handler/FileFormatTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/Scenario/Handler/FileFormatTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/Scenario/Handler/JmeterTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/Scenario/Handler/JmeterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/Scenario/Handler/PhpTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/Scenario/Handler/PhpTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/ScenarioTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/ScenarioTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/Testsuite/OptimizerTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/Testsuite/OptimizerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/TestsuiteTest.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/TestsuiteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/app_base_dir/dev/shell/install.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/app_base_dir/dev/shell/install.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/bootstrap/config_dist/config.php.dist
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/bootstrap/config_dist/config.php.dist
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/bootstrap/config_normal/config.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/bootstrap/config_normal/config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/bootstrap/config_normal/config.php.dist
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/bootstrap/config_normal/config.php.dist
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_bad_loops.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_bad_loops.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_bad_users.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_bad_users.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_data.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_data_invalid_scenarios_format.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_data_invalid_scenarios_format.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_invalid_fixtures_format.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_invalid_fixtures_format.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_no_file_defined.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_no_file_defined.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_no_title.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_no_title.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_non_existing_file.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_non_existing_file.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_non_existing_fixture.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/config_non_existing_fixture.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/fixture.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/fixture.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/fixture2.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/fixture2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario.jmx
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario.jtl
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario.jtl
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_error.jmx
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_error.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_error.jtl
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_error.jtl
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_failure.jmx
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_failure.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_failure.jtl
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_failure.jtl
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_without_report.jmx
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_without_report.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_without_report.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/Performance/_files/scenario_without_report.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/_files/application_test/fixture1.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/_files/application_test/fixture1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/_files/application_test/fixture2.php
+++ b/dev/tests/performance/framework/tests/unit/testsuite/Magento/Test/_files/application_test/fixture2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/run_scenarios.php
+++ b/dev/tests/performance/run_scenarios.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/_samples/_template.jmx
+++ b/dev/tests/performance/testsuite/_samples/_template.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/add_to_cart.jmx
+++ b/dev/tests/performance/testsuite/add_to_cart.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/advanced_search.jmx
+++ b/dev/tests/performance/testsuite/advanced_search.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/backend.jmx
+++ b/dev/tests/performance/testsuite/backend.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/category_view.jmx
+++ b/dev/tests/performance/testsuite/category_view.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/checkout.jmx
+++ b/dev/tests/performance/testsuite/checkout.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/fixtures/catalog_100k_products.php
+++ b/dev/tests/performance/testsuite/fixtures/catalog_100k_products.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/fixtures/catalog_200_categories_80k_products.php
+++ b/dev/tests/performance/testsuite/fixtures/catalog_200_categories_80k_products.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/fixtures/catalog_category.php
+++ b/dev/tests/performance/testsuite/fixtures/catalog_category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/fixtures/catalog_product.php
+++ b/dev/tests/performance/testsuite/fixtures/catalog_product.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/fixtures/customer_100k_customers.php
+++ b/dev/tests/performance/testsuite/fixtures/customer_100k_customers.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/fixtures/sales_100k_orders.php
+++ b/dev/tests/performance/testsuite/fixtures/sales_100k_orders.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/fixtures/shipping_flatrate_enabled.php
+++ b/dev/tests/performance/testsuite/fixtures/shipping_flatrate_enabled.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/home_page.jmx
+++ b/dev/tests/performance/testsuite/home_page.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/product_edit.jmx
+++ b/dev/tests/performance/testsuite/product_edit.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/product_view.jmx
+++ b/dev/tests/performance/testsuite/product_view.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/quick_search.jmx
+++ b/dev/tests/performance/testsuite/quick_search.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/performance/testsuite/reusable/admin_login.jmx
+++ b/dev/tests/performance/testsuite/reusable/admin_login.jmx
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/CodeMessDetector.php
+++ b/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/CodeMessDetector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/CodeSniffer.php
+++ b/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/CodeSniffer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/CodeSniffer/Wrapper.php
+++ b/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/CodeSniffer/Wrapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/CopyPasteDetector.php
+++ b/dev/tests/static/framework/Magento/TestFramework/CodingStandard/Tool/CopyPasteDetector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/CodingStandard/ToolInterface.php
+++ b/dev/tests/static/framework/Magento/TestFramework/CodingStandard/ToolInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Dependency/DbRule.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Dependency/DbRule.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Dependency/LayoutRule.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Dependency/LayoutRule.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Dependency/PhpRule.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Dependency/PhpRule.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Dependency/RuleInterface.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Dependency/RuleInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Dependency/TemplateRule.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Dependency/TemplateRule.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Dependency/_files/tables_ce.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Dependency/_files/tables_ce.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Dependency/_files/tables_ee.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Dependency/_files/tables_ee.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Inspection/AbstractCommand.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Inspection/AbstractCommand.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Inspection/Exception.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Inspection/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Inspection/JsHint/Command.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Inspection/JsHint/Command.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Inspection/WordsFinder.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Inspection/WordsFinder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Integrity/AbstractConfig.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Integrity/AbstractConfig.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Utility/Classes.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Utility/Classes.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/Magento/TestFramework/Utility/Files.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Utility/Files.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/bootstrap.php
+++ b/dev/tests/static/framework/bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/phpunit.xml.dist
+++ b/dev/tests/static/framework/tests/unit/phpunit.xml.dist
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/CodingStandard/Tool/CodeMessDetectorTest.php
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/CodingStandard/Tool/CodeMessDetectorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/CodingStandard/Tool/CodeSniffer/WrapperTest.php
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/CodingStandard/Tool/CodeSniffer/WrapperTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/CodingStandard/Tool/CodeSnifferTest.php
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/CodingStandard/Tool/CodeSnifferTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/JsHint/CommandTest.php
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/JsHint/CommandTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/WordsFinderTest.php
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/WordsFinderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/broken_config.xml
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/broken_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/config.xml
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/config_additional.xml
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/config_additional.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/empty_whitelist_path.xml
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/empty_whitelist_path.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/empty_words_config.xml
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/empty_words_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/words_finder/buffy.php
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/words_finder/buffy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/words_finder/interview_with_the_vampire.php
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/words_finder/interview_with_the_vampire.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/words_finder/self_tested_config.xml
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/words_finder/self_tested_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/words_finder/twilight/eclipse.php
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/words_finder/twilight/eclipse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/words_finder/twilight/newmoon.php
+++ b/dev/tests/static/framework/tests/unit/testsuite/Magento/Test/Inspection/_files/words_finder/twilight/newmoon.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/phpunit-all.xml.dist
+++ b/dev/tests/static/phpunit-all.xml.dist
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/phpunit.xml.dist
+++ b/dev/tests/static/phpunit.xml.dist
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Blacklist.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Blacklist.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/CircularDependencyTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/CircularDependencyTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/ClassesTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/ClassesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/ConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/DependencyTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/DependencyTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/BlocksTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/BlocksTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/FilesTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/FilesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/HandlesTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/HandlesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/ThemeHandlesTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Layout/ThemeHandlesTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Backend/SystemConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Backend/SystemConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/DataService/LayoutConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/DataService/LayoutConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/DataService/SystemConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/DataService/SystemConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/Fieldset/FieldsetConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/Fieldset/FieldsetConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/Fieldset/_files/fieldset.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/Fieldset/_files/fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/Fieldset/_files/fieldset_file.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/Fieldset/_files/fieldset_file.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/Fieldset/_files/invalid_fieldset.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Core/Model/Fieldset/_files/invalid_fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Install/ConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Install/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Install/_files/install_wizard.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Install/_files/install_wizard.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Install/_files/invalid_install_wizard.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Install/_files/invalid_install_wizard.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Install/_files/invalid_partial_install_wizard.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Install/_files/invalid_partial_install_wizard.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Install/_files/partial_install_wizard.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Install/_files/partial_install_wizard.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/Config/ReferentialTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/Config/ReferentialTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/ConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/ConfigTest.php
@@ -14,7 +14,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/_files/invalid_page_layouts.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/_files/invalid_page_layouts.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/_files/invalid_page_layouts_partial.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/_files/invalid_page_layouts_partial.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/_files/valid_page_layouts.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/_files/valid_page_layouts.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/_files/valid_page_layouts_partial.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Page/_files/valid_page_layouts_partial.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Config/ReferentialTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Config/ReferentialTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Model/ConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Model/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Model/_files/invalid_payment.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Model/_files/invalid_payment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Model/_files/invalid_payment_partial.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Model/_files/invalid_payment_partial.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Model/_files/payment.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Model/_files/payment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Model/_files/payment_partial.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Payment/Model/_files/payment_partial.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Persistent/ConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Persistent/ConfigTest.php
@@ -14,7 +14,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Persistent/_files/invalid_persistent.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Persistent/_files/invalid_persistent.xml
@@ -14,7 +14,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Persistent/_files/valid_persistent.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Persistent/_files/valid_persistent.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Reward/LayoutTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Reward/LayoutTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Widget/WidgetConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Widget/WidgetConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Widget/_files/invalid_widget.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Widget/_files/invalid_widget.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Widget/_files/widget.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Widget/_files/widget.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Widget/_files/widget_file.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Widget/_files/widget_file.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Phrase/AbstractTestCase.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Phrase/AbstractTestCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Phrase/ArgumentsTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Phrase/ArgumentsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Phrase/JsTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Phrase/JsTest.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Phrase/Legacy/SignatureTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Phrase/Legacy/SignatureTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Js/Exemplar/JsHintTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Js/Exemplar/JsHintTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Js/LiveCodeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Js/LiveCodeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/ClassesTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/ClassesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/ConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/EmailTemplateTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/EmailTemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/LayoutTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/LayoutTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/LicenseTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/LicenseTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Bundle/Model/Product/TypeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Bundle/Model/Product/TypeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Catalog/Model/Product/AbstractTypeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Catalog/Model/Product/AbstractTypeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Catalog/Model/Product/TypeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Catalog/Model/Product/TypeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Core/Block/AbstractBlockTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Core/Block/AbstractBlockTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Downloadable/Model/Product/TypeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Downloadable/Model/Product/TypeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Install/ConfigTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Install/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Widget/XmlTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/Magento/Widget/XmlTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteAclTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteAclTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteCodeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteCodeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteLayoutLocationTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteLayoutLocationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteMenuTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteMenuTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteSystemConfigurationTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteSystemConfigurationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteThemeLocalXmlTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/ObsoleteThemeLocalXmlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/PhtmlTemplateTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/PhtmlTemplateTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/TableTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/TableTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/WordsTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/WordsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/mage_cleaned_modules.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/mage_cleaned_modules.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_classes.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_classes.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_config_nodes.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_config_nodes.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_constants.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_constants.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_methods.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_methods.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_namespaces.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_namespaces.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_properties.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_properties.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/words_ce.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/words_ce.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Php/Exemplar/CodeMessTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Php/Exemplar/CodeMessTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Php/Exemplar/CodeMessTest/phpmd/data.php
+++ b/dev/tests/static/testsuite/Magento/Test/Php/Exemplar/CodeMessTest/phpmd/data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Php/Exemplar/CodeStyleTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Php/Exemplar/CodeStyleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcs/ruleset.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcs/ruleset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpmd/ruleset.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpmd/ruleset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/static/testsuite/Magento/Test/Twig/TwigExtensionTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Twig/TwigExtensionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/Magento/Test/Block/Adminhtml.php
+++ b/dev/tests/unit/framework/Magento/Test/Block/Adminhtml.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/Magento/Test/Module/Config.php
+++ b/dev/tests/unit/framework/Magento/Test/Module/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/Magento/TestFramework/Helper/ObjectManager.php
+++ b/dev/tests/unit/framework/Magento/TestFramework/Helper/ObjectManager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/Magento/TestFramework/Helper/ProxyTesting.php
+++ b/dev/tests/unit/framework/Magento/TestFramework/Helper/ProxyTesting.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/Magento/TestFramework/Listener/GarbageCleanup.php
+++ b/dev/tests/unit/framework/Magento/TestFramework/Listener/GarbageCleanup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/Magento/TestFramework/Utility/XsdValidator.php
+++ b/dev/tests/unit/framework/Magento/TestFramework/Utility/XsdValidator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/bootstrap.php
+++ b/dev/tests/unit/framework/bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/tests/unit/framework/bootstrap.php
+++ b/dev/tests/unit/framework/tests/unit/framework/bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/tests/unit/phpunit.xml.dist
+++ b/dev/tests/unit/framework/tests/unit/phpunit.xml.dist
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Helper/ObjectManagerTest.php
+++ b/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Helper/ObjectManagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Helper/ProxyTestingTest.php
+++ b/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Helper/ProxyTestingTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Utility/XsdValidatorTest.php
+++ b/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Utility/XsdValidatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Utility/_files/invalid.xml
+++ b/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Utility/_files/invalid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Utility/_files/valid.xml
+++ b/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Utility/_files/valid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Utility/_files/valid.xsd
+++ b/dev/tests/unit/framework/tests/unit/testsuite/Magento/TestFramework/Utility/_files/valid.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/phpunit.xml.dist
+++ b/dev/tests/unit/phpunit.xml.dist
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/BuilderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Acl/BuilderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/Loader/DefaultTest.php
+++ b/dev/tests/unit/testsuite/Magento/Acl/Loader/DefaultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/Loader/ResourceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Acl/Loader/ResourceTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/Converter/DomTest.php
+++ b/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/Converter/DomTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/Converter/_files/converted_valid_acl.php
+++ b/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/Converter/_files/converted_valid_acl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/Converter/_files/valid_acl.xml
+++ b/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/Converter/_files/valid_acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/_files/invalidAclXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/_files/invalidAclXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/_files/valid_acl.xml
+++ b/dev/tests/unit/testsuite/Magento/Acl/Resource/Config/_files/valid_acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/Resource/ProviderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Acl/Resource/ProviderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/Resource/TreeBuilderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Acl/Resource/TreeBuilderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Acl/ResourceFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Acl/ResourceFactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/AdminNotification/Block/ToolbarEntryTest.php
+++ b/dev/tests/unit/testsuite/Magento/AdminNotification/Block/ToolbarEntryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/AdminNotification/Model/NotificationServiceTest.php
+++ b/dev/tests/unit/testsuite/Magento/AdminNotification/Model/NotificationServiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/AdminNotification/Model/System/Message/BaseurlTest.php
+++ b/dev/tests/unit/testsuite/Magento/AdminNotification/Model/System/Message/BaseurlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/AdminNotification/Model/System/Message/CacheOutdatedTest.php
+++ b/dev/tests/unit/testsuite/Magento/AdminNotification/Model/System/Message/CacheOutdatedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/AdminNotification/Model/System/Message/Media/Synchronization/ErrorTest.php
+++ b/dev/tests/unit/testsuite/Magento/AdminNotification/Model/System/Message/Media/Synchronization/ErrorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/AdminNotification/Model/System/Message/Media/Synchronization/SuccessTest.php
+++ b/dev/tests/unit/testsuite/Magento/AdminNotification/Model/System/Message/Media/Synchronization/SuccessTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/AdminNotification/Model/System/Message/SecurityTest.php
+++ b/dev/tests/unit/testsuite/Magento/AdminNotification/Model/System/Message/SecurityTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset/OptionsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Catalog/Product/Composite/Fieldset/OptionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/MatrixTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/MatrixTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/WeightTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Catalog/Product/Helper/Form/WeightTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Page/System/Config/Robots/ResetTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Page/System/Config/Robots/ResetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Sales/Items/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Sales/Items/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Sales/Order/Create/Items/GridTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Sales/Order/Create/Items/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Sales/Order/Invoice/ViewTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Sales/Order/Invoice/ViewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Sales/Order/Totals/TaxTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Sales/Order/Totals/TaxTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Sales/Order/View/GiftmessageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/Sales/Order/View/GiftmessageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/System/Email/Template/EditTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/System/Email/Template/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Block/UrlrewriteTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Block/UrlrewriteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Controller/CacheTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Controller/CacheTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Controller/CustomerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Controller/CustomerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Controller/Sales/Order/CreditmemoTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Controller/Sales/Order/CreditmemoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Controller/System/AccountTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Controller/System/AccountTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/DashboardTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/DashboardTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Model/LayoutUpdate/ValidatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Model/LayoutUpdate/ValidatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Adminhtml/Widget/Form/ContainerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Adminhtml/Widget/Form/ContainerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Authorization/Policy/AclTest.php
+++ b/dev/tests/unit/testsuite/Magento/Authorization/Policy/AclTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Authorization/Policy/DefaultTest.php
+++ b/dev/tests/unit/testsuite/Magento/Authorization/Policy/DefaultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/AuthorizationTest.php
+++ b/dev/tests/unit/testsuite/Magento/AuthorizationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Autoload/ClassMapTest.php
+++ b/dev/tests/unit/testsuite/Magento/Autoload/ClassMapTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Autoload/ClassMapTest/TestMap.php
+++ b/dev/tests/unit/testsuite/Magento/Autoload/ClassMapTest/TestMap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Autoload/IncludePathTest.php
+++ b/dev/tests/unit/testsuite/Magento/Autoload/IncludePathTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Autoload/IncludePathTest/Ns/TestClass.php
+++ b/dev/tests/unit/testsuite/Magento/Autoload/IncludePathTest/Ns/TestClass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Autoload/IncludePathTest/TestClass.php
+++ b/dev/tests/unit/testsuite/Magento/Autoload/IncludePathTest/TestClass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Autoload/IncludePathTest/constant.php
+++ b/dev/tests/unit/testsuite/Magento/Autoload/IncludePathTest/constant.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/Store/SwitcherTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/Store/SwitcherTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/EditTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/EditTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/Field/ExportTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/Field/ExportTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/Field/FieldArray/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/Field/FieldArray/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/Field/ImportTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/Field/ImportTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/Field/Select/AllowspecificTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/Field/Select/AllowspecificTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/FieldTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/FieldTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/FieldsetTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/Form/FieldsetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/FormTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/TabsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/System/Config/TabsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Button/SplitTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Button/SplitTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/ButtonTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/ButtonTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/Column/MultistoreTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/Column/MultistoreTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/Column/Renderer/CurrencyTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/Column/Renderer/CurrencyTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/ColumnSetTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/ColumnSetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/ColumnTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/ColumnTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/MassactionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/MassactionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/SerializerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/Grid/SerializerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/GridTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Block/Widget/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Controller/Adminhtml/System/Config/SaveTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Controller/Adminhtml/System/Config/SaveTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Controller/Adminhtml/System/Config/_files/expected_array.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Controller/Adminhtml/System/Config/_files/expected_array.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Controller/Adminhtml/System/Config/_files/files_array.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Controller/Adminhtml/System/Config/_files/files_array.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Controller/Adminhtml/System/Config/_files/groups_array.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Controller/Adminhtml/System/Config/_files/groups_array.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Helper/DataProxy.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Helper/DataProxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Helper/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Authorization/RoleLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Authorization/RoleLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Backend/BaseurlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Backend/BaseurlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Backend/EncryptedTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Backend/EncryptedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Backend/File/RequestDataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Backend/File/RequestDataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Backend/SecureTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Backend/SecureTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/LoaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/LoaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/ScopeDefinerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/ScopeDefinerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Source/Admin/PageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Source/Admin/PageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Source/Email/TemplateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Source/Email/TemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/AbstractElementTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/AbstractElementTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/AbstractCompositeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/AbstractCompositeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/Dependency/FieldTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/Dependency/FieldTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/Dependency/MapperTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/Dependency/MapperTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/FieldTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/FieldTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/FlyweightFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/FlyweightFactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/Group/ProxyTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/Group/ProxyTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/GroupTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/GroupTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/Iterator/FieldTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/Iterator/FieldTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/IteratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/IteratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/SectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/SectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/TabTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Element/TabTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Mapper/DependenciesTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Mapper/DependenciesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Mapper/ExtendsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Mapper/ExtendsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Mapper/Helper/RelativePathConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Mapper/Helper/RelativePathConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Mapper/PathTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Mapper/PathTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Mapper/SortingTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/Structure/Mapper/SortingTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/StructureTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/StructureTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/_files/invalidSystemXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/_files/invalidSystemXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Config/_files/valid_system.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Config/_files/valid_system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Locale/ManagerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Locale/ManagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Builder/AbstractCommandTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Builder/AbstractCommandTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Builder/Command/AddTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Builder/Command/AddTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Builder/Command/RemoveTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Builder/Command/RemoveTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Builder/Command/UpdateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Builder/Command/UpdateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/BuilderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/BuilderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/_files/invalidMenuXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/_files/invalidMenuXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/_files/invalid_menu.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/_files/invalid_menu.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/_files/valid_menu.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Config/_files/valid_menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Director/DirectorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Director/DirectorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Filter/IteratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Filter/IteratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Item/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Item/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Item/ValidatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/Item/ValidatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/ItemTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Menu/ItemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/MenuTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/MenuTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Router/NoRouteHandlerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Router/NoRouteHandlerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/UrlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Widget/Grid/AbstractTotalsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Widget/Grid/AbstractTotalsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Widget/Grid/ParserTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Widget/Grid/ParserTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Widget/Grid/Row/UrlGeneratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Widget/Grid/Row/UrlGeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Widget/Grid/SubTotalsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Widget/Grid/SubTotalsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/Widget/Grid/TotalsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/Widget/Grid/TotalsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/acl.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/acl_1.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/acl_1.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/acl_2.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/acl_2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/acl_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/acl_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/converted_config.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/converted_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/dependencies_data.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/dependencies_data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/dependencies_mapped.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/dependencies_mapped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/menu_1.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/menu_1.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/menu_2.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/menu_2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/menu_merged.php
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/menu_merged.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/menu_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/menu_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_1.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_1.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_2.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_config_options_1.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_config_options_1.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_config_options_2.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_config_options_2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_unknown_attribute_1.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_unknown_attribute_1.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_unknown_attribute_2.xml
+++ b/dev/tests/unit/testsuite/Magento/Backend/Model/_files/system_unknown_attribute_2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backup/MediaTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backup/MediaTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backup/NomediaTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backup/NomediaTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Backup/SnapshotTest.php
+++ b/dev/tests/unit/testsuite/Magento/Backup/SnapshotTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/OptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/OptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Bundle/Model/Plugin/QuoteItemTest.php
+++ b/dev/tests/unit/testsuite/Magento/Bundle/Model/Plugin/QuoteItemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Bundle/Model/Product/TypeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Bundle/Model/Product/TypeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cache/Backend/Decorator/CompressionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cache/Backend/Decorator/CompressionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cache/Backend/Decorator/DecoratorAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cache/Backend/Decorator/DecoratorAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cache/Backend/MongoDbTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cache/Backend/MongoDbTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cache/CoreTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cache/CoreTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cache/Frontend/Adapter/ZendTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cache/Frontend/Adapter/ZendTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cache/Frontend/Decorator/BareTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cache/Frontend/Decorator/BareTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cache/Frontend/Decorator/ProfilerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cache/Frontend/Decorator/ProfilerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cache/Frontend/Decorator/TagScopeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cache/Frontend/Decorator/TagScopeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Captcha/Helper/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Captcha/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Captcha/Model/CaptchaFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Captcha/Model/CaptchaFactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Captcha/Model/DefaultTest.php
+++ b/dev/tests/unit/testsuite/Magento/Captcha/Model/DefaultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Captcha/Model/ObserverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Captcha/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Block/Layer/ViewTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Block/Layer/ViewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Block/Product/ListTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Block/Product/ListTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Block/Product/View/OptionsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Block/Product/View/OptionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Block/Product/View/TabsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Block/Product/View/TabsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Controller/ProductTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Controller/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Helper/UrlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Helper/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/ReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/XsdTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/_files/attributes_config_merged.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/_files/attributes_config_merged.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/_files/attributes_config_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/_files/attributes_config_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/_files/attributes_config_one.xml
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/_files/attributes_config_one.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/_files/attributes_config_two.xml
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/Config/_files/attributes_config_two.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Attribute/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Category/Attribute/Backend/SortbyTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Category/Attribute/Backend/SortbyTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Layer/Filter/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Layer/Filter/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Observer/ReindexTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Observer/ReindexTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ObserverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Plugin/LogTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Plugin/LogTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Plugin/QuoteItemProductOptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Plugin/QuoteItemProductOptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/CategoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/CategoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/Groupprice/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/Groupprice/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/MediaTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/MediaTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/StockTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/StockTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Indexer/FlatTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Indexer/FlatTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Option/Type/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Option/Type/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Option/Type/FileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Option/Type/FileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Type/ConfigurableTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Type/ConfigurableTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Type/GroupedTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Type/GroupedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Type/SimpleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Type/SimpleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Type/VirtualTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/Type/VirtualTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/TypeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Product/TypeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductOptions/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductOptions/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductOptions/Config/_files/invalidProductOptionsMergedXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductOptions/Config/_files/invalidProductOptionsMergedXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductOptions/Config/_files/product_options_merged_valid.xml
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductOptions/Config/_files/product_options_merged_valid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductOptions/Config/_files/product_options_valid.xml
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductOptions/Config/_files/product_options_valid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/XsdMergedTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/XsdMergedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/invalidProductTypesMergedXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/invalidProductTypesMergedXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/product_types.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/product_types.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/product_types.xml
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/product_types.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/valid_product_types.xml
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/valid_product_types.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/valid_product_types_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/Config/_files/valid_product_types_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/ProductTypes/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Category/Collection/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Category/Collection/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Category/FlatTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Category/FlatTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Category/TreeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Category/TreeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Product/Collection/AssociatedProductUpdaterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Product/Collection/AssociatedProductUpdaterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Product/Option/MysqlStub.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Product/Option/MysqlStub.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Product/Option/Stub.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Product/Option/Stub.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Product/Option/ValueStub.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Product/Option/ValueStub.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Product/Option/ValueTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Resource/Product/Option/ValueTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/Model/Template/Filter/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Model/Template/Filter/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Catalog/_files/eav_attributes_data.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/_files/eav_attributes_data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/CatalogInventory/Block/Adminhtml/Form/Field/StockTest.php
+++ b/dev/tests/unit/testsuite/Magento/CatalogInventory/Block/Adminhtml/Form/Field/StockTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/CatalogRule/Model/Rule/JobTest.php
+++ b/dev/tests/unit/testsuite/Magento/CatalogRule/Model/Rule/JobTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/CatalogSearch/Model/Resource/EngineProviderTest.php
+++ b/dev/tests/unit/testsuite/Magento/CatalogSearch/Model/Resource/EngineProviderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Centinel/Model/State/JcbTest.php
+++ b/dev/tests/unit/testsuite/Magento/Centinel/Model/State/JcbTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Centinel/Model/StateFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Centinel/Model/StateFactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Checkout/Block/Cart/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Checkout/Block/Cart/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Checkout/Block/Cart/Item/RendererTest.php
+++ b/dev/tests/unit/testsuite/Magento/Checkout/Block/Cart/Item/RendererTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Checkout/Block/Cart/LinkTest.php
+++ b/dev/tests/unit/testsuite/Magento/Checkout/Block/Cart/LinkTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Checkout/Block/Cart/SidebarTest.php
+++ b/dev/tests/unit/testsuite/Magento/Checkout/Block/Cart/SidebarTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Checkout/Block/LinkTest.php
+++ b/dev/tests/unit/testsuite/Magento/Checkout/Block/LinkTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Checkout/Controller/CartTest.php
+++ b/dev/tests/unit/testsuite/Magento/Checkout/Controller/CartTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Checkout/Model/SessionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Checkout/Model/SessionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cms/Model/Page/UrlrewriteTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cms/Model/Page/UrlrewriteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cms/Model/Template/FilterProviderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cms/Model/Template/FilterProviderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cms/Model/Wysiwyg/Images/StorageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cms/Model/Wysiwyg/Images/StorageTest.php
@@ -12,7 +12,7 @@ namespace Magento\Cms\Model\Wysiwyg\Images;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Generator/ClassTest.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Generator/ClassTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Generator/CodeGenerator/ZendTest.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Generator/CodeGenerator/ZendTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Generator/EntityAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Generator/EntityAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Generator/IoTest.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Generator/IoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Generator/TestAsset/ParentClass.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Generator/TestAsset/ParentClass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Generator/TestAsset/SourceClass.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Generator/TestAsset/SourceClass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Generator/TestAsset/TestGenerationClass.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Generator/TestAsset/TestGenerationClass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/GeneratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Code/GeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Minifier/Adapter/Js/JsminTest.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Minifier/Adapter/Js/JsminTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Minifier/Strategy/GenerateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Minifier/Strategy/GenerateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Minifier/Strategy/LiteTest.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Minifier/Strategy/LiteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Minifier/_files/js/original.js
+++ b/dev/tests/unit/testsuite/Magento/Code/Minifier/_files/js/original.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/MinifierTest.php
+++ b/dev/tests/unit/testsuite/Magento/Code/MinifierTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Plugin/GeneratorTest/SimpleClass.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Plugin/GeneratorTest/SimpleClass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Plugin/GeneratorTest/SimpleClassPluginA.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Plugin/GeneratorTest/SimpleClassPluginA.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Plugin/GeneratorTest/SimpleClassPluginB.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Plugin/GeneratorTest/SimpleClassPluginB.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Plugin/GeneratorTest/SimpleObjectManager.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Plugin/GeneratorTest/SimpleObjectManager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Code/Plugin/InvocationChainTest.php
+++ b/dev/tests/unit/testsuite/Magento/Code/Plugin/InvocationChainTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/Converter/Dom/FlatTest.php
+++ b/dev/tests/unit/testsuite/Magento/Config/Converter/Dom/FlatTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/Data/ScopedTest.php
+++ b/dev/tests/unit/testsuite/Magento/Config/Data/ScopedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/Dom/Converter/ArrayConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Config/Dom/Converter/ArrayConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/DomTest.php
+++ b/dev/tests/unit/testsuite/Magento/Config/DomTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/Reader/FilesystemTest.php
+++ b/dev/tests/unit/testsuite/Magento/Config/Reader/FilesystemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/ThemeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Config/ThemeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/ValidationStateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Config/ValidationStateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/ViewTest.php
+++ b/dev/tests/unit/testsuite/Magento/Config/ViewTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/area/default_default/theme.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/area/default_default/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/area/default_test/theme.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/area/default_test/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/area/default_test2/theme.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/area/default_test2/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/area/test_default/theme.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/area/test_default/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/area/test_external_package_descendant/theme.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/area/test_external_package_descendant/theme.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/converter/dom/flat/result.php
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/converter/dom/flat/result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/converter/dom/flat/source.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/converter/dom/flat/source.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/ambiguous_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/ambiguous_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/ambiguous_new_one.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/ambiguous_new_one.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/ambiguous_new_two.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/ambiguous_new_two.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/ambiguous_one.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/ambiguous_one.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/ambiguous_two.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/ambiguous_two.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/cdata.php
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/cdata.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/cdata.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/cdata.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/no_attributes.php
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/no_attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/no_attributes.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/no_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/with_attributes.php
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/with_attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/with_attributes.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/converter/with_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/ids.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/ids.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/ids_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/ids_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/ids_new.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/ids_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/namespaced.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/namespaced.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/namespaced_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/namespaced_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/namespaced_new.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/namespaced_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/no_ids.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/no_ids.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/no_ids_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/no_ids_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/no_ids_new.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/no_ids_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/override_node.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/override_node.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/override_node_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/override_node_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/override_node_new.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/override_node_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/text_node.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/text_node.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/text_node_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/text_node_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/dom/text_node_new.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/dom/text_node_new.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/reader/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/reader/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/reader/schema.xsd
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/reader/schema.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/sample.xsd
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/sample.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/theme_invalid.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/theme_invalid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/view_invalid.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/view_invalid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/view_one.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/view_one.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Config/_files/view_two.xml
+++ b/dev/tests/unit/testsuite/Magento/Config/_files/view_two.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Convert/ExcelTest.php
+++ b/dev/tests/unit/testsuite/Magento/Convert/ExcelTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Block/AbstractBlockTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Block/AbstractBlockTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Block/TemplateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Block/TemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Block/_files/template_test_assign.phtml
+++ b/dev/tests/unit/testsuite/Magento/Core/Block/_files/template_test_assign.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Controller/Request/HttpTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Controller/Request/HttpTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Controller/Response/HttpTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Controller/Response/HttpTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Controller/Varien/AbstractActionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Controller/Varien/AbstractActionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Controller/Varien/Action/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Controller/Varien/Action/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Controller/Varien/Action/ForwardTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Controller/Varien/Action/ForwardTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Controller/Varien/Action/RedirectTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Controller/Varien/Action/RedirectTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Helper/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Helper/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Helper/CookieTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Helper/CookieTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Helper/CssTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Helper/CssTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Helper/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Helper/HttpTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Helper/HttpTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Helper/ThemeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Helper/ThemeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Helper/Url/RewriteTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Helper/Url/RewriteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Helper/_files/result.css
+++ b/dev/tests/unit/testsuite/Magento/Core/Helper/_files/result.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Helper/_files/source.css
+++ b/dev/tests/unit/testsuite/Magento/Core/Helper/_files/source.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/AbstractEntryPointTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/AbstractEntryPointTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/AbstractShellTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/AbstractShellTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/App/StateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/App/StateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/AppTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/AppTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Config/_files/cache_config.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Config/_files/cache_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Config/_files/cache_config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Config/_files/cache_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Frontend/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Frontend/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Frontend/FactoryTest/CacheDecoratorDummy.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Frontend/FactoryTest/CacheDecoratorDummy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Frontend/PoolTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Frontend/PoolTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/StateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/StateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Type/AccessProxyTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Type/AccessProxyTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Type/FrontendPoolTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Type/FrontendPoolTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Type/GenericTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Cache/Type/GenericTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/CacheTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/CacheTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/CacheTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/CacheTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Data/BackendModelPoolTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Data/BackendModelPoolTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Data/TestBackendModel.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Data/TestBackendModel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Data/WrongBackendModel.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Data/WrongBackendModel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolver/PrimaryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolver/PrimaryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolver/_files/app/etc/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolver/_files/app/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolver/_files/app/etc/custom/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolver/_files/app/etc/custom/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolver/_files/primary/app/etc/di.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolver/_files/primary/app/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolver/_files/primary/app/etc/some_config/di.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolver/_files/primary/app/etc/some_config/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/FileResolverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/ReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/_files/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/_files/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/_files/converted_config.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/_files/converted_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/_files/initial_config1.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/_files/initial_config1.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/_files/initial_config2.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/_files/initial_config2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/_files/initial_config_merged.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Initial/_files/initial_config_merged.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/InitialTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/InitialTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/LoaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/LoaderTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/MetadataProcessorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/MetadataProcessorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Modules/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Modules/ReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/PrimaryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/PrimaryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/ResourceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/ResourceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/Processor/PlaceholderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/Processor/PlaceholderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/Reader/DefaultReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/Reader/DefaultReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/Reader/StoreTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/Reader/StoreTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/Reader/WebsiteTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/Reader/WebsiteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/ReaderPoolTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/ReaderPoolTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/Store/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Section/Store/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/SectionPoolTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/SectionPoolTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/Storage/Writer/DbTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/Storage/Writer/DbTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/StorageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/StorageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/TestConfigClass.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/TestConfigClass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/TestReaderClass.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/TestReaderClass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/dirtest/etc/test.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/dirtest/etc/test.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/invalidRoutesXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/invalidRoutesXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/locale/de_DE/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/locale/de_DE/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/locale/en_US/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/locale/en_US/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/locale/es_ES/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/locale/es_ES/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/locale/fr_FR/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/locale/fr_FR/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_dependency_circular_input.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_dependency_circular_input.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_dependency_circular_soft_input.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_dependency_circular_soft_input.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_dependency_linear_input.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_dependency_linear_input.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_dependency_wrong_input.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_dependency_wrong_input.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_filtered.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_filtered.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_input.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_input.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_sorted.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/module_sorted.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/modules/Namespace/Module/etc/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/modules/Namespace/Module/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/testdir/etc/directorytest/local.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/testdir/etc/directorytest/local.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/testdir/etc/directorytest/testconfig.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/testdir/etc/directorytest/testconfig.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/testdir/etc/local.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/testdir/etc/local.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/testdir/etc/testconfig.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/testdir/etc/testconfig.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/testdir/etc/testdirectory/customconfig.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/testdir/etc/testdirectory/customconfig.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/valid_routes.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Config/_files/valid_routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DataService/Config/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DataService/Config/ReaderTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DataService/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DataService/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DataService/GraphTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DataService/GraphTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DataService/InvokerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DataService/InvokerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DataService/Path/CompositeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DataService/Path/CompositeTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DataService/Path/NavigatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DataService/Path/NavigatorTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DataService/Path/RequestTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DataService/Path/RequestTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DataService/RepositoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DataService/RepositoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DataService/_files/second_service_calls.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DataService/_files/second_service_calls.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DataService/_files/service_calls.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DataService/_files/service_calls.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Db/_files/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Db/_files/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DefaultClass.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DefaultClass.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Design/Fallback/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Design/Fallback/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Design/Fallback/Rule/CompositeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Design/Fallback/Rule/CompositeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Design/Fallback/Rule/ModularSwitchTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Design/Fallback/Rule/ModularSwitchTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Design/Fallback/Rule/SimpleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Design/Fallback/Rule/SimpleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Design/Fallback/Rule/ThemeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Design/Fallback/Rule/ThemeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Design/FileResolution/Strategy/Fallback/CachingProxyTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Design/FileResolution/Strategy/Fallback/CachingProxyTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Design/FileResolution/Strategy/FallbackTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Design/FileResolution/Strategy/FallbackTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Design/FileResolution/StrategyPoolTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Design/FileResolution/StrategyPoolTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Dir/VerificationTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Dir/VerificationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/DirTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/DirTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/ReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/XsdTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/_files/Fixture/ModuleOne/etc/email_templates_one.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/_files/Fixture/ModuleOne/etc/email_templates_one.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/_files/Fixture/ModuleTwo/etc/email_templates_two.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/_files/Fixture/ModuleTwo/etc/email_templates_two.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/_files/email_templates_merged.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/_files/email_templates_merged.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/_files/email_templates_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/Config/_files/email_templates_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Email/Template/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/EncryptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/EncryptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/EntryPoint/CronTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/EntryPoint/CronTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/EntryPoint/MediaTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/EntryPoint/MediaTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/EntryPoint/_files/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/EntryPoint/_files/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/_files/invalidEventsXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/_files/invalidEventsXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/_files/valid_events.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Event/Config/_files/valid_events.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Event/Invoker/InvokerDefaultTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Event/Invoker/InvokerDefaultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Event/ManagerStub.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Event/ManagerStub.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Event/ManagerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Event/ManagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Fieldset/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Fieldset/Config/ConverterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Fieldset/Config/_files/fieldset.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Fieldset/Config/_files/fieldset.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Fieldset/Config/_files/fieldset_config.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Fieldset/Config/_files/fieldset_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Fieldset/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Fieldset/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/File/Storage/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/File/Storage/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/File/Storage/RequestTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/File/Storage/RequestTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/File/Storage/SynchronizationTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/File/Storage/SynchronizationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/File/Storage/_files/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/File/Storage/_files/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/FrontClass.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/FrontClass.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Image/AdapterFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Image/AdapterFactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/AbstractHandlerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/AbstractHandlerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/ArrayTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/ArrayTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/BooleanTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/BooleanTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/HelperTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/HelperTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/NumberTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/NumberTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/ObjectTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/ObjectTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/OptionsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/OptionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/StringTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/StringTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/TestHelper.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/TestHelper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/TestObject.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/TestObject.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/TestOptions.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/TestOptions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/UrlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/_files/arguments.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/Handler/_files/arguments.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/HandlerFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/HandlerFactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/ProcessorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/ProcessorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/UpdaterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/Argument/UpdaterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/ElementTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/ElementTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/FileList/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/FileList/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/ListTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/ListTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/AggregateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/AggregateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/BaseTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/BaseTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/Decorator/ModuleDependencyTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/Decorator/ModuleDependencyTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/Decorator/ModuleOutputTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/Decorator/ModuleOutputTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/Override/BaseTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/Override/BaseTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/Override/ThemeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/Override/ThemeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/ThemeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/File/Source/ThemeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/FileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/FileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/MergeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/MergeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/ScheduledStructureTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/ScheduledStructureTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/TranslatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/TranslatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/UpdateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/UpdateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/action.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/action.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_category_default.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_category_default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_category_layered.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_category_layered.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_product_view.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_product_view.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_product_view_type_configurable.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_product_view_type_configurable.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_product_view_type_grouped.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_product_view_type_grouped.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_product_view_type_simple.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalog_product_view_type_simple.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalogsearch_ajax_suggest.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/catalogsearch_ajax_suggest.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/checkout_onepage_index.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/checkout_onepage_index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/checkout_onepage_progress.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/checkout_onepage_progress.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/default.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/fixture_handle_one.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/fixture_handle_one.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/fixture_handle_two.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/fixture_handle_two.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/not_a_page_type.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/not_a_page_type.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/print.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/print.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/sales_guest_print.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/sales_guest_print.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/sales_order_print.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/layout/sales_order_print.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/merged.xml
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/pages_hierarchy.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Layout/_files/pages_hierarchy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Locale/Hierarchy/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Locale/Hierarchy/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Locale/Hierarchy/Config/FileResolverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Locale/Hierarchy/Config/FileResolverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Locale/Hierarchy/Config/_files/custom/hierarchy_config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Locale/Hierarchy/Config/_files/custom/hierarchy_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Locale/Hierarchy/Config/_files/default/hierarchy_config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Locale/Hierarchy/Config/_files/default/hierarchy_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Locale/Hierarchy/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Locale/Hierarchy/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Locale/ValidatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Locale/ValidatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/LoggerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/LoggerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/Converter/DomTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/Converter/DomTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/Converter/_files/converted_valid_module.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/Converter/_files/converted_valid_module.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/Converter/_files/valid_module.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/Converter/_files/valid_module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolver/_files/app/code/Module/Four/etc/module.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolver/_files/app/code/Module/Four/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolver/_files/app/code/Module/One/etc/module.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolver/_files/app/code/Module/One/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolver/_files/app/code/Module/Three/etc/module.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolver/_files/app/code/Module/Three/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolver/_files/app/code/Module/Two/etc/module.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolver/_files/app/code/Module/Two/etc/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolver/_files/app/etc/custom/module.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolver/_files/app/etc/custom/module.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/FileResolverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/Reader/FilesystemTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Declaration/Reader/FilesystemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/Dir/ReverseResolverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/Dir/ReverseResolverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/DirTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/DirTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Module/ResourceResolverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Module/ResourceResolverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/ModuleManagerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/ModuleManagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/NoRouteHandlerListTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/NoRouteHandlerListTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/ObjectManager/ConfigLoaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/ObjectManager/ConfigLoaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/ObserverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/CollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MergeServiceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MergeServiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MergeStrategy/ChecksumTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MergeStrategy/ChecksumTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MergeStrategy/DirectTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MergeStrategy/DirectTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MergeStrategy/FileExistsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MergeStrategy/FileExistsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MergedTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MergedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MinifiedTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MinifiedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MinifyServiceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/MinifyServiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/PublicFileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/PublicFileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/RemoteTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/RemoteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/ViewFileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Page/Asset/ViewFileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/PageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/PageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/ReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/_files/invalidResourcesXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/_files/invalidResourcesXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/_files/resources.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/_files/resources.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/_files/resources.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/_files/resources.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/_files/valid_resources.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Config/_files/valid_resources.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Db/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Db/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Layout/AbstractTestCase.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Layout/AbstractTestCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Layout/Link/CollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Layout/Link/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Layout/Update/CollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Layout/Update/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/SessionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/SessionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/MigrationTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/MigrationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_plain_model.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_plain_model.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_plain_pk_fields.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_plain_pk_fields.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_plain_resource.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_plain_resource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_serialized.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_serialized.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_wiki.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_wiki.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_xml.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Resource/Setup/_files/data_content_xml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Route/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Route/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Route/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Route/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Route/Config/_files/routes.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Route/Config/_files/routes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Route/Config/_files/routes.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Route/Config/_files/routes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Route/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Route/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Route/Wrapper.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Route/Wrapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/RouterListTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/RouterListTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/SenderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/SenderTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Source/Urlrewrite/OptionsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Source/Urlrewrite/OptionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Source/Urlrewrite/TypesTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Source/Urlrewrite/TypesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Store/Storage/DefaultTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Store/Storage/DefaultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Store/StorageFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Store/StorageFactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/StoreManagerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/StoreManagerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/PhpTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/PhpTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/Twig/CommonFunctionsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/Twig/CommonFunctionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/Twig/EnvironmentFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/Twig/EnvironmentFactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/Twig/ExtensionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/Twig/ExtensionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/Twig/FullFileNameTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/Twig/FullFileNameTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/Twig/LayoutFunctionsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/Twig/LayoutFunctionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/TwigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/TwigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/_files/simple.phtml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/TemplateEngine/_files/simple.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/TemplateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/TemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/CopyServiceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/CopyServiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Customization/AbstractFileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Customization/AbstractFileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Customization/PathTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Customization/PathTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/CustomizationTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/CustomizationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Domain/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Domain/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Domain/PhysicalTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Domain/PhysicalTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Domain/StagingTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Domain/StagingTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Domain/VirtualTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Domain/VirtualTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Image/PathTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Image/PathTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Image/UploaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/Image/UploaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/ImageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/ImageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Theme/ValidationTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Theme/ValidationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/ThemeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/ThemeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Url/SecurityInfoTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Url/SecurityInfoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/UrlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/Validator/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/Validator/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/View/DeployedFilesManagerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/View/DeployedFilesManagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/View/Design/ProxyTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/View/Design/ProxyTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/View/FileSystemTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/View/FileSystemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/View/UrlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/View/UrlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/_files/cache_types.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/_files/cache_types.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/_files/event_config.php
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/_files/event_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/_files/event_config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/_files/event_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/_files/event_invalid_config.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/_files/event_invalid_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/_files/frontend/magento_iphone/theme.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/_files/frontend/magento_iphone/theme.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Core/Model/_files/frontend/magento_iphone/theme_invalid.xml
+++ b/dev/tests/unit/testsuite/Magento/Core/Model/_files/frontend/magento_iphone/theme_invalid.xml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/Converter/DbTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/Converter/DbTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/Converter/XmlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/Converter/XmlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/Reader/DbTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/Reader/DbTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/Reader/XmlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/Reader/XmlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid.xml
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid_duplicates.xml
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid_duplicates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid_node_typo.xml
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid_node_typo.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid_without_instance.xml
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid_without_instance.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid_without_method.xml
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid_without_method.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid_without_name.xml
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_invalid_without_name.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_valid.xml
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_valid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_valid_without_schedule.xml
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/Config/_files/crontab_valid_without_schedule.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/CronJob.php
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/CronJob.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Cron/Model/ObserverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Cron/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Crypt/_files/_cipher_info.php
+++ b/dev/tests/unit/testsuite/Magento/Crypt/_files/_cipher_info.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Crypt/_files/_crypt_fixtures.php
+++ b/dev/tests/unit/testsuite/Magento/Crypt/_files/_crypt_fixtures.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/CryptTest.php
+++ b/dev/tests/unit/testsuite/Magento/CryptTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Block/Account/AuthorizationLinkTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Block/Account/AuthorizationLinkTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Block/Account/LinkTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Block/Account/LinkTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Block/Account/RegisterLinkTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Block/Account/RegisterLinkTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Controller/AccountTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Controller/AccountTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/ReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/XsdTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/_files/formats_merged.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/_files/formats_merged.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/_files/formats_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/_files/formats_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/_files/formats_one.xml
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/_files/formats_one.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/_files/formats_two.xml
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/Address/Config/_files/formats_two.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/Address/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/Address/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/CustomerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/CustomerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Customer/Service/CustomerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Service/CustomerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DB/Adapter/Pdo/MysqlTest.php
+++ b/dev/tests/unit/testsuite/Magento/DB/Adapter/Pdo/MysqlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DB/ProfilerTest.php
+++ b/dev/tests/unit/testsuite/Magento/DB/ProfilerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DB/SelectTest.php
+++ b/dev/tests/unit/testsuite/Magento/DB/SelectTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Data/Collection/Db/FetchStrategy/CacheTest.php
+++ b/dev/tests/unit/testsuite/Magento/Data/Collection/Db/FetchStrategy/CacheTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Data/Collection/Db/FetchStrategy/QueryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Data/Collection/Db/FetchStrategy/QueryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Data/Collection/DbTest.php
+++ b/dev/tests/unit/testsuite/Magento/Data/Collection/DbTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Data/CollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Data/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Data/Form/Element/EditablemultiselectTest.php
+++ b/dev/tests/unit/testsuite/Magento/Data/Form/Element/EditablemultiselectTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Data/Form/Element/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Data/Form/Element/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Data/Form/Element/MultiselectTest.php
+++ b/dev/tests/unit/testsuite/Magento/Data/Form/Element/MultiselectTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Data/GraphTest.php
+++ b/dev/tests/unit/testsuite/Magento/Data/GraphTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Data/StructureTest.php
+++ b/dev/tests/unit/testsuite/Magento/Data/StructureTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DateTest.php
+++ b/dev/tests/unit/testsuite/Magento/DateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/ContainerTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/ContainerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/BlockAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/BlockAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/Buttons/SaveTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/Buttons/SaveTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/ButtonsTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Toolbar/ButtonsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/CustomTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/CustomTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/JsTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Code/JsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/ContentTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/ContentTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/TreeTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Editor/Tools/Files/TreeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/SelectorList/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/Theme/Selector/SelectorList/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/ThemeTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Block/Adminhtml/ThemeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Controller/Adminhtml/System/Design/EditorTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Controller/Adminhtml/System/Design/EditorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Controller/Varien/Router/StandardTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Controller/Varien/Router/StandardTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Helper/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Config/Control/QuickStylesTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Config/Control/QuickStylesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Editor/QuickStyles/Renderer/BackgroundImageTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Editor/QuickStyles/Renderer/BackgroundImageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Editor/QuickStyles/Renderer/DefaultTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Editor/QuickStyles/Renderer/DefaultTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Editor/QuickStyles/RendererTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Editor/QuickStyles/RendererTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Plugin/ThemeCopyServiceTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Plugin/ThemeCopyServiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Model/StateTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Model/StateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Theme/ContextTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Theme/ContextTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Url/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Url/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Url/NavigationModeTest.php
+++ b/dev/tests/unit/testsuite/Magento/DesignEditor/Model/Url/NavigationModeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Directory/Helper/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Directory/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Directory/Model/Config/Source/CountryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Directory/Model/Config/Source/CountryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Directory/Model/Currency/DefaultLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Directory/Model/Currency/DefaultLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Directory/Model/Currency/Import/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Directory/Model/Currency/Import/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Directory/Model/Currency/Import/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Directory/Model/Currency/Import/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Directory/Model/Currency/Import/Source/ServiceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Directory/Model/Currency/Import/Source/ServiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Directory/Model/Resource/Country/CollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Directory/Model/Resource/Country/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinksTest.php
+++ b/dev/tests/unit/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinksTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SamplesTest.php
+++ b/dev/tests/unit/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SamplesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Downloadable/Model/ObserverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Downloadable/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Downloadable/Model/Product/TypeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Downloadable/Model/Product/TypeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Downloadable/Model/Sales/Order/Pdf/Items/CreditmemoTest.php
+++ b/dev/tests/unit/testsuite/Magento/Downloadable/Model/Sales/Order/Pdf/Items/CreditmemoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Attribute/Data/TextTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Attribute/Data/TextTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/AttributeFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/AttributeFactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Backend/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Backend/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Backend/ArrayTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Backend/ArrayTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Config/_files/eav_attributes.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Config/_files/eav_attributes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Config/_files/eav_attributes.xml
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Config/_files/eav_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Config/_files/invalidEavAttributeXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/Config/_files/invalidEavAttributeXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/SetTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/Attribute/SetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/AttributeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Entity/AttributeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/FormTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Resource/Entity/AttributeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Resource/Entity/AttributeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/Model/Validator/Attribute/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/Model/Validator/Attribute/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Eav/_files/describe_table_eav_attribute.php
+++ b/dev/tests/unit/testsuite/Magento/Eav/_files/describe_table_eav_attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Filesystem/Stream/Mode/ZlibTest.php
+++ b/dev/tests/unit/testsuite/Magento/Filesystem/Stream/Mode/ZlibTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Filesystem/Stream/ModeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Filesystem/Stream/ModeTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/FilesystemTest.php
+++ b/dev/tests/unit/testsuite/Magento/FilesystemTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Filter/Template/SimpleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Filter/Template/SimpleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GiftMessage/Model/Plugin/QuoteItemTest.php
+++ b/dev/tests/unit/testsuite/Magento/GiftMessage/Model/Plugin/QuoteItemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleAdwords/Helper/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleAdwords/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleAdwords/Model/Config/Source/LanguageTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleAdwords/Model/Config/Source/LanguageTest.php
@@ -12,7 +12,7 @@ namespace Magento\GoogleAdwords\Model\Config\Source;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleAdwords/Model/Config/Source/ValueTypeTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleAdwords/Model/Config/Source/ValueTypeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleAdwords/Model/Filter/UppercaseTitleTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleAdwords/Model/Filter/UppercaseTitleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleAdwords/Model/ObserverTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleAdwords/Model/ObserverTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleAdwords/Model/Validator/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleAdwords/Model/Validator/FactoryTest.php
@@ -12,7 +12,7 @@ namespace Magento\GoogleAdwords\Model\Validator;
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Helper/CodeTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Helper/CodeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Helper/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Helper/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Helper/FormTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Helper/FormTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/Block/Category/TabTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/Block/Category/TabTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/Category/DeleteTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/Category/DeleteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/Category/SaveTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/Category/SaveTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/CmsPage/DeleteTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/CmsPage/DeleteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/CmsPage/SaveTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/CmsPage/SaveTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/Product/DeleteTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/Product/DeleteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/Product/SaveTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleOptimizer/Model/Observer/Product/SaveTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleShopping/Block/SiteVerificationTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleShopping/Block/SiteVerificationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/GoogleShopping/Model/AttributeFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/GoogleShopping/Model/AttributeFactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Http/Handler/CompositeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Http/Handler/CompositeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Image/Adapter/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Image/Adapter/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Image/Adapter/ImageMagickTest.php
+++ b/dev/tests/unit/testsuite/Magento/Image/Adapter/ImageMagickTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/export.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/export.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/export.xml
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/export.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/export_merged_valid.xml
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/export_merged_valid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/export_valid.xml
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/export_valid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/invalidExportMergedXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/invalidExportMergedXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/invalidExportXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Config/_files/invalidExportXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Entity/Eav/Customer/AddressTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Entity/Eav/Customer/AddressTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Entity/Eav/CustomerTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Entity/Eav/CustomerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Entity/EavAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Entity/EavAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Entity/ProductTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Entity/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Entity/StubProduct.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/Entity/StubProduct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/EntityAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Export/EntityAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/ExportTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/ExportTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/XsdMergedTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/XsdMergedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/import.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/import.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/import.xml
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/import.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/invalidImportMergedXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/invalidImportMergedXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/invalidImportXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/invalidImportXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/valid_import.xml
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/valid_import.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/valid_import_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Config/_files/valid_import_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/CustomerCompositeTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/CustomerCompositeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/AbstractCustomerTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/AbstractCustomerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/AddressTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/AddressTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_empty_email.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_empty_email.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_empty_website.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_empty_website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_invalid_email.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_invalid_email.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_invalid_website.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_invalid_website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_no_email.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_no_email.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_no_website.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_no_website.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_valid.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_abstract_valid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_delete_address_not_found.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_delete_address_not_found.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_delete_empty_address_id.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_delete_empty_address_id.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_delete_no_customer.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_delete_no_customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_delete_valid.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_delete_valid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_update_absent_required_attribute.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_update_absent_required_attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_update_empty_address_id.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_update_empty_address_id.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_update_invalid_region.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_update_invalid_region.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_update_no_customer.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_update_no_customer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_update_valid.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/Customer/_files/row_data_address_update_valid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/CustomerTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Eav/CustomerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/EavAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/EavAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/OptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/OptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_ambiguity_different_type.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_ambiguity_different_type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_ambiguity_several_db_rows.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_ambiguity_several_db_rows.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_empty_title.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_empty_title.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_incorrect_type.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_incorrect_type.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_invalid_max_characters.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_invalid_max_characters.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_invalid_price.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_invalid_price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_invalid_sort_order.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_invalid_sort_order.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_invalid_store.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_invalid_store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_max_characters_less_zero.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_max_characters_less_zero.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_no_title.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_no_title.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_sort_order_less_zero.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_sort_order_less_zero.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_valid.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_main_valid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_no_custom_option.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_no_custom_option.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_secondary_incorrect_price.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_secondary_incorrect_price.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_secondary_incorrect_row_sort.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_secondary_incorrect_row_sort.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_secondary_invalid_store.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_secondary_invalid_store.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_secondary_row_sort_less_zero.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_secondary_row_sort_less_zero.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_secondary_valid.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Entity/Product/_files/row_data_secondary_valid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/EntityAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/EntityAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Source/CsvTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/Source/CsvTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/SourceAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Import/SourceAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Resource/CollectionByPagesIteratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Resource/CollectionByPagesIteratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Resource/Customer/StorageTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Resource/Customer/StorageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Resource/Import/CustomerComposite/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Resource/Import/CustomerComposite/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Source/Import/AbstractBehaviorTestCase.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Source/Import/AbstractBehaviorTestCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Source/Import/Behavior/BasicTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Source/Import/Behavior/BasicTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Source/Import/Behavior/CustomTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Source/Import/Behavior/CustomTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ImportExport/Model/Source/Import/BehaviorAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/ImportExport/Model/Source/Import/BehaviorAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Config/_files/invalidIndexersXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Config/_files/invalidIndexersXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Config/_files/invalidIndexersXmlMergedArray.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Config/_files/invalidIndexersXmlMergedArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Config/_files/valid_indexers.xml
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Config/_files/valid_indexers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Config/_files/valid_indexers_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Config/_files/valid_indexers_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/EntryPoint/IndexerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/EntryPoint/IndexerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/EntryPoint/ShellTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/EntryPoint/ShellTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/EventRepositoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/EventRepositoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/Config/_files/indexers.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/Config/_files/indexers.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/Config/_files/indexers.xml
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/Config/_files/indexers.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Indexer/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Lock/StorageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Lock/StorageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/Process/FileFactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/Process/FileFactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Index/Model/ProcessTest.php
+++ b/dev/tests/unit/testsuite/Magento/Index/Model/ProcessTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Install/Block/BeginTest.php
+++ b/dev/tests/unit/testsuite/Magento/Install/Block/BeginTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Install/Model/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Install/Model/Config/ConverterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Install/Model/Config/_files/install_wizard.xml
+++ b/dev/tests/unit/testsuite/Magento/Install/Model/Config/_files/install_wizard.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Install/Model/Config/_files/install_wizard_config.php
+++ b/dev/tests/unit/testsuite/Magento/Install/Model/Config/_files/install_wizard_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Install/Model/EntryPoint/ConsoleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Install/Model/EntryPoint/ConsoleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Install/Model/EntryPoint/UpgradeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Install/Model/EntryPoint/UpgradeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Install/Model/EntryPoint/_files/config.php
+++ b/dev/tests/unit/testsuite/Magento/Install/Model/EntryPoint/_files/config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Install/Model/Installer/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Install/Model/Installer/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Install/Model/Installer/Db/Mysql4Test.php
+++ b/dev/tests/unit/testsuite/Magento/Install/Model/Installer/Db/Mysql4Test.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Config/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Interception/Config/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/Item.php
+++ b/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/Item/Enhanced.php
+++ b/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/Item/Enhanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/ItemContainer.php
+++ b/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/ItemContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/ItemContainer/Enhanced.php
+++ b/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/ItemContainer/Enhanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/ItemContainerPlugin/Simple.php
+++ b/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/ItemContainerPlugin/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/ItemPlugin/Advanced.php
+++ b/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/ItemPlugin/Advanced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/ItemPlugin/Simple.php
+++ b/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/Model/ItemPlugin/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/etc/backend/di.xml
+++ b/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/etc/backend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/etc/di.xml
+++ b/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/etc/frontend/di.xml
+++ b/dev/tests/unit/testsuite/Magento/Interception/Custom/Module/etc/frontend/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Interception/PluginList/PluginListTest.php
+++ b/dev/tests/unit/testsuite/Magento/Interception/PluginList/PluginListTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Io/FileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Io/FileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Log/Model/EntryPoint/ShellTest.php
+++ b/dev/tests/unit/testsuite/Magento/Log/Model/EntryPoint/ShellTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Log/Model/Shell/Command/CleanTest.php
+++ b/dev/tests/unit/testsuite/Magento/Log/Model/Shell/Command/CleanTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Log/Model/Shell/Command/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Log/Model/Shell/Command/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Log/Model/Shell/Command/StatusTest.php
+++ b/dev/tests/unit/testsuite/Magento/Log/Model/Shell/Command/StatusTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Log/Model/ShellTest.php
+++ b/dev/tests/unit/testsuite/Magento/Log/Model/ShellTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Newsletter/Model/TemplateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Newsletter/Model/TemplateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Oauth/Helper/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Oauth/Helper/DataTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Oauth/Helper/ServiceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Oauth/Helper/ServiceTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Oauth/Service/OauthV1Test.php
+++ b/dev/tests/unit/testsuite/Magento/Oauth/Service/OauthV1Test.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ObjectManager/Config/Mapper/DomTest.php
+++ b/dev/tests/unit/testsuite/Magento/ObjectManager/Config/Mapper/DomTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ObjectManager/Config/Mapper/_files/mapped_simple_di_config.php
+++ b/dev/tests/unit/testsuite/Magento/ObjectManager/Config/Mapper/_files/mapped_simple_di_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ObjectManager/Config/Mapper/_files/simple_di_config.xml
+++ b/dev/tests/unit/testsuite/Magento/ObjectManager/Config/Mapper/_files/simple_di_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ObjectManager/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/ObjectManager/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ObjectManager/Config/_files/invalidConfigXmlArray.php
+++ b/dev/tests/unit/testsuite/Magento/ObjectManager/Config/_files/invalidConfigXmlArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ObjectManager/Config/_files/valid_config.xml
+++ b/dev/tests/unit/testsuite/Magento/ObjectManager/Config/_files/valid_config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ObjectManager/ObjectManagerTest.php
+++ b/dev/tests/unit/testsuite/Magento/ObjectManager/ObjectManagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ObjectManager/Relations/RuntimeTest.php
+++ b/dev/tests/unit/testsuite/Magento/ObjectManager/Relations/RuntimeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ObjectTest.php
+++ b/dev/tests/unit/testsuite/Magento/ObjectTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Ogone/Model/ApiTest.php
+++ b/dev/tests/unit/testsuite/Magento/Ogone/Model/ApiTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Outbound/Authentication/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Outbound/Authentication/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Outbound/Authentication/HmacTest.php
+++ b/dev/tests/unit/testsuite/Magento/Outbound/Authentication/HmacTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Outbound/Formatter/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Outbound/Formatter/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Outbound/Formatter/JsonTest.php
+++ b/dev/tests/unit/testsuite/Magento/Outbound/Formatter/JsonTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Outbound/Formatter/JsonTest/Data.php
+++ b/dev/tests/unit/testsuite/Magento/Outbound/Formatter/JsonTest/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Outbound/Message/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Outbound/Message/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Outbound/MessageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Outbound/MessageTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Outbound/Transport/Http/ResponseTest.php
+++ b/dev/tests/unit/testsuite/Magento/Outbound/Transport/Http/ResponseTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Outbound/Transport/HttpTest.php
+++ b/dev/tests/unit/testsuite/Magento/Outbound/Transport/HttpTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Page/Block/Html/HeadTest.php
+++ b/dev/tests/unit/testsuite/Magento/Page/Block/Html/HeadTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Page/Block/Html/HeaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Page/Block/Html/HeaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Page/Block/Link/CurrentTest.php
+++ b/dev/tests/unit/testsuite/Magento/Page/Block/Link/CurrentTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Page/Block/LinksTest.php
+++ b/dev/tests/unit/testsuite/Magento/Page/Block/LinksTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Page/Block/SwitchTest.php
+++ b/dev/tests/unit/testsuite/Magento/Page/Block/SwitchTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Page/Model/Asset/GroupedCollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Page/Model/Asset/GroupedCollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Page/Model/Asset/PropertyGroupTest.php
+++ b/dev/tests/unit/testsuite/Magento/Page/Model/Asset/PropertyGroupTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Page/Model/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Page/Model/Config/ConverterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Page/Model/Config/_files/page_layouts.xml
+++ b/dev/tests/unit/testsuite/Magento/Page/Model/Config/_files/page_layouts.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Payment/Block/Form/ContainerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Payment/Block/Form/ContainerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Payment/Block/Info/ContainerAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Payment/Block/Info/ContainerAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Payment/Block/Info/InstructionsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Payment/Block/Info/InstructionsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Payment/Model/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Payment/Model/Config/ConverterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Payment/Model/Config/_files/payment.xml
+++ b/dev/tests/unit/testsuite/Magento/Payment/Model/Config/_files/payment.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Payment/Model/Method/BanktransferTest.php
+++ b/dev/tests/unit/testsuite/Magento/Payment/Model/Method/BanktransferTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Payment/Model/Method/CashondeliveryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Payment/Model/Method/CashondeliveryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Payment/Model/Method/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Payment/Model/Method/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Paypal/Helper/CheckoutTest.php
+++ b/dev/tests/unit/testsuite/Magento/Paypal/Helper/CheckoutTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Paypal/Model/IpnTest.php
+++ b/dev/tests/unit/testsuite/Magento/Paypal/Model/IpnTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Paypal/Model/PayflowadvancedTest.php
+++ b/dev/tests/unit/testsuite/Magento/Paypal/Model/PayflowadvancedTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Paypal/Model/PayflowlinkTest.php
+++ b/dev/tests/unit/testsuite/Magento/Paypal/Model/PayflowlinkTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Paypal/Model/ProTest.php
+++ b/dev/tests/unit/testsuite/Magento/Paypal/Model/ProTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Persistent/Model/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Persistent/Model/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Phrase/Renderer/CompositeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Phrase/Renderer/CompositeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Phrase/Renderer/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Phrase/Renderer/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Phrase/Renderer/PlaceholderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Phrase/Renderer/PlaceholderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Phrase/Renderer/TranslateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Phrase/Renderer/TranslateTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/PhraseTest.php
+++ b/dev/tests/unit/testsuite/Magento/PhraseTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ProductAlert/Block/Product/View/PriceTest.php
+++ b/dev/tests/unit/testsuite/Magento/ProductAlert/Block/Product/View/PriceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ProductAlert/Block/Product/View/StockTest.php
+++ b/dev/tests/unit/testsuite/Magento/ProductAlert/Block/Product/View/StockTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Profiler/Driver/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Profiler/Driver/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Profiler/Driver/Standard/Output/CsvfileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Profiler/Driver/Standard/Output/CsvfileTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Profiler/Driver/Standard/Output/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Profiler/Driver/Standard/Output/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Profiler/Driver/Standard/Output/FirebugTest.php
+++ b/dev/tests/unit/testsuite/Magento/Profiler/Driver/Standard/Output/FirebugTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Profiler/Driver/Standard/OutputAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Profiler/Driver/Standard/OutputAbstractTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Profiler/Driver/Standard/StatTest.php
+++ b/dev/tests/unit/testsuite/Magento/Profiler/Driver/Standard/StatTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Profiler/Driver/StandardTest.php
+++ b/dev/tests/unit/testsuite/Magento/Profiler/Driver/StandardTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ProfilerTest.php
+++ b/dev/tests/unit/testsuite/Magento/ProfilerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/PubSub/Event/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/PubSub/Event/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/PubSub/Event/QueueHandlerTest.php
+++ b/dev/tests/unit/testsuite/Magento/PubSub/Event/QueueHandlerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/PubSub/Event/QueueWriterTest.php
+++ b/dev/tests/unit/testsuite/Magento/PubSub/Event/QueueWriterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/PubSub/EventTest.php
+++ b/dev/tests/unit/testsuite/Magento/PubSub/EventTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/PubSub/Job/QueueHandlerTest.php
+++ b/dev/tests/unit/testsuite/Magento/PubSub/Job/QueueHandlerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/PubSub/Message/DispatcherAsyncTest.php
+++ b/dev/tests/unit/testsuite/Magento/PubSub/Message/DispatcherAsyncTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Reports/Model/Plugin/LogTest.php
+++ b/dev/tests/unit/testsuite/Magento/Reports/Model/Plugin/LogTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Reports/Model/Resource/Report/CollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Reports/Model/Resource/Report/CollectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Review/Helper/Action/PagerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Review/Helper/Action/PagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Block/Guest/LinkTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Block/Guest/LinkTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Block/Items/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Block/Items/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/GridTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/Related/Orders/GridTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/Related/Orders/GridTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/AddressTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/AddressTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/FeesTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/FeesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/ItemTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/ItemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/ReferenceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/ReferenceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/ScheduleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Block/Recurring/Profile/View/ScheduleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Billing/Agreement/OrdersUpdaterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Billing/Agreement/OrdersUpdaterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/DataTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/DataTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/ReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/XsdTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/core_totals_config.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/core_totals_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/custom_totals_config.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/custom_totals_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/sales_invalid.xml
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/sales_invalid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/sales_invalid_duplicates.xml
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/sales_invalid_duplicates.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/sales_invalid_root_node.xml
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/sales_invalid_root_node.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/sales_invalid_without_attributes.xml
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/sales_invalid_without_attributes.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/sales_valid.xml
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Config/_files/sales_valid.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Observer/Backend/BillingAgreementTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Observer/Backend/BillingAgreementTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Observer/Backend/CatalogPriceRuleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Observer/Backend/CatalogPriceRuleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Observer/Backend/CatalogProductQuoteTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Observer/Backend/CatalogProductQuoteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Observer/Backend/CustomerQuoteTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Observer/Backend/CustomerQuoteTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Observer/Backend/RecurringProfile/FormRendererTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Observer/Backend/RecurringProfile/FormRendererTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Invoice/Total/ShippingTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Invoice/Total/ShippingTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/InvoiceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/InvoiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/AbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/ReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/XsdTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/XsdTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/_files/pdf_merged.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/_files/pdf_merged.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/_files/pdf_merged.xml
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/_files/pdf_merged.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/_files/pdf_one.xml
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/_files/pdf_one.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/_files/pdf_two.xml
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Config/_files/pdf_two.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/InvoiceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/InvoiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Total/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Pdf/Total/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Shipment/TrackTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/Shipment/TrackTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Order/StatusTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Order/StatusTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/OrderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/OrderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Quote/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Quote/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sales/Model/Quote/ItemTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sales/Model/Quote/ItemTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/SalesRule/Model/Resource/Report/RuleTest.php
+++ b/dev/tests/unit/testsuite/Magento/SalesRule/Model/Resource/Report/RuleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/SalesRule/Model/ValidatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/SalesRule/Model/ValidatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/SalesRule/Model/_files/quote_item_downloadable.php
+++ b/dev/tests/unit/testsuite/Magento/SalesRule/Model/_files/quote_item_downloadable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/SalesRule/Model/_files/quote_item_simple.php
+++ b/dev/tests/unit/testsuite/Magento/SalesRule/Model/_files/quote_item_simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ShellTest.php
+++ b/dev/tests/unit/testsuite/Magento/ShellTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Simplexml/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Simplexml/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Simplexml/ElementTest.php
+++ b/dev/tests/unit/testsuite/Magento/Simplexml/ElementTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Simplexml/_files/data.xml
+++ b/dev/tests/unit/testsuite/Magento/Simplexml/_files/data.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Simplexml/_files/mixed_data.xml
+++ b/dev/tests/unit/testsuite/Magento/Simplexml/_files/mixed_data.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sitemap/Model/SitemapTest.php
+++ b/dev/tests/unit/testsuite/Magento/Sitemap/Model/SitemapTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-1-1.xml
+++ b/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-1-1.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-1-2.xml
+++ b/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-1-2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-1-3.xml
+++ b/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-1-3.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-1-4.xml
+++ b/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-1-4.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-index.xml
+++ b/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-index.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-single.xml
+++ b/dev/tests/unit/testsuite/Magento/Sitemap/Model/_files/sitemap-single.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Tax/Model/TaxClass/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Tax/Model/TaxClass/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Tax/Model/TaxClass/Type/CustomerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Tax/Model/TaxClass/Type/CustomerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Tax/Model/TaxClass/Type/ProductTest.php
+++ b/dev/tests/unit/testsuite/Magento/Tax/Model/TaxClass/Type/ProductTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/ArrayScannerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/ArrayScannerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/CompositeScannerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/CompositeScannerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/DirectoryScannerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/DirectoryScannerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/PhpScannerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/PhpScannerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/PluginScannerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/PluginScannerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/XmlInterceptorScannerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/XmlInterceptorScannerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/XmlScannerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/Code/Scanner/XmlScannerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/additional.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/additional.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/bootstrap.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/code/Magento/SomeModule/Helper/Test.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/code/Magento/SomeModule/Helper/Test.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/code/Magento/SomeModule/Model/Test.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/code/Magento/SomeModule/Model/Test.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/code/Magento/SomeModule/etc/adminhtml/system.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/code/Magento/SomeModule/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/code/Magento/SomeModule/etc/di.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/code/Magento/SomeModule/etc/di.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/code/Magento/SomeModule/view/frontend/default.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/code/Magento/SomeModule/view/frontend/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/design/adminhtml/default/backend/layout.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/design/adminhtml/default/backend/layout.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/etc/additional.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/etc/additional.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/etc/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/etc/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/etc/di/config.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Di/_files/app/etc/di/config.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/ContextTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/ContextTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/GeneratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/GeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/Loader/File/AbstractFileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/Loader/File/AbstractFileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/PhraseTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/PhraseTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/Writer/Csv/StdoTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/Writer/Csv/StdoTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/Writer/CsvTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Dictionary/Writer/CsvTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/DictionaryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/DictionaryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/FilesCollectorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/FilesCollectorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/LocaleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/LocaleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Pack/GeneratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Pack/GeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/AbstractParserTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/AbstractParserTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/AbstractAdapterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/AbstractAdapterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/JsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/JsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/PhpTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/PhpTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/XmlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/XmlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/_files/default.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/_files/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/_files/file.js
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/Parser/Adapter/_files/file.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/_files/files_collector/default.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/_files/files_collector/default.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/_files/files_collector/file.js
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/I18n/Code/_files/files_collector/file.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/Adapter/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/Adapter/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/FileReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/FileReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/Logger/ConsoleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/Logger/ConsoleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/Logger/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/Logger/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/Logger/FileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/Logger/FileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/LoggerAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/LoggerAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/ReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/UpdaterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/UpdaterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/WriterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Db/WriterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/GeneratorRemoveTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/GeneratorRemoveTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/GeneratorSaveTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/GeneratorSaveTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/GeneratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/GeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Menu/GeneratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/Menu/GeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/community/Namespace/Module/etc/adminhtml.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/community/Namespace/Module/etc/adminhtml.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/community/Namespace/Module/etc/adminhtml/menu.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/community/Namespace/Module/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/core/ANamespace/Module/etc/adminhtml.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/core/ANamespace/Module/etc/adminhtml.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/core/ANamespace/Module/etc/adminhtml/menu.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/core/ANamespace/Module/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/core/BNamespace/Module/etc/adminhtml.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/core/BNamespace/Module/etc/adminhtml.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/core/BNamespace/Module/etc/adminhtml/menu.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/core/BNamespace/Module/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/local/Namespace/Module/etc/adminhtml.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/local/Namespace/Module/etc/adminhtml.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/local/Namespace/Module/etc/adminhtml/menu.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/app/code/local/Namespace/Module/etc/adminhtml/menu.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/parse_node_result.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/parse_node_result.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/parse_node_source.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/parse_node_source.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/remove/empty.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/remove/empty.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/remove/not_empty.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/remove/not_empty.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/save/adminhtml.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/save/adminhtml.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/update_child_acl_nodes_result.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/update_child_acl_nodes_result.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/update_child_acl_nodes_source.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/update_child_acl_nodes_source.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/update_menu_attributes_result.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/update_menu_attributes_result.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/update_menu_attributes_source.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/Acl/_files/update_menu_attributes_source.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/GeneratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/GeneratorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Logger/ConsoleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Logger/ConsoleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Logger/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Logger/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Logger/FileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Logger/FileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/LoggerAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/LoggerAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Mapper/FieldTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Mapper/FieldTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Mapper/GroupTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Mapper/GroupTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Mapper/SectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Mapper/SectionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Mapper/TabTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/Mapper/TabTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/MapperTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/MapperTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/ParserTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/ParserTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/ReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/ReaderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/_files/convertedConfiguration.xml
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/_files/convertedConfiguration.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/_files/mappedConfiguration.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Configuration/_files/mappedConfiguration.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/FileManagerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/FileManagerTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Writer/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/Migration/System/Writer/FactoryTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/CopyRuleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/CopyRuleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/ThemeDeploymentTest.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/ThemeDeploymentTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/constructor_exception/forbidden.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/constructor_exception/forbidden.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/constructor_exception/permitted.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/constructor_exception/permitted.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/run/fixture.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/run/fixture.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/run/forbidden.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/run/forbidden.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/run/forbidden_without_php.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/run/forbidden_without_php.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/run/permitted.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/run/permitted.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/run/permitted_cased_js.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/ThemeDeployment/run/permitted_cased_js.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/fixture_themes.php
+++ b/dev/tests/unit/testsuite/Magento/Test/Tools/View/Generator/_files/fixture_themes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Form/Element/FileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/Form/Element/FileTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/System/Design/Theme/Tab/CssTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/System/Design/Theme/Tab/CssTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/System/Design/Theme/Tab/JsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/System/Design/Theme/Tab/JsTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/System/Design/Theme/TabAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/System/Design/Theme/TabAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/ContentTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/ContentTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/TreeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/TreeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Controller/Adminhtml/System/Design/ThemeTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Controller/Adminhtml/System/Design/ThemeTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Helper/StorageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Helper/StorageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Model/Config/CustomizationTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Model/Config/CustomizationTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Model/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Model/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Model/Uploader/ServiceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Model/Uploader/ServiceTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Theme/Model/Wysiwyg/StorageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Theme/Model/Wysiwyg/StorageTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Translate/AdapterAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Translate/AdapterAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Translate/AdapterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Translate/AdapterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Usa/Model/Simplexml/ElementTest.php
+++ b/dev/tests/unit/testsuite/Magento/Usa/Model/Simplexml/ElementTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/User/Model/Acl/Loader/RoleTest.php
+++ b/dev/tests/unit/testsuite/Magento/User/Model/Acl/Loader/RoleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/User/Model/Acl/Loader/RuleTest.php
+++ b/dev/tests/unit/testsuite/Magento/User/Model/Acl/Loader/RuleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/User/Model/UserTest.php
+++ b/dev/tests/unit/testsuite/Magento/User/Model/UserTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/BuilderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/BuilderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Composite/VarienObjectTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Composite/VarienObjectTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Constraint/Option/CallbackTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Constraint/Option/CallbackTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Constraint/OptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Constraint/OptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Constraint/PropertyTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Constraint/PropertyTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/ConstraintTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/ConstraintTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Entity/PropertiesTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Entity/PropertiesTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/ExceptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/ExceptionTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/StringLengthTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/StringLengthTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Test/Alnum.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Test/Alnum.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Test/Callback.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Test/Callback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Test/Int.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Test/Int.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Test/NotEmpty.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Test/NotEmpty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Test/StringLength.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Test/StringLength.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/Test/True.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/Test/True.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/ValidatorAbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Validator/ValidatorAbstractTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_builder_class.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_builder_class.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_builder_instance.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_builder_instance.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_child_for_option.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_child_for_option.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_constraint.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_constraint.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_content_for callback.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_content_for callback.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_entity_callback.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_entity_callback.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_method.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_method.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_method_callback.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/invalid_method_callback.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/multiple_callback_in_argument.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/multiple_callback_in_argument.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_class_for_constraint.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_class_for_constraint.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_constraint.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_constraint.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_name_for_entity.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_name_for_entity.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_name_for_group.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_name_for_group.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_name_for_rule.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_name_for_rule.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_rule_for_reference.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/no_rule_for_reference.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/not_unique_use.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/negative/not_unique_use.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/positive/builder/validation.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/positive/builder/validation.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/positive/module_a/validation.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/positive/module_a/validation.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Validator/_files/validation/positive/module_b/validation.xml
+++ b/dev/tests/unit/testsuite/Magento/Validator/_files/validation/positive/module_b/validation.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/ValidatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/ValidatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/Role/Edit/Tab/ResourceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/Role/Edit/Tab/ResourceTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/Role/Edit/TabsTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/Role/Edit/TabsTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/Role/EditTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/Role/EditTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/RoleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/RoleTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/User/EditTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/User/EditTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/UserTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Block/Adminhtml/UserTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/ErrorProcessorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/ErrorProcessorTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/ResponseTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/ResponseTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Request/Deserializer/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Request/Deserializer/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Request/Deserializer/JsonTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Request/Deserializer/JsonTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Request/Deserializer/XmlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Request/Deserializer/XmlTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/RequestTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/RequestTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Response/Renderer/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Response/Renderer/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Response/Renderer/JsonTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Response/Renderer/JsonTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Response/Renderer/XmlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Response/Renderer/XmlTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/ResponseTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/ResponseTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Router/RouteTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/Router/RouteTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/RouterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Rest/RouterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/RestTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/RestTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Soap/HandlerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Soap/HandlerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/Soap/RequestTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/Soap/RequestTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Controller/SoapTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Controller/SoapTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/ExceptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/ExceptionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Resource/Config/Converter/DomTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Resource/Config/Converter/DomTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Resource/Config/Converter/_files/converted_valid_webapi_acl.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Resource/Config/Converter/_files/converted_valid_webapi_acl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Resource/Config/Converter/_files/valid_webapi_acl.xml
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Resource/Config/Converter/_files/valid_webapi_acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Resource/Config/SchemaLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Resource/Config/SchemaLocatorTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Resource/ProviderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Resource/ProviderTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Role/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Role/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Role/InRoleUserUpdaterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Role/InRoleUserUpdaterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Role/UsersUpdaterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/Role/UsersUpdaterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/RoleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/RoleTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/RuleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/RuleTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/User/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/User/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/User/RoleUpdaterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/User/RoleUpdaterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/UserTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Acl/UserTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Authorization/Loader/ResourceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Authorization/Loader/ResourceTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Authorization/Loader/RoleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Authorization/Loader/RoleTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Authorization/Loader/RuleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Authorization/Loader/RuleTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Authorization/Role/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Authorization/Role/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Authorization/RoleLocatorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Authorization/RoleLocatorTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Resource/Acl/AbstractTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Resource/Acl/AbstractTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Resource/Acl/RoleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Resource/Acl/RoleTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Resource/Acl/RuleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Resource/Acl/RuleTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Resource/Acl/UserTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Resource/Acl/UserTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Soap/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Soap/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Soap/FaultTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Soap/FaultTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Soap/ServerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Soap/ServerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Soap/Wsdl/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Soap/Wsdl/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Soap/Wsdl/GeneratorTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Soap/Wsdl/GeneratorTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/Source/Acl/RoleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/Source/Acl/RoleTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/_files/acl.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/_files/acl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/_files/acl.xml
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/_files/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/Model/_files/acl.xsd
+++ b/dev/tests/unit/testsuite/Magento/Webapi/Model/_files/acl.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webapi/_files/soap_fault/soap_fault_expected_xmls.php
+++ b/dev/tests/unit/testsuite/Magento/Webapi/_files/soap_fault/soap_fault_expected_xmls.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Registration/ActivateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Registration/ActivateTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Registration/Create/Form/ContainerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Registration/Create/Form/ContainerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Registration/Create/FormTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Registration/Create/FormTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Registration/FailedTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Registration/FailedTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/Edit/FormTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/Edit/FormTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/EditTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/EditTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/Grid/Renderer/ActionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/Subscription/Grid/Renderer/ActionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/SubscriptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Block/Adminhtml/SubscriptionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Controller/Adminhtml/Webhook/RegistrationTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Controller/Adminhtml/Webhook/RegistrationTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Controller/Adminhtml/Webhook/SubscriptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Controller/Adminhtml/Webhook/SubscriptionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/EndpointTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/EndpointTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Event/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Event/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Event/QueueReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Event/QueueReaderTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Event/QueueWriterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Event/QueueWriterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/EventTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/EventTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Job/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Job/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Job/QueueReaderTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Job/QueueReaderTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Job/QueueWriterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Job/QueueWriterTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/JobTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/JobTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/ObserverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/ObserverTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/EndpointTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/EndpointTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/Event/CollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/Event/CollectionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/EventTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/EventTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/Job/CollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/Job/CollectionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/JobTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/JobTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/Subscription/CollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/Subscription/CollectionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/Subscription/Grid/CollectionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/Subscription/Grid/CollectionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/SubscriptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Resource/SubscriptionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Source/AuthenticationTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Source/AuthenticationTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Source/FormatTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Source/FormatTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Source/HookTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Source/HookTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Source/Pkg.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Source/Pkg.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Subscription/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Subscription/ConfigTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Subscription/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Subscription/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Subscription/Options/StatusTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Subscription/Options/StatusTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/SubscriptionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/SubscriptionTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/User/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/User/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/UserTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/UserTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Webapi/EventHandler/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Webapi/EventHandler/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Webapi/EventHandlerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Webapi/EventHandlerTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/Webapi/User/FactoryTest.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/Webapi/User/FactoryTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/_files/acl.xml
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/_files/acl.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/_files/acl.xsd
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/_files/acl.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Model/_files/acl2.xml
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Model/_files/acl2.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Webhook/Service/SubscriptionV1Test.php
+++ b/dev/tests/unit/testsuite/Magento/Webhook/Service/SubscriptionV1Test.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Widget/Model/Config/ConverterTest.php
+++ b/dev/tests/unit/testsuite/Magento/Widget/Model/Config/ConverterTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Widget/Model/Widget/InstanceTest.php
+++ b/dev/tests/unit/testsuite/Magento/Widget/Model/Widget/InstanceTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Widget/Model/WidgetTest.php
+++ b/dev/tests/unit/testsuite/Magento/Widget/Model/WidgetTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Widget/Model/_files/mappedConfigArray1.php
+++ b/dev/tests/unit/testsuite/Magento/Widget/Model/_files/mappedConfigArray1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Widget/Model/_files/mappedConfigArray2.php
+++ b/dev/tests/unit/testsuite/Magento/Widget/Model/_files/mappedConfigArray2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Widget/Model/_files/mappedConfigArrayAll.php
+++ b/dev/tests/unit/testsuite/Magento/Widget/Model/_files/mappedConfigArrayAll.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Widget/Model/_files/widget.xml
+++ b/dev/tests/unit/testsuite/Magento/Widget/Model/_files/widget.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Widget/Model/_files/widget_config.php
+++ b/dev/tests/unit/testsuite/Magento/Widget/Model/_files/widget_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Wishlist/Block/Item/ConfigureTest.php
+++ b/dev/tests/unit/testsuite/Magento/Wishlist/Block/Item/ConfigureTest.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Wishlist/Controller/IndexTest.php
+++ b/dev/tests/unit/testsuite/Magento/Wishlist/Controller/IndexTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/Wishlist/Model/ConfigTest.php
+++ b/dev/tests/unit/testsuite/Magento/Wishlist/Model/ConfigTest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Acl/Resource/resourceList.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Acl/Resource/resourceList.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Acl/Resource/result.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Acl/Resource/result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Aggregate/AggregateInterface.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Aggregate/AggregateInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Aggregate/AggregateParent.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Aggregate/AggregateParent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Aggregate/Child.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Aggregate/Child.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Aggregate/WithOptional.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Aggregate/WithOptional.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Child.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Child.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Child/A.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Child/A.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Child/Circular.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Child/Circular.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Child/Interceptor.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Child/Interceptor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Child/Interceptor/A.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Child/Interceptor/A.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/Child/Interceptor/B.php
+++ b/dev/tests/unit/testsuite/Magento/_files/Child/Interceptor/B.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/ChildInterface.php
+++ b/dev/tests/unit/testsuite/Magento/_files/ChildInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/DiInterface.php
+++ b/dev/tests/unit/testsuite/Magento/_files/DiInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tests/unit/testsuite/Magento/_files/DiParent.php
+++ b/dev/tests/unit/testsuite/Magento/_files/DiParent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/ArrayScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/ArrayScanner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/CompositeScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/CompositeScanner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/DirectoryScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/DirectoryScanner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/FileScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/FileScanner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/PhpScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/PhpScanner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/PluginScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/PluginScanner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/ScannerInterface.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/ScannerInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/XmlInterceptorScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/XmlInterceptorScanner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/XmlScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/XmlScanner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Compiler/Directory.php
+++ b/dev/tools/Magento/Tools/Di/Compiler/Directory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Compiler/Log/Log.php
+++ b/dev/tools/Magento/Tools/Di/Compiler/Log/Log.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Compiler/Log/Writer/Console.php
+++ b/dev/tools/Magento/Tools/Di/Compiler/Log/Writer/Console.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Compiler/Log/Writer/Quiet.php
+++ b/dev/tools/Magento/Tools/Di/Compiler/Log/Writer/Quiet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Compiler/Log/Writer/WriterInterface.php
+++ b/dev/tools/Magento/Tools/Di/Compiler/Log/Writer/WriterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Definition/Compressor.php
+++ b/dev/tools/Magento/Tools/Di/Definition/Compressor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Definition/Compressor/UniqueList.php
+++ b/dev/tools/Magento/Tools/Di/Definition/Compressor/UniqueList.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Definition/Serializer/Igbinary.php
+++ b/dev/tools/Magento/Tools/Di/Definition/Serializer/Igbinary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Definition/Serializer/SerializerInterface.php
+++ b/dev/tools/Magento/Tools/Di/Definition/Serializer/SerializerInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/Definition/Serializer/Standard.php
+++ b/dev/tools/Magento/Tools/Di/Definition/Serializer/Standard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/compiler.php
+++ b/dev/tools/Magento/Tools/Di/compiler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Di/entity_generator.php
+++ b/dev/tools/Magento/Tools/Di/entity_generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Context.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Context.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Dictionary.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Dictionary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Dictionary/Generator.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Dictionary/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Dictionary/Loader/File/AbstractFile.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Dictionary/Loader/File/AbstractFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Dictionary/Loader/File/Csv.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Dictionary/Loader/File/Csv.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Dictionary/Loader/FileInterface.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Dictionary/Loader/FileInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Dictionary/Phrase.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Dictionary/Phrase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Dictionary/Writer/Csv.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Dictionary/Writer/Csv.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Dictionary/Writer/Csv/Stdo.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Dictionary/Writer/Csv/Stdo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Dictionary/WriterInterface.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Dictionary/WriterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Factory.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/FilesCollector.php
+++ b/dev/tools/Magento/Tools/I18n/Code/FilesCollector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Locale.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Locale.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Pack/Generator.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Pack/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Pack/Writer/File/AbstractFile.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Pack/Writer/File/AbstractFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Pack/Writer/File/Csv.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Pack/Writer/File/Csv.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Pack/WriterInterface.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Pack/WriterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/AbstractParser.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/AbstractParser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/AbstractAdapter.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/AbstractAdapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Js.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Js.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Php.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Php.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Php/Tokenizer.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Php/Tokenizer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Php/Tokenizer/PhraseCollector.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Php/Tokenizer/PhraseCollector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Php/Tokenizer/Token.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Php/Tokenizer/Token.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Php/Tokenizer/Translate/MethodCollector.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Php/Tokenizer/Translate/MethodCollector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Xml.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/Adapter/Xml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/AdapterInterface.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/AdapterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/Contextual.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/Contextual.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/Parser/Parser.php
+++ b/dev/tools/Magento/Tools/I18n/Code/Parser/Parser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/ParserInterface.php
+++ b/dev/tools/Magento/Tools/I18n/Code/ParserInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Code/ServiceLocator.php
+++ b/dev/tools/Magento/Tools/I18n/Code/ServiceLocator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/Zend/Console/Getopt.php
+++ b/dev/tools/Magento/Tools/I18n/Zend/Console/Getopt.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/dev/tools/Magento/Tools/I18n/Zend/Console/Getopt/Exception.php
+++ b/dev/tools/Magento/Tools/I18n/Zend/Console/Getopt/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/dev/tools/Magento/Tools/I18n/Zend/Exception.php
+++ b/dev/tools/Magento/Tools/I18n/Zend/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/dev/tools/Magento/Tools/I18n/bootstrap.php
+++ b/dev/tools/Magento/Tools/I18n/bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/generator.php
+++ b/dev/tools/Magento/Tools/I18n/generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/I18n/pack.php
+++ b/dev/tools/Magento/Tools/I18n/pack.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Layout/Formatter.php
+++ b/dev/tools/Magento/Tools/Layout/Formatter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Layout/Reference/Processor.php
+++ b/dev/tools/Magento/Tools/Layout/Reference/Processor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Layout/processors/layoutArguments.xsl
+++ b/dev/tools/Magento/Tools/Layout/processors/layoutArguments.xsl
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Layout/processors/layoutGridContainer.xsl
+++ b/dev/tools/Magento/Tools/Layout/processors/layoutGridContainer.xsl
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Layout/processors/layoutHandles.xsl
+++ b/dev/tools/Magento/Tools/Layout/processors/layoutHandles.xsl
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Layout/processors/layoutLabels.xsl
+++ b/dev/tools/Magento/Tools/Layout/processors/layoutLabels.xsl
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Layout/processors/layoutReferences.xsl
+++ b/dev/tools/Magento/Tools/Layout/processors/layoutReferences.xsl
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Layout/processors/layoutTranslate.xsl
+++ b/dev/tools/Magento/Tools/Layout/processors/layoutTranslate.xsl
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Layout/reference.php
+++ b/dev/tools/Magento/Tools/Layout/reference.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Layout/xmlUpdater.php
+++ b/dev/tools/Magento/Tools/Layout/xmlUpdater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Db/AbstractLogger.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Db/AbstractLogger.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Db/Adapter/Factory.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Db/Adapter/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Db/FileReader.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Db/FileReader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Db/Logger/Console.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Db/Logger/Console.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Db/Logger/Factory.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Db/Logger/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Db/Logger/File.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Db/Logger/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Db/Reader.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Db/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Db/Updater.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Db/Updater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Db/Writer.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Db/Writer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/FileManager.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/FileManager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Formatter.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Formatter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Generator.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/Menu/Generator.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/Menu/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/Acl/db.php
+++ b/dev/tools/Magento/Tools/Migration/Acl/db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/AbstractLogger.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/AbstractLogger.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Formatter.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Formatter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Generator.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Logger/Console.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Logger/Console.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Logger/Factory.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Logger/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Logger/File.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Logger/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper/AbstractMapper.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper/AbstractMapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper/Field.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper/Field.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper/Group.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper/Group.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper/Section.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper/Section.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper/Tab.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Mapper/Tab.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Parser.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Parser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Configuration/Reader.php
+++ b/dev/tools/Magento/Tools/Migration/System/Configuration/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/FileManager.php
+++ b/dev/tools/Magento/Tools/Migration/System/FileManager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/FileReader.php
+++ b/dev/tools/Magento/Tools/Migration/System/FileReader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Writer/Factory.php
+++ b/dev/tools/Magento/Tools/Migration/System/Writer/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Writer/FileSystem.php
+++ b/dev/tools/Magento/Tools/Migration/System/Writer/FileSystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/Writer/Memory.php
+++ b/dev/tools/Magento/Tools/Migration/System/Writer/Memory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/System/WriterInterface.php
+++ b/dev/tools/Magento/Tools/Migration/System/WriterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/acl.php
+++ b/dev/tools/Magento/Tools/Migration/acl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/aliases_map/cms_content_tables_ce.php
+++ b/dev/tools/Magento/Tools/Migration/aliases_map/cms_content_tables_ce.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/aliases_map/composite_modules_ce.php
+++ b/dev/tools/Magento/Tools/Migration/aliases_map/composite_modules_ce.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/factory_names.php
+++ b/dev/tools/Magento/Tools/Migration/factory_names.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/factory_table_names.php
+++ b/dev/tools/Magento/Tools/Migration/factory_table_names.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/factory_table_names/blacklist_ce.php
+++ b/dev/tools/Magento/Tools/Migration/factory_table_names/blacklist_ce.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/factory_table_names/replace_ce.php
+++ b/dev/tools/Magento/Tools/Migration/factory_table_names/replace_ce.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/get_aliases_map.php
+++ b/dev/tools/Magento/Tools/Migration/get_aliases_map.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/system_config.php
+++ b/dev/tools/Magento/Tools/Migration/system_config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/Migration/themes_view.php
+++ b/dev/tools/Magento/Tools/Migration/themes_view.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/View/Generator/Config.php
+++ b/dev/tools/Magento/Tools/View/Generator/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/View/Generator/CopyRule.php
+++ b/dev/tools/Magento/Tools/View/Generator/CopyRule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/View/Generator/ThemeDeployment.php
+++ b/dev/tools/Magento/Tools/View/Generator/ThemeDeployment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/View/Generator/ThemeLight.php
+++ b/dev/tools/Magento/Tools/View/Generator/ThemeLight.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/View/config/forbidden.php
+++ b/dev/tools/Magento/Tools/View/config/forbidden.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/View/config/permitted.php
+++ b/dev/tools/Magento/Tools/View/config/permitted.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/View/generator.php
+++ b/dev/tools/Magento/Tools/View/generator.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/classmap/fs_generator.php
+++ b/dev/tools/Magento/Tools/classmap/fs_generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/classmap/log_generator.php
+++ b/dev/tools/Magento/Tools/classmap/log_generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/Magento/Tools/classmap/logger.php
+++ b/dev/tools/Magento/Tools/classmap/logger.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/bootstrap.php
+++ b/dev/tools/bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/layout/processors/addItemRenderer.xsl
+++ b/dev/tools/layout/processors/addItemRenderer.xsl
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/layout/processors/headBlocks.xsl
+++ b/dev/tools/layout/processors/headBlocks.xsl
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/layout/xml-updater.php
+++ b/dev/tools/layout/xml-updater.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/tests.php
+++ b/dev/tools/tests.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/xml/transform_logging.php
+++ b/dev/tools/xml/transform_logging.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/dev/tools/xml/translate.php
+++ b/dev/tools/xml/translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Connect.php
+++ b/downloader/app/Magento/Downloader/Connect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Connect/Frontend.php
+++ b/downloader/app/Magento/Downloader/Connect/Frontend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Controller.php
+++ b/downloader/app/Magento/Downloader/Controller.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Exception.php
+++ b/downloader/app/Magento/Downloader/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Model.php
+++ b/downloader/app/Magento/Downloader/Model.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Model/Config.php
+++ b/downloader/app/Magento/Downloader/Model/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Model/Config/AbstractConfig.php
+++ b/downloader/app/Magento/Downloader/Model/Config/AbstractConfig.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Model/Config/Community.php
+++ b/downloader/app/Magento/Downloader/Model/Config/Community.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Model/Config/ConfigInterface.php
+++ b/downloader/app/Magento/Downloader/Model/Config/ConfigInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Model/Connect.php
+++ b/downloader/app/Magento/Downloader/Model/Connect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Model/Connect/Request.php
+++ b/downloader/app/Magento/Downloader/Model/Connect/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Model/Downloader.php
+++ b/downloader/app/Magento/Downloader/Model/Downloader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/Model/Session.php
+++ b/downloader/app/Magento/Downloader/Model/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/app/Magento/Downloader/View.php
+++ b/downloader/app/Magento/Downloader/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/index.php
+++ b/downloader/index.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Archive.php
+++ b/downloader/lib/Magento/Archive.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Archive/AbstractArchive.php
+++ b/downloader/lib/Magento/Archive/AbstractArchive.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Archive/ArchiveInterface.php
+++ b/downloader/lib/Magento/Archive/ArchiveInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Archive/Bz.php
+++ b/downloader/lib/Magento/Archive/Bz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Archive/Gz.php
+++ b/downloader/lib/Magento/Archive/Gz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Archive/Helper/File.php
+++ b/downloader/lib/Magento/Archive/Helper/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Archive/Helper/File/Bz.php
+++ b/downloader/lib/Magento/Archive/Helper/File/Bz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Archive/Helper/File/Gz.php
+++ b/downloader/lib/Magento/Archive/Helper/File/Gz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Archive/Tar.php
+++ b/downloader/lib/Magento/Archive/Tar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Autoload/Simple.php
+++ b/downloader/lib/Magento/Autoload/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup.php
+++ b/downloader/lib/Magento/Backup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/AbstractBackup.php
+++ b/downloader/lib/Magento/Backup/AbstractBackup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Archive/Tar.php
+++ b/downloader/lib/Magento/Backup/Archive/Tar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/BackupInterface.php
+++ b/downloader/lib/Magento/Backup/BackupInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Db.php
+++ b/downloader/lib/Magento/Backup/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Exception.php
+++ b/downloader/lib/Magento/Backup/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Exception/CantLoadSnapshot.php
+++ b/downloader/lib/Magento/Backup/Exception/CantLoadSnapshot.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Exception/FtpConnectionFailed.php
+++ b/downloader/lib/Magento/Backup/Exception/FtpConnectionFailed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Exception/FtpValidationFailed.php
+++ b/downloader/lib/Magento/Backup/Exception/FtpValidationFailed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Exception/NotEnoughFreeSpace.php
+++ b/downloader/lib/Magento/Backup/Exception/NotEnoughFreeSpace.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Exception/NotEnoughPermissions.php
+++ b/downloader/lib/Magento/Backup/Exception/NotEnoughPermissions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Filesystem.php
+++ b/downloader/lib/Magento/Backup/Filesystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Filesystem/Helper.php
+++ b/downloader/lib/Magento/Backup/Filesystem/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Filesystem/Iterator/File.php
+++ b/downloader/lib/Magento/Backup/Filesystem/Iterator/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Filesystem/Iterator/Filter.php
+++ b/downloader/lib/Magento/Backup/Filesystem/Iterator/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Filesystem/Rollback/AbstractRollback.php
+++ b/downloader/lib/Magento/Backup/Filesystem/Rollback/AbstractRollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Filesystem/Rollback/Fs.php
+++ b/downloader/lib/Magento/Backup/Filesystem/Rollback/Fs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Filesystem/Rollback/Ftp.php
+++ b/downloader/lib/Magento/Backup/Filesystem/Rollback/Ftp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Media.php
+++ b/downloader/lib/Magento/Backup/Media.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Nomedia.php
+++ b/downloader/lib/Magento/Backup/Nomedia.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Backup/Snapshot.php
+++ b/downloader/lib/Magento/Backup/Snapshot.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Channel/Generator.php
+++ b/downloader/lib/Magento/Connect/Channel/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Channel/Parser.php
+++ b/downloader/lib/Magento/Connect/Channel/Parser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Channel/VO.php
+++ b/downloader/lib/Magento/Connect/Channel/VO.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command.php
+++ b/downloader/lib/Magento/Connect/Command.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Channels.php
+++ b/downloader/lib/Magento/Connect/Command/Channels.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Channels_Header.php
+++ b/downloader/lib/Magento/Connect/Command/Channels_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Config.php
+++ b/downloader/lib/Magento/Connect/Command/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Config_Header.php
+++ b/downloader/lib/Magento/Connect/Command/Config_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Install.php
+++ b/downloader/lib/Magento/Connect/Command/Install.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Install_Header.php
+++ b/downloader/lib/Magento/Connect/Command/Install_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Package.php
+++ b/downloader/lib/Magento/Connect/Command/Package.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Package_Header.php
+++ b/downloader/lib/Magento/Connect/Command/Package_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Registry.php
+++ b/downloader/lib/Magento/Connect/Command/Registry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Registry_Header.php
+++ b/downloader/lib/Magento/Connect/Command/Registry_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Remote.php
+++ b/downloader/lib/Magento/Connect/Command/Remote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Command/Remote_Header.php
+++ b/downloader/lib/Magento/Connect/Command/Remote_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Config.php
+++ b/downloader/lib/Magento/Connect/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Converter.php
+++ b/downloader/lib/Magento/Connect/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Frontend.php
+++ b/downloader/lib/Magento/Connect/Frontend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Frontend/CLI.php
+++ b/downloader/lib/Magento/Connect/Frontend/CLI.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Ftp.php
+++ b/downloader/lib/Magento/Connect/Ftp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Loader.php
+++ b/downloader/lib/Magento/Connect/Loader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Loader/Ftp.php
+++ b/downloader/lib/Magento/Connect/Loader/Ftp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Package.php
+++ b/downloader/lib/Magento/Connect/Package.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Package/Hotfix.php
+++ b/downloader/lib/Magento/Connect/Package/Hotfix.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Package/Reader.php
+++ b/downloader/lib/Magento/Connect/Package/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Package/Target.php
+++ b/downloader/lib/Magento/Connect/Package/Target.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Package/VO.php
+++ b/downloader/lib/Magento/Connect/Package/VO.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Package/Writer.php
+++ b/downloader/lib/Magento/Connect/Package/Writer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Packager.php
+++ b/downloader/lib/Magento/Connect/Packager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Rest.php
+++ b/downloader/lib/Magento/Connect/Rest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Singleconfig.php
+++ b/downloader/lib/Magento/Connect/Singleconfig.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Structures/Graph.php
+++ b/downloader/lib/Magento/Connect/Structures/Graph.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Structures/Node.php
+++ b/downloader/lib/Magento/Connect/Structures/Node.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Connect/Validator.php
+++ b/downloader/lib/Magento/Connect/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Exception.php
+++ b/downloader/lib/Magento/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/HTTP/Client.php
+++ b/downloader/lib/Magento/HTTP/Client.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/HTTP/Client/Curl.php
+++ b/downloader/lib/Magento/HTTP/Client/Curl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/HTTP/Client/Socket.php
+++ b/downloader/lib/Magento/HTTP/Client/Socket.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/HTTP/IClient.php
+++ b/downloader/lib/Magento/HTTP/IClient.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/System/Args.php
+++ b/downloader/lib/Magento/System/Args.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/System/Dirs.php
+++ b/downloader/lib/Magento/System/Dirs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/System/Ftp.php
+++ b/downloader/lib/Magento/System/Ftp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Util.php
+++ b/downloader/lib/Magento/Util.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Xml/Generator.php
+++ b/downloader/lib/Magento/Xml/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/lib/Magento/Xml/Parser.php
+++ b/downloader/lib/Magento/Xml/Parser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/mage.php
+++ b/downloader/mage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/skin/boxes.css
+++ b/downloader/skin/boxes.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/skin/ie7boxes.css
+++ b/downloader/skin/ie7boxes.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/skin/ieboxes.css
+++ b/downloader/skin/ieboxes.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/skin/install/boxes.css
+++ b/downloader/skin/install/boxes.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/skin/install/clears.css
+++ b/downloader/skin/install/clears.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/skin/install/ie7minus.css
+++ b/downloader/skin/install/ie7minus.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/skin/install/iestyles.css
+++ b/downloader/skin/install/iestyles.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/skin/install/reset.css
+++ b/downloader/skin/install/reset.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/target.xml
+++ b/downloader/target.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/connect/iframe.phtml
+++ b/downloader/template/connect/iframe.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/connect/packages.phtml
+++ b/downloader/template/connect/packages.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/connect/packages_prepare.phtml
+++ b/downloader/template/connect/packages_prepare.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/exception.phtml
+++ b/downloader/template/exception.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/footer.phtml
+++ b/downloader/template/footer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/header.phtml
+++ b/downloader/template/header.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/index.phtml
+++ b/downloader/template/index.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/install/download.phtml
+++ b/downloader/template/install/download.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/install/footer.phtml
+++ b/downloader/template/install/footer.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/install/header.phtml
+++ b/downloader/template/install/header.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/install/writable.phtml
+++ b/downloader/template/install/writable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/login.phtml
+++ b/downloader/template/login.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/messages.phtml
+++ b/downloader/template/messages.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/noroute.phtml
+++ b/downloader/template/noroute.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/settings.phtml
+++ b/downloader/template/settings.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/downloader/template/writable.phtml
+++ b/downloader/template/writable.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/index.php
+++ b/index.php
@@ -20,7 +20,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl.php
+++ b/lib/Magento/Acl.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Builder.php
+++ b/lib/Magento/Acl/Builder.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/CacheInterface.php
+++ b/lib/Magento/Acl/CacheInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Loader/DefaultLoader.php
+++ b/lib/Magento/Acl/Loader/DefaultLoader.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Loader/Resource.php
+++ b/lib/Magento/Acl/Loader/Resource.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/LoaderInterface.php
+++ b/lib/Magento/Acl/LoaderInterface.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Resource.php
+++ b/lib/Magento/Acl/Resource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Resource/Config/Converter/Dom.php
+++ b/lib/Magento/Acl/Resource/Config/Converter/Dom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Resource/Config/Dom.php
+++ b/lib/Magento/Acl/Resource/Config/Dom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Resource/Config/Reader/Filesystem.php
+++ b/lib/Magento/Acl/Resource/Config/Reader/Filesystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Resource/Config/SchemaLocator.php
+++ b/lib/Magento/Acl/Resource/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Resource/Provider.php
+++ b/lib/Magento/Acl/Resource/Provider.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Resource/ProviderInterface.php
+++ b/lib/Magento/Acl/Resource/ProviderInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Resource/TreeBuilder.php
+++ b/lib/Magento/Acl/Resource/TreeBuilder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/ResourceFactory.php
+++ b/lib/Magento/Acl/ResourceFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/Role/Registry.php
+++ b/lib/Magento/Acl/Role/Registry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Acl/etc/acl.xsd
+++ b/lib/Magento/Acl/etc/acl.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/AclFactory.php
+++ b/lib/Magento/AclFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Archive.php
+++ b/lib/Magento/Archive.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Archive/AbstractArchive.php
+++ b/lib/Magento/Archive/AbstractArchive.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Archive/ArchiveInterface.php
+++ b/lib/Magento/Archive/ArchiveInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Archive/Bz.php
+++ b/lib/Magento/Archive/Bz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Archive/Gz.php
+++ b/lib/Magento/Archive/Gz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Archive/Helper/File.php
+++ b/lib/Magento/Archive/Helper/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Archive/Helper/File/Bz.php
+++ b/lib/Magento/Archive/Helper/File/Bz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Archive/Helper/File/Gz.php
+++ b/lib/Magento/Archive/Helper/File/Gz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Archive/Tar.php
+++ b/lib/Magento/Archive/Tar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Authorization.php
+++ b/lib/Magento/Authorization.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Authorization/Factory.php
+++ b/lib/Magento/Authorization/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Authorization/Policy.php
+++ b/lib/Magento/Authorization/Policy.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Authorization/Policy/Acl.php
+++ b/lib/Magento/Authorization/Policy/Acl.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Authorization/Policy/DefaultPolicy.php
+++ b/lib/Magento/Authorization/Policy/DefaultPolicy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Authorization/RoleLocator.php
+++ b/lib/Magento/Authorization/RoleLocator.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Authorization/RoleLocator/DefaultRoleLocator.php
+++ b/lib/Magento/Authorization/RoleLocator/DefaultRoleLocator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/AuthorizationInterface.php
+++ b/lib/Magento/AuthorizationInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Autoload/ClassMap.php
+++ b/lib/Magento/Autoload/ClassMap.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Autoload/IncludePath.php
+++ b/lib/Magento/Autoload/IncludePath.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Autoload/Simple.php
+++ b/lib/Magento/Autoload/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup.php
+++ b/lib/Magento/Backup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/AbstractBackup.php
+++ b/lib/Magento/Backup/AbstractBackup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Archive/Tar.php
+++ b/lib/Magento/Backup/Archive/Tar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/BackupException.php
+++ b/lib/Magento/Backup/BackupException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/BackupInterface.php
+++ b/lib/Magento/Backup/BackupInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Db.php
+++ b/lib/Magento/Backup/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Exception/CantLoadSnapshot.php
+++ b/lib/Magento/Backup/Exception/CantLoadSnapshot.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Exception/FtpConnectionFailed.php
+++ b/lib/Magento/Backup/Exception/FtpConnectionFailed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Exception/FtpValidationFailed.php
+++ b/lib/Magento/Backup/Exception/FtpValidationFailed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Exception/NotEnoughFreeSpace.php
+++ b/lib/Magento/Backup/Exception/NotEnoughFreeSpace.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Exception/NotEnoughPermissions.php
+++ b/lib/Magento/Backup/Exception/NotEnoughPermissions.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Filesystem.php
+++ b/lib/Magento/Backup/Filesystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Filesystem/Helper.php
+++ b/lib/Magento/Backup/Filesystem/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Filesystem/Iterator/File.php
+++ b/lib/Magento/Backup/Filesystem/Iterator/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Filesystem/Iterator/Filter.php
+++ b/lib/Magento/Backup/Filesystem/Iterator/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Filesystem/Rollback/AbstractRollback.php
+++ b/lib/Magento/Backup/Filesystem/Rollback/AbstractRollback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Filesystem/Rollback/Fs.php
+++ b/lib/Magento/Backup/Filesystem/Rollback/Fs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Filesystem/Rollback/Ftp.php
+++ b/lib/Magento/Backup/Filesystem/Rollback/Ftp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Media.php
+++ b/lib/Magento/Backup/Media.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Nomedia.php
+++ b/lib/Magento/Backup/Nomedia.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Backup/Snapshot.php
+++ b/lib/Magento/Backup/Snapshot.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/BootstrapException.php
+++ b/lib/Magento/BootstrapException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Backend/Database.php
+++ b/lib/Magento/Cache/Backend/Database.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Backend/Decorator/AbstractDecorator.php
+++ b/lib/Magento/Cache/Backend/Decorator/AbstractDecorator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Backend/Decorator/Compression.php
+++ b/lib/Magento/Cache/Backend/Decorator/Compression.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Backend/Eaccelerator.php
+++ b/lib/Magento/Cache/Backend/Eaccelerator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Backend/Memcached.php
+++ b/lib/Magento/Cache/Backend/Memcached.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Backend/MongoDb.php
+++ b/lib/Magento/Cache/Backend/MongoDb.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Core.php
+++ b/lib/Magento/Cache/Core.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Frontend/Adapter/Zend.php
+++ b/lib/Magento/Cache/Frontend/Adapter/Zend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Frontend/Decorator/Bare.php
+++ b/lib/Magento/Cache/Frontend/Decorator/Bare.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Frontend/Decorator/Profiler.php
+++ b/lib/Magento/Cache/Frontend/Decorator/Profiler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/Frontend/Decorator/TagScope.php
+++ b/lib/Magento/Cache/Frontend/Decorator/TagScope.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Cache/FrontendInterface.php
+++ b/lib/Magento/Cache/FrontendInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Generator.php
+++ b/lib/Magento/Code/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Generator/ClassGenerator.php
+++ b/lib/Magento/Code/Generator/ClassGenerator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Generator/CodeGenerator/CodeGeneratorInterface.php
+++ b/lib/Magento/Code/Generator/CodeGenerator/CodeGeneratorInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Generator/CodeGenerator/Zend.php
+++ b/lib/Magento/Code/Generator/CodeGenerator/Zend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Generator/DefinitionDecorator.php
+++ b/lib/Magento/Code/Generator/DefinitionDecorator.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Generator/EntityAbstract.php
+++ b/lib/Magento/Code/Generator/EntityAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Generator/Factory.php
+++ b/lib/Magento/Code/Generator/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Generator/Interceptor.php
+++ b/lib/Magento/Code/Generator/Interceptor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Generator/Io.php
+++ b/lib/Magento/Code/Generator/Io.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Generator/Proxy.php
+++ b/lib/Magento/Code/Generator/Proxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Minifier.php
+++ b/lib/Magento/Code/Minifier.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Minifier/Adapter/Js/Jsmin.php
+++ b/lib/Magento/Code/Minifier/Adapter/Js/Jsmin.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Minifier/AdapterInterface.php
+++ b/lib/Magento/Code/Minifier/AdapterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Minifier/Strategy/Generate.php
+++ b/lib/Magento/Code/Minifier/Strategy/Generate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Minifier/Strategy/Lite.php
+++ b/lib/Magento/Code/Minifier/Strategy/Lite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Minifier/StrategyInterface.php
+++ b/lib/Magento/Code/Minifier/StrategyInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Plugin/InvocationChain.php
+++ b/lib/Magento/Code/Plugin/InvocationChain.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Code/Reader/ClassReader.php
+++ b/lib/Magento/Code/Reader/ClassReader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/AbstractXml.php
+++ b/lib/Magento/Config/AbstractXml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/CacheInterface.php
+++ b/lib/Magento/Config/CacheInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/Converter/Dom.php
+++ b/lib/Magento/Config/Converter/Dom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/Converter/Dom/Flat.php
+++ b/lib/Magento/Config/Converter/Dom/Flat.php
@@ -23,7 +23,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/ConverterInterface.php
+++ b/lib/Magento/Config/ConverterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/Data.php
+++ b/lib/Magento/Config/Data.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/Data/Scoped.php
+++ b/lib/Magento/Config/Data/Scoped.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/DataInterface.php
+++ b/lib/Magento/Config/DataInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/Dom.php
+++ b/lib/Magento/Config/Dom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/Dom/Converter/ArrayConverter.php
+++ b/lib/Magento/Config/Dom/Converter/ArrayConverter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/Dom/ValidationException.php
+++ b/lib/Magento/Config/Dom/ValidationException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/DomFactory.php
+++ b/lib/Magento/Config/DomFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/FileResolverInterface.php
+++ b/lib/Magento/Config/FileResolverInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/Reader/Filesystem.php
+++ b/lib/Magento/Config/Reader/Filesystem.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/ReaderInterface.php
+++ b/lib/Magento/Config/ReaderInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/SchemaLocatorInterface.php
+++ b/lib/Magento/Config/SchemaLocatorInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/ScopeInterface.php
+++ b/lib/Magento/Config/ScopeInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/Theme.php
+++ b/lib/Magento/Config/Theme.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/ValidationStateInterface.php
+++ b/lib/Magento/Config/ValidationStateInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/View.php
+++ b/lib/Magento/Config/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/etc/theme.xsd
+++ b/lib/Magento/Config/etc/theme.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Config/etc/view.xsd
+++ b/lib/Magento/Config/etc/view.xsd
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Channel/Generator.php
+++ b/lib/Magento/Connect/Channel/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Channel/Parser.php
+++ b/lib/Magento/Connect/Channel/Parser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Channel/VO.php
+++ b/lib/Magento/Connect/Channel/VO.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command.php
+++ b/lib/Magento/Connect/Command.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Channels.php
+++ b/lib/Magento/Connect/Command/Channels.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Channels_Header.php
+++ b/lib/Magento/Connect/Command/Channels_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Config.php
+++ b/lib/Magento/Connect/Command/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Config_Header.php
+++ b/lib/Magento/Connect/Command/Config_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Install.php
+++ b/lib/Magento/Connect/Command/Install.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Install_Header.php
+++ b/lib/Magento/Connect/Command/Install_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Package.php
+++ b/lib/Magento/Connect/Command/Package.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Package_Header.php
+++ b/lib/Magento/Connect/Command/Package_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Registry.php
+++ b/lib/Magento/Connect/Command/Registry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Registry_Header.php
+++ b/lib/Magento/Connect/Command/Registry_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Remote.php
+++ b/lib/Magento/Connect/Command/Remote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Command/Remote_Header.php
+++ b/lib/Magento/Connect/Command/Remote_Header.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Config.php
+++ b/lib/Magento/Connect/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Converter.php
+++ b/lib/Magento/Connect/Converter.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Frontend.php
+++ b/lib/Magento/Connect/Frontend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Frontend/CLI.php
+++ b/lib/Magento/Connect/Frontend/CLI.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Ftp.php
+++ b/lib/Magento/Connect/Ftp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Loader.php
+++ b/lib/Magento/Connect/Loader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Loader/Ftp.php
+++ b/lib/Magento/Connect/Loader/Ftp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Package.php
+++ b/lib/Magento/Connect/Package.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Package/Hotfix.php
+++ b/lib/Magento/Connect/Package/Hotfix.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Package/Reader.php
+++ b/lib/Magento/Connect/Package/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Package/Target.php
+++ b/lib/Magento/Connect/Package/Target.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Package/VO.php
+++ b/lib/Magento/Connect/Package/VO.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Package/Writer.php
+++ b/lib/Magento/Connect/Package/Writer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Packager.php
+++ b/lib/Magento/Connect/Packager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Rest.php
+++ b/lib/Magento/Connect/Rest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Singleconfig.php
+++ b/lib/Magento/Connect/Singleconfig.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Structures/Graph.php
+++ b/lib/Magento/Connect/Structures/Graph.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Structures/Node.php
+++ b/lib/Magento/Connect/Structures/Node.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Connect/Validator.php
+++ b/lib/Magento/Connect/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Convert/Container/AbstractContainer.php
+++ b/lib/Magento/Convert/Container/AbstractContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Convert/ConvertException.php
+++ b/lib/Magento/Convert/ConvertException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Convert/Excel.php
+++ b/lib/Magento/Convert/Excel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Convert/Mapper/Column.php
+++ b/lib/Magento/Convert/Mapper/Column.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Convert/Mapper/MapperInterface.php
+++ b/lib/Magento/Convert/Mapper/MapperInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Convert/Object.php
+++ b/lib/Magento/Convert/Object.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Crypt.php
+++ b/lib/Magento/Crypt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Adapter/AdapterInterface.php
+++ b/lib/Magento/DB/Adapter/AdapterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Adapter/Pdo/Mysql.php
+++ b/lib/Magento/DB/Adapter/Pdo/Mysql.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/DBException.php
+++ b/lib/Magento/DB/DBException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Ddl/Table.php
+++ b/lib/Magento/DB/Ddl/Table.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Helper.php
+++ b/lib/Magento/DB/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Profiler.php
+++ b/lib/Magento/DB/Profiler.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Select.php
+++ b/lib/Magento/DB/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Statement/Parameter.php
+++ b/lib/Magento/DB/Statement/Parameter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Statement/Pdo/Mysql.php
+++ b/lib/Magento/DB/Statement/Pdo/Mysql.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Tree.php
+++ b/lib/Magento/DB/Tree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Tree/Node.php
+++ b/lib/Magento/DB/Tree/Node.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Tree/Node/NodeException.php
+++ b/lib/Magento/DB/Tree/Node/NodeException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Tree/NodeSet.php
+++ b/lib/Magento/DB/Tree/NodeSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Tree/NodeSet/NodeSetException.php
+++ b/lib/Magento/DB/Tree/NodeSet/NodeSetException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/DB/Tree/TreeException.php
+++ b/lib/Magento/DB/Tree/TreeException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Collection.php
+++ b/lib/Magento/Data/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Collection/Db.php
+++ b/lib/Magento/Data/Collection/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Collection/Db/FetchStrategy/Cache.php
+++ b/lib/Magento/Data/Collection/Db/FetchStrategy/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Collection/Db/FetchStrategy/Query.php
+++ b/lib/Magento/Data/Collection/Db/FetchStrategy/Query.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Collection/Db/FetchStrategyInterface.php
+++ b/lib/Magento/Data/Collection/Db/FetchStrategyInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Collection/Filesystem.php
+++ b/lib/Magento/Data/Collection/Filesystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form.php
+++ b/lib/Magento/Data/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/AbstractForm.php
+++ b/lib/Magento/Data/Form/AbstractForm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/AbstractElement.php
+++ b/lib/Magento/Data/Form/Element/AbstractElement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Button.php
+++ b/lib/Magento/Data/Form/Element/Button.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Checkbox.php
+++ b/lib/Magento/Data/Form/Element/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Checkboxes.php
+++ b/lib/Magento/Data/Form/Element/Checkboxes.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Collection.php
+++ b/lib/Magento/Data/Form/Element/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Column.php
+++ b/lib/Magento/Data/Form/Element/Column.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Date.php
+++ b/lib/Magento/Data/Form/Element/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Editablemultiselect.php
+++ b/lib/Magento/Data/Form/Element/Editablemultiselect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Editor.php
+++ b/lib/Magento/Data/Form/Element/Editor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Factory.php
+++ b/lib/Magento/Data/Form/Element/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Fieldset.php
+++ b/lib/Magento/Data/Form/Element/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/File.php
+++ b/lib/Magento/Data/Form/Element/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Gallery.php
+++ b/lib/Magento/Data/Form/Element/Gallery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Hidden.php
+++ b/lib/Magento/Data/Form/Element/Hidden.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Image.php
+++ b/lib/Magento/Data/Form/Element/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Imagefile.php
+++ b/lib/Magento/Data/Form/Element/Imagefile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Label.php
+++ b/lib/Magento/Data/Form/Element/Label.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Link.php
+++ b/lib/Magento/Data/Form/Element/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Multiline.php
+++ b/lib/Magento/Data/Form/Element/Multiline.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Multiselect.php
+++ b/lib/Magento/Data/Form/Element/Multiselect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Note.php
+++ b/lib/Magento/Data/Form/Element/Note.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Obscure.php
+++ b/lib/Magento/Data/Form/Element/Obscure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Password.php
+++ b/lib/Magento/Data/Form/Element/Password.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Radio.php
+++ b/lib/Magento/Data/Form/Element/Radio.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Radios.php
+++ b/lib/Magento/Data/Form/Element/Radios.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Renderer/RendererInterface.php
+++ b/lib/Magento/Data/Form/Element/Renderer/RendererInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Reset.php
+++ b/lib/Magento/Data/Form/Element/Reset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Select.php
+++ b/lib/Magento/Data/Form/Element/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Submit.php
+++ b/lib/Magento/Data/Form/Element/Submit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Text.php
+++ b/lib/Magento/Data/Form/Element/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Textarea.php
+++ b/lib/Magento/Data/Form/Element/Textarea.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Element/Time.php
+++ b/lib/Magento/Data/Form/Element/Time.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/ElementFactory.php
+++ b/lib/Magento/Data/Form/ElementFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Filter/Date.php
+++ b/lib/Magento/Data/Form/Filter/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Filter/Escapehtml.php
+++ b/lib/Magento/Data/Form/Filter/Escapehtml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Filter/FilterInterface.php
+++ b/lib/Magento/Data/Form/Filter/FilterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Form/Filter/Striptags.php
+++ b/lib/Magento/Data/Form/Filter/Striptags.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Tree.php
+++ b/lib/Magento/Data/Tree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Tree/Db.php
+++ b/lib/Magento/Data/Tree/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Tree/Dbp.php
+++ b/lib/Magento/Data/Tree/Dbp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Tree/Node.php
+++ b/lib/Magento/Data/Tree/Node.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Data/Tree/Node/Collection.php
+++ b/lib/Magento/Data/Tree/Node/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Date.php
+++ b/lib/Magento/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Debug.php
+++ b/lib/Magento/Debug.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Event.php
+++ b/lib/Magento/Event.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Event/Collection.php
+++ b/lib/Magento/Event/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Event/Observer.php
+++ b/lib/Magento/Event/Observer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Event/Observer/Collection.php
+++ b/lib/Magento/Event/Observer/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Event/Observer/Cron.php
+++ b/lib/Magento/Event/Observer/Cron.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Event/Observer/Regex.php
+++ b/lib/Magento/Event/Observer/Regex.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Exception.php
+++ b/lib/Magento/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/File/Csv.php
+++ b/lib/Magento/File/Csv.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/File/CsvMulty.php
+++ b/lib/Magento/File/CsvMulty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/File/Size.php
+++ b/lib/Magento/File/Size.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/File/Transfer/Adapter/Http.php
+++ b/lib/Magento/File/Transfer/Adapter/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/File/Uploader.php
+++ b/lib/Magento/File/Uploader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem.php
+++ b/lib/Magento/Filesystem.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem/Adapter/Local.php
+++ b/lib/Magento/Filesystem/Adapter/Local.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem/Adapter/Zlib.php
+++ b/lib/Magento/Filesystem/Adapter/Zlib.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem/AdapterInterface.php
+++ b/lib/Magento/Filesystem/AdapterInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem/FilesystemException.php
+++ b/lib/Magento/Filesystem/FilesystemException.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem/Stream/FactoryInterface.php
+++ b/lib/Magento/Filesystem/Stream/FactoryInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem/Stream/Local.php
+++ b/lib/Magento/Filesystem/Stream/Local.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem/Stream/Mode.php
+++ b/lib/Magento/Filesystem/Stream/Mode.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem/Stream/Mode/Zlib.php
+++ b/lib/Magento/Filesystem/Stream/Mode/Zlib.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem/Stream/Zlib.php
+++ b/lib/Magento/Filesystem/Stream/Zlib.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filesystem/StreamInterface.php
+++ b/lib/Magento/Filesystem/StreamInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/ArrayFilter.php
+++ b/lib/Magento/Filter/ArrayFilter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/Email.php
+++ b/lib/Magento/Filter/Email.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/GridArray/Grid.php
+++ b/lib/Magento/Filter/GridArray/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/Money.php
+++ b/lib/Magento/Filter/Money.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/Object.php
+++ b/lib/Magento/Filter/Object.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/Object/Grid.php
+++ b/lib/Magento/Filter/Object/Grid.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/Sprintf.php
+++ b/lib/Magento/Filter/Sprintf.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/Template.php
+++ b/lib/Magento/Filter/Template.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/Template/Simple.php
+++ b/lib/Magento/Filter/Template/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/Template/Tokenizer/AbstractTokenizer.php
+++ b/lib/Magento/Filter/Template/Tokenizer/AbstractTokenizer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/Template/Tokenizer/Parameter.php
+++ b/lib/Magento/Filter/Template/Tokenizer/Parameter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Filter/Template/Tokenizer/Variable.php
+++ b/lib/Magento/Filter/Template/Tokenizer/Variable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Gdata/Gshopping/Content.php
+++ b/lib/Magento/Gdata/Gshopping/Content.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Gdata/Gshopping/Entry.php
+++ b/lib/Magento/Gdata/Gshopping/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Gdata/Gshopping/Extension/Attribute.php
+++ b/lib/Magento/Gdata/Gshopping/Extension/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Gdata/Gshopping/Extension/Control.php
+++ b/lib/Magento/Gdata/Gshopping/Extension/Control.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Gdata/Gshopping/Extension/Shipping.php
+++ b/lib/Magento/Gdata/Gshopping/Extension/Shipping.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Gdata/Gshopping/Extension/Tax.php
+++ b/lib/Magento/Gdata/Gshopping/Extension/Tax.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Gdata/Gshopping/HttpException.php
+++ b/lib/Magento/Gdata/Gshopping/HttpException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Gdata/Gshopping/ItemQuery.php
+++ b/lib/Magento/Gdata/Gshopping/ItemQuery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/HTTP/Adapter/Curl.php
+++ b/lib/Magento/HTTP/Adapter/Curl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/HTTP/Client.php
+++ b/lib/Magento/HTTP/Client.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/HTTP/Client/Curl.php
+++ b/lib/Magento/HTTP/Client/Curl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/HTTP/Client/Socket.php
+++ b/lib/Magento/HTTP/Client/Socket.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/HTTP/Handler/Composite.php
+++ b/lib/Magento/HTTP/Handler/Composite.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/HTTP/HandlerFactory.php
+++ b/lib/Magento/HTTP/HandlerFactory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/HTTP/HandlerInterface.php
+++ b/lib/Magento/HTTP/HandlerInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/HTTP/IClient.php
+++ b/lib/Magento/HTTP/IClient.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/HTTP/ZendClient.php
+++ b/lib/Magento/HTTP/ZendClient.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Image.php
+++ b/lib/Magento/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Image/Adapter/AbstractAdapter.php
+++ b/lib/Magento/Image/Adapter/AbstractAdapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Image/Adapter/Gd2.php
+++ b/lib/Magento/Image/Adapter/Gd2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Image/Adapter/ImageMagick.php
+++ b/lib/Magento/Image/Adapter/ImageMagick.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Interception/CodeGenerator.php
+++ b/lib/Magento/Interception/CodeGenerator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Interception/CodeGenerator/CodeGenerator.php
+++ b/lib/Magento/Interception/CodeGenerator/CodeGenerator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Interception/Config.php
+++ b/lib/Magento/Interception/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Interception/Config/Config.php
+++ b/lib/Magento/Interception/Config/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Interception/Definition.php
+++ b/lib/Magento/Interception/Definition.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Interception/Definition/Compiled.php
+++ b/lib/Magento/Interception/Definition/Compiled.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Interception/Definition/Runtime.php
+++ b/lib/Magento/Interception/Definition/Runtime.php
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Interception/FactoryDecorator.php
+++ b/lib/Magento/Interception/FactoryDecorator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Interception/PluginList.php
+++ b/lib/Magento/Interception/PluginList.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Interception/PluginList/PluginList.php
+++ b/lib/Magento/Interception/PluginList/PluginList.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Io/AbstractIo.php
+++ b/lib/Magento/Io/AbstractIo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Io/File.php
+++ b/lib/Magento/Io/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Io/Ftp.php
+++ b/lib/Magento/Io/Ftp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Io/IoException.php
+++ b/lib/Magento/Io/IoException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Io/IoInterface.php
+++ b/lib/Magento/Io/IoInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Io/Sftp.php
+++ b/lib/Magento/Io/Sftp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Object.php
+++ b/lib/Magento/Object.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Object/Cache.php
+++ b/lib/Magento/Object/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Object/Factory.php
+++ b/lib/Magento/Object/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Object/Mapper.php
+++ b/lib/Magento/Object/Mapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager.php
+++ b/lib/Magento/ObjectManager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Config.php
+++ b/lib/Magento/ObjectManager/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Config/Config.php
+++ b/lib/Magento/ObjectManager/Config/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Config/Mapper/Dom.php
+++ b/lib/Magento/ObjectManager/Config/Mapper/Dom.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Config/Reader/Dom.php
+++ b/lib/Magento/ObjectManager/Config/Reader/Dom.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Config/SchemaLocator.php
+++ b/lib/Magento/ObjectManager/Config/SchemaLocator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/ConfigCache.php
+++ b/lib/Magento/ObjectManager/ConfigCache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/ContextInterface.php
+++ b/lib/Magento/ObjectManager/ContextInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Definition.php
+++ b/lib/Magento/ObjectManager/Definition.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Definition/Compiled.php
+++ b/lib/Magento/ObjectManager/Definition/Compiled.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Definition/Compiled/Binary.php
+++ b/lib/Magento/ObjectManager/Definition/Compiled/Binary.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Definition/Compiled/Serialized.php
+++ b/lib/Magento/ObjectManager/Definition/Compiled/Serialized.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Definition/Runtime.php
+++ b/lib/Magento/ObjectManager/Definition/Runtime.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Factory.php
+++ b/lib/Magento/ObjectManager/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Factory/Factory.php
+++ b/lib/Magento/ObjectManager/Factory/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/ObjectManager.php
+++ b/lib/Magento/ObjectManager/ObjectManager.php
@@ -16,7 +16,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Relations.php
+++ b/lib/Magento/ObjectManager/Relations.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/Relations/Runtime.php
+++ b/lib/Magento/ObjectManager/Relations/Runtime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ObjectManager/etc/config.xsd
+++ b/lib/Magento/ObjectManager/etc/config.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/Authentication/Factory.php
+++ b/lib/Magento/Outbound/Authentication/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/Authentication/Hmac.php
+++ b/lib/Magento/Outbound/Authentication/Hmac.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/AuthenticationInterface.php
+++ b/lib/Magento/Outbound/AuthenticationInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/EndpointInterface.php
+++ b/lib/Magento/Outbound/EndpointInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/Formatter/Factory.php
+++ b/lib/Magento/Outbound/Formatter/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/Formatter/Json.php
+++ b/lib/Magento/Outbound/Formatter/Json.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/FormatterInterface.php
+++ b/lib/Magento/Outbound/FormatterInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/Message.php
+++ b/lib/Magento/Outbound/Message.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/Message/Factory.php
+++ b/lib/Magento/Outbound/Message/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/Message/FactoryInterface.php
+++ b/lib/Magento/Outbound/Message/FactoryInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/MessageInterface.php
+++ b/lib/Magento/Outbound/MessageInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/Transport/Http.php
+++ b/lib/Magento/Outbound/Transport/Http.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/Transport/Http/Response.php
+++ b/lib/Magento/Outbound/Transport/Http/Response.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/TransportInterface.php
+++ b/lib/Magento/Outbound/TransportInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Outbound/UserInterface.php
+++ b/lib/Magento/Outbound/UserInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Pear.php
+++ b/lib/Magento/Pear.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Pear/Frontend.php
+++ b/lib/Magento/Pear/Frontend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Pear/Package.php
+++ b/lib/Magento/Pear/Package.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Pear/Registry.php
+++ b/lib/Magento/Pear/Registry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Phrase.php
+++ b/lib/Magento/Phrase.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Phrase/Renderer/Composite.php
+++ b/lib/Magento/Phrase/Renderer/Composite.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Phrase/Renderer/Factory.php
+++ b/lib/Magento/Phrase/Renderer/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Phrase/Renderer/Placeholder.php
+++ b/lib/Magento/Phrase/Renderer/Placeholder.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Phrase/Renderer/Translate.php
+++ b/lib/Magento/Phrase/Renderer/Translate.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Phrase/RendererInterface.php
+++ b/lib/Magento/Phrase/RendererInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler.php
+++ b/lib/Magento/Profiler.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler/Driver/Factory.php
+++ b/lib/Magento/Profiler/Driver/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler/Driver/Standard.php
+++ b/lib/Magento/Profiler/Driver/Standard.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler/Driver/Standard/AbstractOutput.php
+++ b/lib/Magento/Profiler/Driver/Standard/AbstractOutput.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler/Driver/Standard/Output/Csvfile.php
+++ b/lib/Magento/Profiler/Driver/Standard/Output/Csvfile.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler/Driver/Standard/Output/Factory.php
+++ b/lib/Magento/Profiler/Driver/Standard/Output/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler/Driver/Standard/Output/Firebug.php
+++ b/lib/Magento/Profiler/Driver/Standard/Output/Firebug.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler/Driver/Standard/Output/Html.php
+++ b/lib/Magento/Profiler/Driver/Standard/Output/Html.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler/Driver/Standard/OutputInterface.php
+++ b/lib/Magento/Profiler/Driver/Standard/OutputInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler/Driver/Standard/Stat.php
+++ b/lib/Magento/Profiler/Driver/Standard/Stat.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Profiler/DriverInterface.php
+++ b/lib/Magento/Profiler/DriverInterface.php
@@ -13,7 +13,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Event.php
+++ b/lib/Magento/PubSub/Event.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Event/Factory.php
+++ b/lib/Magento/PubSub/Event/Factory.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Event/FactoryInterface.php
+++ b/lib/Magento/PubSub/Event/FactoryInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Event/QueueHandler.php
+++ b/lib/Magento/PubSub/Event/QueueHandler.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Event/QueueReaderInterface.php
+++ b/lib/Magento/PubSub/Event/QueueReaderInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Event/QueueWriter.php
+++ b/lib/Magento/PubSub/Event/QueueWriter.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Event/QueueWriterInterface.php
+++ b/lib/Magento/PubSub/Event/QueueWriterInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/EventInterface.php
+++ b/lib/Magento/PubSub/EventInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Job/FactoryInterface.php
+++ b/lib/Magento/PubSub/Job/FactoryInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Job/QueueHandler.php
+++ b/lib/Magento/PubSub/Job/QueueHandler.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Job/QueueReaderInterface.php
+++ b/lib/Magento/PubSub/Job/QueueReaderInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Job/QueueWriterInterface.php
+++ b/lib/Magento/PubSub/Job/QueueWriterInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/JobInterface.php
+++ b/lib/Magento/PubSub/JobInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Message/DispatcherAsync.php
+++ b/lib/Magento/PubSub/Message/DispatcherAsync.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Message/DispatcherAsyncInterface.php
+++ b/lib/Magento/PubSub/Message/DispatcherAsyncInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/Subscription/CollectionInterface.php
+++ b/lib/Magento/PubSub/Subscription/CollectionInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/PubSub/SubscriptionInterface.php
+++ b/lib/Magento/PubSub/SubscriptionInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Shell.php
+++ b/lib/Magento/Shell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Simplexml/Config.php
+++ b/lib/Magento/Simplexml/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Simplexml/Config/Cache/AbstractCache.php
+++ b/lib/Magento/Simplexml/Config/Cache/AbstractCache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Simplexml/Config/Cache/File.php
+++ b/lib/Magento/Simplexml/Config/Cache/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Simplexml/Element.php
+++ b/lib/Magento/Simplexml/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/System/Args.php
+++ b/lib/Magento/System/Args.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/System/Dirs.php
+++ b/lib/Magento/System/Dirs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/System/Ftp.php
+++ b/lib/Magento/System/Ftp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Translate/AbstractAdapter.php
+++ b/lib/Magento/Translate/AbstractAdapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Translate/Adapter.php
+++ b/lib/Magento/Translate/Adapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Translate/AdapterInterface.php
+++ b/lib/Magento/Translate/AdapterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Util.php
+++ b/lib/Magento/Util.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator.php
+++ b/lib/Magento/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/AbstractValidator.php
+++ b/lib/Magento/Validator/AbstractValidator.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Alnum.php
+++ b/lib/Magento/Validator/Alnum.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Builder.php
+++ b/lib/Magento/Validator/Builder.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Composite/VarienObject.php
+++ b/lib/Magento/Validator/Composite/VarienObject.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Config.php
+++ b/lib/Magento/Validator/Config.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Constraint.php
+++ b/lib/Magento/Validator/Constraint.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Constraint/Option.php
+++ b/lib/Magento/Validator/Constraint/Option.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Constraint/Option/Callback.php
+++ b/lib/Magento/Validator/Constraint/Option/Callback.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Constraint/OptionInterface.php
+++ b/lib/Magento/Validator/Constraint/OptionInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Constraint/Property.php
+++ b/lib/Magento/Validator/Constraint/Property.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/ConstraintFactory.php
+++ b/lib/Magento/Validator/ConstraintFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/EmailAddress.php
+++ b/lib/Magento/Validator/EmailAddress.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Entity/Properties.php
+++ b/lib/Magento/Validator/Entity/Properties.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/File/Extension.php
+++ b/lib/Magento/Validator/File/Extension.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/File/ImageSize.php
+++ b/lib/Magento/Validator/File/ImageSize.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/File/IsImage.php
+++ b/lib/Magento/Validator/File/IsImage.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/File/Size.php
+++ b/lib/Magento/Validator/File/Size.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Float.php
+++ b/lib/Magento/Validator/Float.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Int.php
+++ b/lib/Magento/Validator/Int.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/NotEmpty.php
+++ b/lib/Magento/Validator/NotEmpty.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/Regex.php
+++ b/lib/Magento/Validator/Regex.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/StringLength.php
+++ b/lib/Magento/Validator/StringLength.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/UniversalFactory.php
+++ b/lib/Magento/Validator/UniversalFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/ValidatorException.php
+++ b/lib/Magento/Validator/ValidatorException.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/ValidatorInterface.php
+++ b/lib/Magento/Validator/ValidatorInterface.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Validator/etc/validation.xsd
+++ b/lib/Magento/Validator/etc/validation.xsd
@@ -12,7 +12,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/ValidatorFactory.php
+++ b/lib/Magento/ValidatorFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Xml/Generator.php
+++ b/lib/Magento/Xml/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Magento/Xml/Parser.php
+++ b/lib/Magento/Xml/Parser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/Zend/Acl.php
+++ b/lib/Zend/Acl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Acl/Assert/Interface.php
+++ b/lib/Zend/Acl/Assert/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Acl/Exception.php
+++ b/lib/Zend/Acl/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Acl/Resource.php
+++ b/lib/Zend/Acl/Resource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Acl/Resource/Interface.php
+++ b/lib/Zend/Acl/Resource/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Acl/Role.php
+++ b/lib/Zend/Acl/Role.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Acl/Role/Interface.php
+++ b/lib/Zend/Acl/Role/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Acl/Role/Registry.php
+++ b/lib/Zend/Acl/Role/Registry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Acl/Role/Registry/Exception.php
+++ b/lib/Zend/Acl/Role/Registry/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Adobe/Auth.php
+++ b/lib/Zend/Amf/Adobe/Auth.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Adobe/DbInspector.php
+++ b/lib/Zend/Amf/Adobe/DbInspector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Adobe/Introspector.php
+++ b/lib/Zend/Amf/Adobe/Introspector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Auth/Abstract.php
+++ b/lib/Zend/Amf/Auth/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Constants.php
+++ b/lib/Zend/Amf/Constants.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Exception.php
+++ b/lib/Zend/Amf/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/Amf0/Deserializer.php
+++ b/lib/Zend/Amf/Parse/Amf0/Deserializer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/Amf0/Serializer.php
+++ b/lib/Zend/Amf/Parse/Amf0/Serializer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/Amf3/Deserializer.php
+++ b/lib/Zend/Amf/Parse/Amf3/Deserializer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/Amf3/Serializer.php
+++ b/lib/Zend/Amf/Parse/Amf3/Serializer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/Deserializer.php
+++ b/lib/Zend/Amf/Parse/Deserializer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/InputStream.php
+++ b/lib/Zend/Amf/Parse/InputStream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/OutputStream.php
+++ b/lib/Zend/Amf/Parse/OutputStream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/Resource/MysqlResult.php
+++ b/lib/Zend/Amf/Parse/Resource/MysqlResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/Resource/MysqliResult.php
+++ b/lib/Zend/Amf/Parse/Resource/MysqliResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/Resource/Stream.php
+++ b/lib/Zend/Amf/Parse/Resource/Stream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/Serializer.php
+++ b/lib/Zend/Amf/Parse/Serializer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Parse/TypeLoader.php
+++ b/lib/Zend/Amf/Parse/TypeLoader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Request.php
+++ b/lib/Zend/Amf/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Request/Http.php
+++ b/lib/Zend/Amf/Request/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Response.php
+++ b/lib/Zend/Amf/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Response/Http.php
+++ b/lib/Zend/Amf/Response/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Server.php
+++ b/lib/Zend/Amf/Server.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Server/Exception.php
+++ b/lib/Zend/Amf/Server/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Util/BinaryStream.php
+++ b/lib/Zend/Amf/Util/BinaryStream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/ByteArray.php
+++ b/lib/Zend/Amf/Value/ByteArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/MessageBody.php
+++ b/lib/Zend/Amf/Value/MessageBody.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/MessageHeader.php
+++ b/lib/Zend/Amf/Value/MessageHeader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/Messaging/AbstractMessage.php
+++ b/lib/Zend/Amf/Value/Messaging/AbstractMessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/Messaging/AcknowledgeMessage.php
+++ b/lib/Zend/Amf/Value/Messaging/AcknowledgeMessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/Messaging/ArrayCollection.php
+++ b/lib/Zend/Amf/Value/Messaging/ArrayCollection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/Messaging/AsyncMessage.php
+++ b/lib/Zend/Amf/Value/Messaging/AsyncMessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/Messaging/CommandMessage.php
+++ b/lib/Zend/Amf/Value/Messaging/CommandMessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/Messaging/ErrorMessage.php
+++ b/lib/Zend/Amf/Value/Messaging/ErrorMessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/Messaging/RemotingMessage.php
+++ b/lib/Zend/Amf/Value/Messaging/RemotingMessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Amf/Value/TraitsInfo.php
+++ b/lib/Zend/Amf/Value/TraitsInfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application.php
+++ b/lib/Zend/Application.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Bootstrap/Bootstrap.php
+++ b/lib/Zend/Application/Bootstrap/Bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Bootstrap/BootstrapAbstract.php
+++ b/lib/Zend/Application/Bootstrap/BootstrapAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Bootstrap/Bootstrapper.php
+++ b/lib/Zend/Application/Bootstrap/Bootstrapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Bootstrap/Exception.php
+++ b/lib/Zend/Application/Bootstrap/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Application/Bootstrap/ResourceBootstrapper.php
+++ b/lib/Zend/Application/Bootstrap/ResourceBootstrapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Exception.php
+++ b/lib/Zend/Application/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Application/Module/Autoloader.php
+++ b/lib/Zend/Application/Module/Autoloader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Module/Bootstrap.php
+++ b/lib/Zend/Application/Module/Bootstrap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Cachemanager.php
+++ b/lib/Zend/Application/Resource/Cachemanager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Db.php
+++ b/lib/Zend/Application/Resource/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Dojo.php
+++ b/lib/Zend/Application/Resource/Dojo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Exception.php
+++ b/lib/Zend/Application/Resource/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Frontcontroller.php
+++ b/lib/Zend/Application/Resource/Frontcontroller.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Layout.php
+++ b/lib/Zend/Application/Resource/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Locale.php
+++ b/lib/Zend/Application/Resource/Locale.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Log.php
+++ b/lib/Zend/Application/Resource/Log.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Mail.php
+++ b/lib/Zend/Application/Resource/Mail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Modules.php
+++ b/lib/Zend/Application/Resource/Modules.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Multidb.php
+++ b/lib/Zend/Application/Resource/Multidb.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Navigation.php
+++ b/lib/Zend/Application/Resource/Navigation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Resource.php
+++ b/lib/Zend/Application/Resource/Resource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/ResourceAbstract.php
+++ b/lib/Zend/Application/Resource/ResourceAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Router.php
+++ b/lib/Zend/Application/Resource/Router.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Session.php
+++ b/lib/Zend/Application/Resource/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Translate.php
+++ b/lib/Zend/Application/Resource/Translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/Useragent.php
+++ b/lib/Zend/Application/Resource/Useragent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Application/Resource/View.php
+++ b/lib/Zend/Application/Resource/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth.php
+++ b/lib/Zend/Auth.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/DbTable.php
+++ b/lib/Zend/Auth/Adapter/DbTable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/Digest.php
+++ b/lib/Zend/Auth/Adapter/Digest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/Exception.php
+++ b/lib/Zend/Auth/Adapter/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/Http.php
+++ b/lib/Zend/Auth/Adapter/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/Http/Resolver/Exception.php
+++ b/lib/Zend/Auth/Adapter/Http/Resolver/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/Http/Resolver/File.php
+++ b/lib/Zend/Auth/Adapter/Http/Resolver/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/Http/Resolver/Interface.php
+++ b/lib/Zend/Auth/Adapter/Http/Resolver/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/InfoCard.php
+++ b/lib/Zend/Auth/Adapter/InfoCard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/Interface.php
+++ b/lib/Zend/Auth/Adapter/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/Ldap.php
+++ b/lib/Zend/Auth/Adapter/Ldap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Adapter/OpenId.php
+++ b/lib/Zend/Auth/Adapter/OpenId.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Exception.php
+++ b/lib/Zend/Auth/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Result.php
+++ b/lib/Zend/Auth/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Storage/Exception.php
+++ b/lib/Zend/Auth/Storage/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Storage/Interface.php
+++ b/lib/Zend/Auth/Storage/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Storage/NonPersistent.php
+++ b/lib/Zend/Auth/Storage/NonPersistent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Auth/Storage/Session.php
+++ b/lib/Zend/Auth/Storage/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode.php
+++ b/lib/Zend/Barcode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Code128.php
+++ b/lib/Zend/Barcode/Object/Code128.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Code25.php
+++ b/lib/Zend/Barcode/Object/Code25.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Code25interleaved.php
+++ b/lib/Zend/Barcode/Object/Code25interleaved.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Code39.php
+++ b/lib/Zend/Barcode/Object/Code39.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Ean13.php
+++ b/lib/Zend/Barcode/Object/Ean13.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Ean2.php
+++ b/lib/Zend/Barcode/Object/Ean2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Ean5.php
+++ b/lib/Zend/Barcode/Object/Ean5.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Ean8.php
+++ b/lib/Zend/Barcode/Object/Ean8.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Error.php
+++ b/lib/Zend/Barcode/Object/Error.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Identcode.php
+++ b/lib/Zend/Barcode/Object/Identcode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Itf14.php
+++ b/lib/Zend/Barcode/Object/Itf14.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Leitcode.php
+++ b/lib/Zend/Barcode/Object/Leitcode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/ObjectAbstract.php
+++ b/lib/Zend/Barcode/Object/ObjectAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Planet.php
+++ b/lib/Zend/Barcode/Object/Planet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Postnet.php
+++ b/lib/Zend/Barcode/Object/Postnet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Royalmail.php
+++ b/lib/Zend/Barcode/Object/Royalmail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Upca.php
+++ b/lib/Zend/Barcode/Object/Upca.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Object/Upce.php
+++ b/lib/Zend/Barcode/Object/Upce.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Renderer/Image.php
+++ b/lib/Zend/Barcode/Renderer/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Renderer/Pdf.php
+++ b/lib/Zend/Barcode/Renderer/Pdf.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Renderer/RendererAbstract.php
+++ b/lib/Zend/Barcode/Renderer/RendererAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Barcode/Renderer/Svg.php
+++ b/lib/Zend/Barcode/Renderer/Svg.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache.php
+++ b/lib/Zend/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend.php
+++ b/lib/Zend/Cache/Backend.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/Apc.php
+++ b/lib/Zend/Cache/Backend/Apc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/BlackHole.php
+++ b/lib/Zend/Cache/Backend/BlackHole.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/ExtendedInterface.php
+++ b/lib/Zend/Cache/Backend/ExtendedInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/File.php
+++ b/lib/Zend/Cache/Backend/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/Interface.php
+++ b/lib/Zend/Cache/Backend/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/Libmemcached.php
+++ b/lib/Zend/Cache/Backend/Libmemcached.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/Memcached.php
+++ b/lib/Zend/Cache/Backend/Memcached.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/Sqlite.php
+++ b/lib/Zend/Cache/Backend/Sqlite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/Static.php
+++ b/lib/Zend/Cache/Backend/Static.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/Test.php
+++ b/lib/Zend/Cache/Backend/Test.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/TwoLevels.php
+++ b/lib/Zend/Cache/Backend/TwoLevels.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/Xcache.php
+++ b/lib/Zend/Cache/Backend/Xcache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/ZendPlatform.php
+++ b/lib/Zend/Cache/Backend/ZendPlatform.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/ZendServer.php
+++ b/lib/Zend/Cache/Backend/ZendServer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/ZendServer/Disk.php
+++ b/lib/Zend/Cache/Backend/ZendServer/Disk.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Backend/ZendServer/ShMem.php
+++ b/lib/Zend/Cache/Backend/ZendServer/ShMem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Core.php
+++ b/lib/Zend/Cache/Core.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Exception.php
+++ b/lib/Zend/Cache/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Frontend/Capture.php
+++ b/lib/Zend/Cache/Frontend/Capture.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Frontend/Class.php
+++ b/lib/Zend/Cache/Frontend/Class.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Frontend/File.php
+++ b/lib/Zend/Cache/Frontend/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Frontend/Function.php
+++ b/lib/Zend/Cache/Frontend/Function.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Frontend/Output.php
+++ b/lib/Zend/Cache/Frontend/Output.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Frontend/Page.php
+++ b/lib/Zend/Cache/Frontend/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cache/Manager.php
+++ b/lib/Zend/Cache/Manager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Captcha/Adapter.php
+++ b/lib/Zend/Captcha/Adapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Captcha/Base.php
+++ b/lib/Zend/Captcha/Base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Captcha/Dumb.php
+++ b/lib/Zend/Captcha/Dumb.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Captcha/Exception.php
+++ b/lib/Zend/Captcha/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Captcha/Figlet.php
+++ b/lib/Zend/Captcha/Figlet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Captcha/Image.php
+++ b/lib/Zend/Captcha/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Captcha/ReCaptcha.php
+++ b/lib/Zend/Captcha/ReCaptcha.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Captcha/Word.php
+++ b/lib/Zend/Captcha/Word.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/AbstractFactory.php
+++ b/lib/Zend/Cloud/AbstractFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/Adapter.php
+++ b/lib/Zend/Cloud/DocumentService/Adapter.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/Adapter/AbstractAdapter.php
+++ b/lib/Zend/Cloud/DocumentService/Adapter/AbstractAdapter.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/Adapter/SimpleDb.php
+++ b/lib/Zend/Cloud/DocumentService/Adapter/SimpleDb.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/Adapter/SimpleDb/Query.php
+++ b/lib/Zend/Cloud/DocumentService/Adapter/SimpleDb/Query.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/Adapter/WindowsAzure.php
+++ b/lib/Zend/Cloud/DocumentService/Adapter/WindowsAzure.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/Adapter/WindowsAzure/Query.php
+++ b/lib/Zend/Cloud/DocumentService/Adapter/WindowsAzure/Query.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/Document.php
+++ b/lib/Zend/Cloud/DocumentService/Document.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/DocumentSet.php
+++ b/lib/Zend/Cloud/DocumentService/DocumentSet.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/Exception.php
+++ b/lib/Zend/Cloud/DocumentService/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/Factory.php
+++ b/lib/Zend/Cloud/DocumentService/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/Query.php
+++ b/lib/Zend/Cloud/DocumentService/Query.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/DocumentService/QueryAdapter.php
+++ b/lib/Zend/Cloud/DocumentService/QueryAdapter.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/Exception.php
+++ b/lib/Zend/Cloud/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/OperationNotAvailableException.php
+++ b/lib/Zend/Cloud/OperationNotAvailableException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/QueueService/Adapter.php
+++ b/lib/Zend/Cloud/QueueService/Adapter.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/QueueService/Adapter/AbstractAdapter.php
+++ b/lib/Zend/Cloud/QueueService/Adapter/AbstractAdapter.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/QueueService/Adapter/Sqs.php
+++ b/lib/Zend/Cloud/QueueService/Adapter/Sqs.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/QueueService/Adapter/WindowsAzure.php
+++ b/lib/Zend/Cloud/QueueService/Adapter/WindowsAzure.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/QueueService/Adapter/ZendQueue.php
+++ b/lib/Zend/Cloud/QueueService/Adapter/ZendQueue.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/QueueService/Exception.php
+++ b/lib/Zend/Cloud/QueueService/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/QueueService/Factory.php
+++ b/lib/Zend/Cloud/QueueService/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/QueueService/Message.php
+++ b/lib/Zend/Cloud/QueueService/Message.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/QueueService/MessageSet.php
+++ b/lib/Zend/Cloud/QueueService/MessageSet.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/StorageService/Adapter.php
+++ b/lib/Zend/Cloud/StorageService/Adapter.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/StorageService/Adapter/FileSystem.php
+++ b/lib/Zend/Cloud/StorageService/Adapter/FileSystem.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/StorageService/Adapter/Nirvanix.php
+++ b/lib/Zend/Cloud/StorageService/Adapter/Nirvanix.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/StorageService/Adapter/S3.php
+++ b/lib/Zend/Cloud/StorageService/Adapter/S3.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/StorageService/Adapter/WindowsAzure.php
+++ b/lib/Zend/Cloud/StorageService/Adapter/WindowsAzure.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/StorageService/Exception.php
+++ b/lib/Zend/Cloud/StorageService/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Cloud/StorageService/Factory.php
+++ b/lib/Zend/Cloud/StorageService/Factory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Abstract.php
+++ b/lib/Zend/CodeGenerator/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Exception.php
+++ b/lib/Zend/CodeGenerator/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Abstract.php
+++ b/lib/Zend/CodeGenerator/Php/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Body.php
+++ b/lib/Zend/CodeGenerator/Php/Body.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Class.php
+++ b/lib/Zend/CodeGenerator/Php/Class.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Docblock.php
+++ b/lib/Zend/CodeGenerator/Php/Docblock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Docblock/Tag.php
+++ b/lib/Zend/CodeGenerator/Php/Docblock/Tag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Docblock/Tag/License.php
+++ b/lib/Zend/CodeGenerator/Php/Docblock/Tag/License.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Docblock/Tag/Param.php
+++ b/lib/Zend/CodeGenerator/Php/Docblock/Tag/Param.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Docblock/Tag/Return.php
+++ b/lib/Zend/CodeGenerator/Php/Docblock/Tag/Return.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Exception.php
+++ b/lib/Zend/CodeGenerator/Php/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/File.php
+++ b/lib/Zend/CodeGenerator/Php/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Member/Abstract.php
+++ b/lib/Zend/CodeGenerator/Php/Member/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Member/Container.php
+++ b/lib/Zend/CodeGenerator/Php/Member/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Method.php
+++ b/lib/Zend/CodeGenerator/Php/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Parameter.php
+++ b/lib/Zend/CodeGenerator/Php/Parameter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Parameter/DefaultValue.php
+++ b/lib/Zend/CodeGenerator/Php/Parameter/DefaultValue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Property.php
+++ b/lib/Zend/CodeGenerator/Php/Property.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/CodeGenerator/Php/Property/DefaultValue.php
+++ b/lib/Zend/CodeGenerator/Php/Property/DefaultValue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config.php
+++ b/lib/Zend/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config/Exception.php
+++ b/lib/Zend/Config/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config/Ini.php
+++ b/lib/Zend/Config/Ini.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config/Json.php
+++ b/lib/Zend/Config/Json.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Config/Writer.php
+++ b/lib/Zend/Config/Writer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config/Writer/Array.php
+++ b/lib/Zend/Config/Writer/Array.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config/Writer/FileAbstract.php
+++ b/lib/Zend/Config/Writer/FileAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config/Writer/Ini.php
+++ b/lib/Zend/Config/Writer/Ini.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config/Writer/Json.php
+++ b/lib/Zend/Config/Writer/Json.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config/Writer/Xml.php
+++ b/lib/Zend/Config/Writer/Xml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config/Writer/Yaml.php
+++ b/lib/Zend/Config/Writer/Yaml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Config/Xml.php
+++ b/lib/Zend/Config/Xml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Config/Yaml.php
+++ b/lib/Zend/Config/Yaml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Console/Getopt.php
+++ b/lib/Zend/Console/Getopt.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Console/Getopt/Exception.php
+++ b/lib/Zend/Console/Getopt/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action.php
+++ b/lib/Zend/Controller/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Exception.php
+++ b/lib/Zend/Controller/Action/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/Abstract.php
+++ b/lib/Zend/Controller/Action/Helper/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/ActionStack.php
+++ b/lib/Zend/Controller/Action/Helper/ActionStack.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/AjaxContext.php
+++ b/lib/Zend/Controller/Action/Helper/AjaxContext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/AutoComplete/Abstract.php
+++ b/lib/Zend/Controller/Action/Helper/AutoComplete/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/AutoCompleteDojo.php
+++ b/lib/Zend/Controller/Action/Helper/AutoCompleteDojo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/AutoCompleteScriptaculous.php
+++ b/lib/Zend/Controller/Action/Helper/AutoCompleteScriptaculous.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/Cache.php
+++ b/lib/Zend/Controller/Action/Helper/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/ContextSwitch.php
+++ b/lib/Zend/Controller/Action/Helper/ContextSwitch.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/FlashMessenger.php
+++ b/lib/Zend/Controller/Action/Helper/FlashMessenger.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/Json.php
+++ b/lib/Zend/Controller/Action/Helper/Json.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/Redirector.php
+++ b/lib/Zend/Controller/Action/Helper/Redirector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/Url.php
+++ b/lib/Zend/Controller/Action/Helper/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Helper/ViewRenderer.php
+++ b/lib/Zend/Controller/Action/Helper/ViewRenderer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/HelperBroker.php
+++ b/lib/Zend/Controller/Action/HelperBroker.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/HelperBroker/PriorityStack.php
+++ b/lib/Zend/Controller/Action/HelperBroker/PriorityStack.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Action/Interface.php
+++ b/lib/Zend/Controller/Action/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Dispatcher/Abstract.php
+++ b/lib/Zend/Controller/Dispatcher/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Dispatcher/Exception.php
+++ b/lib/Zend/Controller/Dispatcher/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Dispatcher/Interface.php
+++ b/lib/Zend/Controller/Dispatcher/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Dispatcher/Standard.php
+++ b/lib/Zend/Controller/Dispatcher/Standard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Exception.php
+++ b/lib/Zend/Controller/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Front.php
+++ b/lib/Zend/Controller/Front.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Plugin/Abstract.php
+++ b/lib/Zend/Controller/Plugin/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Plugin/ActionStack.php
+++ b/lib/Zend/Controller/Plugin/ActionStack.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Plugin/Broker.php
+++ b/lib/Zend/Controller/Plugin/Broker.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Plugin/ErrorHandler.php
+++ b/lib/Zend/Controller/Plugin/ErrorHandler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Plugin/PutHandler.php
+++ b/lib/Zend/Controller/Plugin/PutHandler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Request/Abstract.php
+++ b/lib/Zend/Controller/Request/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Request/Apache404.php
+++ b/lib/Zend/Controller/Request/Apache404.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Request/Exception.php
+++ b/lib/Zend/Controller/Request/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Request/Http.php
+++ b/lib/Zend/Controller/Request/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Request/HttpTestCase.php
+++ b/lib/Zend/Controller/Request/HttpTestCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Request/Simple.php
+++ b/lib/Zend/Controller/Request/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Response/Abstract.php
+++ b/lib/Zend/Controller/Response/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Response/Cli.php
+++ b/lib/Zend/Controller/Response/Cli.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Response/Exception.php
+++ b/lib/Zend/Controller/Response/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Response/Http.php
+++ b/lib/Zend/Controller/Response/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Response/HttpTestCase.php
+++ b/lib/Zend/Controller/Response/HttpTestCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Abstract.php
+++ b/lib/Zend/Controller/Router/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Exception.php
+++ b/lib/Zend/Controller/Router/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Interface.php
+++ b/lib/Zend/Controller/Router/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Rewrite.php
+++ b/lib/Zend/Controller/Router/Rewrite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Route.php
+++ b/lib/Zend/Controller/Router/Route.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Route/Abstract.php
+++ b/lib/Zend/Controller/Router/Route/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Route/Chain.php
+++ b/lib/Zend/Controller/Router/Route/Chain.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Route/Hostname.php
+++ b/lib/Zend/Controller/Router/Route/Hostname.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Route/Interface.php
+++ b/lib/Zend/Controller/Router/Route/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Route/Module.php
+++ b/lib/Zend/Controller/Router/Route/Module.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Route/Regex.php
+++ b/lib/Zend/Controller/Router/Route/Regex.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Controller/Router/Route/Static.php
+++ b/lib/Zend/Controller/Router/Route/Static.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt.php
+++ b/lib/Zend/Crypt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/DiffieHellman.php
+++ b/lib/Zend/Crypt/DiffieHellman.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/DiffieHellman/Exception.php
+++ b/lib/Zend/Crypt/DiffieHellman/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Exception.php
+++ b/lib/Zend/Crypt/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Hmac.php
+++ b/lib/Zend/Crypt/Hmac.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Hmac/Exception.php
+++ b/lib/Zend/Crypt/Hmac/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Math.php
+++ b/lib/Zend/Crypt/Math.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Math/BigInteger.php
+++ b/lib/Zend/Crypt/Math/BigInteger.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Math/BigInteger/Bcmath.php
+++ b/lib/Zend/Crypt/Math/BigInteger/Bcmath.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Math/BigInteger/Exception.php
+++ b/lib/Zend/Crypt/Math/BigInteger/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Math/BigInteger/Gmp.php
+++ b/lib/Zend/Crypt/Math/BigInteger/Gmp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Math/BigInteger/Interface.php
+++ b/lib/Zend/Crypt/Math/BigInteger/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Math/Exception.php
+++ b/lib/Zend/Crypt/Math/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Rsa.php
+++ b/lib/Zend/Crypt/Rsa.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Rsa/Exception.php
+++ b/lib/Zend/Crypt/Rsa/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Rsa/Key.php
+++ b/lib/Zend/Crypt/Rsa/Key.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Rsa/Key/Private.php
+++ b/lib/Zend/Crypt/Rsa/Key/Private.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Crypt/Rsa/Key/Public.php
+++ b/lib/Zend/Crypt/Rsa/Key/Public.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Currency.php
+++ b/lib/Zend/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Currency/CurrencyInterface.php
+++ b/lib/Zend/Currency/CurrencyInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Currency/Exception.php
+++ b/lib/Zend/Currency/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Date.php
+++ b/lib/Zend/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Date/Cities.php
+++ b/lib/Zend/Date/Cities.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Date/DateObject.php
+++ b/lib/Zend/Date/DateObject.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Date/Exception.php
+++ b/lib/Zend/Date/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db.php
+++ b/lib/Zend/Db.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Abstract.php
+++ b/lib/Zend/Db/Adapter/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Db2.php
+++ b/lib/Zend/Db/Adapter/Db2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Db2/Exception.php
+++ b/lib/Zend/Db/Adapter/Db2/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Exception.php
+++ b/lib/Zend/Db/Adapter/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Mysqli.php
+++ b/lib/Zend/Db/Adapter/Mysqli.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Mysqli/Exception.php
+++ b/lib/Zend/Db/Adapter/Mysqli/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Oracle.php
+++ b/lib/Zend/Db/Adapter/Oracle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Oracle/Exception.php
+++ b/lib/Zend/Db/Adapter/Oracle/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Pdo/Abstract.php
+++ b/lib/Zend/Db/Adapter/Pdo/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Pdo/Ibm.php
+++ b/lib/Zend/Db/Adapter/Pdo/Ibm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Pdo/Ibm/Db2.php
+++ b/lib/Zend/Db/Adapter/Pdo/Ibm/Db2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Pdo/Ibm/Ids.php
+++ b/lib/Zend/Db/Adapter/Pdo/Ibm/Ids.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Pdo/Mssql.php
+++ b/lib/Zend/Db/Adapter/Pdo/Mssql.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Pdo/Mysql.php
+++ b/lib/Zend/Db/Adapter/Pdo/Mysql.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Pdo/Oci.php
+++ b/lib/Zend/Db/Adapter/Pdo/Oci.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Pdo/Pgsql.php
+++ b/lib/Zend/Db/Adapter/Pdo/Pgsql.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Pdo/Sqlite.php
+++ b/lib/Zend/Db/Adapter/Pdo/Sqlite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Sqlsrv.php
+++ b/lib/Zend/Db/Adapter/Sqlsrv.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Adapter/Sqlsrv/Exception.php
+++ b/lib/Zend/Db/Adapter/Sqlsrv/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Exception.php
+++ b/lib/Zend/Db/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Expr.php
+++ b/lib/Zend/Db/Expr.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Profiler.php
+++ b/lib/Zend/Db/Profiler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Profiler/Exception.php
+++ b/lib/Zend/Db/Profiler/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Profiler/Firebug.php
+++ b/lib/Zend/Db/Profiler/Firebug.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Profiler/Query.php
+++ b/lib/Zend/Db/Profiler/Query.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Select.php
+++ b/lib/Zend/Db/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Select/Exception.php
+++ b/lib/Zend/Db/Select/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement.php
+++ b/lib/Zend/Db/Statement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Db2.php
+++ b/lib/Zend/Db/Statement/Db2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Db2/Exception.php
+++ b/lib/Zend/Db/Statement/Db2/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Exception.php
+++ b/lib/Zend/Db/Statement/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Interface.php
+++ b/lib/Zend/Db/Statement/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Mysqli.php
+++ b/lib/Zend/Db/Statement/Mysqli.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Mysqli/Exception.php
+++ b/lib/Zend/Db/Statement/Mysqli/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Oracle.php
+++ b/lib/Zend/Db/Statement/Oracle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Oracle/Exception.php
+++ b/lib/Zend/Db/Statement/Oracle/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Pdo.php
+++ b/lib/Zend/Db/Statement/Pdo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Pdo/Ibm.php
+++ b/lib/Zend/Db/Statement/Pdo/Ibm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Pdo/Oci.php
+++ b/lib/Zend/Db/Statement/Pdo/Oci.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Sqlsrv.php
+++ b/lib/Zend/Db/Statement/Sqlsrv.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Statement/Sqlsrv/Exception.php
+++ b/lib/Zend/Db/Statement/Sqlsrv/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table.php
+++ b/lib/Zend/Db/Table.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Abstract.php
+++ b/lib/Zend/Db/Table/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Definition.php
+++ b/lib/Zend/Db/Table/Definition.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Exception.php
+++ b/lib/Zend/Db/Table/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Row.php
+++ b/lib/Zend/Db/Table/Row.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Row/Abstract.php
+++ b/lib/Zend/Db/Table/Row/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Row/Exception.php
+++ b/lib/Zend/Db/Table/Row/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Rowset.php
+++ b/lib/Zend/Db/Table/Rowset.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Rowset/Abstract.php
+++ b/lib/Zend/Db/Table/Rowset/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Rowset/Exception.php
+++ b/lib/Zend/Db/Table/Rowset/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Select.php
+++ b/lib/Zend/Db/Table/Select.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Db/Table/Select/Exception.php
+++ b/lib/Zend/Db/Table/Select/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Debug.php
+++ b/lib/Zend/Debug.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo.php
+++ b/lib/Zend/Dojo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/BuildLayer.php
+++ b/lib/Zend/Dojo/BuildLayer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Data.php
+++ b/lib/Zend/Dojo/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Exception.php
+++ b/lib/Zend/Dojo/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form.php
+++ b/lib/Zend/Dojo/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Decorator/AccordionContainer.php
+++ b/lib/Zend/Dojo/Form/Decorator/AccordionContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Decorator/AccordionPane.php
+++ b/lib/Zend/Dojo/Form/Decorator/AccordionPane.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Decorator/BorderContainer.php
+++ b/lib/Zend/Dojo/Form/Decorator/BorderContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Decorator/ContentPane.php
+++ b/lib/Zend/Dojo/Form/Decorator/ContentPane.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Decorator/DijitContainer.php
+++ b/lib/Zend/Dojo/Form/Decorator/DijitContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Decorator/DijitElement.php
+++ b/lib/Zend/Dojo/Form/Decorator/DijitElement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Decorator/DijitForm.php
+++ b/lib/Zend/Dojo/Form/Decorator/DijitForm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Decorator/SplitContainer.php
+++ b/lib/Zend/Dojo/Form/Decorator/SplitContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Decorator/StackContainer.php
+++ b/lib/Zend/Dojo/Form/Decorator/StackContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Decorator/TabContainer.php
+++ b/lib/Zend/Dojo/Form/Decorator/TabContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/DisplayGroup.php
+++ b/lib/Zend/Dojo/Form/DisplayGroup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/Button.php
+++ b/lib/Zend/Dojo/Form/Element/Button.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/CheckBox.php
+++ b/lib/Zend/Dojo/Form/Element/CheckBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/ComboBox.php
+++ b/lib/Zend/Dojo/Form/Element/ComboBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/CurrencyTextBox.php
+++ b/lib/Zend/Dojo/Form/Element/CurrencyTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/DateTextBox.php
+++ b/lib/Zend/Dojo/Form/Element/DateTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/Dijit.php
+++ b/lib/Zend/Dojo/Form/Element/Dijit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/DijitMulti.php
+++ b/lib/Zend/Dojo/Form/Element/DijitMulti.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/Editor.php
+++ b/lib/Zend/Dojo/Form/Element/Editor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/FilteringSelect.php
+++ b/lib/Zend/Dojo/Form/Element/FilteringSelect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/HorizontalSlider.php
+++ b/lib/Zend/Dojo/Form/Element/HorizontalSlider.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/NumberSpinner.php
+++ b/lib/Zend/Dojo/Form/Element/NumberSpinner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/NumberTextBox.php
+++ b/lib/Zend/Dojo/Form/Element/NumberTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/PasswordTextBox.php
+++ b/lib/Zend/Dojo/Form/Element/PasswordTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/RadioButton.php
+++ b/lib/Zend/Dojo/Form/Element/RadioButton.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/SimpleTextarea.php
+++ b/lib/Zend/Dojo/Form/Element/SimpleTextarea.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/Slider.php
+++ b/lib/Zend/Dojo/Form/Element/Slider.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/SubmitButton.php
+++ b/lib/Zend/Dojo/Form/Element/SubmitButton.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/TextBox.php
+++ b/lib/Zend/Dojo/Form/Element/TextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/Textarea.php
+++ b/lib/Zend/Dojo/Form/Element/Textarea.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/TimeTextBox.php
+++ b/lib/Zend/Dojo/Form/Element/TimeTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/ValidationTextBox.php
+++ b/lib/Zend/Dojo/Form/Element/ValidationTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/Element/VerticalSlider.php
+++ b/lib/Zend/Dojo/Form/Element/VerticalSlider.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/Form/SubForm.php
+++ b/lib/Zend/Dojo/Form/SubForm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Exception.php
+++ b/lib/Zend/Dojo/View/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/AccordionContainer.php
+++ b/lib/Zend/Dojo/View/Helper/AccordionContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/AccordionPane.php
+++ b/lib/Zend/Dojo/View/Helper/AccordionPane.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/BorderContainer.php
+++ b/lib/Zend/Dojo/View/Helper/BorderContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/Button.php
+++ b/lib/Zend/Dojo/View/Helper/Button.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/CheckBox.php
+++ b/lib/Zend/Dojo/View/Helper/CheckBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/ComboBox.php
+++ b/lib/Zend/Dojo/View/Helper/ComboBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/ContentPane.php
+++ b/lib/Zend/Dojo/View/Helper/ContentPane.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/CurrencyTextBox.php
+++ b/lib/Zend/Dojo/View/Helper/CurrencyTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/CustomDijit.php
+++ b/lib/Zend/Dojo/View/Helper/CustomDijit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/DateTextBox.php
+++ b/lib/Zend/Dojo/View/Helper/DateTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/Dijit.php
+++ b/lib/Zend/Dojo/View/Helper/Dijit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/DijitContainer.php
+++ b/lib/Zend/Dojo/View/Helper/DijitContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/Dojo.php
+++ b/lib/Zend/Dojo/View/Helper/Dojo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/Dojo/Container.php
+++ b/lib/Zend/Dojo/View/Helper/Dojo/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/Editor.php
+++ b/lib/Zend/Dojo/View/Helper/Editor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/FilteringSelect.php
+++ b/lib/Zend/Dojo/View/Helper/FilteringSelect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/Form.php
+++ b/lib/Zend/Dojo/View/Helper/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/HorizontalSlider.php
+++ b/lib/Zend/Dojo/View/Helper/HorizontalSlider.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/NumberSpinner.php
+++ b/lib/Zend/Dojo/View/Helper/NumberSpinner.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/NumberTextBox.php
+++ b/lib/Zend/Dojo/View/Helper/NumberTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/PasswordTextBox.php
+++ b/lib/Zend/Dojo/View/Helper/PasswordTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/RadioButton.php
+++ b/lib/Zend/Dojo/View/Helper/RadioButton.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/SimpleTextarea.php
+++ b/lib/Zend/Dojo/View/Helper/SimpleTextarea.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/Slider.php
+++ b/lib/Zend/Dojo/View/Helper/Slider.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/SplitContainer.php
+++ b/lib/Zend/Dojo/View/Helper/SplitContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/StackContainer.php
+++ b/lib/Zend/Dojo/View/Helper/StackContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/SubmitButton.php
+++ b/lib/Zend/Dojo/View/Helper/SubmitButton.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/TabContainer.php
+++ b/lib/Zend/Dojo/View/Helper/TabContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/TextBox.php
+++ b/lib/Zend/Dojo/View/Helper/TextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/Textarea.php
+++ b/lib/Zend/Dojo/View/Helper/Textarea.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/TimeTextBox.php
+++ b/lib/Zend/Dojo/View/Helper/TimeTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/ValidationTextBox.php
+++ b/lib/Zend/Dojo/View/Helper/ValidationTextBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dojo/View/Helper/VerticalSlider.php
+++ b/lib/Zend/Dojo/View/Helper/VerticalSlider.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dom/Exception.php
+++ b/lib/Zend/Dom/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dom/Query.php
+++ b/lib/Zend/Dom/Query.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dom/Query/Css2Xpath.php
+++ b/lib/Zend/Dom/Query/Css2Xpath.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Dom/Query/Result.php
+++ b/lib/Zend/Dom/Query/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Exception.php
+++ b/lib/Zend/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed.php
+++ b/lib/Zend/Feed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Abstract.php
+++ b/lib/Zend/Feed/Abstract.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Atom.php
+++ b/lib/Zend/Feed/Atom.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Builder.php
+++ b/lib/Zend/Feed/Builder.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Builder/Entry.php
+++ b/lib/Zend/Feed/Builder/Entry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Builder/Exception.php
+++ b/lib/Zend/Feed/Builder/Exception.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Builder/Header.php
+++ b/lib/Zend/Feed/Builder/Header.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Builder/Header/Itunes.php
+++ b/lib/Zend/Feed/Builder/Header/Itunes.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Builder/Interface.php
+++ b/lib/Zend/Feed/Builder/Interface.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Element.php
+++ b/lib/Zend/Feed/Element.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Entry/Abstract.php
+++ b/lib/Zend/Feed/Entry/Abstract.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Entry/Atom.php
+++ b/lib/Zend/Feed/Entry/Atom.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Entry/Rss.php
+++ b/lib/Zend/Feed/Entry/Rss.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Exception.php
+++ b/lib/Zend/Feed/Exception.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub.php
+++ b/lib/Zend/Feed/Pubsubhubbub.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub/CallbackAbstract.php
+++ b/lib/Zend/Feed/Pubsubhubbub/CallbackAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub/CallbackInterface.php
+++ b/lib/Zend/Feed/Pubsubhubbub/CallbackInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub/Exception.php
+++ b/lib/Zend/Feed/Pubsubhubbub/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub/HttpResponse.php
+++ b/lib/Zend/Feed/Pubsubhubbub/HttpResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub/Model/ModelAbstract.php
+++ b/lib/Zend/Feed/Pubsubhubbub/Model/ModelAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub/Model/Subscription.php
+++ b/lib/Zend/Feed/Pubsubhubbub/Model/Subscription.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub/Model/SubscriptionInterface.php
+++ b/lib/Zend/Feed/Pubsubhubbub/Model/SubscriptionInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub/Publisher.php
+++ b/lib/Zend/Feed/Pubsubhubbub/Publisher.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub/Subscriber.php
+++ b/lib/Zend/Feed/Pubsubhubbub/Subscriber.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Pubsubhubbub/Subscriber/Callback.php
+++ b/lib/Zend/Feed/Pubsubhubbub/Subscriber/Callback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader.php
+++ b/lib/Zend/Feed/Reader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Collection.php
+++ b/lib/Zend/Feed/Reader/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Collection/Author.php
+++ b/lib/Zend/Feed/Reader/Collection/Author.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Collection/Category.php
+++ b/lib/Zend/Feed/Reader/Collection/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Collection/CollectionAbstract.php
+++ b/lib/Zend/Feed/Reader/Collection/CollectionAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Entry/Atom.php
+++ b/lib/Zend/Feed/Reader/Entry/Atom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Entry/Rss.php
+++ b/lib/Zend/Feed/Reader/Entry/Rss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/EntryAbstract.php
+++ b/lib/Zend/Feed/Reader/EntryAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/EntryInterface.php
+++ b/lib/Zend/Feed/Reader/EntryInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/lib/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/Atom/Feed.php
+++ b/lib/Zend/Feed/Reader/Extension/Atom/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/Content/Entry.php
+++ b/lib/Zend/Feed/Reader/Extension/Content/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/CreativeCommons/Entry.php
+++ b/lib/Zend/Feed/Reader/Extension/CreativeCommons/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/CreativeCommons/Feed.php
+++ b/lib/Zend/Feed/Reader/Extension/CreativeCommons/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/DublinCore/Entry.php
+++ b/lib/Zend/Feed/Reader/Extension/DublinCore/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/DublinCore/Feed.php
+++ b/lib/Zend/Feed/Reader/Extension/DublinCore/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/EntryAbstract.php
+++ b/lib/Zend/Feed/Reader/Extension/EntryAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/FeedAbstract.php
+++ b/lib/Zend/Feed/Reader/Extension/FeedAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/Podcast/Entry.php
+++ b/lib/Zend/Feed/Reader/Extension/Podcast/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/Podcast/Feed.php
+++ b/lib/Zend/Feed/Reader/Extension/Podcast/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/Slash/Entry.php
+++ b/lib/Zend/Feed/Reader/Extension/Slash/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/Syndication/Feed.php
+++ b/lib/Zend/Feed/Reader/Extension/Syndication/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/Thread/Entry.php
+++ b/lib/Zend/Feed/Reader/Extension/Thread/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Extension/WellFormedWeb/Entry.php
+++ b/lib/Zend/Feed/Reader/Extension/WellFormedWeb/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Feed/Atom.php
+++ b/lib/Zend/Feed/Reader/Feed/Atom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Feed/Atom/Source.php
+++ b/lib/Zend/Feed/Reader/Feed/Atom/Source.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/Feed/Rss.php
+++ b/lib/Zend/Feed/Reader/Feed/Rss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/FeedAbstract.php
+++ b/lib/Zend/Feed/Reader/FeedAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/FeedInterface.php
+++ b/lib/Zend/Feed/Reader/FeedInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Reader/FeedSet.php
+++ b/lib/Zend/Feed/Reader/FeedSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Rss.php
+++ b/lib/Zend/Feed/Rss.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer.php
+++ b/lib/Zend/Feed/Writer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Deleted.php
+++ b/lib/Zend/Feed/Writer/Deleted.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Entry.php
+++ b/lib/Zend/Feed/Writer/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Exception/InvalidMethodException.php
+++ b/lib/Zend/Feed/Writer/Exception/InvalidMethodException.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/Atom/Renderer/Feed.php
+++ b/lib/Zend/Feed/Writer/Extension/Atom/Renderer/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/Content/Renderer/Entry.php
+++ b/lib/Zend/Feed/Writer/Extension/Content/Renderer/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/DublinCore/Renderer/Entry.php
+++ b/lib/Zend/Feed/Writer/Extension/DublinCore/Renderer/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/DublinCore/Renderer/Feed.php
+++ b/lib/Zend/Feed/Writer/Extension/DublinCore/Renderer/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/ITunes/Entry.php
+++ b/lib/Zend/Feed/Writer/Extension/ITunes/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/ITunes/Feed.php
+++ b/lib/Zend/Feed/Writer/Extension/ITunes/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/ITunes/Renderer/Entry.php
+++ b/lib/Zend/Feed/Writer/Extension/ITunes/Renderer/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/ITunes/Renderer/Feed.php
+++ b/lib/Zend/Feed/Writer/Extension/ITunes/Renderer/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/RendererAbstract.php
+++ b/lib/Zend/Feed/Writer/Extension/RendererAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to padraic dot brady at yahoo dot com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/RendererInterface.php
+++ b/lib/Zend/Feed/Writer/Extension/RendererInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to padraic dot brady at yahoo dot com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/Slash/Renderer/Entry.php
+++ b/lib/Zend/Feed/Writer/Extension/Slash/Renderer/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/Threading/Renderer/Entry.php
+++ b/lib/Zend/Feed/Writer/Extension/Threading/Renderer/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Extension/WellFormedWeb/Renderer/Entry.php
+++ b/lib/Zend/Feed/Writer/Extension/WellFormedWeb/Renderer/Entry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Feed.php
+++ b/lib/Zend/Feed/Writer/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Feed/FeedAbstract.php
+++ b/lib/Zend/Feed/Writer/Feed/FeedAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Renderer/Entry/Atom.php
+++ b/lib/Zend/Feed/Writer/Renderer/Entry/Atom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Renderer/Entry/Atom/Deleted.php
+++ b/lib/Zend/Feed/Writer/Renderer/Entry/Atom/Deleted.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Renderer/Entry/Rss.php
+++ b/lib/Zend/Feed/Writer/Renderer/Entry/Rss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Renderer/Feed/Atom.php
+++ b/lib/Zend/Feed/Writer/Renderer/Feed/Atom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Renderer/Feed/Atom/AtomAbstract.php
+++ b/lib/Zend/Feed/Writer/Renderer/Feed/Atom/AtomAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Renderer/Feed/Atom/Source.php
+++ b/lib/Zend/Feed/Writer/Renderer/Feed/Atom/Source.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Renderer/Feed/Rss.php
+++ b/lib/Zend/Feed/Writer/Renderer/Feed/Rss.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Renderer/RendererAbstract.php
+++ b/lib/Zend/Feed/Writer/Renderer/RendererAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Renderer/RendererInterface.php
+++ b/lib/Zend/Feed/Writer/Renderer/RendererInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Feed/Writer/Source.php
+++ b/lib/Zend/Feed/Writer/Source.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/File/Transfer.php
+++ b/lib/Zend/File/Transfer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/File/Transfer/Adapter/Abstract.php
+++ b/lib/Zend/File/Transfer/Adapter/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/File/Transfer/Adapter/Http.php
+++ b/lib/Zend/File/Transfer/Adapter/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/File/Transfer/Exception.php
+++ b/lib/Zend/File/Transfer/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Filter.php
+++ b/lib/Zend/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Alnum.php
+++ b/lib/Zend/Filter/Alnum.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Alpha.php
+++ b/lib/Zend/Filter/Alpha.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/BaseName.php
+++ b/lib/Zend/Filter/BaseName.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Boolean.php
+++ b/lib/Zend/Filter/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Callback.php
+++ b/lib/Zend/Filter/Callback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Compress.php
+++ b/lib/Zend/Filter/Compress.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Compress/Bz2.php
+++ b/lib/Zend/Filter/Compress/Bz2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Compress/CompressAbstract.php
+++ b/lib/Zend/Filter/Compress/CompressAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Compress/CompressInterface.php
+++ b/lib/Zend/Filter/Compress/CompressInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Compress/Gz.php
+++ b/lib/Zend/Filter/Compress/Gz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Compress/Lzf.php
+++ b/lib/Zend/Filter/Compress/Lzf.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Compress/Rar.php
+++ b/lib/Zend/Filter/Compress/Rar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Compress/Tar.php
+++ b/lib/Zend/Filter/Compress/Tar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Compress/Zip.php
+++ b/lib/Zend/Filter/Compress/Zip.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Decompress.php
+++ b/lib/Zend/Filter/Decompress.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Decrypt.php
+++ b/lib/Zend/Filter/Decrypt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Digits.php
+++ b/lib/Zend/Filter/Digits.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Dir.php
+++ b/lib/Zend/Filter/Dir.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Encrypt.php
+++ b/lib/Zend/Filter/Encrypt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Encrypt/Interface.php
+++ b/lib/Zend/Filter/Encrypt/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Encrypt/Mcrypt.php
+++ b/lib/Zend/Filter/Encrypt/Mcrypt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Encrypt/Openssl.php
+++ b/lib/Zend/Filter/Encrypt/Openssl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Exception.php
+++ b/lib/Zend/Filter/Exception.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/File/Decrypt.php
+++ b/lib/Zend/Filter/File/Decrypt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/File/Encrypt.php
+++ b/lib/Zend/Filter/File/Encrypt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/File/LowerCase.php
+++ b/lib/Zend/Filter/File/LowerCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/File/Rename.php
+++ b/lib/Zend/Filter/File/Rename.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/File/UpperCase.php
+++ b/lib/Zend/Filter/File/UpperCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/HtmlEntities.php
+++ b/lib/Zend/Filter/HtmlEntities.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Inflector.php
+++ b/lib/Zend/Filter/Inflector.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Input.php
+++ b/lib/Zend/Filter/Input.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Int.php
+++ b/lib/Zend/Filter/Int.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Interface.php
+++ b/lib/Zend/Filter/Interface.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/LocalizedToNormalized.php
+++ b/lib/Zend/Filter/LocalizedToNormalized.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/NormalizedToLocalized.php
+++ b/lib/Zend/Filter/NormalizedToLocalized.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Null.php
+++ b/lib/Zend/Filter/Null.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/PregReplace.php
+++ b/lib/Zend/Filter/PregReplace.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/RealPath.php
+++ b/lib/Zend/Filter/RealPath.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/StringToLower.php
+++ b/lib/Zend/Filter/StringToLower.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/StringToUpper.php
+++ b/lib/Zend/Filter/StringToUpper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/StringTrim.php
+++ b/lib/Zend/Filter/StringTrim.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/StripNewlines.php
+++ b/lib/Zend/Filter/StripNewlines.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/StripTags.php
+++ b/lib/Zend/Filter/StripTags.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/CamelCaseToDash.php
+++ b/lib/Zend/Filter/Word/CamelCaseToDash.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/CamelCaseToSeparator.php
+++ b/lib/Zend/Filter/Word/CamelCaseToSeparator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/CamelCaseToUnderscore.php
+++ b/lib/Zend/Filter/Word/CamelCaseToUnderscore.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/DashToCamelCase.php
+++ b/lib/Zend/Filter/Word/DashToCamelCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/DashToSeparator.php
+++ b/lib/Zend/Filter/Word/DashToSeparator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/DashToUnderscore.php
+++ b/lib/Zend/Filter/Word/DashToUnderscore.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/Separator/Abstract.php
+++ b/lib/Zend/Filter/Word/Separator/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/SeparatorToCamelCase.php
+++ b/lib/Zend/Filter/Word/SeparatorToCamelCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/SeparatorToDash.php
+++ b/lib/Zend/Filter/Word/SeparatorToDash.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/SeparatorToSeparator.php
+++ b/lib/Zend/Filter/Word/SeparatorToSeparator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/UnderscoreToCamelCase.php
+++ b/lib/Zend/Filter/Word/UnderscoreToCamelCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/UnderscoreToDash.php
+++ b/lib/Zend/Filter/Word/UnderscoreToDash.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Filter/Word/UnderscoreToSeparator.php
+++ b/lib/Zend/Filter/Word/UnderscoreToSeparator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form.php
+++ b/lib/Zend/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Abstract.php
+++ b/lib/Zend/Form/Decorator/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Callback.php
+++ b/lib/Zend/Form/Decorator/Callback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Captcha.php
+++ b/lib/Zend/Form/Decorator/Captcha.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Captcha/Word.php
+++ b/lib/Zend/Form/Decorator/Captcha/Word.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Description.php
+++ b/lib/Zend/Form/Decorator/Description.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/DtDdWrapper.php
+++ b/lib/Zend/Form/Decorator/DtDdWrapper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Errors.php
+++ b/lib/Zend/Form/Decorator/Errors.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Exception.php
+++ b/lib/Zend/Form/Decorator/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Fieldset.php
+++ b/lib/Zend/Form/Decorator/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/File.php
+++ b/lib/Zend/Form/Decorator/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Form.php
+++ b/lib/Zend/Form/Decorator/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/FormElements.php
+++ b/lib/Zend/Form/Decorator/FormElements.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/FormErrors.php
+++ b/lib/Zend/Form/Decorator/FormErrors.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/HtmlTag.php
+++ b/lib/Zend/Form/Decorator/HtmlTag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Image.php
+++ b/lib/Zend/Form/Decorator/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Interface.php
+++ b/lib/Zend/Form/Decorator/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Label.php
+++ b/lib/Zend/Form/Decorator/Label.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Marker/File/Interface.php
+++ b/lib/Zend/Form/Decorator/Marker/File/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/PrepareElements.php
+++ b/lib/Zend/Form/Decorator/PrepareElements.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/Tooltip.php
+++ b/lib/Zend/Form/Decorator/Tooltip.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/ViewHelper.php
+++ b/lib/Zend/Form/Decorator/ViewHelper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Decorator/ViewScript.php
+++ b/lib/Zend/Form/Decorator/ViewScript.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/DisplayGroup.php
+++ b/lib/Zend/Form/DisplayGroup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element.php
+++ b/lib/Zend/Form/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Button.php
+++ b/lib/Zend/Form/Element/Button.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Captcha.php
+++ b/lib/Zend/Form/Element/Captcha.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Checkbox.php
+++ b/lib/Zend/Form/Element/Checkbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Exception.php
+++ b/lib/Zend/Form/Element/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/File.php
+++ b/lib/Zend/Form/Element/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Hash.php
+++ b/lib/Zend/Form/Element/Hash.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Hidden.php
+++ b/lib/Zend/Form/Element/Hidden.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Image.php
+++ b/lib/Zend/Form/Element/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Multi.php
+++ b/lib/Zend/Form/Element/Multi.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/MultiCheckbox.php
+++ b/lib/Zend/Form/Element/MultiCheckbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Multiselect.php
+++ b/lib/Zend/Form/Element/Multiselect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Password.php
+++ b/lib/Zend/Form/Element/Password.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Radio.php
+++ b/lib/Zend/Form/Element/Radio.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Reset.php
+++ b/lib/Zend/Form/Element/Reset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Select.php
+++ b/lib/Zend/Form/Element/Select.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Submit.php
+++ b/lib/Zend/Form/Element/Submit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Text.php
+++ b/lib/Zend/Form/Element/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Textarea.php
+++ b/lib/Zend/Form/Element/Textarea.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Element/Xhtml.php
+++ b/lib/Zend/Form/Element/Xhtml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/Exception.php
+++ b/lib/Zend/Form/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Form/SubForm.php
+++ b/lib/Zend/Form/SubForm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata.php
+++ b/lib/Zend/Gdata.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App.php
+++ b/lib/Zend/Gdata/App.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/AuthException.php
+++ b/lib/Zend/Gdata/App/AuthException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/BadMethodCallException.php
+++ b/lib/Zend/Gdata/App/BadMethodCallException.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Base.php
+++ b/lib/Zend/Gdata/App/Base.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/BaseMediaSource.php
+++ b/lib/Zend/Gdata/App/BaseMediaSource.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/CaptchaRequiredException.php
+++ b/lib/Zend/Gdata/App/CaptchaRequiredException.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Entry.php
+++ b/lib/Zend/Gdata/App/Entry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Exception.php
+++ b/lib/Zend/Gdata/App/Exception.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension.php
+++ b/lib/Zend/Gdata/App/Extension.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Author.php
+++ b/lib/Zend/Gdata/App/Extension/Author.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Category.php
+++ b/lib/Zend/Gdata/App/Extension/Category.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Content.php
+++ b/lib/Zend/Gdata/App/Extension/Content.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Contributor.php
+++ b/lib/Zend/Gdata/App/Extension/Contributor.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Control.php
+++ b/lib/Zend/Gdata/App/Extension/Control.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Draft.php
+++ b/lib/Zend/Gdata/App/Extension/Draft.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Edited.php
+++ b/lib/Zend/Gdata/App/Extension/Edited.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Element.php
+++ b/lib/Zend/Gdata/App/Extension/Element.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Email.php
+++ b/lib/Zend/Gdata/App/Extension/Email.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Generator.php
+++ b/lib/Zend/Gdata/App/Extension/Generator.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Icon.php
+++ b/lib/Zend/Gdata/App/Extension/Icon.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Id.php
+++ b/lib/Zend/Gdata/App/Extension/Id.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Link.php
+++ b/lib/Zend/Gdata/App/Extension/Link.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Logo.php
+++ b/lib/Zend/Gdata/App/Extension/Logo.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Name.php
+++ b/lib/Zend/Gdata/App/Extension/Name.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Person.php
+++ b/lib/Zend/Gdata/App/Extension/Person.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Published.php
+++ b/lib/Zend/Gdata/App/Extension/Published.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Rights.php
+++ b/lib/Zend/Gdata/App/Extension/Rights.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Source.php
+++ b/lib/Zend/Gdata/App/Extension/Source.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Subtitle.php
+++ b/lib/Zend/Gdata/App/Extension/Subtitle.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Summary.php
+++ b/lib/Zend/Gdata/App/Extension/Summary.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Text.php
+++ b/lib/Zend/Gdata/App/Extension/Text.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Title.php
+++ b/lib/Zend/Gdata/App/Extension/Title.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Extension/Updated.php
+++ b/lib/Zend/Gdata/App/Extension/Updated.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Feed.php
+++ b/lib/Zend/Gdata/App/Feed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/FeedEntryParent.php
+++ b/lib/Zend/Gdata/App/FeedEntryParent.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/FeedSourceParent.php
+++ b/lib/Zend/Gdata/App/FeedSourceParent.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/HttpException.php
+++ b/lib/Zend/Gdata/App/HttpException.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/IOException.php
+++ b/lib/Zend/Gdata/App/IOException.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/InvalidArgumentException.php
+++ b/lib/Zend/Gdata/App/InvalidArgumentException.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/LoggingHttpClientAdapterSocket.php
+++ b/lib/Zend/Gdata/App/LoggingHttpClientAdapterSocket.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/MediaEntry.php
+++ b/lib/Zend/Gdata/App/MediaEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/MediaFileSource.php
+++ b/lib/Zend/Gdata/App/MediaFileSource.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/MediaSource.php
+++ b/lib/Zend/Gdata/App/MediaSource.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/Util.php
+++ b/lib/Zend/Gdata/App/Util.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/App/VersionException.php
+++ b/lib/Zend/Gdata/App/VersionException.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/AuthSub.php
+++ b/lib/Zend/Gdata/AuthSub.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books.php
+++ b/lib/Zend/Gdata/Books.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/CollectionEntry.php
+++ b/lib/Zend/Gdata/Books/CollectionEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/CollectionFeed.php
+++ b/lib/Zend/Gdata/Books/CollectionFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/Extension/AnnotationLink.php
+++ b/lib/Zend/Gdata/Books/Extension/AnnotationLink.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/Extension/BooksCategory.php
+++ b/lib/Zend/Gdata/Books/Extension/BooksCategory.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/Extension/BooksLink.php
+++ b/lib/Zend/Gdata/Books/Extension/BooksLink.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/Extension/Embeddability.php
+++ b/lib/Zend/Gdata/Books/Extension/Embeddability.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/Extension/InfoLink.php
+++ b/lib/Zend/Gdata/Books/Extension/InfoLink.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/Extension/PreviewLink.php
+++ b/lib/Zend/Gdata/Books/Extension/PreviewLink.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/Extension/Review.php
+++ b/lib/Zend/Gdata/Books/Extension/Review.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/Extension/ThumbnailLink.php
+++ b/lib/Zend/Gdata/Books/Extension/ThumbnailLink.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/Extension/Viewability.php
+++ b/lib/Zend/Gdata/Books/Extension/Viewability.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/VolumeEntry.php
+++ b/lib/Zend/Gdata/Books/VolumeEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/VolumeFeed.php
+++ b/lib/Zend/Gdata/Books/VolumeFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Books/VolumeQuery.php
+++ b/lib/Zend/Gdata/Books/VolumeQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar.php
+++ b/lib/Zend/Gdata/Calendar.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/EventEntry.php
+++ b/lib/Zend/Gdata/Calendar/EventEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/EventFeed.php
+++ b/lib/Zend/Gdata/Calendar/EventFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/EventQuery.php
+++ b/lib/Zend/Gdata/Calendar/EventQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/Extension/AccessLevel.php
+++ b/lib/Zend/Gdata/Calendar/Extension/AccessLevel.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/Extension/Color.php
+++ b/lib/Zend/Gdata/Calendar/Extension/Color.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/Extension/Hidden.php
+++ b/lib/Zend/Gdata/Calendar/Extension/Hidden.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/Extension/Link.php
+++ b/lib/Zend/Gdata/Calendar/Extension/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/Extension/QuickAdd.php
+++ b/lib/Zend/Gdata/Calendar/Extension/QuickAdd.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/Extension/Selected.php
+++ b/lib/Zend/Gdata/Calendar/Extension/Selected.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/Extension/SendEventNotifications.php
+++ b/lib/Zend/Gdata/Calendar/Extension/SendEventNotifications.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/Extension/Timezone.php
+++ b/lib/Zend/Gdata/Calendar/Extension/Timezone.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/Extension/WebContent.php
+++ b/lib/Zend/Gdata/Calendar/Extension/WebContent.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/ListEntry.php
+++ b/lib/Zend/Gdata/Calendar/ListEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Calendar/ListFeed.php
+++ b/lib/Zend/Gdata/Calendar/ListFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/ClientLogin.php
+++ b/lib/Zend/Gdata/ClientLogin.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Docs.php
+++ b/lib/Zend/Gdata/Docs.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Docs/DocumentListEntry.php
+++ b/lib/Zend/Gdata/Docs/DocumentListEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Docs/DocumentListFeed.php
+++ b/lib/Zend/Gdata/Docs/DocumentListFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Docs/Query.php
+++ b/lib/Zend/Gdata/Docs/Query.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore.php
+++ b/lib/Zend/Gdata/DublinCore.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore/Extension/Creator.php
+++ b/lib/Zend/Gdata/DublinCore/Extension/Creator.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore/Extension/Date.php
+++ b/lib/Zend/Gdata/DublinCore/Extension/Date.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore/Extension/Description.php
+++ b/lib/Zend/Gdata/DublinCore/Extension/Description.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore/Extension/Format.php
+++ b/lib/Zend/Gdata/DublinCore/Extension/Format.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore/Extension/Identifier.php
+++ b/lib/Zend/Gdata/DublinCore/Extension/Identifier.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore/Extension/Language.php
+++ b/lib/Zend/Gdata/DublinCore/Extension/Language.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore/Extension/Publisher.php
+++ b/lib/Zend/Gdata/DublinCore/Extension/Publisher.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore/Extension/Rights.php
+++ b/lib/Zend/Gdata/DublinCore/Extension/Rights.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore/Extension/Subject.php
+++ b/lib/Zend/Gdata/DublinCore/Extension/Subject.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/DublinCore/Extension/Title.php
+++ b/lib/Zend/Gdata/DublinCore/Extension/Title.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Entry.php
+++ b/lib/Zend/Gdata/Entry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif.php
+++ b/lib/Zend/Gdata/Exif.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Entry.php
+++ b/lib/Zend/Gdata/Exif/Entry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/Distance.php
+++ b/lib/Zend/Gdata/Exif/Extension/Distance.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/Exposure.php
+++ b/lib/Zend/Gdata/Exif/Extension/Exposure.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/FStop.php
+++ b/lib/Zend/Gdata/Exif/Extension/FStop.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/Flash.php
+++ b/lib/Zend/Gdata/Exif/Extension/Flash.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/FocalLength.php
+++ b/lib/Zend/Gdata/Exif/Extension/FocalLength.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/ImageUniqueId.php
+++ b/lib/Zend/Gdata/Exif/Extension/ImageUniqueId.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/Iso.php
+++ b/lib/Zend/Gdata/Exif/Extension/Iso.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/Make.php
+++ b/lib/Zend/Gdata/Exif/Extension/Make.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/Model.php
+++ b/lib/Zend/Gdata/Exif/Extension/Model.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/Tags.php
+++ b/lib/Zend/Gdata/Exif/Extension/Tags.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Extension/Time.php
+++ b/lib/Zend/Gdata/Exif/Extension/Time.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Exif/Feed.php
+++ b/lib/Zend/Gdata/Exif/Feed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension.php
+++ b/lib/Zend/Gdata/Extension.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/AttendeeStatus.php
+++ b/lib/Zend/Gdata/Extension/AttendeeStatus.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/AttendeeType.php
+++ b/lib/Zend/Gdata/Extension/AttendeeType.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/Comments.php
+++ b/lib/Zend/Gdata/Extension/Comments.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/EntryLink.php
+++ b/lib/Zend/Gdata/Extension/EntryLink.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/EventStatus.php
+++ b/lib/Zend/Gdata/Extension/EventStatus.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/ExtendedProperty.php
+++ b/lib/Zend/Gdata/Extension/ExtendedProperty.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/FeedLink.php
+++ b/lib/Zend/Gdata/Extension/FeedLink.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/OpenSearchItemsPerPage.php
+++ b/lib/Zend/Gdata/Extension/OpenSearchItemsPerPage.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/OpenSearchStartIndex.php
+++ b/lib/Zend/Gdata/Extension/OpenSearchStartIndex.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/OpenSearchTotalResults.php
+++ b/lib/Zend/Gdata/Extension/OpenSearchTotalResults.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/OriginalEvent.php
+++ b/lib/Zend/Gdata/Extension/OriginalEvent.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/Rating.php
+++ b/lib/Zend/Gdata/Extension/Rating.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/Recurrence.php
+++ b/lib/Zend/Gdata/Extension/Recurrence.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/RecurrenceException.php
+++ b/lib/Zend/Gdata/Extension/RecurrenceException.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/Reminder.php
+++ b/lib/Zend/Gdata/Extension/Reminder.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/Transparency.php
+++ b/lib/Zend/Gdata/Extension/Transparency.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/Visibility.php
+++ b/lib/Zend/Gdata/Extension/Visibility.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/When.php
+++ b/lib/Zend/Gdata/Extension/When.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/Where.php
+++ b/lib/Zend/Gdata/Extension/Where.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Extension/Who.php
+++ b/lib/Zend/Gdata/Extension/Who.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Feed.php
+++ b/lib/Zend/Gdata/Feed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps.php
+++ b/lib/Zend/Gdata/Gapps.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/EmailListEntry.php
+++ b/lib/Zend/Gdata/Gapps/EmailListEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/EmailListFeed.php
+++ b/lib/Zend/Gdata/Gapps/EmailListFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/EmailListQuery.php
+++ b/lib/Zend/Gdata/Gapps/EmailListQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/EmailListRecipientEntry.php
+++ b/lib/Zend/Gdata/Gapps/EmailListRecipientEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/EmailListRecipientFeed.php
+++ b/lib/Zend/Gdata/Gapps/EmailListRecipientFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/EmailListRecipientQuery.php
+++ b/lib/Zend/Gdata/Gapps/EmailListRecipientQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/Error.php
+++ b/lib/Zend/Gdata/Gapps/Error.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/Extension/EmailList.php
+++ b/lib/Zend/Gdata/Gapps/Extension/EmailList.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/Extension/Login.php
+++ b/lib/Zend/Gdata/Gapps/Extension/Login.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/Extension/Name.php
+++ b/lib/Zend/Gdata/Gapps/Extension/Name.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/Extension/Nickname.php
+++ b/lib/Zend/Gdata/Gapps/Extension/Nickname.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/Extension/Property.php
+++ b/lib/Zend/Gdata/Gapps/Extension/Property.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/Extension/Quota.php
+++ b/lib/Zend/Gdata/Gapps/Extension/Quota.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/GroupEntry.php
+++ b/lib/Zend/Gdata/Gapps/GroupEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/GroupFeed.php
+++ b/lib/Zend/Gdata/Gapps/GroupFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/GroupQuery.php
+++ b/lib/Zend/Gdata/Gapps/GroupQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/MemberEntry.php
+++ b/lib/Zend/Gdata/Gapps/MemberEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/MemberFeed.php
+++ b/lib/Zend/Gdata/Gapps/MemberFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/MemberQuery.php
+++ b/lib/Zend/Gdata/Gapps/MemberQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/NicknameEntry.php
+++ b/lib/Zend/Gdata/Gapps/NicknameEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/NicknameFeed.php
+++ b/lib/Zend/Gdata/Gapps/NicknameFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/NicknameQuery.php
+++ b/lib/Zend/Gdata/Gapps/NicknameQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/OwnerEntry.php
+++ b/lib/Zend/Gdata/Gapps/OwnerEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/OwnerFeed.php
+++ b/lib/Zend/Gdata/Gapps/OwnerFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/OwnerQuery.php
+++ b/lib/Zend/Gdata/Gapps/OwnerQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/Query.php
+++ b/lib/Zend/Gdata/Gapps/Query.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/ServiceException.php
+++ b/lib/Zend/Gdata/Gapps/ServiceException.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/UserEntry.php
+++ b/lib/Zend/Gdata/Gapps/UserEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/UserFeed.php
+++ b/lib/Zend/Gdata/Gapps/UserFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gapps/UserQuery.php
+++ b/lib/Zend/Gdata/Gapps/UserQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase.php
+++ b/lib/Zend/Gdata/Gbase.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase/Entry.php
+++ b/lib/Zend/Gdata/Gbase/Entry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase/Extension/BaseAttribute.php
+++ b/lib/Zend/Gdata/Gbase/Extension/BaseAttribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase/Feed.php
+++ b/lib/Zend/Gdata/Gbase/Feed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase/ItemEntry.php
+++ b/lib/Zend/Gdata/Gbase/ItemEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase/ItemFeed.php
+++ b/lib/Zend/Gdata/Gbase/ItemFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase/ItemQuery.php
+++ b/lib/Zend/Gdata/Gbase/ItemQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase/Query.php
+++ b/lib/Zend/Gdata/Gbase/Query.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase/SnippetEntry.php
+++ b/lib/Zend/Gdata/Gbase/SnippetEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase/SnippetFeed.php
+++ b/lib/Zend/Gdata/Gbase/SnippetFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Gbase/SnippetQuery.php
+++ b/lib/Zend/Gdata/Gbase/SnippetQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Geo.php
+++ b/lib/Zend/Gdata/Geo.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Geo/Entry.php
+++ b/lib/Zend/Gdata/Geo/Entry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Geo/Extension/GeoRssWhere.php
+++ b/lib/Zend/Gdata/Geo/Extension/GeoRssWhere.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Geo/Extension/GmlPoint.php
+++ b/lib/Zend/Gdata/Geo/Extension/GmlPoint.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Geo/Extension/GmlPos.php
+++ b/lib/Zend/Gdata/Geo/Extension/GmlPos.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Geo/Feed.php
+++ b/lib/Zend/Gdata/Geo/Feed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Health.php
+++ b/lib/Zend/Gdata/Health.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Health/Extension/Ccr.php
+++ b/lib/Zend/Gdata/Health/Extension/Ccr.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Health/ProfileEntry.php
+++ b/lib/Zend/Gdata/Health/ProfileEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Health/ProfileFeed.php
+++ b/lib/Zend/Gdata/Health/ProfileFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Health/ProfileListEntry.php
+++ b/lib/Zend/Gdata/Health/ProfileListEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Health/ProfileListFeed.php
+++ b/lib/Zend/Gdata/Health/ProfileListFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Health/Query.php
+++ b/lib/Zend/Gdata/Health/Query.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/HttpAdapterStreamingProxy.php
+++ b/lib/Zend/Gdata/HttpAdapterStreamingProxy.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/HttpAdapterStreamingSocket.php
+++ b/lib/Zend/Gdata/HttpAdapterStreamingSocket.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/HttpClient.php
+++ b/lib/Zend/Gdata/HttpClient.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Kind/EventEntry.php
+++ b/lib/Zend/Gdata/Kind/EventEntry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media.php
+++ b/lib/Zend/Gdata/Media.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Entry.php
+++ b/lib/Zend/Gdata/Media/Entry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaCategory.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaCategory.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaContent.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaContent.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaCopyright.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaCopyright.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaCredit.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaCredit.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaDescription.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaDescription.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaGroup.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaGroup.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaHash.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaHash.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaKeywords.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaKeywords.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaPlayer.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaPlayer.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaRating.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaRating.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaRestriction.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaRestriction.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaText.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaText.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaThumbnail.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaThumbnail.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Extension/MediaTitle.php
+++ b/lib/Zend/Gdata/Media/Extension/MediaTitle.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Media/Feed.php
+++ b/lib/Zend/Gdata/Media/Feed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/MediaMimeStream.php
+++ b/lib/Zend/Gdata/MediaMimeStream.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/MimeBodyString.php
+++ b/lib/Zend/Gdata/MimeBodyString.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/MimeFile.php
+++ b/lib/Zend/Gdata/MimeFile.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos.php
+++ b/lib/Zend/Gdata/Photos.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/AlbumEntry.php
+++ b/lib/Zend/Gdata/Photos/AlbumEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/AlbumFeed.php
+++ b/lib/Zend/Gdata/Photos/AlbumFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/AlbumQuery.php
+++ b/lib/Zend/Gdata/Photos/AlbumQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/CommentEntry.php
+++ b/lib/Zend/Gdata/Photos/CommentEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Access.php
+++ b/lib/Zend/Gdata/Photos/Extension/Access.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/AlbumId.php
+++ b/lib/Zend/Gdata/Photos/Extension/AlbumId.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/BytesUsed.php
+++ b/lib/Zend/Gdata/Photos/Extension/BytesUsed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Checksum.php
+++ b/lib/Zend/Gdata/Photos/Extension/Checksum.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Client.php
+++ b/lib/Zend/Gdata/Photos/Extension/Client.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/CommentCount.php
+++ b/lib/Zend/Gdata/Photos/Extension/CommentCount.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/CommentingEnabled.php
+++ b/lib/Zend/Gdata/Photos/Extension/CommentingEnabled.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Height.php
+++ b/lib/Zend/Gdata/Photos/Extension/Height.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Id.php
+++ b/lib/Zend/Gdata/Photos/Extension/Id.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Location.php
+++ b/lib/Zend/Gdata/Photos/Extension/Location.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/MaxPhotosPerAlbum.php
+++ b/lib/Zend/Gdata/Photos/Extension/MaxPhotosPerAlbum.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Name.php
+++ b/lib/Zend/Gdata/Photos/Extension/Name.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Nickname.php
+++ b/lib/Zend/Gdata/Photos/Extension/Nickname.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/NumPhotos.php
+++ b/lib/Zend/Gdata/Photos/Extension/NumPhotos.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/NumPhotosRemaining.php
+++ b/lib/Zend/Gdata/Photos/Extension/NumPhotosRemaining.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/PhotoId.php
+++ b/lib/Zend/Gdata/Photos/Extension/PhotoId.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Position.php
+++ b/lib/Zend/Gdata/Photos/Extension/Position.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/QuotaCurrent.php
+++ b/lib/Zend/Gdata/Photos/Extension/QuotaCurrent.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/QuotaLimit.php
+++ b/lib/Zend/Gdata/Photos/Extension/QuotaLimit.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Rotation.php
+++ b/lib/Zend/Gdata/Photos/Extension/Rotation.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Size.php
+++ b/lib/Zend/Gdata/Photos/Extension/Size.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Thumbnail.php
+++ b/lib/Zend/Gdata/Photos/Extension/Thumbnail.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Timestamp.php
+++ b/lib/Zend/Gdata/Photos/Extension/Timestamp.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/User.php
+++ b/lib/Zend/Gdata/Photos/Extension/User.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Version.php
+++ b/lib/Zend/Gdata/Photos/Extension/Version.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Weight.php
+++ b/lib/Zend/Gdata/Photos/Extension/Weight.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/Extension/Width.php
+++ b/lib/Zend/Gdata/Photos/Extension/Width.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/PhotoEntry.php
+++ b/lib/Zend/Gdata/Photos/PhotoEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/PhotoFeed.php
+++ b/lib/Zend/Gdata/Photos/PhotoFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/PhotoQuery.php
+++ b/lib/Zend/Gdata/Photos/PhotoQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/TagEntry.php
+++ b/lib/Zend/Gdata/Photos/TagEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/UserEntry.php
+++ b/lib/Zend/Gdata/Photos/UserEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/UserFeed.php
+++ b/lib/Zend/Gdata/Photos/UserFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Photos/UserQuery.php
+++ b/lib/Zend/Gdata/Photos/UserQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Query.php
+++ b/lib/Zend/Gdata/Query.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets.php
+++ b/lib/Zend/Gdata/Spreadsheets.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category     Zend

--- a/lib/Zend/Gdata/Spreadsheets/CellEntry.php
+++ b/lib/Zend/Gdata/Spreadsheets/CellEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category     Zend

--- a/lib/Zend/Gdata/Spreadsheets/CellFeed.php
+++ b/lib/Zend/Gdata/Spreadsheets/CellFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/CellQuery.php
+++ b/lib/Zend/Gdata/Spreadsheets/CellQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/DocumentQuery.php
+++ b/lib/Zend/Gdata/Spreadsheets/DocumentQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/Extension/Cell.php
+++ b/lib/Zend/Gdata/Spreadsheets/Extension/Cell.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/Extension/ColCount.php
+++ b/lib/Zend/Gdata/Spreadsheets/Extension/ColCount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/Extension/Custom.php
+++ b/lib/Zend/Gdata/Spreadsheets/Extension/Custom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/Extension/RowCount.php
+++ b/lib/Zend/Gdata/Spreadsheets/Extension/RowCount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/ListEntry.php
+++ b/lib/Zend/Gdata/Spreadsheets/ListEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category     Zend

--- a/lib/Zend/Gdata/Spreadsheets/ListFeed.php
+++ b/lib/Zend/Gdata/Spreadsheets/ListFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/ListQuery.php
+++ b/lib/Zend/Gdata/Spreadsheets/ListQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/SpreadsheetEntry.php
+++ b/lib/Zend/Gdata/Spreadsheets/SpreadsheetEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/SpreadsheetFeed.php
+++ b/lib/Zend/Gdata/Spreadsheets/SpreadsheetFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/WorksheetEntry.php
+++ b/lib/Zend/Gdata/Spreadsheets/WorksheetEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/Spreadsheets/WorksheetFeed.php
+++ b/lib/Zend/Gdata/Spreadsheets/WorksheetFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube.php
+++ b/lib/Zend/Gdata/YouTube.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/ActivityEntry.php
+++ b/lib/Zend/Gdata/YouTube/ActivityEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/ActivityFeed.php
+++ b/lib/Zend/Gdata/YouTube/ActivityFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/CommentEntry.php
+++ b/lib/Zend/Gdata/YouTube/CommentEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/CommentFeed.php
+++ b/lib/Zend/Gdata/YouTube/CommentFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/ContactEntry.php
+++ b/lib/Zend/Gdata/YouTube/ContactEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/ContactFeed.php
+++ b/lib/Zend/Gdata/YouTube/ContactFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/AboutMe.php
+++ b/lib/Zend/Gdata/YouTube/Extension/AboutMe.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Age.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Age.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Books.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Books.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Company.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Company.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Control.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Control.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/CountHint.php
+++ b/lib/Zend/Gdata/YouTube/Extension/CountHint.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Description.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Description.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Duration.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Duration.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/FirstName.php
+++ b/lib/Zend/Gdata/YouTube/Extension/FirstName.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Gender.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Gender.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Hobbies.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Hobbies.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Hometown.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Hometown.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/LastName.php
+++ b/lib/Zend/Gdata/YouTube/Extension/LastName.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Link.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Location.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Location.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/MediaContent.php
+++ b/lib/Zend/Gdata/YouTube/Extension/MediaContent.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/MediaCredit.php
+++ b/lib/Zend/Gdata/YouTube/Extension/MediaCredit.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/MediaGroup.php
+++ b/lib/Zend/Gdata/YouTube/Extension/MediaGroup.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/MediaRating.php
+++ b/lib/Zend/Gdata/YouTube/Extension/MediaRating.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Movies.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Movies.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Music.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Music.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/NoEmbed.php
+++ b/lib/Zend/Gdata/YouTube/Extension/NoEmbed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Occupation.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Occupation.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/PlaylistId.php
+++ b/lib/Zend/Gdata/YouTube/Extension/PlaylistId.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/PlaylistTitle.php
+++ b/lib/Zend/Gdata/YouTube/Extension/PlaylistTitle.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Position.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Position.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Private.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Private.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/QueryString.php
+++ b/lib/Zend/Gdata/YouTube/Extension/QueryString.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Racy.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Racy.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Recorded.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Recorded.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Relationship.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Relationship.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/ReleaseDate.php
+++ b/lib/Zend/Gdata/YouTube/Extension/ReleaseDate.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/School.php
+++ b/lib/Zend/Gdata/YouTube/Extension/School.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/State.php
+++ b/lib/Zend/Gdata/YouTube/Extension/State.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Statistics.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Statistics.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Status.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Status.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Token.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Token.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Uploaded.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Uploaded.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/Username.php
+++ b/lib/Zend/Gdata/YouTube/Extension/Username.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/Extension/VideoId.php
+++ b/lib/Zend/Gdata/YouTube/Extension/VideoId.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/InboxEntry.php
+++ b/lib/Zend/Gdata/YouTube/InboxEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/InboxFeed.php
+++ b/lib/Zend/Gdata/YouTube/InboxFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/MediaEntry.php
+++ b/lib/Zend/Gdata/YouTube/MediaEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/PlaylistListEntry.php
+++ b/lib/Zend/Gdata/YouTube/PlaylistListEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/PlaylistListFeed.php
+++ b/lib/Zend/Gdata/YouTube/PlaylistListFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/PlaylistVideoEntry.php
+++ b/lib/Zend/Gdata/YouTube/PlaylistVideoEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/PlaylistVideoFeed.php
+++ b/lib/Zend/Gdata/YouTube/PlaylistVideoFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/SubscriptionEntry.php
+++ b/lib/Zend/Gdata/YouTube/SubscriptionEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/SubscriptionFeed.php
+++ b/lib/Zend/Gdata/YouTube/SubscriptionFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/UserProfileEntry.php
+++ b/lib/Zend/Gdata/YouTube/UserProfileEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/VideoEntry.php
+++ b/lib/Zend/Gdata/YouTube/VideoEntry.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/VideoFeed.php
+++ b/lib/Zend/Gdata/YouTube/VideoFeed.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Gdata/YouTube/VideoQuery.php
+++ b/lib/Zend/Gdata/YouTube/VideoQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Client.php
+++ b/lib/Zend/Http/Client.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Client/Adapter/Curl.php
+++ b/lib/Zend/Http/Client/Adapter/Curl.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Client/Adapter/Exception.php
+++ b/lib/Zend/Http/Client/Adapter/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Client/Adapter/Interface.php
+++ b/lib/Zend/Http/Client/Adapter/Interface.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Client/Adapter/Proxy.php
+++ b/lib/Zend/Http/Client/Adapter/Proxy.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Client/Adapter/Socket.php
+++ b/lib/Zend/Http/Client/Adapter/Socket.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Client/Adapter/Stream.php
+++ b/lib/Zend/Http/Client/Adapter/Stream.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Client/Adapter/Test.php
+++ b/lib/Zend/Http/Client/Adapter/Test.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Client/Exception.php
+++ b/lib/Zend/Http/Client/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Cookie.php
+++ b/lib/Zend/Http/Cookie.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/CookieJar.php
+++ b/lib/Zend/Http/CookieJar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Exception.php
+++ b/lib/Zend/Http/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Response.php
+++ b/lib/Zend/Http/Response.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/Response/Stream.php
+++ b/lib/Zend/Http/Response/Stream.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent.php
+++ b/lib/Zend/Http/UserAgent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/AbstractDevice.php
+++ b/lib/Zend/Http/UserAgent/AbstractDevice.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Bot.php
+++ b/lib/Zend/Http/UserAgent/Bot.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Checker.php
+++ b/lib/Zend/Http/UserAgent/Checker.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Console.php
+++ b/lib/Zend/Http/UserAgent/Console.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Desktop.php
+++ b/lib/Zend/Http/UserAgent/Desktop.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Device.php
+++ b/lib/Zend/Http/UserAgent/Device.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Email.php
+++ b/lib/Zend/Http/UserAgent/Email.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Exception.php
+++ b/lib/Zend/Http/UserAgent/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Features/Adapter.php
+++ b/lib/Zend/Http/UserAgent/Features/Adapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Features/Adapter/DeviceAtlas.php
+++ b/lib/Zend/Http/UserAgent/Features/Adapter/DeviceAtlas.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php
+++ b/lib/Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Features/Adapter/WurflApi.php
+++ b/lib/Zend/Http/UserAgent/Features/Adapter/WurflApi.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Features/Exception.php
+++ b/lib/Zend/Http/UserAgent/Features/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Feed.php
+++ b/lib/Zend/Http/UserAgent/Feed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Mobile.php
+++ b/lib/Zend/Http/UserAgent/Mobile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Offline.php
+++ b/lib/Zend/Http/UserAgent/Offline.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Probe.php
+++ b/lib/Zend/Http/UserAgent/Probe.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Spam.php
+++ b/lib/Zend/Http/UserAgent/Spam.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Storage.php
+++ b/lib/Zend/Http/UserAgent/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Storage/Exception.php
+++ b/lib/Zend/Http/UserAgent/Storage/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Storage/NonPersistent.php
+++ b/lib/Zend/Http/UserAgent/Storage/NonPersistent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Storage/Session.php
+++ b/lib/Zend/Http/UserAgent/Storage/Session.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Text.php
+++ b/lib/Zend/Http/UserAgent/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Http/UserAgent/Validator.php
+++ b/lib/Zend/Http/UserAgent/Validator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard.php
+++ b/lib/Zend/InfoCard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Adapter/Default.php
+++ b/lib/Zend/InfoCard/Adapter/Default.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Adapter/Exception.php
+++ b/lib/Zend/InfoCard/Adapter/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Adapter/Interface.php
+++ b/lib/Zend/InfoCard/Adapter/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher.php
+++ b/lib/Zend/InfoCard/Cipher.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Exception.php
+++ b/lib/Zend/InfoCard/Cipher/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Pki/Adapter/Abstract.php
+++ b/lib/Zend/InfoCard/Cipher/Pki/Adapter/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Pki/Adapter/Rsa.php
+++ b/lib/Zend/InfoCard/Cipher/Pki/Adapter/Rsa.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Pki/Interface.php
+++ b/lib/Zend/InfoCard/Cipher/Pki/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Pki/Rsa/Interface.php
+++ b/lib/Zend/InfoCard/Cipher/Pki/Rsa/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Symmetric/Adapter/Abstract.php
+++ b/lib/Zend/InfoCard/Cipher/Symmetric/Adapter/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Symmetric/Adapter/Aes128cbc.php
+++ b/lib/Zend/InfoCard/Cipher/Symmetric/Adapter/Aes128cbc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Symmetric/Adapter/Aes256cbc.php
+++ b/lib/Zend/InfoCard/Cipher/Symmetric/Adapter/Aes256cbc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Symmetric/Aes128cbc/Interface.php
+++ b/lib/Zend/InfoCard/Cipher/Symmetric/Aes128cbc/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Symmetric/Aes256cbc/Interface.php
+++ b/lib/Zend/InfoCard/Cipher/Symmetric/Aes256cbc/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Cipher/Symmetric/Interface.php
+++ b/lib/Zend/InfoCard/Cipher/Symmetric/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Claims.php
+++ b/lib/Zend/InfoCard/Claims.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Exception.php
+++ b/lib/Zend/InfoCard/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Assertion.php
+++ b/lib/Zend/InfoCard/Xml/Assertion.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Assertion/Interface.php
+++ b/lib/Zend/InfoCard/Xml/Assertion/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Assertion/Saml.php
+++ b/lib/Zend/InfoCard/Xml/Assertion/Saml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Element.php
+++ b/lib/Zend/InfoCard/Xml/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Element/Interface.php
+++ b/lib/Zend/InfoCard/Xml/Element/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/EncryptedData.php
+++ b/lib/Zend/InfoCard/Xml/EncryptedData.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/EncryptedData/Abstract.php
+++ b/lib/Zend/InfoCard/Xml/EncryptedData/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/EncryptedData/XmlEnc.php
+++ b/lib/Zend/InfoCard/Xml/EncryptedData/XmlEnc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/EncryptedKey.php
+++ b/lib/Zend/InfoCard/Xml/EncryptedKey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Exception.php
+++ b/lib/Zend/InfoCard/Xml/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/KeyInfo.php
+++ b/lib/Zend/InfoCard/Xml/KeyInfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/KeyInfo/Abstract.php
+++ b/lib/Zend/InfoCard/Xml/KeyInfo/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/KeyInfo/Default.php
+++ b/lib/Zend/InfoCard/Xml/KeyInfo/Default.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/KeyInfo/Interface.php
+++ b/lib/Zend/InfoCard/Xml/KeyInfo/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/KeyInfo/XmlDSig.php
+++ b/lib/Zend/InfoCard/Xml/KeyInfo/XmlDSig.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Security.php
+++ b/lib/Zend/InfoCard/Xml/Security.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Security/Exception.php
+++ b/lib/Zend/InfoCard/Xml/Security/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Security/Transform.php
+++ b/lib/Zend/InfoCard/Xml/Security/Transform.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Security/Transform/EnvelopedSignature.php
+++ b/lib/Zend/InfoCard/Xml/Security/Transform/EnvelopedSignature.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Security/Transform/Exception.php
+++ b/lib/Zend/InfoCard/Xml/Security/Transform/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Security/Transform/Interface.php
+++ b/lib/Zend/InfoCard/Xml/Security/Transform/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/Security/Transform/XmlExcC14N.php
+++ b/lib/Zend/InfoCard/Xml/Security/Transform/XmlExcC14N.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/InfoCard/Xml/SecurityTokenReference.php
+++ b/lib/Zend/InfoCard/Xml/SecurityTokenReference.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json.php
+++ b/lib/Zend/Json.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Decoder.php
+++ b/lib/Zend/Json/Decoder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Encoder.php
+++ b/lib/Zend/Json/Encoder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Exception.php
+++ b/lib/Zend/Json/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Expr.php
+++ b/lib/Zend/Json/Expr.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Server.php
+++ b/lib/Zend/Json/Server.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Server/Cache.php
+++ b/lib/Zend/Json/Server/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Server/Error.php
+++ b/lib/Zend/Json/Server/Error.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Server/Exception.php
+++ b/lib/Zend/Json/Server/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Server/Request.php
+++ b/lib/Zend/Json/Server/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Server/Request/Http.php
+++ b/lib/Zend/Json/Server/Request/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Server/Response.php
+++ b/lib/Zend/Json/Server/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Server/Response/Http.php
+++ b/lib/Zend/Json/Server/Response/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Server/Smd.php
+++ b/lib/Zend/Json/Server/Smd.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Json/Server/Smd/Service.php
+++ b/lib/Zend/Json/Server/Smd/Service.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Layout.php
+++ b/lib/Zend/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Layout/Controller/Action/Helper/Layout.php
+++ b/lib/Zend/Layout/Controller/Action/Helper/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Layout/Controller/Plugin/Layout.php
+++ b/lib/Zend/Layout/Controller/Plugin/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Layout/Exception.php
+++ b/lib/Zend/Layout/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap.php
+++ b/lib/Zend/Ldap.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Attribute.php
+++ b/lib/Zend/Ldap/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Collection.php
+++ b/lib/Zend/Ldap/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Collection/Iterator/Default.php
+++ b/lib/Zend/Ldap/Collection/Iterator/Default.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Converter.php
+++ b/lib/Zend/Ldap/Converter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Converter/Exception.php
+++ b/lib/Zend/Ldap/Converter/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Dn.php
+++ b/lib/Zend/Ldap/Dn.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Exception.php
+++ b/lib/Zend/Ldap/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Filter.php
+++ b/lib/Zend/Ldap/Filter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Filter/Abstract.php
+++ b/lib/Zend/Ldap/Filter/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Filter/And.php
+++ b/lib/Zend/Ldap/Filter/And.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Filter/Exception.php
+++ b/lib/Zend/Ldap/Filter/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Filter/Logical.php
+++ b/lib/Zend/Ldap/Filter/Logical.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Filter/Mask.php
+++ b/lib/Zend/Ldap/Filter/Mask.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Filter/Not.php
+++ b/lib/Zend/Ldap/Filter/Not.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Filter/Or.php
+++ b/lib/Zend/Ldap/Filter/Or.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Filter/String.php
+++ b/lib/Zend/Ldap/Filter/String.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Ldif/Encoder.php
+++ b/lib/Zend/Ldap/Ldif/Encoder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node.php
+++ b/lib/Zend/Ldap/Node.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Abstract.php
+++ b/lib/Zend/Ldap/Node/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/ChildrenIterator.php
+++ b/lib/Zend/Ldap/Node/ChildrenIterator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Collection.php
+++ b/lib/Zend/Ldap/Node/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/RootDse.php
+++ b/lib/Zend/Ldap/Node/RootDse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/RootDse/ActiveDirectory.php
+++ b/lib/Zend/Ldap/Node/RootDse/ActiveDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/RootDse/OpenLdap.php
+++ b/lib/Zend/Ldap/Node/RootDse/OpenLdap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/RootDse/eDirectory.php
+++ b/lib/Zend/Ldap/Node/RootDse/eDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Schema.php
+++ b/lib/Zend/Ldap/Node/Schema.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Schema/ActiveDirectory.php
+++ b/lib/Zend/Ldap/Node/Schema/ActiveDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Schema/AttributeType/ActiveDirectory.php
+++ b/lib/Zend/Ldap/Node/Schema/AttributeType/ActiveDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Schema/AttributeType/Interface.php
+++ b/lib/Zend/Ldap/Node/Schema/AttributeType/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Schema/AttributeType/OpenLdap.php
+++ b/lib/Zend/Ldap/Node/Schema/AttributeType/OpenLdap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Schema/Item.php
+++ b/lib/Zend/Ldap/Node/Schema/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Schema/ObjectClass/ActiveDirectory.php
+++ b/lib/Zend/Ldap/Node/Schema/ObjectClass/ActiveDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Schema/ObjectClass/Interface.php
+++ b/lib/Zend/Ldap/Node/Schema/ObjectClass/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Schema/ObjectClass/OpenLdap.php
+++ b/lib/Zend/Ldap/Node/Schema/ObjectClass/OpenLdap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Ldap/Node/Schema/OpenLdap.php
+++ b/lib/Zend/Ldap/Node/Schema/OpenLdap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Loader.php
+++ b/lib/Zend/Loader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Loader/Autoloader.php
+++ b/lib/Zend/Loader/Autoloader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Loader/Autoloader/Interface.php
+++ b/lib/Zend/Loader/Autoloader/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Loader/Autoloader/Resource.php
+++ b/lib/Zend/Loader/Autoloader/Resource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Loader/Exception.php
+++ b/lib/Zend/Loader/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Loader/PluginLoader.php
+++ b/lib/Zend/Loader/PluginLoader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Loader/PluginLoader/Exception.php
+++ b/lib/Zend/Loader/PluginLoader/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Loader/PluginLoader/Interface.php
+++ b/lib/Zend/Loader/PluginLoader/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Locale.php
+++ b/lib/Zend/Locale.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Locale/Data.php
+++ b/lib/Zend/Locale/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Locale/Data/Translation.php
+++ b/lib/Zend/Locale/Data/Translation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Locale/Exception.php
+++ b/lib/Zend/Locale/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Locale/Format.php
+++ b/lib/Zend/Locale/Format.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Locale/Math.php
+++ b/lib/Zend/Locale/Math.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Locale/Math/Exception.php
+++ b/lib/Zend/Locale/Math/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Locale/Math/PhpMath.php
+++ b/lib/Zend/Locale/Math/PhpMath.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log.php
+++ b/lib/Zend/Log.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Exception.php
+++ b/lib/Zend/Log/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/FactoryInterface.php
+++ b/lib/Zend/Log/FactoryInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Filter/Abstract.php
+++ b/lib/Zend/Log/Filter/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Filter/Interface.php
+++ b/lib/Zend/Log/Filter/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Filter/Message.php
+++ b/lib/Zend/Log/Filter/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Filter/Priority.php
+++ b/lib/Zend/Log/Filter/Priority.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Filter/Suppress.php
+++ b/lib/Zend/Log/Filter/Suppress.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Formatter/Firebug.php
+++ b/lib/Zend/Log/Formatter/Firebug.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Formatter/Interface.php
+++ b/lib/Zend/Log/Formatter/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Formatter/Simple.php
+++ b/lib/Zend/Log/Formatter/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Formatter/Xml.php
+++ b/lib/Zend/Log/Formatter/Xml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Writer/Abstract.php
+++ b/lib/Zend/Log/Writer/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Writer/Db.php
+++ b/lib/Zend/Log/Writer/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Writer/Firebug.php
+++ b/lib/Zend/Log/Writer/Firebug.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Writer/Mail.php
+++ b/lib/Zend/Log/Writer/Mail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Writer/Mock.php
+++ b/lib/Zend/Log/Writer/Mock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Writer/Null.php
+++ b/lib/Zend/Log/Writer/Null.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Writer/Stream.php
+++ b/lib/Zend/Log/Writer/Stream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Writer/Syslog.php
+++ b/lib/Zend/Log/Writer/Syslog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Log/Writer/ZendMonitor.php
+++ b/lib/Zend/Log/Writer/ZendMonitor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail.php
+++ b/lib/Zend/Mail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Exception.php
+++ b/lib/Zend/Mail/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Message.php
+++ b/lib/Zend/Mail/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Message/File.php
+++ b/lib/Zend/Mail/Message/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Message/Interface.php
+++ b/lib/Zend/Mail/Message/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Part.php
+++ b/lib/Zend/Mail/Part.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Part/File.php
+++ b/lib/Zend/Mail/Part/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Part/Interface.php
+++ b/lib/Zend/Mail/Part/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Protocol/Abstract.php
+++ b/lib/Zend/Mail/Protocol/Abstract.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Protocol/Exception.php
+++ b/lib/Zend/Mail/Protocol/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Protocol/Imap.php
+++ b/lib/Zend/Mail/Protocol/Imap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Protocol/Pop3.php
+++ b/lib/Zend/Mail/Protocol/Pop3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Protocol/Smtp.php
+++ b/lib/Zend/Mail/Protocol/Smtp.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Protocol/Smtp/Auth/Crammd5.php
+++ b/lib/Zend/Mail/Protocol/Smtp/Auth/Crammd5.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Protocol/Smtp/Auth/Login.php
+++ b/lib/Zend/Mail/Protocol/Smtp/Auth/Login.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Protocol/Smtp/Auth/Plain.php
+++ b/lib/Zend/Mail/Protocol/Smtp/Auth/Plain.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage.php
+++ b/lib/Zend/Mail/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Abstract.php
+++ b/lib/Zend/Mail/Storage/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Exception.php
+++ b/lib/Zend/Mail/Storage/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Folder.php
+++ b/lib/Zend/Mail/Storage/Folder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Folder/Interface.php
+++ b/lib/Zend/Mail/Storage/Folder/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Folder/Maildir.php
+++ b/lib/Zend/Mail/Storage/Folder/Maildir.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Folder/Mbox.php
+++ b/lib/Zend/Mail/Storage/Folder/Mbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Imap.php
+++ b/lib/Zend/Mail/Storage/Imap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Maildir.php
+++ b/lib/Zend/Mail/Storage/Maildir.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Mbox.php
+++ b/lib/Zend/Mail/Storage/Mbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Pop3.php
+++ b/lib/Zend/Mail/Storage/Pop3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Writable/Interface.php
+++ b/lib/Zend/Mail/Storage/Writable/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Storage/Writable/Maildir.php
+++ b/lib/Zend/Mail/Storage/Writable/Maildir.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Transport/Abstract.php
+++ b/lib/Zend/Mail/Transport/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Transport/Exception.php
+++ b/lib/Zend/Mail/Transport/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Transport/File.php
+++ b/lib/Zend/Mail/Transport/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Transport/Sendmail.php
+++ b/lib/Zend/Mail/Transport/Sendmail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mail/Transport/Smtp.php
+++ b/lib/Zend/Mail/Transport/Smtp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup.php
+++ b/lib/Zend/Markup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Exception.php
+++ b/lib/Zend/Markup/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Parser/Bbcode.php
+++ b/lib/Zend/Markup/Parser/Bbcode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Parser/Exception.php
+++ b/lib/Zend/Markup/Parser/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Parser/ParserInterface.php
+++ b/lib/Zend/Markup/Parser/ParserInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Parser/Textile.php
+++ b/lib/Zend/Markup/Parser/Textile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Renderer/Exception.php
+++ b/lib/Zend/Markup/Renderer/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Renderer/Html.php
+++ b/lib/Zend/Markup/Renderer/Html.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Renderer/Html/Code.php
+++ b/lib/Zend/Markup/Renderer/Html/Code.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Renderer/Html/HtmlAbstract.php
+++ b/lib/Zend/Markup/Renderer/Html/HtmlAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Renderer/Html/Img.php
+++ b/lib/Zend/Markup/Renderer/Html/Img.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Renderer/Html/List.php
+++ b/lib/Zend/Markup/Renderer/Html/List.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Renderer/Html/Url.php
+++ b/lib/Zend/Markup/Renderer/Html/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Renderer/RendererAbstract.php
+++ b/lib/Zend/Markup/Renderer/RendererAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Renderer/TokenConverterInterface.php
+++ b/lib/Zend/Markup/Renderer/TokenConverterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/Token.php
+++ b/lib/Zend/Markup/Token.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Markup/TokenList.php
+++ b/lib/Zend/Markup/TokenList.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Measure/Abstract.php
+++ b/lib/Zend/Measure/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Acceleration.php
+++ b/lib/Zend/Measure/Acceleration.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Angle.php
+++ b/lib/Zend/Measure/Angle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Area.php
+++ b/lib/Zend/Measure/Area.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Binary.php
+++ b/lib/Zend/Measure/Binary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Capacitance.php
+++ b/lib/Zend/Measure/Capacitance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Cooking/Volume.php
+++ b/lib/Zend/Measure/Cooking/Volume.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Cooking/Weight.php
+++ b/lib/Zend/Measure/Cooking/Weight.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Current.php
+++ b/lib/Zend/Measure/Current.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Density.php
+++ b/lib/Zend/Measure/Density.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Energy.php
+++ b/lib/Zend/Measure/Energy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Exception.php
+++ b/lib/Zend/Measure/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Flow/Mass.php
+++ b/lib/Zend/Measure/Flow/Mass.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Flow/Mole.php
+++ b/lib/Zend/Measure/Flow/Mole.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Flow/Volume.php
+++ b/lib/Zend/Measure/Flow/Volume.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Force.php
+++ b/lib/Zend/Measure/Force.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Frequency.php
+++ b/lib/Zend/Measure/Frequency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Illumination.php
+++ b/lib/Zend/Measure/Illumination.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Length.php
+++ b/lib/Zend/Measure/Length.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Lightness.php
+++ b/lib/Zend/Measure/Lightness.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Number.php
+++ b/lib/Zend/Measure/Number.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Power.php
+++ b/lib/Zend/Measure/Power.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Pressure.php
+++ b/lib/Zend/Measure/Pressure.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Speed.php
+++ b/lib/Zend/Measure/Speed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Temperature.php
+++ b/lib/Zend/Measure/Temperature.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Time.php
+++ b/lib/Zend/Measure/Time.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Torque.php
+++ b/lib/Zend/Measure/Torque.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Viscosity/Dynamic.php
+++ b/lib/Zend/Measure/Viscosity/Dynamic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Viscosity/Kinematic.php
+++ b/lib/Zend/Measure/Viscosity/Kinematic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Volume.php
+++ b/lib/Zend/Measure/Volume.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Measure/Weight.php
+++ b/lib/Zend/Measure/Weight.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Memory.php
+++ b/lib/Zend/Memory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Memory/AccessController.php
+++ b/lib/Zend/Memory/AccessController.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Memory/Container.php
+++ b/lib/Zend/Memory/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Memory/Container/Interface.php
+++ b/lib/Zend/Memory/Container/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Memory/Container/Locked.php
+++ b/lib/Zend/Memory/Container/Locked.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Memory/Container/Movable.php
+++ b/lib/Zend/Memory/Container/Movable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Memory/Exception.php
+++ b/lib/Zend/Memory/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Memory/Manager.php
+++ b/lib/Zend/Memory/Manager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Memory/Value.php
+++ b/lib/Zend/Memory/Value.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mime.php
+++ b/lib/Zend/Mime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mime/Decode.php
+++ b/lib/Zend/Mime/Decode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mime/Exception.php
+++ b/lib/Zend/Mime/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mime/Message.php
+++ b/lib/Zend/Mime/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Mime/Part.php
+++ b/lib/Zend/Mime/Part.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Navigation.php
+++ b/lib/Zend/Navigation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Navigation/Container.php
+++ b/lib/Zend/Navigation/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Navigation/Exception.php
+++ b/lib/Zend/Navigation/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Navigation/Page.php
+++ b/lib/Zend/Navigation/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Navigation/Page/Mvc.php
+++ b/lib/Zend/Navigation/Page/Mvc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Navigation/Page/Uri.php
+++ b/lib/Zend/Navigation/Page/Uri.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth.php
+++ b/lib/Zend/Oauth.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Client.php
+++ b/lib/Zend/Oauth/Client.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Config.php
+++ b/lib/Zend/Oauth/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Config/ConfigInterface.php
+++ b/lib/Zend/Oauth/Config/ConfigInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Consumer.php
+++ b/lib/Zend/Oauth/Consumer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Exception.php
+++ b/lib/Zend/Oauth/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Http.php
+++ b/lib/Zend/Oauth/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Http/AccessToken.php
+++ b/lib/Zend/Oauth/Http/AccessToken.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Http/RequestToken.php
+++ b/lib/Zend/Oauth/Http/RequestToken.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Http/UserAuthorization.php
+++ b/lib/Zend/Oauth/Http/UserAuthorization.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Http/Utility.php
+++ b/lib/Zend/Oauth/Http/Utility.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Signature/Hmac.php
+++ b/lib/Zend/Oauth/Signature/Hmac.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Signature/Plaintext.php
+++ b/lib/Zend/Oauth/Signature/Plaintext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Signature/Rsa.php
+++ b/lib/Zend/Oauth/Signature/Rsa.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Signature/SignatureAbstract.php
+++ b/lib/Zend/Oauth/Signature/SignatureAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Token.php
+++ b/lib/Zend/Oauth/Token.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Token/Access.php
+++ b/lib/Zend/Oauth/Token/Access.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Token/AuthorizedRequest.php
+++ b/lib/Zend/Oauth/Token/AuthorizedRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Oauth/Token/Request.php
+++ b/lib/Zend/Oauth/Token/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId.php
+++ b/lib/Zend/OpenId.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Consumer.php
+++ b/lib/Zend/OpenId/Consumer.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Consumer/Storage.php
+++ b/lib/Zend/OpenId/Consumer/Storage.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Consumer/Storage/File.php
+++ b/lib/Zend/OpenId/Consumer/Storage/File.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Exception.php
+++ b/lib/Zend/OpenId/Exception.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Extension.php
+++ b/lib/Zend/OpenId/Extension.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Extension/Sreg.php
+++ b/lib/Zend/OpenId/Extension/Sreg.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Provider.php
+++ b/lib/Zend/OpenId/Provider.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Provider/Storage.php
+++ b/lib/Zend/OpenId/Provider/Storage.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Provider/Storage/File.php
+++ b/lib/Zend/OpenId/Provider/Storage/File.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Provider/User.php
+++ b/lib/Zend/OpenId/Provider/User.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/OpenId/Provider/User/Session.php
+++ b/lib/Zend/OpenId/Provider/User/Session.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator.php
+++ b/lib/Zend/Paginator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/Adapter/Array.php
+++ b/lib/Zend/Paginator/Adapter/Array.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/Adapter/DbSelect.php
+++ b/lib/Zend/Paginator/Adapter/DbSelect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/Adapter/DbTableSelect.php
+++ b/lib/Zend/Paginator/Adapter/DbTableSelect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/Adapter/Interface.php
+++ b/lib/Zend/Paginator/Adapter/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/Adapter/Iterator.php
+++ b/lib/Zend/Paginator/Adapter/Iterator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/Adapter/Null.php
+++ b/lib/Zend/Paginator/Adapter/Null.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/AdapterAggregate.php
+++ b/lib/Zend/Paginator/AdapterAggregate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/Exception.php
+++ b/lib/Zend/Paginator/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/ScrollingStyle/All.php
+++ b/lib/Zend/Paginator/ScrollingStyle/All.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/ScrollingStyle/Elastic.php
+++ b/lib/Zend/Paginator/ScrollingStyle/Elastic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/ScrollingStyle/Interface.php
+++ b/lib/Zend/Paginator/ScrollingStyle/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/ScrollingStyle/Jumping.php
+++ b/lib/Zend/Paginator/ScrollingStyle/Jumping.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/ScrollingStyle/Sliding.php
+++ b/lib/Zend/Paginator/ScrollingStyle/Sliding.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Paginator/SerializableLimitIterator.php
+++ b/lib/Zend/Paginator/SerializableLimitIterator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf.php
+++ b/lib/Zend/Pdf.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action.php
+++ b/lib/Zend/Pdf/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/GoTo.php
+++ b/lib/Zend/Pdf/Action/GoTo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/GoTo3DView.php
+++ b/lib/Zend/Pdf/Action/GoTo3DView.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/GoToE.php
+++ b/lib/Zend/Pdf/Action/GoToE.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/GoToR.php
+++ b/lib/Zend/Pdf/Action/GoToR.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/Hide.php
+++ b/lib/Zend/Pdf/Action/Hide.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/ImportData.php
+++ b/lib/Zend/Pdf/Action/ImportData.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/JavaScript.php
+++ b/lib/Zend/Pdf/Action/JavaScript.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/Launch.php
+++ b/lib/Zend/Pdf/Action/Launch.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/Movie.php
+++ b/lib/Zend/Pdf/Action/Movie.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/Named.php
+++ b/lib/Zend/Pdf/Action/Named.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/Rendition.php
+++ b/lib/Zend/Pdf/Action/Rendition.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/ResetForm.php
+++ b/lib/Zend/Pdf/Action/ResetForm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/SetOCGState.php
+++ b/lib/Zend/Pdf/Action/SetOCGState.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/Sound.php
+++ b/lib/Zend/Pdf/Action/Sound.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/SubmitForm.php
+++ b/lib/Zend/Pdf/Action/SubmitForm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/Thread.php
+++ b/lib/Zend/Pdf/Action/Thread.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/Trans.php
+++ b/lib/Zend/Pdf/Action/Trans.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/URI.php
+++ b/lib/Zend/Pdf/Action/URI.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Action/Unknown.php
+++ b/lib/Zend/Pdf/Action/Unknown.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Annotation.php
+++ b/lib/Zend/Pdf/Annotation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Annotation/FileAttachment.php
+++ b/lib/Zend/Pdf/Annotation/FileAttachment.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Annotation/Link.php
+++ b/lib/Zend/Pdf/Annotation/Link.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Annotation/Markup.php
+++ b/lib/Zend/Pdf/Annotation/Markup.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Annotation/Text.php
+++ b/lib/Zend/Pdf/Annotation/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Canvas.php
+++ b/lib/Zend/Pdf/Canvas.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Canvas/Abstract.php
+++ b/lib/Zend/Pdf/Canvas/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Canvas/Interface.php
+++ b/lib/Zend/Pdf/Canvas/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Cmap.php
+++ b/lib/Zend/Pdf/Cmap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Cmap/ByteEncoding.php
+++ b/lib/Zend/Pdf/Cmap/ByteEncoding.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Cmap/ByteEncoding/Static.php
+++ b/lib/Zend/Pdf/Cmap/ByteEncoding/Static.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Cmap/SegmentToDelta.php
+++ b/lib/Zend/Pdf/Cmap/SegmentToDelta.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Cmap/TrimmedTable.php
+++ b/lib/Zend/Pdf/Cmap/TrimmedTable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Color.php
+++ b/lib/Zend/Pdf/Color.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Color/Cmyk.php
+++ b/lib/Zend/Pdf/Color/Cmyk.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Color/GrayScale.php
+++ b/lib/Zend/Pdf/Color/GrayScale.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Color/Html.php
+++ b/lib/Zend/Pdf/Color/Html.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Color/Rgb.php
+++ b/lib/Zend/Pdf/Color/Rgb.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination.php
+++ b/lib/Zend/Pdf/Destination.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/Explicit.php
+++ b/lib/Zend/Pdf/Destination/Explicit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/Fit.php
+++ b/lib/Zend/Pdf/Destination/Fit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/FitBoundingBox.php
+++ b/lib/Zend/Pdf/Destination/FitBoundingBox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/FitBoundingBoxHorizontally.php
+++ b/lib/Zend/Pdf/Destination/FitBoundingBoxHorizontally.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/FitBoundingBoxVertically.php
+++ b/lib/Zend/Pdf/Destination/FitBoundingBoxVertically.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/FitHorizontally.php
+++ b/lib/Zend/Pdf/Destination/FitHorizontally.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/FitRectangle.php
+++ b/lib/Zend/Pdf/Destination/FitRectangle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/FitVertically.php
+++ b/lib/Zend/Pdf/Destination/FitVertically.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/Named.php
+++ b/lib/Zend/Pdf/Destination/Named.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/Unknown.php
+++ b/lib/Zend/Pdf/Destination/Unknown.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Destination/Zoom.php
+++ b/lib/Zend/Pdf/Destination/Zoom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element.php
+++ b/lib/Zend/Pdf/Element.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Array.php
+++ b/lib/Zend/Pdf/Element/Array.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Boolean.php
+++ b/lib/Zend/Pdf/Element/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Dictionary.php
+++ b/lib/Zend/Pdf/Element/Dictionary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Name.php
+++ b/lib/Zend/Pdf/Element/Name.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Null.php
+++ b/lib/Zend/Pdf/Element/Null.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Numeric.php
+++ b/lib/Zend/Pdf/Element/Numeric.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Object.php
+++ b/lib/Zend/Pdf/Element/Object.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Object/Stream.php
+++ b/lib/Zend/Pdf/Element/Object/Stream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Reference.php
+++ b/lib/Zend/Pdf/Element/Reference.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Reference/Context.php
+++ b/lib/Zend/Pdf/Element/Reference/Context.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Reference/Table.php
+++ b/lib/Zend/Pdf/Element/Reference/Table.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/Stream.php
+++ b/lib/Zend/Pdf/Element/Stream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/String.php
+++ b/lib/Zend/Pdf/Element/String.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Element/String/Binary.php
+++ b/lib/Zend/Pdf/Element/String/Binary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/ElementFactory.php
+++ b/lib/Zend/Pdf/ElementFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/ElementFactory/Interface.php
+++ b/lib/Zend/Pdf/ElementFactory/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/ElementFactory/Proxy.php
+++ b/lib/Zend/Pdf/ElementFactory/Proxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Exception.php
+++ b/lib/Zend/Pdf/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/FileParser.php
+++ b/lib/Zend/Pdf/FileParser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/FileParser/Font.php
+++ b/lib/Zend/Pdf/FileParser/Font.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/FileParser/Font/OpenType.php
+++ b/lib/Zend/Pdf/FileParser/Font/OpenType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/FileParser/Font/OpenType/TrueType.php
+++ b/lib/Zend/Pdf/FileParser/Font/OpenType/TrueType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/FileParser/Image.php
+++ b/lib/Zend/Pdf/FileParser/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/FileParser/Image/Png.php
+++ b/lib/Zend/Pdf/FileParser/Image/Png.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/FileParserDataSource.php
+++ b/lib/Zend/Pdf/FileParserDataSource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/FileParserDataSource/File.php
+++ b/lib/Zend/Pdf/FileParserDataSource/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/FileParserDataSource/String.php
+++ b/lib/Zend/Pdf/FileParserDataSource/String.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Filter/Ascii85.php
+++ b/lib/Zend/Pdf/Filter/Ascii85.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Filter/AsciiHex.php
+++ b/lib/Zend/Pdf/Filter/AsciiHex.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Filter/Compression.php
+++ b/lib/Zend/Pdf/Filter/Compression.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Filter/Compression/Flate.php
+++ b/lib/Zend/Pdf/Filter/Compression/Flate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Filter/Compression/Lzw.php
+++ b/lib/Zend/Pdf/Filter/Compression/Lzw.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Filter/Interface.php
+++ b/lib/Zend/Pdf/Filter/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Filter/RunLength.php
+++ b/lib/Zend/Pdf/Filter/RunLength.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Font.php
+++ b/lib/Zend/Pdf/Font.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Image.php
+++ b/lib/Zend/Pdf/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/NameTree.php
+++ b/lib/Zend/Pdf/NameTree.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Outline.php
+++ b/lib/Zend/Pdf/Outline.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Outline/Created.php
+++ b/lib/Zend/Pdf/Outline/Created.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Outline/Loaded.php
+++ b/lib/Zend/Pdf/Outline/Loaded.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Page.php
+++ b/lib/Zend/Pdf/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Parser.php
+++ b/lib/Zend/Pdf/Parser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/RecursivelyIteratableObjectsContainer.php
+++ b/lib/Zend/Pdf/RecursivelyIteratableObjectsContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource.php
+++ b/lib/Zend/Pdf/Resource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/ContentStream.php
+++ b/lib/Zend/Pdf/Resource/ContentStream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Extractor.php
+++ b/lib/Zend/Pdf/Resource/Extractor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font.php
+++ b/lib/Zend/Pdf/Resource/Font.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/CidFont.php
+++ b/lib/Zend/Pdf/Resource/Font/CidFont.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/CidFont/TrueType.php
+++ b/lib/Zend/Pdf/Resource/Font/CidFont/TrueType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Extracted.php
+++ b/lib/Zend/Pdf/Resource/Font/Extracted.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/FontDescriptor.php
+++ b/lib/Zend/Pdf/Resource/Font/FontDescriptor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Parsed.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Parsed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Parsed/TrueType.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Parsed/TrueType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/Courier.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/Courier.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/CourierBold.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/CourierBold.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/CourierBoldOblique.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/CourierBoldOblique.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/CourierOblique.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/CourierOblique.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/Helvetica.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/Helvetica.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBold.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBold.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaOblique.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaOblique.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/Symbol.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/Symbol.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/TimesBold.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/TimesBold.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/TimesBoldItalic.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/TimesBoldItalic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/TimesItalic.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/TimesItalic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/TimesRoman.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/TimesRoman.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Simple/Standard/ZapfDingbats.php
+++ b/lib/Zend/Pdf/Resource/Font/Simple/Standard/ZapfDingbats.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Font/Type0.php
+++ b/lib/Zend/Pdf/Resource/Font/Type0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/GraphicsState.php
+++ b/lib/Zend/Pdf/Resource/GraphicsState.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Image.php
+++ b/lib/Zend/Pdf/Resource/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Image/Jpeg.php
+++ b/lib/Zend/Pdf/Resource/Image/Jpeg.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Image/Png.php
+++ b/lib/Zend/Pdf/Resource/Image/Png.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Image/Tiff.php
+++ b/lib/Zend/Pdf/Resource/Image/Tiff.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/ImageFactory.php
+++ b/lib/Zend/Pdf/Resource/ImageFactory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Resource/Unified.php
+++ b/lib/Zend/Pdf/Resource/Unified.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/StringParser.php
+++ b/lib/Zend/Pdf/StringParser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Style.php
+++ b/lib/Zend/Pdf/Style.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Target.php
+++ b/lib/Zend/Pdf/Target.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Trailer.php
+++ b/lib/Zend/Pdf/Trailer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Trailer/Generator.php
+++ b/lib/Zend/Pdf/Trailer/Generator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/Trailer/Keeper.php
+++ b/lib/Zend/Pdf/Trailer/Keeper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Pdf/UpdateInfoContainer.php
+++ b/lib/Zend/Pdf/UpdateInfoContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/ProgressBar.php
+++ b/lib/Zend/ProgressBar.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/ProgressBar/Adapter.php
+++ b/lib/Zend/ProgressBar/Adapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/ProgressBar/Adapter/Console.php
+++ b/lib/Zend/ProgressBar/Adapter/Console.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/ProgressBar/Adapter/Exception.php
+++ b/lib/Zend/ProgressBar/Adapter/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/ProgressBar/Adapter/JsPull.php
+++ b/lib/Zend/ProgressBar/Adapter/JsPull.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/ProgressBar/Adapter/JsPush.php
+++ b/lib/Zend/ProgressBar/Adapter/JsPush.php
@@ -7,7 +7,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/ProgressBar/Exception.php
+++ b/lib/Zend/ProgressBar/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Queue.php
+++ b/lib/Zend/Queue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Adapter/Activemq.php
+++ b/lib/Zend/Queue/Adapter/Activemq.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Adapter/AdapterAbstract.php
+++ b/lib/Zend/Queue/Adapter/AdapterAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Adapter/AdapterInterface.php
+++ b/lib/Zend/Queue/Adapter/AdapterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Adapter/Array.php
+++ b/lib/Zend/Queue/Adapter/Array.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Adapter/Db.php
+++ b/lib/Zend/Queue/Adapter/Db.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Adapter/Db/Message.php
+++ b/lib/Zend/Queue/Adapter/Db/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Adapter/Db/Queue.php
+++ b/lib/Zend/Queue/Adapter/Db/Queue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Adapter/Memcacheq.php
+++ b/lib/Zend/Queue/Adapter/Memcacheq.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Adapter/Null.php
+++ b/lib/Zend/Queue/Adapter/Null.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Adapter/PlatformJobQueue.php
+++ b/lib/Zend/Queue/Adapter/PlatformJobQueue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Exception.php
+++ b/lib/Zend/Queue/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Message.php
+++ b/lib/Zend/Queue/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Message/Iterator.php
+++ b/lib/Zend/Queue/Message/Iterator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Message/PlatformJob.php
+++ b/lib/Zend/Queue/Message/PlatformJob.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Stomp/Client.php
+++ b/lib/Zend/Queue/Stomp/Client.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Stomp/Client/Connection.php
+++ b/lib/Zend/Queue/Stomp/Client/Connection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Stomp/Client/ConnectionInterface.php
+++ b/lib/Zend/Queue/Stomp/Client/ConnectionInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Stomp/Frame.php
+++ b/lib/Zend/Queue/Stomp/Frame.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Queue/Stomp/FrameInterface.php
+++ b/lib/Zend/Queue/Stomp/FrameInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Class.php
+++ b/lib/Zend/Reflection/Class.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Docblock.php
+++ b/lib/Zend/Reflection/Docblock.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Docblock/Tag.php
+++ b/lib/Zend/Reflection/Docblock/Tag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Docblock/Tag/Param.php
+++ b/lib/Zend/Reflection/Docblock/Tag/Param.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Docblock/Tag/Return.php
+++ b/lib/Zend/Reflection/Docblock/Tag/Return.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Exception.php
+++ b/lib/Zend/Reflection/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Extension.php
+++ b/lib/Zend/Reflection/Extension.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/File.php
+++ b/lib/Zend/Reflection/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Function.php
+++ b/lib/Zend/Reflection/Function.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Method.php
+++ b/lib/Zend/Reflection/Method.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Parameter.php
+++ b/lib/Zend/Reflection/Parameter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Reflection/Property.php
+++ b/lib/Zend/Reflection/Property.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Registry.php
+++ b/lib/Zend/Registry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Rest/Client.php
+++ b/lib/Zend/Rest/Client.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Rest/Client/Exception.php
+++ b/lib/Zend/Rest/Client/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Rest/Client/Result.php
+++ b/lib/Zend/Rest/Client/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Rest/Client/Result/Exception.php
+++ b/lib/Zend/Rest/Client/Result/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Rest/Controller.php
+++ b/lib/Zend/Rest/Controller.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Rest/Exception.php
+++ b/lib/Zend/Rest/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Rest/Route.php
+++ b/lib/Zend/Rest/Route.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Rest/Server.php
+++ b/lib/Zend/Rest/Server.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Rest/Server/Exception.php
+++ b/lib/Zend/Rest/Server/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Exception.php
+++ b/lib/Zend/Search/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene.php
+++ b/lib/Zend/Search/Lucene.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Analyzer.php
+++ b/lib/Zend/Search/Lucene/Analysis/Analyzer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Analyzer/Common.php
+++ b/lib/Zend/Search/Lucene/Analysis/Analyzer/Common.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Text.php
+++ b/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Text.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Text/CaseInsensitive.php
+++ b/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Text/CaseInsensitive.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/TextNum.php
+++ b/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/TextNum.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/TextNum/CaseInsensitive.php
+++ b/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/TextNum/CaseInsensitive.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Utf8.php
+++ b/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Utf8.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Utf8/CaseInsensitive.php
+++ b/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Utf8/CaseInsensitive.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Utf8Num.php
+++ b/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Utf8Num.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Utf8Num/CaseInsensitive.php
+++ b/lib/Zend/Search/Lucene/Analysis/Analyzer/Common/Utf8Num/CaseInsensitive.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/Token.php
+++ b/lib/Zend/Search/Lucene/Analysis/Token.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/TokenFilter.php
+++ b/lib/Zend/Search/Lucene/Analysis/TokenFilter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/TokenFilter/LowerCase.php
+++ b/lib/Zend/Search/Lucene/Analysis/TokenFilter/LowerCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/TokenFilter/LowerCaseUtf8.php
+++ b/lib/Zend/Search/Lucene/Analysis/TokenFilter/LowerCaseUtf8.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/TokenFilter/ShortWords.php
+++ b/lib/Zend/Search/Lucene/Analysis/TokenFilter/ShortWords.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Analysis/TokenFilter/StopWords.php
+++ b/lib/Zend/Search/Lucene/Analysis/TokenFilter/StopWords.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Document.php
+++ b/lib/Zend/Search/Lucene/Document.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Document/Docx.php
+++ b/lib/Zend/Search/Lucene/Document/Docx.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Document/Exception.php
+++ b/lib/Zend/Search/Lucene/Document/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Document/Html.php
+++ b/lib/Zend/Search/Lucene/Document/Html.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Document/OpenXml.php
+++ b/lib/Zend/Search/Lucene/Document/OpenXml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Document/Pptx.php
+++ b/lib/Zend/Search/Lucene/Document/Pptx.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Document/Xlsx.php
+++ b/lib/Zend/Search/Lucene/Document/Xlsx.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Exception.php
+++ b/lib/Zend/Search/Lucene/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/FSM.php
+++ b/lib/Zend/Search/Lucene/FSM.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/FSMAction.php
+++ b/lib/Zend/Search/Lucene/FSMAction.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Field.php
+++ b/lib/Zend/Search/Lucene/Field.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/DictionaryLoader.php
+++ b/lib/Zend/Search/Lucene/Index/DictionaryLoader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/DocsFilter.php
+++ b/lib/Zend/Search/Lucene/Index/DocsFilter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/FieldInfo.php
+++ b/lib/Zend/Search/Lucene/Index/FieldInfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/SegmentInfo.php
+++ b/lib/Zend/Search/Lucene/Index/SegmentInfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/SegmentMerger.php
+++ b/lib/Zend/Search/Lucene/Index/SegmentMerger.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/SegmentWriter.php
+++ b/lib/Zend/Search/Lucene/Index/SegmentWriter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/SegmentWriter/DocumentWriter.php
+++ b/lib/Zend/Search/Lucene/Index/SegmentWriter/DocumentWriter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/SegmentWriter/StreamWriter.php
+++ b/lib/Zend/Search/Lucene/Index/SegmentWriter/StreamWriter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/Term.php
+++ b/lib/Zend/Search/Lucene/Index/Term.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/TermInfo.php
+++ b/lib/Zend/Search/Lucene/Index/TermInfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/TermsPriorityQueue.php
+++ b/lib/Zend/Search/Lucene/Index/TermsPriorityQueue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/TermsStream/Interface.php
+++ b/lib/Zend/Search/Lucene/Index/TermsStream/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Index/Writer.php
+++ b/lib/Zend/Search/Lucene/Index/Writer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Interface.php
+++ b/lib/Zend/Search/Lucene/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/LockManager.php
+++ b/lib/Zend/Search/Lucene/LockManager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/MultiSearcher.php
+++ b/lib/Zend/Search/Lucene/MultiSearcher.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/PriorityQueue.php
+++ b/lib/Zend/Search/Lucene/PriorityQueue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Proxy.php
+++ b/lib/Zend/Search/Lucene/Proxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/BooleanExpressionRecognizer.php
+++ b/lib/Zend/Search/Lucene/Search/BooleanExpressionRecognizer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Highlighter/Default.php
+++ b/lib/Zend/Search/Lucene/Search/Highlighter/Default.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Highlighter/Interface.php
+++ b/lib/Zend/Search/Lucene/Search/Highlighter/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query.php
+++ b/lib/Zend/Search/Lucene/Search/Query.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Boolean.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Empty.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Empty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Fuzzy.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Fuzzy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Insignificant.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Insignificant.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/MultiTerm.php
+++ b/lib/Zend/Search/Lucene/Search/Query/MultiTerm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Phrase.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Phrase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Preprocessing.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Preprocessing.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Preprocessing/Fuzzy.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Preprocessing/Fuzzy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Preprocessing/Phrase.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Preprocessing/Phrase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Preprocessing/Term.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Preprocessing/Term.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Range.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Range.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Term.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Term.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Query/Wildcard.php
+++ b/lib/Zend/Search/Lucene/Search/Query/Wildcard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/QueryEntry.php
+++ b/lib/Zend/Search/Lucene/Search/QueryEntry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/QueryEntry/Phrase.php
+++ b/lib/Zend/Search/Lucene/Search/QueryEntry/Phrase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/QueryEntry/Subquery.php
+++ b/lib/Zend/Search/Lucene/Search/QueryEntry/Subquery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/QueryEntry/Term.php
+++ b/lib/Zend/Search/Lucene/Search/QueryEntry/Term.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/QueryHit.php
+++ b/lib/Zend/Search/Lucene/Search/QueryHit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/QueryLexer.php
+++ b/lib/Zend/Search/Lucene/Search/QueryLexer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/QueryParser.php
+++ b/lib/Zend/Search/Lucene/Search/QueryParser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/QueryParserContext.php
+++ b/lib/Zend/Search/Lucene/Search/QueryParserContext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/QueryParserException.php
+++ b/lib/Zend/Search/Lucene/Search/QueryParserException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/QueryToken.php
+++ b/lib/Zend/Search/Lucene/Search/QueryToken.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Similarity.php
+++ b/lib/Zend/Search/Lucene/Search/Similarity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Similarity/Default.php
+++ b/lib/Zend/Search/Lucene/Search/Similarity/Default.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Weight.php
+++ b/lib/Zend/Search/Lucene/Search/Weight.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Weight/Boolean.php
+++ b/lib/Zend/Search/Lucene/Search/Weight/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Weight/Empty.php
+++ b/lib/Zend/Search/Lucene/Search/Weight/Empty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Weight/MultiTerm.php
+++ b/lib/Zend/Search/Lucene/Search/Weight/MultiTerm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Weight/Phrase.php
+++ b/lib/Zend/Search/Lucene/Search/Weight/Phrase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Search/Weight/Term.php
+++ b/lib/Zend/Search/Lucene/Search/Weight/Term.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Storage/Directory.php
+++ b/lib/Zend/Search/Lucene/Storage/Directory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Storage/Directory/Filesystem.php
+++ b/lib/Zend/Search/Lucene/Storage/Directory/Filesystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Storage/File.php
+++ b/lib/Zend/Search/Lucene/Storage/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Storage/File/Filesystem.php
+++ b/lib/Zend/Search/Lucene/Storage/File/Filesystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/Storage/File/Memory.php
+++ b/lib/Zend/Search/Lucene/Storage/File/Memory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Search/Lucene/TermStreamsPriorityQueue.php
+++ b/lib/Zend/Search/Lucene/TermStreamsPriorityQueue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer.php
+++ b/lib/Zend/Serializer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Adapter/AdapterAbstract.php
+++ b/lib/Zend/Serializer/Adapter/AdapterAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Adapter/AdapterInterface.php
+++ b/lib/Zend/Serializer/Adapter/AdapterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Adapter/Amf0.php
+++ b/lib/Zend/Serializer/Adapter/Amf0.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Adapter/Amf3.php
+++ b/lib/Zend/Serializer/Adapter/Amf3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Adapter/Igbinary.php
+++ b/lib/Zend/Serializer/Adapter/Igbinary.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Adapter/Json.php
+++ b/lib/Zend/Serializer/Adapter/Json.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Adapter/PhpCode.php
+++ b/lib/Zend/Serializer/Adapter/PhpCode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Adapter/PhpSerialize.php
+++ b/lib/Zend/Serializer/Adapter/PhpSerialize.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Adapter/PythonPickle.php
+++ b/lib/Zend/Serializer/Adapter/PythonPickle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Adapter/Wddx.php
+++ b/lib/Zend/Serializer/Adapter/Wddx.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Serializer/Exception.php
+++ b/lib/Zend/Serializer/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Abstract.php
+++ b/lib/Zend/Service/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Akismet.php
+++ b/lib/Zend/Service/Akismet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon.php
+++ b/lib/Zend/Service/Amazon.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Abstract.php
+++ b/lib/Zend/Service/Amazon/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Accessories.php
+++ b/lib/Zend/Service/Amazon/Accessories.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Authentication.php
+++ b/lib/Zend/Service/Amazon/Authentication.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Authentication/Exception.php
+++ b/lib/Zend/Service/Amazon/Authentication/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Authentication/S3.php
+++ b/lib/Zend/Service/Amazon/Authentication/S3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Authentication/V1.php
+++ b/lib/Zend/Service/Amazon/Authentication/V1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Authentication/V2.php
+++ b/lib/Zend/Service/Amazon/Authentication/V2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/CustomerReview.php
+++ b/lib/Zend/Service/Amazon/CustomerReview.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2.php
+++ b/lib/Zend/Service/Amazon/Ec2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Abstract.php
+++ b/lib/Zend/Service/Amazon/Ec2/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Availabilityzones.php
+++ b/lib/Zend/Service/Amazon/Ec2/Availabilityzones.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/CloudWatch.php
+++ b/lib/Zend/Service/Amazon/Ec2/CloudWatch.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Ebs.php
+++ b/lib/Zend/Service/Amazon/Ec2/Ebs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Elasticip.php
+++ b/lib/Zend/Service/Amazon/Ec2/Elasticip.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Exception.php
+++ b/lib/Zend/Service/Amazon/Ec2/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Image.php
+++ b/lib/Zend/Service/Amazon/Ec2/Image.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Instance.php
+++ b/lib/Zend/Service/Amazon/Ec2/Instance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Instance/Reserved.php
+++ b/lib/Zend/Service/Amazon/Ec2/Instance/Reserved.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Instance/Windows.php
+++ b/lib/Zend/Service/Amazon/Ec2/Instance/Windows.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Keypair.php
+++ b/lib/Zend/Service/Amazon/Ec2/Keypair.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Region.php
+++ b/lib/Zend/Service/Amazon/Ec2/Region.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Response.php
+++ b/lib/Zend/Service/Amazon/Ec2/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Ec2/Securitygroups.php
+++ b/lib/Zend/Service/Amazon/Ec2/Securitygroups.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/EditorialReview.php
+++ b/lib/Zend/Service/Amazon/EditorialReview.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Exception.php
+++ b/lib/Zend/Service/Amazon/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Image.php
+++ b/lib/Zend/Service/Amazon/Image.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Item.php
+++ b/lib/Zend/Service/Amazon/Item.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/ListmaniaList.php
+++ b/lib/Zend/Service/Amazon/ListmaniaList.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Offer.php
+++ b/lib/Zend/Service/Amazon/Offer.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/OfferSet.php
+++ b/lib/Zend/Service/Amazon/OfferSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Query.php
+++ b/lib/Zend/Service/Amazon/Query.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/ResultSet.php
+++ b/lib/Zend/Service/Amazon/ResultSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/S3.php
+++ b/lib/Zend/Service/Amazon/S3.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/S3/Exception.php
+++ b/lib/Zend/Service/Amazon/S3/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/S3/Stream.php
+++ b/lib/Zend/Service/Amazon/S3/Stream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/SimilarProduct.php
+++ b/lib/Zend/Service/Amazon/SimilarProduct.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/SimpleDb.php
+++ b/lib/Zend/Service/Amazon/SimpleDb.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/SimpleDb/Attribute.php
+++ b/lib/Zend/Service/Amazon/SimpleDb/Attribute.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/SimpleDb/Exception.php
+++ b/lib/Zend/Service/Amazon/SimpleDb/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/SimpleDb/Page.php
+++ b/lib/Zend/Service/Amazon/SimpleDb/Page.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/SimpleDb/Response.php
+++ b/lib/Zend/Service/Amazon/SimpleDb/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Sqs.php
+++ b/lib/Zend/Service/Amazon/Sqs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Amazon/Sqs/Exception.php
+++ b/lib/Zend/Service/Amazon/Sqs/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Audioscrobbler.php
+++ b/lib/Zend/Service/Audioscrobbler.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Delicious.php
+++ b/lib/Zend/Service/Delicious.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Delicious/Exception.php
+++ b/lib/Zend/Service/Delicious/Exception.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Delicious/Post.php
+++ b/lib/Zend/Service/Delicious/Post.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Delicious/PostList.php
+++ b/lib/Zend/Service/Delicious/PostList.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Delicious/SimplePost.php
+++ b/lib/Zend/Service/Delicious/SimplePost.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/BaseUserService.php
+++ b/lib/Zend/Service/DeveloperGarden/BaseUserService.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/BaseUserService/AccountBalance.php
+++ b/lib/Zend/Service/DeveloperGarden/BaseUserService/AccountBalance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Client/ClientAbstract.php
+++ b/lib/Zend/Service/DeveloperGarden/Client/ClientAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Client/Exception.php
+++ b/lib/Zend/Service/DeveloperGarden/Client/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Client/Soap.php
+++ b/lib/Zend/Service/DeveloperGarden/Client/Soap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/ConferenceCall.php
+++ b/lib/Zend/Service/DeveloperGarden/ConferenceCall.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/ConferenceCall/ConferenceAccount.php
+++ b/lib/Zend/Service/DeveloperGarden/ConferenceCall/ConferenceAccount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/ConferenceCall/ConferenceDetail.php
+++ b/lib/Zend/Service/DeveloperGarden/ConferenceCall/ConferenceDetail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/ConferenceCall/ConferenceSchedule.php
+++ b/lib/Zend/Service/DeveloperGarden/ConferenceCall/ConferenceSchedule.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/ConferenceCall/Exception.php
+++ b/lib/Zend/Service/DeveloperGarden/ConferenceCall/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/ConferenceCall/Participant.php
+++ b/lib/Zend/Service/DeveloperGarden/ConferenceCall/Participant.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/ConferenceCall/ParticipantDetail.php
+++ b/lib/Zend/Service/DeveloperGarden/ConferenceCall/ParticipantDetail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/ConferenceCall/ParticipantStatus.php
+++ b/lib/Zend/Service/DeveloperGarden/ConferenceCall/ParticipantStatus.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Credential.php
+++ b/lib/Zend/Service/DeveloperGarden/Credential.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Exception.php
+++ b/lib/Zend/Service/DeveloperGarden/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/IpLocation.php
+++ b/lib/Zend/Service/DeveloperGarden/IpLocation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/IpLocation/IpAddress.php
+++ b/lib/Zend/Service/DeveloperGarden/IpLocation/IpAddress.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/LocalSearch.php
+++ b/lib/Zend/Service/DeveloperGarden/LocalSearch.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/LocalSearch/Exception.php
+++ b/lib/Zend/Service/DeveloperGarden/LocalSearch/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/LocalSearch/SearchParameters.php
+++ b/lib/Zend/Service/DeveloperGarden/LocalSearch/SearchParameters.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/BaseUserService/ChangeQuotaPool.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/BaseUserService/ChangeQuotaPool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/BaseUserService/GetAccountBalance.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/BaseUserService/GetAccountBalance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/BaseUserService/GetQuotaInformation.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/BaseUserService/GetQuotaInformation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/AddConferenceTemplateParticipantRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/AddConferenceTemplateParticipantRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/CommitConferenceRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/CommitConferenceRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/CreateConferenceRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/CreateConferenceRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/CreateConferenceTemplateRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/CreateConferenceTemplateRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetConferenceListRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetConferenceListRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetConferenceStatusRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetConferenceStatusRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetConferenceTemplateListRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetConferenceTemplateListRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetConferenceTemplateParticipantRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetConferenceTemplateParticipantRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetConferenceTemplateRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetConferenceTemplateRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetParticipantStatusRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetParticipantStatusRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetRunningConferenceRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/GetRunningConferenceRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/NewParticipantRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/NewParticipantRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/RemoveConferenceRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/RemoveConferenceRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/RemoveConferenceTemplateParticipantRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/RemoveConferenceTemplateParticipantRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/RemoveConferenceTemplateRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/RemoveConferenceTemplateRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/RemoveParticipantRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/RemoveParticipantRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/UpdateConferenceRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/UpdateConferenceRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/UpdateConferenceTemplateParticipantRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/UpdateConferenceTemplateParticipantRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/UpdateConferenceTemplateRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/UpdateConferenceTemplateRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/UpdateParticipantRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/ConferenceCall/UpdateParticipantRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/Exception.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/IpLocation/LocateIPRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/IpLocation/LocateIPRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/LocalSearch/LocalSearchRequest.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/LocalSearch/LocalSearchRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/RequestAbstract.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/RequestAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/SendSms/SendFlashSMS.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/SendSms/SendFlashSMS.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/SendSms/SendSMS.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/SendSms/SendSMS.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/SendSms/SendSmsAbstract.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/SendSms/SendSmsAbstract.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/SmsValidation/GetValidatedNumbers.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/SmsValidation/GetValidatedNumbers.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/SmsValidation/Invalidate.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/SmsValidation/Invalidate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/SmsValidation/SendValidationKeyword.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/SmsValidation/SendValidationKeyword.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/SmsValidation/Validate.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/SmsValidation/Validate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/VoiceButler/CallStatus.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/VoiceButler/CallStatus.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/VoiceButler/NewCall.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/VoiceButler/NewCall.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/VoiceButler/NewCallSequenced.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/VoiceButler/NewCallSequenced.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/VoiceButler/TearDownCall.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/VoiceButler/TearDownCall.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Request/VoiceButler/VoiceButlerAbstract.php
+++ b/lib/Zend/Service/DeveloperGarden/Request/VoiceButler/VoiceButlerAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/BaseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/BaseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/BaseUserService/ChangeQuotaPoolResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/BaseUserService/ChangeQuotaPoolResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/BaseUserService/GetAccountBalanceResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/BaseUserService/GetAccountBalanceResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/BaseUserService/GetQuotaInformationResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/BaseUserService/GetQuotaInformationResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/AddConferenceTemplateParticipantResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/AddConferenceTemplateParticipantResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/AddConferenceTemplateParticipantResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/AddConferenceTemplateParticipantResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CCSResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CCSResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CommitConferenceResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CommitConferenceResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/ConferenceCallAbstract.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/ConferenceCallAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CreateConferenceResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CreateConferenceResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CreateConferenceResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CreateConferenceResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CreateConferenceTemplateResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CreateConferenceTemplateResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CreateConferenceTemplateResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/CreateConferenceTemplateResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceListResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceListResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceListResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceListResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceStatusResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceStatusResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceStatusResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceStatusResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateListResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateListResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateListResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateListResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateParticipantResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateParticipantResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateParticipantResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateParticipantResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetConferenceTemplateResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetParticipantStatusResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetParticipantStatusResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetParticipantStatusResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetParticipantStatusResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetRunningConferenceResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetRunningConferenceResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetRunningConferenceResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/GetRunningConferenceResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/NewParticipantResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/NewParticipantResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/NewParticipantResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/NewParticipantResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/RemoveConferenceResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/RemoveConferenceResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/RemoveConferenceTemplateParticipantResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/RemoveConferenceTemplateParticipantResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/RemoveConferenceTemplateResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/RemoveConferenceTemplateResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/RemoveParticipantResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/RemoveParticipantResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/UpdateConferenceResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/UpdateConferenceResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/UpdateConferenceTemplateParticipantResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/UpdateConferenceTemplateParticipantResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/UpdateConferenceTemplateResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/UpdateConferenceTemplateResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/UpdateParticipantResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ConferenceCall/UpdateParticipantResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/Exception.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/IpLocation/CityType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/IpLocation/CityType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/IpLocation/GeoCoordinatesType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/IpLocation/GeoCoordinatesType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/IpLocation/IPAddressLocationType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/IpLocation/IPAddressLocationType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/IpLocation/LocateIPResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/IpLocation/LocateIPResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/IpLocation/LocateIPResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/IpLocation/LocateIPResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/IpLocation/RegionType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/IpLocation/RegionType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/LocalSearch/LocalSearchResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/LocalSearch/LocalSearchResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/LocalSearch/LocalSearchResponseType.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/LocalSearch/LocalSearchResponseType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/ResponseAbstract.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/ResponseAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SecurityTokenServer/Exception.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SecurityTokenServer/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SecurityTokenServer/GetTokensResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SecurityTokenServer/GetTokensResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SecurityTokenServer/Interface.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SecurityTokenServer/Interface.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SecurityTokenServer/SecurityTokenResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SecurityTokenServer/SecurityTokenResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SendSms/SendFlashSMSResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SendSms/SendFlashSMSResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SendSms/SendSMSResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SendSms/SendSMSResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SendSms/SendSmsAbstract.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SendSms/SendSmsAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SmsValidation/GetValidatedNumbersResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SmsValidation/GetValidatedNumbersResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SmsValidation/InvalidateResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SmsValidation/InvalidateResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SmsValidation/SendValidationKeywordResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SmsValidation/SendValidationKeywordResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SmsValidation/ValidateResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SmsValidation/ValidateResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/SmsValidation/ValidatedNumber.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/SmsValidation/ValidatedNumber.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/CallStatus2Response.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/CallStatus2Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/CallStatusResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/CallStatusResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/NewCallResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/NewCallResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/NewCallSequencedResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/NewCallSequencedResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/TearDownCallResponse.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/TearDownCallResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/VoiceButlerAbstract.php
+++ b/lib/Zend/Service/DeveloperGarden/Response/VoiceButler/VoiceButlerAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/SecurityTokenServer.php
+++ b/lib/Zend/Service/DeveloperGarden/SecurityTokenServer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/SecurityTokenServer/Cache.php
+++ b/lib/Zend/Service/DeveloperGarden/SecurityTokenServer/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/SendSms.php
+++ b/lib/Zend/Service/DeveloperGarden/SendSms.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/SmsValidation.php
+++ b/lib/Zend/Service/DeveloperGarden/SmsValidation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/DeveloperGarden/VoiceCall.php
+++ b/lib/Zend/Service/DeveloperGarden/VoiceCall.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Abstract.php
+++ b/lib/Zend/Service/Ebay/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Exception.php
+++ b/lib/Zend/Service/Ebay/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding.php
+++ b/lib/Zend/Service/Ebay/Finding.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Abstract.php
+++ b/lib/Zend/Service/Ebay/Finding/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Aspect.php
+++ b/lib/Zend/Service/Ebay/Finding/Aspect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Aspect/Histogram/Container.php
+++ b/lib/Zend/Service/Ebay/Finding/Aspect/Histogram/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Aspect/Histogram/Value.php
+++ b/lib/Zend/Service/Ebay/Finding/Aspect/Histogram/Value.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Aspect/Histogram/Value/Set.php
+++ b/lib/Zend/Service/Ebay/Finding/Aspect/Histogram/Value/Set.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Aspect/Set.php
+++ b/lib/Zend/Service/Ebay/Finding/Aspect/Set.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Category.php
+++ b/lib/Zend/Service/Ebay/Finding/Category.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Category/Histogram.php
+++ b/lib/Zend/Service/Ebay/Finding/Category/Histogram.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Category/Histogram/Container.php
+++ b/lib/Zend/Service/Ebay/Finding/Category/Histogram/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Category/Histogram/Set.php
+++ b/lib/Zend/Service/Ebay/Finding/Category/Histogram/Set.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Error/Data.php
+++ b/lib/Zend/Service/Ebay/Finding/Error/Data.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Error/Data/Set.php
+++ b/lib/Zend/Service/Ebay/Finding/Error/Data/Set.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Error/Message.php
+++ b/lib/Zend/Service/Ebay/Finding/Error/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Exception.php
+++ b/lib/Zend/Service/Ebay/Finding/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/ListingInfo.php
+++ b/lib/Zend/Service/Ebay/Finding/ListingInfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/PaginationOutput.php
+++ b/lib/Zend/Service/Ebay/Finding/PaginationOutput.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Response/Abstract.php
+++ b/lib/Zend/Service/Ebay/Finding/Response/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Response/Histograms.php
+++ b/lib/Zend/Service/Ebay/Finding/Response/Histograms.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Response/Items.php
+++ b/lib/Zend/Service/Ebay/Finding/Response/Items.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Response/Keywords.php
+++ b/lib/Zend/Service/Ebay/Finding/Response/Keywords.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Search/Item.php
+++ b/lib/Zend/Service/Ebay/Finding/Search/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http:framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Search/Item/Set.php
+++ b/lib/Zend/Service/Ebay/Finding/Search/Item/Set.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Search/Result.php
+++ b/lib/Zend/Service/Ebay/Finding/Search/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/SellerInfo.php
+++ b/lib/Zend/Service/Ebay/Finding/SellerInfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/SellingStatus.php
+++ b/lib/Zend/Service/Ebay/Finding/SellingStatus.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Set/Abstract.php
+++ b/lib/Zend/Service/Ebay/Finding/Set/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/ShippingInfo.php
+++ b/lib/Zend/Service/Ebay/Finding/ShippingInfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Ebay/Finding/Storefront.php
+++ b/lib/Zend/Service/Ebay/Finding/Storefront.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Exception.php
+++ b/lib/Zend/Service/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Flickr.php
+++ b/lib/Zend/Service/Flickr.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Flickr/Image.php
+++ b/lib/Zend/Service/Flickr/Image.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Flickr/Result.php
+++ b/lib/Zend/Service/Flickr/Result.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Flickr/ResultSet.php
+++ b/lib/Zend/Service/Flickr/ResultSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/LiveDocx.php
+++ b/lib/Zend/Service/LiveDocx.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/LiveDocx/Exception.php
+++ b/lib/Zend/Service/LiveDocx/Exception.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/LiveDocx/MailMerge.php
+++ b/lib/Zend/Service/LiveDocx/MailMerge.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Nirvanix.php
+++ b/lib/Zend/Service/Nirvanix.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Nirvanix/Exception.php
+++ b/lib/Zend/Service/Nirvanix/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Nirvanix/Namespace/Base.php
+++ b/lib/Zend/Service/Nirvanix/Namespace/Base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Nirvanix/Namespace/Imfs.php
+++ b/lib/Zend/Service/Nirvanix/Namespace/Imfs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Nirvanix/Response.php
+++ b/lib/Zend/Service/Nirvanix/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ReCaptcha.php
+++ b/lib/Zend/Service/ReCaptcha.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ReCaptcha/Exception.php
+++ b/lib/Zend/Service/ReCaptcha/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ReCaptcha/MailHide.php
+++ b/lib/Zend/Service/ReCaptcha/MailHide.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ReCaptcha/MailHide/Exception.php
+++ b/lib/Zend/Service/ReCaptcha/MailHide/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ReCaptcha/Response.php
+++ b/lib/Zend/Service/ReCaptcha/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ShortUrl/AbstractShortener.php
+++ b/lib/Zend/Service/ShortUrl/AbstractShortener.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ShortUrl/Exception.php
+++ b/lib/Zend/Service/ShortUrl/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ShortUrl/IsGd.php
+++ b/lib/Zend/Service/ShortUrl/IsGd.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ShortUrl/JdemCz.php
+++ b/lib/Zend/Service/ShortUrl/JdemCz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ShortUrl/MetamarkNet.php
+++ b/lib/Zend/Service/ShortUrl/MetamarkNet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ShortUrl/Shortener.php
+++ b/lib/Zend/Service/ShortUrl/Shortener.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/ShortUrl/TinyUrlCom.php
+++ b/lib/Zend/Service/ShortUrl/TinyUrlCom.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy.php
+++ b/lib/Zend/Service/Simpy.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/Link.php
+++ b/lib/Zend/Service/Simpy/Link.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/LinkQuery.php
+++ b/lib/Zend/Service/Simpy/LinkQuery.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/LinkSet.php
+++ b/lib/Zend/Service/Simpy/LinkSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/Note.php
+++ b/lib/Zend/Service/Simpy/Note.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/NoteSet.php
+++ b/lib/Zend/Service/Simpy/NoteSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/Tag.php
+++ b/lib/Zend/Service/Simpy/Tag.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/TagSet.php
+++ b/lib/Zend/Service/Simpy/TagSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/Watchlist.php
+++ b/lib/Zend/Service/Simpy/Watchlist.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/WatchlistFilter.php
+++ b/lib/Zend/Service/Simpy/WatchlistFilter.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/WatchlistFilterSet.php
+++ b/lib/Zend/Service/Simpy/WatchlistFilterSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Simpy/WatchlistSet.php
+++ b/lib/Zend/Service/Simpy/WatchlistSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/SlideShare.php
+++ b/lib/Zend/Service/SlideShare.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/SlideShare/Exception.php
+++ b/lib/Zend/Service/SlideShare/Exception.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/SlideShare/SlideShow.php
+++ b/lib/Zend/Service/SlideShare/SlideShow.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/StrikeIron.php
+++ b/lib/Zend/Service/StrikeIron.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/StrikeIron/Base.php
+++ b/lib/Zend/Service/StrikeIron/Base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/StrikeIron/Decorator.php
+++ b/lib/Zend/Service/StrikeIron/Decorator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/StrikeIron/Exception.php
+++ b/lib/Zend/Service/StrikeIron/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/StrikeIron/SalesUseTaxBasic.php
+++ b/lib/Zend/Service/StrikeIron/SalesUseTaxBasic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/StrikeIron/USAddressVerification.php
+++ b/lib/Zend/Service/StrikeIron/USAddressVerification.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/StrikeIron/ZipCodeInfo.php
+++ b/lib/Zend/Service/StrikeIron/ZipCodeInfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati.php
+++ b/lib/Zend/Service/Technorati.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/Author.php
+++ b/lib/Zend/Service/Technorati/Author.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/BlogInfoResult.php
+++ b/lib/Zend/Service/Technorati/BlogInfoResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/CosmosResult.php
+++ b/lib/Zend/Service/Technorati/CosmosResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/CosmosResultSet.php
+++ b/lib/Zend/Service/Technorati/CosmosResultSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/DailyCountsResult.php
+++ b/lib/Zend/Service/Technorati/DailyCountsResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/DailyCountsResultSet.php
+++ b/lib/Zend/Service/Technorati/DailyCountsResultSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/Exception.php
+++ b/lib/Zend/Service/Technorati/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/GetInfoResult.php
+++ b/lib/Zend/Service/Technorati/GetInfoResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/KeyInfoResult.php
+++ b/lib/Zend/Service/Technorati/KeyInfoResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/Result.php
+++ b/lib/Zend/Service/Technorati/Result.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/ResultSet.php
+++ b/lib/Zend/Service/Technorati/ResultSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/SearchResult.php
+++ b/lib/Zend/Service/Technorati/SearchResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/SearchResultSet.php
+++ b/lib/Zend/Service/Technorati/SearchResultSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/TagResult.php
+++ b/lib/Zend/Service/Technorati/TagResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/TagResultSet.php
+++ b/lib/Zend/Service/Technorati/TagResultSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/TagsResult.php
+++ b/lib/Zend/Service/Technorati/TagsResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/TagsResultSet.php
+++ b/lib/Zend/Service/Technorati/TagsResultSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/Utils.php
+++ b/lib/Zend/Service/Technorati/Utils.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Technorati/Weblog.php
+++ b/lib/Zend/Service/Technorati/Weblog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Twitter.php
+++ b/lib/Zend/Service/Twitter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Twitter/Exception.php
+++ b/lib/Zend/Service/Twitter/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Twitter/Search.php
+++ b/lib/Zend/Service/Twitter/Search.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Credentials/CredentialsAbstract.php
+++ b/lib/Zend/Service/WindowsAzure/Credentials/CredentialsAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Credentials/Exception.php
+++ b/lib/Zend/Service/WindowsAzure/Credentials/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Credentials/SharedAccessSignature.php
+++ b/lib/Zend/Service/WindowsAzure/Credentials/SharedAccessSignature.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Credentials/SharedKey.php
+++ b/lib/Zend/Service/WindowsAzure/Credentials/SharedKey.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Credentials/SharedKeyLite.php
+++ b/lib/Zend/Service/WindowsAzure/Credentials/SharedKeyLite.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationDataSources.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationDataSources.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationDiagnosticInfrastructureLogs.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationDiagnosticInfrastructureLogs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationDirectories.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationDirectories.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationInstance.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationInstance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationLogs.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationLogs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationObjectBaseAbstract.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationObjectBaseAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationPerformanceCounters.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationPerformanceCounters.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationWindowsEventLog.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/ConfigurationWindowsEventLog.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/DirectoryConfigurationSubscription.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/DirectoryConfigurationSubscription.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/Exception.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/LogLevel.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/LogLevel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/Manager.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/Manager.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Diagnostics/PerformanceCounterSubscription.php
+++ b/lib/Zend/Service/WindowsAzure/Diagnostics/PerformanceCounterSubscription.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Exception.php
+++ b/lib/Zend/Service/WindowsAzure/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/RetryPolicy/Exception.php
+++ b/lib/Zend/Service/WindowsAzure/RetryPolicy/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/RetryPolicy/NoRetry.php
+++ b/lib/Zend/Service/WindowsAzure/RetryPolicy/NoRetry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/RetryPolicy/RetryN.php
+++ b/lib/Zend/Service/WindowsAzure/RetryPolicy/RetryN.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/RetryPolicy/RetryPolicyAbstract.php
+++ b/lib/Zend/Service/WindowsAzure/RetryPolicy/RetryPolicyAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/SessionHandler.php
+++ b/lib/Zend/Service/WindowsAzure/SessionHandler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage.php
+++ b/lib/Zend/Service/WindowsAzure/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/Batch.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/Batch.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/BatchStorageAbstract.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/BatchStorageAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/Blob.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/Blob.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/Blob/Stream.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/Blob/Stream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/BlobContainer.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/BlobContainer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/BlobInstance.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/BlobInstance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/DynamicTableEntity.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/DynamicTableEntity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/LeaseInstance.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/LeaseInstance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/PageRegionInstance.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/PageRegionInstance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/Queue.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/Queue.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/QueueInstance.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/QueueInstance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/QueueMessage.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/QueueMessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/SignedIdentifier.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/SignedIdentifier.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/StorageEntityAbstract.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/StorageEntityAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/Table.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/Table.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/TableEntity.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/TableEntity.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/TableEntityQuery.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/TableEntityQuery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/WindowsAzure/Storage/TableInstance.php
+++ b/lib/Zend/Service/WindowsAzure/Storage/TableInstance.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo.php
+++ b/lib/Zend/Service/Yahoo.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/Image.php
+++ b/lib/Zend/Service/Yahoo/Image.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/ImageResult.php
+++ b/lib/Zend/Service/Yahoo/ImageResult.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/ImageResultSet.php
+++ b/lib/Zend/Service/Yahoo/ImageResultSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/InlinkDataResult.php
+++ b/lib/Zend/Service/Yahoo/InlinkDataResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/InlinkDataResultSet.php
+++ b/lib/Zend/Service/Yahoo/InlinkDataResultSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/LocalResult.php
+++ b/lib/Zend/Service/Yahoo/LocalResult.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/LocalResultSet.php
+++ b/lib/Zend/Service/Yahoo/LocalResultSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/NewsResult.php
+++ b/lib/Zend/Service/Yahoo/NewsResult.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/NewsResultSet.php
+++ b/lib/Zend/Service/Yahoo/NewsResultSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/PageDataResult.php
+++ b/lib/Zend/Service/Yahoo/PageDataResult.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/PageDataResultSet.php
+++ b/lib/Zend/Service/Yahoo/PageDataResultSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/Result.php
+++ b/lib/Zend/Service/Yahoo/Result.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/ResultSet.php
+++ b/lib/Zend/Service/Yahoo/ResultSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/VideoResult.php
+++ b/lib/Zend/Service/Yahoo/VideoResult.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/VideoResultSet.php
+++ b/lib/Zend/Service/Yahoo/VideoResultSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/WebResult.php
+++ b/lib/Zend/Service/Yahoo/WebResult.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Service/Yahoo/WebResultSet.php
+++ b/lib/Zend/Service/Yahoo/WebResultSet.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Session.php
+++ b/lib/Zend/Session.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Session/Abstract.php
+++ b/lib/Zend/Session/Abstract.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Session/Exception.php
+++ b/lib/Zend/Session/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Session/Namespace.php
+++ b/lib/Zend/Session/Namespace.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Session/SaveHandler/DbTable.php
+++ b/lib/Zend/Session/SaveHandler/DbTable.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-webat this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Session/SaveHandler/Exception.php
+++ b/lib/Zend/Session/SaveHandler/Exception.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Session/SaveHandler/Interface.php
+++ b/lib/Zend/Session/SaveHandler/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Session/Validator/Abstract.php
+++ b/lib/Zend/Session/Validator/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Session/Validator/HttpUserAgent.php
+++ b/lib/Zend/Session/Validator/HttpUserAgent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Session/Validator/Interface.php
+++ b/lib/Zend/Session/Validator/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tag/Cloud.php
+++ b/lib/Zend/Tag/Cloud.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tag/Cloud/Decorator/Cloud.php
+++ b/lib/Zend/Tag/Cloud/Decorator/Cloud.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tag/Cloud/Decorator/Exception.php
+++ b/lib/Zend/Tag/Cloud/Decorator/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tag/Cloud/Decorator/HtmlCloud.php
+++ b/lib/Zend/Tag/Cloud/Decorator/HtmlCloud.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tag/Cloud/Decorator/HtmlTag.php
+++ b/lib/Zend/Tag/Cloud/Decorator/HtmlTag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tag/Cloud/Decorator/Tag.php
+++ b/lib/Zend/Tag/Cloud/Decorator/Tag.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tag/Cloud/Exception.php
+++ b/lib/Zend/Tag/Cloud/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Tag/Exception.php
+++ b/lib/Zend/Tag/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Tag/Item.php
+++ b/lib/Zend/Tag/Item.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tag/ItemList.php
+++ b/lib/Zend/Tag/ItemList.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tag/Taggable.php
+++ b/lib/Zend/Tag/Taggable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/DbAdapter.php
+++ b/lib/Zend/Test/DbAdapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/DbStatement.php
+++ b/lib/Zend/Test/DbStatement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Constraint/DomQuery.php
+++ b/lib/Zend/Test/PHPUnit/Constraint/DomQuery.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Constraint/Exception.php
+++ b/lib/Zend/Test/PHPUnit/Constraint/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Constraint/Redirect.php
+++ b/lib/Zend/Test/PHPUnit/Constraint/Redirect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Constraint/ResponseHeader.php
+++ b/lib/Zend/Test/PHPUnit/Constraint/ResponseHeader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/lib/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/DatabaseTestCase.php
+++ b/lib/Zend/Test/PHPUnit/DatabaseTestCase.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/Connection.php
+++ b/lib/Zend/Test/PHPUnit/Db/Connection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/DataSet/DbRowset.php
+++ b/lib/Zend/Test/PHPUnit/Db/DataSet/DbRowset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/DataSet/DbTable.php
+++ b/lib/Zend/Test/PHPUnit/Db/DataSet/DbTable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSet.php
+++ b/lib/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/DataSet/QueryDataSet.php
+++ b/lib/Zend/Test/PHPUnit/Db/DataSet/QueryDataSet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/DataSet/QueryTable.php
+++ b/lib/Zend/Test/PHPUnit/Db/DataSet/QueryTable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/Exception.php
+++ b/lib/Zend/Test/PHPUnit/Db/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/Metadata/Generic.php
+++ b/lib/Zend/Test/PHPUnit/Db/Metadata/Generic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/Operation/DeleteAll.php
+++ b/lib/Zend/Test/PHPUnit/Db/Operation/DeleteAll.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/Operation/Insert.php
+++ b/lib/Zend/Test/PHPUnit/Db/Operation/Insert.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/Operation/Truncate.php
+++ b/lib/Zend/Test/PHPUnit/Db/Operation/Truncate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Test/PHPUnit/Db/SimpleTester.php
+++ b/lib/Zend/Test/PHPUnit/Db/SimpleTester.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Text/Exception.php
+++ b/lib/Zend/Text/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Text/Figlet.php
+++ b/lib/Zend/Text/Figlet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Text/Figlet/Exception.php
+++ b/lib/Zend/Text/Figlet/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Text/Figlet/zend-framework.flf
+++ b/lib/Zend/Text/Figlet/zend-framework.flf
@@ -14,7 +14,7 @@ Version: 1.0
  It is also available through the world-wide-web at this URL:
  http://framework.zend.com/license/new-bsd
  If you did not receive a copy of the license and are unable to
- obtain it through the world-wide-web, please send an email
+ obtain it through the world-wide-web, please send an e-mail
  to license@zend.com so we can send you a copy immediately.
  
  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)

--- a/lib/Zend/Text/MultiByte.php
+++ b/lib/Zend/Text/MultiByte.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Text/Table.php
+++ b/lib/Zend/Text/Table.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Text/Table/Column.php
+++ b/lib/Zend/Text/Table/Column.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Text/Table/Decorator/Ascii.php
+++ b/lib/Zend/Text/Table/Decorator/Ascii.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Text/Table/Decorator/Interface.php
+++ b/lib/Zend/Text/Table/Decorator/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Text/Table/Decorator/Unicode.php
+++ b/lib/Zend/Text/Table/Decorator/Unicode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Text/Table/Exception.php
+++ b/lib/Zend/Text/Table/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Text/Table/Row.php
+++ b/lib/Zend/Text/Table/Row.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/TimeSync.php
+++ b/lib/Zend/TimeSync.php
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/TimeSync/Exception.php
+++ b/lib/Zend/TimeSync/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/TimeSync/Ntp.php
+++ b/lib/Zend/TimeSync/Ntp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/TimeSync/Protocol.php
+++ b/lib/Zend/TimeSync/Protocol.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/TimeSync/Sntp.php
+++ b/lib/Zend/TimeSync/Sntp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Tool/Framework/Action/Base.php
+++ b/lib/Zend/Tool/Framework/Action/Base.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Action/Exception.php
+++ b/lib/Zend/Tool/Framework/Action/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Action/Interface.php
+++ b/lib/Zend/Tool/Framework/Action/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Action/Repository.php
+++ b/lib/Zend/Tool/Framework/Action/Repository.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Abstract.php
+++ b/lib/Zend/Tool/Framework/Client/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Config.php
+++ b/lib/Zend/Tool/Framework/Client/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Console.php
+++ b/lib/Zend/Tool/Framework/Client/Console.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Console/ArgumentParser.php
+++ b/lib/Zend/Tool/Framework/Client/Console/ArgumentParser.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Console/HelpSystem.php
+++ b/lib/Zend/Tool/Framework/Client/Console/HelpSystem.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Console/Manifest.php
+++ b/lib/Zend/Tool/Framework/Client/Console/Manifest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Console/ResponseDecorator/AlignCenter.php
+++ b/lib/Zend/Tool/Framework/Client/Console/ResponseDecorator/AlignCenter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Console/ResponseDecorator/Blockize.php
+++ b/lib/Zend/Tool/Framework/Client/Console/ResponseDecorator/Blockize.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Console/ResponseDecorator/Colorizer.php
+++ b/lib/Zend/Tool/Framework/Client/Console/ResponseDecorator/Colorizer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Console/ResponseDecorator/Indention.php
+++ b/lib/Zend/Tool/Framework/Client/Console/ResponseDecorator/Indention.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Exception.php
+++ b/lib/Zend/Tool/Framework/Client/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Interactive/InputHandler.php
+++ b/lib/Zend/Tool/Framework/Client/Interactive/InputHandler.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Interactive/InputInterface.php
+++ b/lib/Zend/Tool/Framework/Client/Interactive/InputInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Interactive/InputRequest.php
+++ b/lib/Zend/Tool/Framework/Client/Interactive/InputRequest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Interactive/InputResponse.php
+++ b/lib/Zend/Tool/Framework/Client/Interactive/InputResponse.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Interactive/OutputInterface.php
+++ b/lib/Zend/Tool/Framework/Client/Interactive/OutputInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Manifest.php
+++ b/lib/Zend/Tool/Framework/Client/Manifest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Request.php
+++ b/lib/Zend/Tool/Framework/Client/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Response.php
+++ b/lib/Zend/Tool/Framework/Client/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Response/ContentDecorator/Interface.php
+++ b/lib/Zend/Tool/Framework/Client/Response/ContentDecorator/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Response/ContentDecorator/Separator.php
+++ b/lib/Zend/Tool/Framework/Client/Response/ContentDecorator/Separator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Storage.php
+++ b/lib/Zend/Tool/Framework/Client/Storage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Storage/AdapterInterface.php
+++ b/lib/Zend/Tool/Framework/Client/Storage/AdapterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Client/Storage/Directory.php
+++ b/lib/Zend/Tool/Framework/Client/Storage/Directory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Exception.php
+++ b/lib/Zend/Tool/Framework/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Loader/Abstract.php
+++ b/lib/Zend/Tool/Framework/Loader/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Loader/BasicLoader.php
+++ b/lib/Zend/Tool/Framework/Loader/BasicLoader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Loader/IncludePathLoader.php
+++ b/lib/Zend/Tool/Framework/Loader/IncludePathLoader.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Loader/IncludePathLoader/RecursiveFilterIterator.php
+++ b/lib/Zend/Tool/Framework/Loader/IncludePathLoader/RecursiveFilterIterator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Loader/Interface.php
+++ b/lib/Zend/Tool/Framework/Loader/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Manifest/ActionManifestable.php
+++ b/lib/Zend/Tool/Framework/Manifest/ActionManifestable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Manifest/Exception.php
+++ b/lib/Zend/Tool/Framework/Manifest/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Manifest/Indexable.php
+++ b/lib/Zend/Tool/Framework/Manifest/Indexable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Manifest/Interface.php
+++ b/lib/Zend/Tool/Framework/Manifest/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Manifest/MetadataManifestable.php
+++ b/lib/Zend/Tool/Framework/Manifest/MetadataManifestable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Manifest/ProviderManifestable.php
+++ b/lib/Zend/Tool/Framework/Manifest/ProviderManifestable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Manifest/Repository.php
+++ b/lib/Zend/Tool/Framework/Manifest/Repository.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Metadata/Attributable.php
+++ b/lib/Zend/Tool/Framework/Metadata/Attributable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Metadata/Basic.php
+++ b/lib/Zend/Tool/Framework/Metadata/Basic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Metadata/Dynamic.php
+++ b/lib/Zend/Tool/Framework/Metadata/Dynamic.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Metadata/Interface.php
+++ b/lib/Zend/Tool/Framework/Metadata/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Metadata/Tool.php
+++ b/lib/Zend/Tool/Framework/Metadata/Tool.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Provider/Abstract.php
+++ b/lib/Zend/Tool/Framework/Provider/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Provider/DocblockManifestable.php
+++ b/lib/Zend/Tool/Framework/Provider/DocblockManifestable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Provider/Exception.php
+++ b/lib/Zend/Tool/Framework/Provider/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Provider/Initializable.php
+++ b/lib/Zend/Tool/Framework/Provider/Initializable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Provider/Interactable.php
+++ b/lib/Zend/Tool/Framework/Provider/Interactable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Provider/Interface.php
+++ b/lib/Zend/Tool/Framework/Provider/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Provider/Pretendable.php
+++ b/lib/Zend/Tool/Framework/Provider/Pretendable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Provider/Repository.php
+++ b/lib/Zend/Tool/Framework/Provider/Repository.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Provider/Signature.php
+++ b/lib/Zend/Tool/Framework/Provider/Signature.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Registry.php
+++ b/lib/Zend/Tool/Framework/Registry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Registry/EnabledInterface.php
+++ b/lib/Zend/Tool/Framework/Registry/EnabledInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Registry/Exception.php
+++ b/lib/Zend/Tool/Framework/Registry/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/Registry/Interface.php
+++ b/lib/Zend/Tool/Framework/Registry/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/System/Action/Create.php
+++ b/lib/Zend/Tool/Framework/System/Action/Create.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/System/Action/Delete.php
+++ b/lib/Zend/Tool/Framework/System/Action/Delete.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/System/Manifest.php
+++ b/lib/Zend/Tool/Framework/System/Manifest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/System/Provider/Config.php
+++ b/lib/Zend/Tool/Framework/System/Provider/Config.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/System/Provider/Manifest.php
+++ b/lib/Zend/Tool/Framework/System/Provider/Manifest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/System/Provider/Phpinfo.php
+++ b/lib/Zend/Tool/Framework/System/Provider/Phpinfo.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Framework/System/Provider/Version.php
+++ b/lib/Zend/Tool/Framework/System/Provider/Version.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Content/Engine.php
+++ b/lib/Zend/Tool/Project/Context/Content/Engine.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Content/Engine/CodeGenerator.php
+++ b/lib/Zend/Tool/Project/Context/Content/Engine/CodeGenerator.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Content/Engine/Phtml.php
+++ b/lib/Zend/Tool/Project/Context/Content/Engine/Phtml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Exception.php
+++ b/lib/Zend/Tool/Project/Context/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Filesystem/Abstract.php
+++ b/lib/Zend/Tool/Project/Context/Filesystem/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Filesystem/Directory.php
+++ b/lib/Zend/Tool/Project/Context/Filesystem/Directory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Filesystem/File.php
+++ b/lib/Zend/Tool/Project/Context/Filesystem/File.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Interface.php
+++ b/lib/Zend/Tool/Project/Context/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Repository.php
+++ b/lib/Zend/Tool/Project/Context/Repository.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/System/Interface.php
+++ b/lib/Zend/Tool/Project/Context/System/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/System/NotOverwritable.php
+++ b/lib/Zend/Tool/Project/Context/System/NotOverwritable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/System/ProjectDirectory.php
+++ b/lib/Zend/Tool/Project/Context/System/ProjectDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/System/ProjectProfileFile.php
+++ b/lib/Zend/Tool/Project/Context/System/ProjectProfileFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/System/ProjectProvidersDirectory.php
+++ b/lib/Zend/Tool/Project/Context/System/ProjectProvidersDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/System/TopLevelRestrictable.php
+++ b/lib/Zend/Tool/Project/Context/System/TopLevelRestrictable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/AbstractClassFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/AbstractClassFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ActionMethod.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ActionMethod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ApisDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ApisDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ApplicationConfigFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ApplicationConfigFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ApplicationDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ApplicationDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/BootstrapFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/BootstrapFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/CacheDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/CacheDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ConfigFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ConfigFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ConfigsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ConfigsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ControllerFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ControllerFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ControllersDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ControllersDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/DataDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/DataDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/DbTableDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/DbTableDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/DbTableFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/DbTableFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/DocsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/DocsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/FormFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/FormFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/FormsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/FormsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/HtaccessFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/HtaccessFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/LayoutScriptFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/LayoutScriptFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/LayoutScriptsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/LayoutScriptsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/LayoutsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/LayoutsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/LibraryDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/LibraryDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/LocalesDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/LocalesDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/LogsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/LogsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ModelFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ModelFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ModelsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ModelsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ModuleDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ModuleDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ModulesDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ModulesDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ProjectProviderFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ProjectProviderFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/PublicDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/PublicDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/PublicImagesDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/PublicImagesDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/PublicIndexFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/PublicIndexFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/PublicScriptsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/PublicScriptsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/PublicStylesheetsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/PublicStylesheetsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/SearchIndexesDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/SearchIndexesDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/SessionsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/SessionsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TemporaryDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TemporaryDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TestApplicationBootstrapFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TestApplicationBootstrapFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TestApplicationControllerDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TestApplicationControllerDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TestApplicationControllerFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TestApplicationControllerFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TestApplicationDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TestApplicationDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TestLibraryBootstrapFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TestLibraryBootstrapFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TestLibraryDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TestLibraryDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TestLibraryFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TestLibraryFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TestLibraryNamespaceDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TestLibraryNamespaceDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TestPHPUnitConfigFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TestPHPUnitConfigFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/TestsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/TestsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/UploadsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/UploadsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ViewControllerScriptsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ViewControllerScriptsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ViewFiltersDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ViewFiltersDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ViewHelpersDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ViewHelpersDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ViewScriptFile.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ViewScriptFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ViewScriptsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ViewScriptsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ViewsDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ViewsDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Context/Zf/ZfStandardLibraryDirectory.php
+++ b/lib/Zend/Tool/Project/Context/Zf/ZfStandardLibraryDirectory.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Exception.php
+++ b/lib/Zend/Tool/Project/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Profile.php
+++ b/lib/Zend/Tool/Project/Profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Profile/Exception.php
+++ b/lib/Zend/Tool/Project/Profile/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Profile/FileParser/Interface.php
+++ b/lib/Zend/Tool/Project/Profile/FileParser/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Profile/FileParser/Xml.php
+++ b/lib/Zend/Tool/Project/Profile/FileParser/Xml.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Profile/Iterator/ContextFilter.php
+++ b/lib/Zend/Tool/Project/Profile/Iterator/ContextFilter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Profile/Iterator/EnabledResourceFilter.php
+++ b/lib/Zend/Tool/Project/Profile/Iterator/EnabledResourceFilter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Profile/Resource.php
+++ b/lib/Zend/Tool/Project/Profile/Resource.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Profile/Resource/Container.php
+++ b/lib/Zend/Tool/Project/Profile/Resource/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Profile/Resource/SearchConstraints.php
+++ b/lib/Zend/Tool/Project/Profile/Resource/SearchConstraints.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Abstract.php
+++ b/lib/Zend/Tool/Project/Provider/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Action.php
+++ b/lib/Zend/Tool/Project/Provider/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Application.php
+++ b/lib/Zend/Tool/Project/Provider/Application.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Controller.php
+++ b/lib/Zend/Tool/Project/Provider/Controller.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/DbAdapter.php
+++ b/lib/Zend/Tool/Project/Provider/DbAdapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/DbTable.php
+++ b/lib/Zend/Tool/Project/Provider/DbTable.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Exception.php
+++ b/lib/Zend/Tool/Project/Provider/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Form.php
+++ b/lib/Zend/Tool/Project/Provider/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Layout.php
+++ b/lib/Zend/Tool/Project/Provider/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Manifest.php
+++ b/lib/Zend/Tool/Project/Provider/Manifest.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Model.php
+++ b/lib/Zend/Tool/Project/Provider/Model.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Module.php
+++ b/lib/Zend/Tool/Project/Provider/Module.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Profile.php
+++ b/lib/Zend/Tool/Project/Provider/Profile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Project.php
+++ b/lib/Zend/Tool/Project/Provider/Project.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/ProjectProvider.php
+++ b/lib/Zend/Tool/Project/Provider/ProjectProvider.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/Test.php
+++ b/lib/Zend/Tool/Project/Provider/Test.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Tool/Project/Provider/View.php
+++ b/lib/Zend/Tool/Project/Provider/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate.php
+++ b/lib/Zend/Translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Adapter.php
+++ b/lib/Zend/Translate/Adapter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Adapter/Array.php
+++ b/lib/Zend/Translate/Adapter/Array.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Adapter/Csv.php
+++ b/lib/Zend/Translate/Adapter/Csv.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Adapter/Gettext.php
+++ b/lib/Zend/Translate/Adapter/Gettext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Adapter/Ini.php
+++ b/lib/Zend/Translate/Adapter/Ini.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Adapter/Qt.php
+++ b/lib/Zend/Translate/Adapter/Qt.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Adapter/Tbx.php
+++ b/lib/Zend/Translate/Adapter/Tbx.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Adapter/Tmx.php
+++ b/lib/Zend/Translate/Adapter/Tmx.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Adapter/Xliff.php
+++ b/lib/Zend/Translate/Adapter/Xliff.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Adapter/XmlTm.php
+++ b/lib/Zend/Translate/Adapter/XmlTm.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Exception.php
+++ b/lib/Zend/Translate/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Translate/Plural.php
+++ b/lib/Zend/Translate/Plural.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Uri.php
+++ b/lib/Zend/Uri.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Uri/Exception.php
+++ b/lib/Zend/Uri/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Uri/Http.php
+++ b/lib/Zend/Uri/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate.php
+++ b/lib/Zend/Validate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Abstract.php
+++ b/lib/Zend/Validate/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Alnum.php
+++ b/lib/Zend/Validate/Alnum.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Alpha.php
+++ b/lib/Zend/Validate/Alpha.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode.php
+++ b/lib/Zend/Validate/Barcode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/AdapterAbstract.php
+++ b/lib/Zend/Validate/Barcode/AdapterAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/AdapterInterface.php
+++ b/lib/Zend/Validate/Barcode/AdapterInterface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Code25.php
+++ b/lib/Zend/Validate/Barcode/Code25.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Code25interleaved.php
+++ b/lib/Zend/Validate/Barcode/Code25interleaved.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Code39.php
+++ b/lib/Zend/Validate/Barcode/Code39.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Code39ext.php
+++ b/lib/Zend/Validate/Barcode/Code39ext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Code93.php
+++ b/lib/Zend/Validate/Barcode/Code93.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Code93ext.php
+++ b/lib/Zend/Validate/Barcode/Code93ext.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Ean12.php
+++ b/lib/Zend/Validate/Barcode/Ean12.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Ean13.php
+++ b/lib/Zend/Validate/Barcode/Ean13.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Ean14.php
+++ b/lib/Zend/Validate/Barcode/Ean14.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Ean18.php
+++ b/lib/Zend/Validate/Barcode/Ean18.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Ean2.php
+++ b/lib/Zend/Validate/Barcode/Ean2.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Ean5.php
+++ b/lib/Zend/Validate/Barcode/Ean5.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Ean8.php
+++ b/lib/Zend/Validate/Barcode/Ean8.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Gtin12.php
+++ b/lib/Zend/Validate/Barcode/Gtin12.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Gtin13.php
+++ b/lib/Zend/Validate/Barcode/Gtin13.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Gtin14.php
+++ b/lib/Zend/Validate/Barcode/Gtin14.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Identcode.php
+++ b/lib/Zend/Validate/Barcode/Identcode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Intelligentmail.php
+++ b/lib/Zend/Validate/Barcode/Intelligentmail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Issn.php
+++ b/lib/Zend/Validate/Barcode/Issn.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Itf14.php
+++ b/lib/Zend/Validate/Barcode/Itf14.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Leitcode.php
+++ b/lib/Zend/Validate/Barcode/Leitcode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Planet.php
+++ b/lib/Zend/Validate/Barcode/Planet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Postnet.php
+++ b/lib/Zend/Validate/Barcode/Postnet.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Royalmail.php
+++ b/lib/Zend/Validate/Barcode/Royalmail.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Sscc.php
+++ b/lib/Zend/Validate/Barcode/Sscc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Upca.php
+++ b/lib/Zend/Validate/Barcode/Upca.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Barcode/Upce.php
+++ b/lib/Zend/Validate/Barcode/Upce.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Between.php
+++ b/lib/Zend/Validate/Between.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Callback.php
+++ b/lib/Zend/Validate/Callback.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Ccnum.php
+++ b/lib/Zend/Validate/Ccnum.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/CreditCard.php
+++ b/lib/Zend/Validate/CreditCard.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Date.php
+++ b/lib/Zend/Validate/Date.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Db/Abstract.php
+++ b/lib/Zend/Validate/Db/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Db/NoRecordExists.php
+++ b/lib/Zend/Validate/Db/NoRecordExists.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Db/RecordExists.php
+++ b/lib/Zend/Validate/Db/RecordExists.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Digits.php
+++ b/lib/Zend/Validate/Digits.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/EmailAddress.php
+++ b/lib/Zend/Validate/EmailAddress.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Exception.php
+++ b/lib/Zend/Validate/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/File/Count.php
+++ b/lib/Zend/Validate/File/Count.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/Crc32.php
+++ b/lib/Zend/Validate/File/Crc32.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/ExcludeExtension.php
+++ b/lib/Zend/Validate/File/ExcludeExtension.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/ExcludeMimeType.php
+++ b/lib/Zend/Validate/File/ExcludeMimeType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/Exists.php
+++ b/lib/Zend/Validate/File/Exists.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/Extension.php
+++ b/lib/Zend/Validate/File/Extension.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/FilesSize.php
+++ b/lib/Zend/Validate/File/FilesSize.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/Hash.php
+++ b/lib/Zend/Validate/File/Hash.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/ImageSize.php
+++ b/lib/Zend/Validate/File/ImageSize.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/IsCompressed.php
+++ b/lib/Zend/Validate/File/IsCompressed.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/IsImage.php
+++ b/lib/Zend/Validate/File/IsImage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/Md5.php
+++ b/lib/Zend/Validate/File/Md5.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/MimeType.php
+++ b/lib/Zend/Validate/File/MimeType.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/NotExists.php
+++ b/lib/Zend/Validate/File/NotExists.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/Sha1.php
+++ b/lib/Zend/Validate/File/Sha1.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/Size.php
+++ b/lib/Zend/Validate/File/Size.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/Upload.php
+++ b/lib/Zend/Validate/File/Upload.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/File/WordCount.php
+++ b/lib/Zend/Validate/File/WordCount.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category  Zend

--- a/lib/Zend/Validate/Float.php
+++ b/lib/Zend/Validate/Float.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/GreaterThan.php
+++ b/lib/Zend/Validate/GreaterThan.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Hex.php
+++ b/lib/Zend/Validate/Hex.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Hostname.php
+++ b/lib/Zend/Validate/Hostname.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Hostname/Biz.php
+++ b/lib/Zend/Validate/Hostname/Biz.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Hostname/Cn.php
+++ b/lib/Zend/Validate/Hostname/Cn.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Hostname/Com.php
+++ b/lib/Zend/Validate/Hostname/Com.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Hostname/Jp.php
+++ b/lib/Zend/Validate/Hostname/Jp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Iban.php
+++ b/lib/Zend/Validate/Iban.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Identical.php
+++ b/lib/Zend/Validate/Identical.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/InArray.php
+++ b/lib/Zend/Validate/InArray.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Int.php
+++ b/lib/Zend/Validate/Int.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Interface.php
+++ b/lib/Zend/Validate/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Ip.php
+++ b/lib/Zend/Validate/Ip.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Isbn.php
+++ b/lib/Zend/Validate/Isbn.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/LessThan.php
+++ b/lib/Zend/Validate/LessThan.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/NotEmpty.php
+++ b/lib/Zend/Validate/NotEmpty.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/PostCode.php
+++ b/lib/Zend/Validate/PostCode.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Regex.php
+++ b/lib/Zend/Validate/Regex.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Sitemap/Changefreq.php
+++ b/lib/Zend/Validate/Sitemap/Changefreq.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Sitemap/Lastmod.php
+++ b/lib/Zend/Validate/Sitemap/Lastmod.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Sitemap/Loc.php
+++ b/lib/Zend/Validate/Sitemap/Loc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/Sitemap/Priority.php
+++ b/lib/Zend/Validate/Sitemap/Priority.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Validate/StringLength.php
+++ b/lib/Zend/Validate/StringLength.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Version.php
+++ b/lib/Zend/Version.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View.php
+++ b/lib/Zend/View.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Abstract.php
+++ b/lib/Zend/View/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Exception.php
+++ b/lib/Zend/View/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Abstract.php
+++ b/lib/Zend/View/Helper/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Action.php
+++ b/lib/Zend/View/Helper/Action.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/BaseUrl.php
+++ b/lib/Zend/View/Helper/BaseUrl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Currency.php
+++ b/lib/Zend/View/Helper/Currency.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Cycle.php
+++ b/lib/Zend/View/Helper/Cycle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/DeclareVars.php
+++ b/lib/Zend/View/Helper/DeclareVars.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Doctype.php
+++ b/lib/Zend/View/Helper/Doctype.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Fieldset.php
+++ b/lib/Zend/View/Helper/Fieldset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Form.php
+++ b/lib/Zend/View/Helper/Form.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormButton.php
+++ b/lib/Zend/View/Helper/FormButton.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormCheckbox.php
+++ b/lib/Zend/View/Helper/FormCheckbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormElement.php
+++ b/lib/Zend/View/Helper/FormElement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormErrors.php
+++ b/lib/Zend/View/Helper/FormErrors.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormFile.php
+++ b/lib/Zend/View/Helper/FormFile.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormHidden.php
+++ b/lib/Zend/View/Helper/FormHidden.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormImage.php
+++ b/lib/Zend/View/Helper/FormImage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormLabel.php
+++ b/lib/Zend/View/Helper/FormLabel.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormMultiCheckbox.php
+++ b/lib/Zend/View/Helper/FormMultiCheckbox.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormNote.php
+++ b/lib/Zend/View/Helper/FormNote.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormPassword.php
+++ b/lib/Zend/View/Helper/FormPassword.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormRadio.php
+++ b/lib/Zend/View/Helper/FormRadio.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormReset.php
+++ b/lib/Zend/View/Helper/FormReset.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormSelect.php
+++ b/lib/Zend/View/Helper/FormSelect.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormSubmit.php
+++ b/lib/Zend/View/Helper/FormSubmit.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormText.php
+++ b/lib/Zend/View/Helper/FormText.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/FormTextarea.php
+++ b/lib/Zend/View/Helper/FormTextarea.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Gravatar.php
+++ b/lib/Zend/View/Helper/Gravatar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HeadLink.php
+++ b/lib/Zend/View/Helper/HeadLink.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HeadMeta.php
+++ b/lib/Zend/View/Helper/HeadMeta.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HeadScript.php
+++ b/lib/Zend/View/Helper/HeadScript.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HeadStyle.php
+++ b/lib/Zend/View/Helper/HeadStyle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HeadTitle.php
+++ b/lib/Zend/View/Helper/HeadTitle.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HtmlElement.php
+++ b/lib/Zend/View/Helper/HtmlElement.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HtmlFlash.php
+++ b/lib/Zend/View/Helper/HtmlFlash.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HtmlList.php
+++ b/lib/Zend/View/Helper/HtmlList.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HtmlObject.php
+++ b/lib/Zend/View/Helper/HtmlObject.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HtmlPage.php
+++ b/lib/Zend/View/Helper/HtmlPage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/HtmlQuicktime.php
+++ b/lib/Zend/View/Helper/HtmlQuicktime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/InlineScript.php
+++ b/lib/Zend/View/Helper/InlineScript.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Interface.php
+++ b/lib/Zend/View/Helper/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Json.php
+++ b/lib/Zend/View/Helper/Json.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Layout.php
+++ b/lib/Zend/View/Helper/Layout.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Navigation.php
+++ b/lib/Zend/View/Helper/Navigation.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/lib/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Navigation/Helper.php
+++ b/lib/Zend/View/Helper/Navigation/Helper.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Navigation/HelperAbstract.php
+++ b/lib/Zend/View/Helper/Navigation/HelperAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Navigation/Links.php
+++ b/lib/Zend/View/Helper/Navigation/Links.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Navigation/Menu.php
+++ b/lib/Zend/View/Helper/Navigation/Menu.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Navigation/Sitemap.php
+++ b/lib/Zend/View/Helper/Navigation/Sitemap.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/PaginationControl.php
+++ b/lib/Zend/View/Helper/PaginationControl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Partial.php
+++ b/lib/Zend/View/Helper/Partial.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Partial/Exception.php
+++ b/lib/Zend/View/Helper/Partial/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/PartialLoop.php
+++ b/lib/Zend/View/Helper/PartialLoop.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Placeholder.php
+++ b/lib/Zend/View/Helper/Placeholder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Placeholder/Container.php
+++ b/lib/Zend/View/Helper/Placeholder/Container.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Placeholder/Container/Abstract.php
+++ b/lib/Zend/View/Helper/Placeholder/Container/Abstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Placeholder/Container/Exception.php
+++ b/lib/Zend/View/Helper/Placeholder/Container/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Placeholder/Container/Standalone.php
+++ b/lib/Zend/View/Helper/Placeholder/Container/Standalone.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Placeholder/Registry.php
+++ b/lib/Zend/View/Helper/Placeholder/Registry.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Placeholder/Registry/Exception.php
+++ b/lib/Zend/View/Helper/Placeholder/Registry/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/RenderToPlaceholder.php
+++ b/lib/Zend/View/Helper/RenderToPlaceholder.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/ServerUrl.php
+++ b/lib/Zend/View/Helper/ServerUrl.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/TinySrc.php
+++ b/lib/Zend/View/Helper/TinySrc.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Translate.php
+++ b/lib/Zend/View/Helper/Translate.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/Url.php
+++ b/lib/Zend/View/Helper/Url.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Helper/UserAgent.php
+++ b/lib/Zend/View/Helper/UserAgent.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Interface.php
+++ b/lib/Zend/View/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/View/Stream.php
+++ b/lib/Zend/View/Stream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Wildfire/Channel/HttpHeaders.php
+++ b/lib/Zend/Wildfire/Channel/HttpHeaders.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Wildfire/Channel/Interface.php
+++ b/lib/Zend/Wildfire/Channel/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Wildfire/Exception.php
+++ b/lib/Zend/Wildfire/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Wildfire/Plugin/FirePhp.php
+++ b/lib/Zend/Wildfire/Plugin/FirePhp.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Wildfire/Plugin/FirePhp/Message.php
+++ b/lib/Zend/Wildfire/Plugin/FirePhp/Message.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Wildfire/Plugin/FirePhp/TableMessage.php
+++ b/lib/Zend/Wildfire/Plugin/FirePhp/TableMessage.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Wildfire/Plugin/Interface.php
+++ b/lib/Zend/Wildfire/Plugin/Interface.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/Wildfire/Protocol/JsonStream.php
+++ b/lib/Zend/Wildfire/Protocol/JsonStream.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Client.php
+++ b/lib/Zend/XmlRpc/Client.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Client/Exception.php
+++ b/lib/Zend/XmlRpc/Client/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Client/FaultException.php
+++ b/lib/Zend/XmlRpc/Client/FaultException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Client/HttpException.php
+++ b/lib/Zend/XmlRpc/Client/HttpException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Client/IntrospectException.php
+++ b/lib/Zend/XmlRpc/Client/IntrospectException.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Client/ServerIntrospection.php
+++ b/lib/Zend/XmlRpc/Client/ServerIntrospection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Client/ServerProxy.php
+++ b/lib/Zend/XmlRpc/Client/ServerProxy.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Exception.php
+++ b/lib/Zend/XmlRpc/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Fault.php
+++ b/lib/Zend/XmlRpc/Fault.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @package    Zend_XmlRpc

--- a/lib/Zend/XmlRpc/Generator/DomDocument.php
+++ b/lib/Zend/XmlRpc/Generator/DomDocument.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Generator/GeneratorAbstract.php
+++ b/lib/Zend/XmlRpc/Generator/GeneratorAbstract.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Generator/XmlWriter.php
+++ b/lib/Zend/XmlRpc/Generator/XmlWriter.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Request.php
+++ b/lib/Zend/XmlRpc/Request.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Request/Http.php
+++ b/lib/Zend/XmlRpc/Request/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Request/Stdin.php
+++ b/lib/Zend/XmlRpc/Request/Stdin.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Response.php
+++ b/lib/Zend/XmlRpc/Response.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Response/Http.php
+++ b/lib/Zend/XmlRpc/Response/Http.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Server.php
+++ b/lib/Zend/XmlRpc/Server.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Server/Cache.php
+++ b/lib/Zend/XmlRpc/Server/Cache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Server/Exception.php
+++ b/lib/Zend/XmlRpc/Server/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Server/Fault.php
+++ b/lib/Zend/XmlRpc/Server/Fault.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Server/System.php
+++ b/lib/Zend/XmlRpc/Server/System.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value.php
+++ b/lib/Zend/XmlRpc/Value.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/Array.php
+++ b/lib/Zend/XmlRpc/Value/Array.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/Base64.php
+++ b/lib/Zend/XmlRpc/Value/Base64.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/BigInteger.php
+++ b/lib/Zend/XmlRpc/Value/BigInteger.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/Boolean.php
+++ b/lib/Zend/XmlRpc/Value/Boolean.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/Collection.php
+++ b/lib/Zend/XmlRpc/Value/Collection.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/DateTime.php
+++ b/lib/Zend/XmlRpc/Value/DateTime.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/Double.php
+++ b/lib/Zend/XmlRpc/Value/Double.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/Exception.php
+++ b/lib/Zend/XmlRpc/Value/Exception.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/Integer.php
+++ b/lib/Zend/XmlRpc/Value/Integer.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/Nil.php
+++ b/lib/Zend/XmlRpc/Value/Nil.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/Scalar.php
+++ b/lib/Zend/XmlRpc/Value/Scalar.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/String.php
+++ b/lib/Zend/XmlRpc/Value/String.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/Zend/XmlRpc/Value/Struct.php
+++ b/lib/Zend/XmlRpc/Value/Struct.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://framework.zend.com/license/new-bsd
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend

--- a/lib/flex/uploader/uploader.mxml
+++ b/lib/flex/uploader/uploader.mxml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/flex/uploader/uploaderSingle.mxml
+++ b/lib/flex/uploader/uploaderSingle.mxml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/flex/varien/varien/upload/Uploader.as
+++ b/lib/flex/varien/varien/upload/Uploader.as
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/flex/varien/varien/upload/UploaderEvent.as
+++ b/lib/flex/varien/varien/upload/UploaderEvent.as
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/lib/flex/varien/varien/upload/UploaderSingle.as
+++ b/lib/flex/varien/varien/upload/UploaderSingle.as
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/cron.php
+++ b/pub/cron.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/404.php
+++ b/pub/errors/404.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/503.php
+++ b/pub/errors/503.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/default/404.phtml
+++ b/pub/errors/default/404.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/default/503.phtml
+++ b/pub/errors/default/503.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/default/css/styles.css
+++ b/pub/errors/default/css/styles.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/default/nocache.phtml
+++ b/pub/errors/default/nocache.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/default/page.phtml
+++ b/pub/errors/default/page.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/default/report.phtml
+++ b/pub/errors/default/report.phtml
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/design.xml
+++ b/pub/errors/design.xml
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/local.xml.sample
+++ b/pub/errors/local.xml.sample
@@ -10,7 +10,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/noCache.php
+++ b/pub/errors/noCache.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/errors/report.php
+++ b/pub/errors/report.php
@@ -9,7 +9,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/get.php
+++ b/pub/get.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/index.php
+++ b/pub/index.php
@@ -11,7 +11,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/lib/dropdown.js
+++ b/pub/lib/lib/dropdown.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/lib/flex.js
+++ b/pub/lib/lib/flex.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/accordion.js
+++ b/pub/lib/mage/accordion.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/accordion.js
+++ b/pub/lib/mage/adminhtml/accordion.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/backup.js
+++ b/pub/lib/mage/adminhtml/backup.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/browser.js
+++ b/pub/lib/mage/adminhtml/browser.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/events.js
+++ b/pub/lib/mage/adminhtml/events.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/flexuploader.js
+++ b/pub/lib/mage/adminhtml/flexuploader.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/form.js
+++ b/pub/lib/mage/adminhtml/form.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/grid.js
+++ b/pub/lib/mage/adminhtml/grid.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/image.js
+++ b/pub/lib/mage/adminhtml/image.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/tabs.js
+++ b/pub/lib/mage/adminhtml/tabs.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/tools.js
+++ b/pub/lib/mage/adminhtml/tools.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/varienLoader.js
+++ b/pub/lib/mage/adminhtml/varienLoader.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
+++ b/pub/lib/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
+++ b/pub/lib/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/wysiwyg/tiny_mce/setup.js
+++ b/pub/lib/mage/adminhtml/wysiwyg/tiny_mce/setup.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/content.css
+++ b/pub/lib/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/content.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/dialog.css
+++ b/pub/lib/mage/adminhtml/wysiwyg/tiny_mce/themes/advanced/skins/default/dialog.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/adminhtml/wysiwyg/widget.js
+++ b/pub/lib/mage/adminhtml/wysiwyg/widget.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/action-link.js
+++ b/pub/lib/mage/backend/action-link.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/ajax-setup.js
+++ b/pub/lib/mage/backend/ajax-setup.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/bootstrap.js
+++ b/pub/lib/mage/backend/bootstrap.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/button.js
+++ b/pub/lib/mage/backend/button.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/editablemultiselect.js
+++ b/pub/lib/mage/backend/editablemultiselect.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/floating-header.js
+++ b/pub/lib/mage/backend/floating-header.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/form.js
+++ b/pub/lib/mage/backend/form.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/menu.js
+++ b/pub/lib/mage/backend/menu.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/notification.js
+++ b/pub/lib/mage/backend/notification.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/suggest.js
+++ b/pub/lib/mage/backend/suggest.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/tabs.js
+++ b/pub/lib/mage/backend/tabs.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/tree-suggest.js
+++ b/pub/lib/mage/backend/tree-suggest.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/backend/validation.js
+++ b/pub/lib/mage/backend/validation.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/bootstrap.js
+++ b/pub/lib/mage/bootstrap.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/calendar.css
+++ b/pub/lib/mage/calendar.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/calendar.js
+++ b/pub/lib/mage/calendar.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/captcha.js
+++ b/pub/lib/mage/captcha.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/common.js
+++ b/pub/lib/mage/common.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/cookies.js
+++ b/pub/lib/mage/cookies.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/decorate.js
+++ b/pub/lib/mage/decorate.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/deletable-item.js
+++ b/pub/lib/mage/deletable-item.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/directpost.js
+++ b/pub/lib/mage/directpost.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/dropdown.js
+++ b/pub/lib/mage/dropdown.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/edit-trigger.js
+++ b/pub/lib/mage/edit-trigger.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/fieldset-controls.js
+++ b/pub/lib/mage/fieldset-controls.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/gallery.css
+++ b/pub/lib/mage/gallery.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/item-table.js
+++ b/pub/lib/mage/item-table.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/jquery-no-conflict.js
+++ b/pub/lib/mage/jquery-no-conflict.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/loader.js
+++ b/pub/lib/mage/loader.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/mage.js
+++ b/pub/lib/mage/mage.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/popup-window.js
+++ b/pub/lib/mage/popup-window.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/proxy-event.js
+++ b/pub/lib/mage/proxy-event.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/redirect-url.js
+++ b/pub/lib/mage/redirect-url.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/toggle.js
+++ b/pub/lib/mage/toggle.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/translate-inline-vde.css
+++ b/pub/lib/mage/translate-inline-vde.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/translate-inline-vde.js
+++ b/pub/lib/mage/translate-inline-vde.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/translate-inline.css
+++ b/pub/lib/mage/translate-inline.css
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/translate-inline.js
+++ b/pub/lib/mage/translate-inline.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/translate.js
+++ b/pub/lib/mage/translate.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/validation.js
+++ b/pub/lib/mage/validation.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/validation/dob-rule.js
+++ b/pub/lib/mage/validation/dob-rule.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/validation/validation.js
+++ b/pub/lib/mage/validation/validation.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/webapi.js
+++ b/pub/lib/mage/webapi.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/mage/zoom.js
+++ b/pub/lib/mage/zoom.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/varien/configurable.js
+++ b/pub/lib/varien/configurable.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/varien/form.js
+++ b/pub/lib/varien/form.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/varien/js.js
+++ b/pub/lib/varien/js.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER

--- a/pub/lib/varien/product.js
+++ b/pub/lib/varien/product.js
@@ -8,7 +8,7 @@
  * It is also available through the world-wide-web at this URL:
  * http://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
+ * obtain it through the world-wide-web, please send an e-mail
  * to license@magentocommerce.com so we can send you a copy immediately.
  *
  * DISCLAIMER


### PR DESCRIPTION
Whilst accepted as correct, e-mail is a 1980s: abbreviation of electronic mail.
As such should be correctly spelt as 'e-mail' and not 'email'.
This commit corrects the spelling within the NOTICE OF LICENSE header.
Future commits can then be made to correct further misspellings with adequate testing.

This replaces the line...
- obtain it through the world-wide-web, please send an email
  to...
- obtain it through the world-wide-web, please send an e-mail

Please feel free to check any major dictionary.
http://www.thefreedictionary.com/email
