### PR TITLE
Fixing a bug for loading config from local.xml

### DIFF
--- a/lib/Magento/App/Config.php
+++ b/lib/Magento/App/Config.php
@@ -79,6 +79,9 @@ class Config
                     foreach ($value as $subKey => $node) {
                         $build[$key . $separator . $subKey] = $node;
                     }
+                    if(array_key_exists($key, $build)){
+                        unset($build[$key]);
+                    }
                 } else {
                     $build[$key] = null;
                 }


### PR DESCRIPTION
The existing logic has a problem if the depth of the xml path is more than five, for example, try old cache node in local.xml. Fixed with a key check. By the way, how to add memcache support for magento2?
