### PR TITLE
Add Sort Order to Rules

### DIFF
--- a/app/code/Mage/CatalogRule/Model/Resource/Rule.php
+++ b/app/code/Mage/CatalogRule/Model/Resource/Rule.php
@@ -670,7 +670,8 @@ class Mage_CatalogRule_Model_Resource_Rule extends Mage_Rule_Model_Resource_Abst
             ->where('customer_group_id = ?', $customerGroupId)
             ->where('product_id = ?', $productId)
             ->where('from_time = 0 or from_time < ?', $date)
-            ->where('to_time = 0 or to_time > ?', $date);
+            ->where('to_time = 0 or to_time > ?', $date)
+            ->order('sort_order asc');
 
         return $adapter->fetchAll($select);
     }


### PR DESCRIPTION
Sub Product discounts use this function separately from the main product.
In some cases Sub Products would run a different rule to the main product.

To replicate:
- Create a Configurable Product
  - Add an associated product with an increased value (sub product price)
- Create Rule A
  - Product Discount: 50%
  - Sub Product Discount: 50%
  - Priority: 100
  - Stop further rules processing
- Create Rule B
  - Product Discount: 10%
  - Sub Product Discount: 10%
  - Stop further rules processing

When getting the product price discount, it correctly gets the 10% discount.
However, when getting the sub product price discount, it incorrectly gets the 50% discount.
This happens because there is no ordering on the Sub Product discounts, so it MySQL applies a default order by rule_id
- This issue also exists in 1.9.0.1
