### PR TITLE
Update Config.php

### DIFF
--- a/app/code/Magento/Paypal/Model/Config.php
+++ b/app/code/Magento/Paypal/Model/Config.php
@@ -200,7 +200,7 @@ class Config
      * @var array
      */
     protected $_supportedCurrencyCodes = array('AUD', 'CAD', 'CZK', 'DKK', 'EUR', 'HKD', 'HUF', 'ILS', 'JPY', 'MXN',
-        'NOK', 'NZD', 'PLN', 'GBP', 'SGD', 'SEK', 'CHF', 'USD', 'TWD', 'THB');
+        'NOK', 'NZD', 'PLN', 'GBP', 'SGD', 'SEK', 'CHF', 'USD', 'TWD', 'THB', 'TRY', 'TRL', 'TL');
 
     /**
      * Merchant country supported by PayPal


### PR DESCRIPTION
Paypal is not working in Turkey. Because there is no Turkish Lira sign in $_supportedCurrencyCodes array...
