### PR TITLE
Bugfix Magento\Framework\DB\Adapter\Pdo\Mysql::getForeignKeys()

### DIFF
--- a/lib/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -1141,7 +1141,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
 
             // collect CONSTRAINT
             $regExp  = '#,\s+CONSTRAINT `([^`]*)` FOREIGN KEY \(`([^`]*)`\) '
-                . 'REFERENCES (`[^`]*\.)?`([^`]*)` \(`([^`]*)`\)'
+                . 'REFERENCES (`[^`]*`\.)?`([^`]*)` \(`([^`]*)`\)'
                 . '( ON DELETE (RESTRICT|CASCADE|SET NULL|NO ACTION))?'
                 . '( ON UPDATE (RESTRICT|CASCADE|SET NULL|NO ACTION))?#';
             $matches = array();


### PR DESCRIPTION
This bugfix add a missing backtick to fix the $regExp for method getForeignKeys() to detect the schema name in a reference.

This bug is also in all Magento 1 versions.
