### PR TITLE
Change Request for InvokerDefault::_callObserverMethod()

### DIFF
--- a/lib/Magento/Framework/Event/Invoker/InvokerDefault.php
+++ b/lib/Magento/Framework/Event/Invoker/InvokerDefault.php
@@ -87,7 +87,7 @@ class InvokerDefault implements \Magento\Framework\Event\InvokerInterface
      */
     protected function _callObserverMethod($object, $method, $observer)
     {
-        if (method_exists($object, $method)) {
+        if (is_callable(array($object, $method))) {
             $object->{$method}($observer);
         } elseif ($this->_appState->getMode() == \Magento\Framework\App\State::MODE_DEVELOPER) {
             throw new \LogicException('Method "' . $method . '" is not defined in "' . get_class($object) . '"');


### PR DESCRIPTION
Instead of `method_exists()` it should be `is_callable()` within an OO environment.

It should be possible that you can use observer objects with the magic __call implementation and a "non-existing" method. 

There is a nice blog post about those two functions: [http://blog.jmfeurprier.com/2010/01/03/method_exists-vs-is_callable/](http://blog.jmfeurprier.com/2010/01/03/method_exists-vs-is_callable/)

`method_exists()`: There are also 25 more occurrences in the `app` folder and 23 in `lib/Magento`. Maybe you can consider changing them also to `is_callable()`, if not it would be at least nice if you accept that PR :-)

Thanks!
