### PR TITLE
GD2 Adapter PHP memory_limit

### DIFF
--- a/lib/Magento/Image/Adapter/Gd2.php
+++ b/lib/Magento/Image/Adapter/Gd2.php
@@ -80,9 +80,14 @@ class Gd2 extends \Magento\Image\Adapter\AbstractAdapter
      */
     protected function _isMemoryLimitReached()
     {
-        $limit = $this->_convertToByte(ini_get('memory_limit'));
-        $requiredMemory = $this->_getImageNeedMemorySize($this->_fileName);
-        return (memory_get_usage(true) + $requiredMemory) > $limit;
+        $memory_limit = ini_get('memory_limit');
+        if ($memory_limit == -1) {
+          return false;
+        } else {
+          $limit = $this->_convertToByte($memory_limit);
+          $requiredMemory = $this->_getImageNeedMemorySize($this->_fileName);
+          return (memory_get_usage(true) + $requiredMemory) > $limit;
+        }
     }
 
     /**


### PR DESCRIPTION
When performing manipulation on images the PHP memory limit is checked.

When the available memory is less than the required an error _"Memory limit has been reached"_ is thrown. 
This is seen by users when uploading product images though it also happens background processes happen (e.g. when thumbnails are generated).

In `lib/Magento/Image/Adapter/Gd2.php` the functions `_isMemoryLimitReached` and `_convertToByte` do this checking.

`_isMemoryLimitReached` retrieves PHP's memory_limit value. It passes this directly to _convertToByte without any sanity checking. 

`_convertToByte` assumes that the value is an integer in bytes (or has a suffix indicating units).

Valid values for PHP > 5.1.0 `memory_limit` are:

`-1` = no limit
positive integers without suffix = value in bytes
positive integers with the upper or lower case suffixes _k_, _m_, _g_ = value in kilobytes, megabytes and gigabytes.

References for this: http://nz1.php.net/manual/en/ini.core.php#ini.memory-limit and http://nz1.php.net/manual/en/faq.using.php#faq.using.shorthandbytes

With the current implementation if the `memory_limit` is set to the valid value of `-1` the _"Memory limit has been reached"_ error is returned incorrectly.

The suffixes currently parsed in `_convertToByte` are "KB" and "M". As above "KB" is not a valid suffix. "G", for gigabytes, is supported by PHP but omitted from Magento check which will lead to the "Memory limit has been reached" error.

This pull request changes `KB` suffix to the valid `K`, though this isn't likely to be used it should be correct.

It also returns `false` to `_isMemoryLimitReached` when the value of PHP's `memory_limit` is `-1`. 

(This issue also exists in 1.8: http://www.magentocommerce.com/bug-tracking/issue?issue=16071)
