### PR TITLE
PHPUnit 3.8 Compatibility

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Event/PhpUnit.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Event/PhpUnit.php
@@ -187,4 +187,17 @@ class PhpUnit implements \PHPUnit_Framework_TestListener
         }
         $this->_eventManager->fireEvent('endTest', array($test), true);
     }
+
+   /**
+     * Risky test.
+     *
+     * @param PHPUnit_Framework_Test $test
+     * @param Exception              $e
+     * @param float                  $time
+     * @since  Method available since Release 3.8.0
+     */
+    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    	// Stub out to support PHPUnit 3.8
+    }
 }

--- a/dev/tests/unit/framework/Magento/TestFramework/Listener/GarbageCleanup.php
+++ b/dev/tests/unit/framework/Magento/TestFramework/Listener/GarbageCleanup.php
@@ -100,4 +100,17 @@ class GarbageCleanup implements \PHPUnit_Framework_TestListener
     public function endTest(\PHPUnit_Framework_Test $test, $time)
     {
     }
+
+   /**
+     * Risky test.
+     *
+     * @param PHPUnit_Framework_Test $test
+     * @param Exception              $e
+     * @param float                  $time
+     * @since  Method available since Release 3.8.0
+     */
+    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+        // Stub out to support PHPUnit 3.8
+    }
 }


### PR DESCRIPTION
PHPUnit 3.8+ adds a new method to PHPUnit_Framework_TestListener (addRiskyTest). Stub this out in places that need it so we can use PHPUnit 3.8+
