### PR TITLE
allow _resolveArguments to do sequential lookups

### DIFF
--- a/app/code/Magento/Backend/Block/Menu.php
+++ b/app/code/Magento/Backend/Block/Menu.php
@@ -226,7 +226,7 @@ class Menu extends \Magento\Backend\Block\Template
      */
     protected function _getMenuIterator($menu)
     {
-        return $this->_iteratorFactory->create(array('iterator' => $menu->getIterator()));
+        return $this->_iteratorFactory->create(array($menu->getIterator()));
     }
 
     /**

--- a/lib/Magento/ObjectManager/Factory/Factory.php
+++ b/lib/Magento/ObjectManager/Factory/Factory.php
@@ -91,11 +91,13 @@ class Factory implements \Magento\ObjectManager\Factory
     {
         $resolvedArguments = array();
         $arguments = $this->_config->getArguments($requestedType, $arguments);
-        foreach ($parameters as $parameter) {
+        foreach ($parameters as $key => $parameter) {
             list($paramName, $paramType, $paramRequired, $paramDefault) = $parameter;
             $argument = null;
             if (array_key_exists($paramName, $arguments)) {
                 $argument = $arguments[$paramName];
+            } elseif (isset($arguments[$key])) {
+                $argument = $arguments[$key];
             } elseif (array_key_exists('options', $arguments) && array_key_exists($paramName, $arguments['options'])) {
                 // The parameter name doesn't exist in the arguments, but it is contained in the 'options' argument.
                 $argument = $arguments['options'][$paramName];


### PR DESCRIPTION
When resolving the arguments of PHP's internal classes, we cannot be
sure about argument names. In many places of the PHP core, documentation
differs from the implementation.

A good example is the FilterIterator which triggered this bugreport:
- The argument name is documented as $it:
  https://github.com/php/php-src/blob/PHP-5.6/ext/spl/internal/filteriterator.inc#L35
- But it is implemented as $iterator:
  https://github.com/php/php-src/blob/PHP-5.6/ext/spl/spl_iterators.c#L2305

This can cause problems with PHP runtimes (read: HHVM) that properly
implement the documented specs. See the following HHVM issue for more
information:
https://github.com/facebook/hhvm/pull/1492

The attached patch keeps existing functionality working, but adds an
additional fallback to sequentially based argument lookups. This is
demonstrated in the change to Menu.php.
