### PR TITLE
BUGFIX: dev45: Design Editor (VDE) broken

### DIFF
--- a/app/code/Magento/DesignEditor/Controller/Varien/Router/Standard.php
+++ b/app/code/Magento/DesignEditor/Controller/Varien/Router/Standard.php
@@ -160,10 +160,10 @@ class Standard extends \Magento\Core\App\Router\Base
      */
     protected function _getMatchedRouters()
     {
-        $routers = $this->_routerList->getRouters();
-        foreach (array_keys($routers) as $name) {
-            if (in_array($name, $this->_excludedRouters)) {
-                unset($routers[$name]);
+        $routers = array();
+        foreach ($this->_routerList as $name => $router) {
+            if (!in_array($name, $this->_excludedRouters)) {
+                $routers[$name] = $router;
             }
         }
         return $routers;


### PR DESCRIPTION
_\Magento\App\RouterList::getRouters()_ does not exists, but +RouterList+ is an iterator, them I change the loop logic.

This a very simple thing.
