### PR TITLE
Add travis tests for hhvm + php 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 php:
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
 env:
   - TEST_SUITE=unit
   - TEST_SUITE=integration


### PR DESCRIPTION
I think we should test Magento with latest PHP version 5.6(for now it R2, but thavis allow use it for tests) and HHVM
