### PR TITLE
Use translates for Quote\Address\Total\Shipping

### DIFF
--- a/app/code/Magento/Sales/Model/Quote/Address/Total/Shipping.php
+++ b/app/code/Magento/Sales/Model/Quote/Address/Total/Shipping.php
@@ -182,10 +182,9 @@ class Shipping extends \Magento\Sales\Model\Quote\Address\Total\AbstractTotal
     {
         $amount = $address->getShippingAmount();
         if ($amount != 0 || $address->getShippingDescription()) {
-            $title = __('Shipping & Handling');
-            if ($address->getShippingDescription()) {
-                $title .= ' (' . $address->getShippingDescription() . ')';
-            }
+            $shippingDescription = $address->getShippingDescription();
+            $title = $shippingDescription ? __('Shipping & Handling (%s)', $shippingDescription) : __('Shipping & Handling');
+            
             $address->addTotal(array(
                 'code' => $this->getCode(),
                 'title' => $title,


### PR DESCRIPTION
Use case:
We should disable visibility of Shipping & Handling description in some theme(for example block with totals is very small). Before this change, we should rewrite this block and make some changes. After - we may add some translation to translate.csv file in some theme
