### PR TITLE
Fixed Typo ($_attribite -> $_attribute)

### DIFF
--- a/app/code/Magento/Eav/Model/Attribute/Data/AbstractData.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/AbstractData.php
@@ -38,7 +38,7 @@ abstract class AbstractData
      *
      * @var \Magento\Eav\Model\Attribute
      */
-    protected $_attribite;
+    protected $_attribute;
 
     /**
      * Entity instance
@@ -121,7 +121,7 @@ abstract class AbstractData
      */
     public function setAttribute(\Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute)
     {
-        $this->_attribite = $attribute;
+        $this->_attribute = $attribute;
         return $this;
     }
 
@@ -133,10 +133,10 @@ abstract class AbstractData
      */
     public function getAttribute()
     {
-        if (!$this->_attribite) {
+        if (!$this->_attribute) {
             throw new CoreException(__('Attribute object is undefined'));
         }
-        return $this->_attribite;
+        return $this->_attribute;
     }
 
     /**


### PR DESCRIPTION
Magento\Eav\Model\Attribute\Data\AbstractData::$_attribute was incorrectly named `$_attribite`.
