### PR TITLE
Include composer's autoloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ atlassian*
 !/pub/static/.htaccess
 /var/*
 /app/code/Magento/TestModule*
+/vendor

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -61,6 +61,8 @@ define('BP', dirname(__DIR__));
 /**
  * Require necessary files
  */
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
 require_once BP . '/app/code/Magento/Core/functions.php';
 
 require_once __DIR__ . '/autoload.php';


### PR DESCRIPTION
Without it the configuration set in composer.json

``` json
autoload": {
    "psr-0": {
        "": ["app/code", "lib"]
    }
}
```

will not be used, causing errors like `Fatal error: Maximum function nesting level of '100' reached, aborting! in /Users/chadrien/projects/magento2/lib/Magento/Autoload/IncludePath.php on line 56`
located at the create simple product page.
