### PR TITLE
Bugfix Magento\Framework\DB\Adapter\Pdo\Mysql::getCreateTable()

### DIFF
--- a/lib/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -1100,7 +1100,8 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         $cacheKey = $this->_getTableName($tableName, $schemaName);
         $ddl = $this->loadDdlCache($cacheKey, self::DDL_CREATE);
         if ($ddl === false) {
-            $sql = 'SHOW CREATE TABLE ' . $this->quoteIdentifier($tableName);
+            $schemaName = empty($schemaName) === true ? '' : $this->quoteIdentifier($schemaName) . '.';
+            $sql        = 'SHOW CREATE TABLE ' . $schemaName . $this->quoteIdentifier($tableName);
             $ddl = $this->rawFetchRow($sql, 'Create Table');
             $this->saveDdlCache($cacheKey, self::DDL_CREATE, $ddl);
         }


### PR DESCRIPTION
This bugfix inserts the schema name into the SHOW CREATE TABLE statement for method getCreateTable().

Seems like it was previously forgotten ...

This bug is also in all Magento 1 versions.
