### PR TITLE
Don't delete session data when regenerating ids on login

### DIFF
--- a/app/code/Magento/Backend/Model/Auth/Session.php
+++ b/app/code/Magento/Backend/Model/Auth/Session.php
@@ -236,7 +236,7 @@ class Session extends \Magento\Session\SessionManager implements \Magento\Backen
     public function processLogin()
     {
         if ($this->getUser()) {
-            $this->regenerateId();
+            $this->regenerateId(false);
 
             if ($this->_backendUrl->useSecretKey()) {
                 $this->_backendUrl->renewSecretUrls();


### PR DESCRIPTION
this would also remove the data of logged in user, so a login is actually not possible.

See the php manual for details on using session_regenerate_id: http://www.php.net/manual/en/function.session-regenerate-id.php
