### PR TITLE
Fixed bug for js/css minify

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -39,6 +39,7 @@
     <preference for="Magento\View\DesignInterface" type="Magento\Core\Model\View\Design\Proxy" />
     <preference for="Magento\View\Design\ThemeInterface" type="Magento\Core\Model\Theme" />
     <preference for="Magento\View\ConfigInterface" type="Magento\View\Config" />
+    <preference for="Magento\View\Asset\MergeStrategyInterface" type="Magento\View\Asset\MergeStrategy\Direct" />
     <preference for="Magento\Core\Model\LocaleInterface" type="Magento\Core\Model\Locale" />
     <preference for="Magento\UrlInterface" type="Magento\Url" />
     <preference for="Magento\Data\Collection\Db\FetchStrategyInterface" type="Magento\Data\Collection\Db\FetchStrategy\Query" />


### PR DESCRIPTION
PHP Fatal error:  Cannot instantiate interface Magento\View\Asset\MergeStrategyInterface in /srv/www/magento2.home/pub/lib/Magento/ObjectManager/Factory/Factory.php on line 172
