### PR TITLE
Changed rounding to 2 decimals to 4 decimals because of rounding errors

### DIFF
--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -998,7 +998,7 @@ class Store extends AbstractModel implements
      */
     public function roundPrice($price)
     {
-        return round($price, 2);
+        return round($price, 4);
     }
 
     /**


### PR DESCRIPTION
I would like to propose to change the default rounding decimal to 4 instead of 2. Magento's database supports 4 decimals from way back, but still all calculations are fed through this function where everything is rounded to two decimals.

This is particularly annoying when the products have prices excluding VAT in the catalog, and the price needs to be shown including VAT (which is pretty much always).

Let's say I have a product that costs 0.60 euro excluding VAT. My VAT percentage is 6%. So the including VAT price is 0.6 * 1.06 = 0.636. The problem is; after creating an invoice, the corresponding row 'base_price_incl_tax' (which holds the result of this equation) in sales_flat_invoice_item holds a rounded version of this, namely 0.6400. This doesn't really matter when the quantity is 1, but as soon as the quantities run into the tens, hundreds or even thousands, the differences add up quickly. 

Let's say I ordered 1000 of that product, then the difference is (0.64-0.636)*1000 = 4 euro!