### PR TITLE
`Frontend Label` fixed for indexed array

### DIFF
--- a/app/code/Magento/Eav/Model/Resource/Entity/Attribute.php
+++ b/app/code/Magento/Eav/Model/Resource/Entity/Attribute.php
@@ -206,6 +206,7 @@ class Attribute extends \Magento\Core\Model\Resource\Db\AbstractDb
     {
         $frontendLabel = $object->getFrontendLabel();
         if (is_array($frontendLabel)) {
+            $frontendLabel = array_values($frontendLabel);
             if (!isset($frontendLabel[0]) || is_null($frontendLabel[0]) || $frontendLabel[0] == '') {
                 throw new \Magento\Core\Exception(__('Frontend label is not defined'));
             }


### PR DESCRIPTION
I made integration c# code with magento [SOAP](http://www.magentocommerce.com/api/soap/catalog/catalogProductAttribute/product_attribute.create.html) . I tried to insert new product attribute but the error "Frontend label is not defined" popped up.

The problem was SAOP array started with `0` index and `catalogProductAttributeFrontendLabelEntity[]` in .NET Entity array started with `1` index. So I added this code for fixing index. This code makes reindexing the frontendLabel array.
