### PR TITLE
Calling clear / removeAllItems / removeItemByKey on Magento\Eav\Model\Entity\Collection\AbstractCollection  does not remove model from protected _itemsById array

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -1533,4 +1533,38 @@ abstract class AbstractCollection extends \Magento\Data\Collection\Db
     {
         return array_keys($this->_items);
     }
+
+    /**
+     * Clear collection
+     * @return \Magento\Eav\Model\Entity\Collection\AbstractCollection
+     */
+    public function clear()
+    {
+        $this->_itemsById = array();
+        return parent::clear();
+    }
+
+    /**
+     * Remove all items from collection
+     * @return \Magento\Eav\Model\Entity\Collection\AbstractCollection
+     */
+    public function removeAllItems()
+    {
+        $this->_itemsById = array();
+        return parent::removeAllItems();
+    }
+
+    /**
+     * Remove item from collection by item key
+     *
+     * @param   mixed $key
+     * @return \Magento\Eav\Model\Entity\Collection\AbstractCollection
+     */
+    public function removeItemByKey($key)
+    {
+        if (isset($this->_items[$key])) {
+            unset($this->_itemsById[$this->_items[$key]->getId()]);
+        }
+        return parent::removeItemByKey($key);
+    }
 }


### PR DESCRIPTION
When paginating through EAV collection models (e.g. customers or products) calling the `clear` method does not reset the `$_itemsById` protected member. This causes the list of objects referenced in that array to grow exponentially. When working with large collections (e.g. for exports or reports) this can lead to exhausting the amount of memory that a script is allowed to allocate. 

NOTE: This issue exists in mage1 as well.

I also went ahead and updated `removeAllItems` and `removeItemByKey`. 

I'd be happy to write a test case but there doesn't appear to be a base one at this time. I'd be helpful if you could point me in the right direction (another similar test case) as this functionality relies on loading entities.

On a side note, whats the difference supposed to be between `clear` and `removeAllItems` ? 
