### PR TITLE
Bad tax calculation function

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/catalog/product/js.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/catalog/product/js.phtml
@@ -70,7 +70,7 @@ function recalculateTax()
 
         var spanValue = '';
         if (rate != 0) {
-            spanValue = ' ' + formatCurrency(input.value/(100+rate)*rate, priceFormat);
+            spanValue = ' ' + formatCurrency((input.value/100)*rate, priceFormat);
         }
         span.innerHTML = spanValue;
     }


### PR DESCRIPTION
On this file app/code/Magento/Catalog/view/adminhtml/catalog/product/js.phtml on line 73 I think there is an error when calculating the tax rate, this should read `php spanValue = ' ' + formatCurrency((input.value/100)*rate, priceFormat);` instead of `php spanValue = ' ' + formatCurrency(input.value/(100+rate)*rate, priceFormat);`

The problem is adding rate to 100(%).

This is present on current Magento EE 1.13 and Magento CE.
