### PR TITLE
Set memory_limit in phpunit's bootstrap to 512M

### DIFF
--- a/dev/tests/unit/framework/bootstrap.php
+++ b/dev/tests/unit/framework/bootstrap.php
@@ -58,3 +58,4 @@ function tool_autoloader($className)
 spl_autoload_register('tool_autoloader');
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
+ini_set('memory_limit', '512M');


### PR DESCRIPTION
Without it, depending on the user's php.ini, tests may fail with a
`Allowed memory size of xxxxxxxxx bytes exhausted`
