### PR TITLE
Use composer's autoloader in the phpunit bootstrap, have phpunit as a dev requirement in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
     "require": {
         "php": ">=5.4.0"
     },
+    "require-dev": {
+        "phpunit/phpunit" : "3.7.*@stable"
+    },
     "autoload": {
         "psr-0": {
             "": ["app/code", "lib"]

--- a/dev/tests/unit/framework/bootstrap.php
+++ b/dev/tests/unit/framework/bootstrap.php
@@ -26,6 +26,7 @@ define('BP', realpath(__DIR__ . '/../../../../'));
 define('TESTS_TEMP_DIR', dirname(__DIR__) . DIRECTORY_SEPARATOR . 'tmp');
 define('DS', DIRECTORY_SEPARATOR);
 require BP . '/app/code/Magento/Core/functions.php';
+require BP . '/vendor/autoload.php';
 require BP . '/app/autoload.php';
 \Magento\Autoload\IncludePath::addIncludePath(array(
     __DIR__,


### PR DESCRIPTION
So anyone can run the tests with the right version of phpunit.
