### PR TITLE
Make Sure That save_before Event Is Dispatched

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Stock/Item.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Item.php
@@ -801,6 +801,8 @@ class Item extends \Magento\Core\Model\AbstractModel
      */
     protected function _beforeSave()
     {
+        parent::_beforeSave();
+
         // see if quantity is defined for this item type
         $typeId = $this->getTypeId();
         if ($productTypeId = $this->getProductTypeId()) {


### PR DESCRIPTION
The parent `_beforeSave` method should be called, so that the save_before events are dispatched.
