### PR TITLE
Tiny improvement on render() method in Magento\Backend\Block\Widget\Grid\Column\Ren...

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Concat.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Concat.php
@@ -43,9 +43,12 @@ class Concat extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstract
         $methods = $this->getColumn()->getGetter() ? $this->getColumn()->getGetter() : $this->getColumn()->getIndex();
         foreach ($methods as $m) {
             if (true === is_callable([$row, $m])) {
-                $dataArr[] = call_user_func(array($row, $m), $this->getColumn());
+                $data = call_user_func(array($row, $m), $this->getColumn());
             } else {
-                $dataArr[] = $row->getData($m);
+                $data = $row->getData($m);
+            }
+            if (false === empty($data)) {
+                $dataArr[] = $data;
             }
         }
         $data = join($this->getColumn()->getSeparator(), $dataArr);


### PR DESCRIPTION
...derer\Concat which allows now calls to any method on a model. Which is a huge win!

Configuration in adminhtml grid can look like this:

``` php
        $this->addColumn('product_price', array(
            'header'    => __('RRP incl. Tax<br>Sales Prices incl. Tax'),
            'getter'    => ['returnProductPrice', 'getProductFinalPrice'],
            'align'     => 'right',
            'type'  => 'concat',
            'separator' => '<br>',
        ));
```

or this

``` php
        $this->addColumn('product_price2', array(
            'header'    => __('RRP incl. Tax<br>Sales Prices incl. Tax'),
            'index'    => ['product_price', 'product_final_price'],
            'align'     => 'right',
            'type'  => 'concat',
            'separator' => '<br>',
        ));
```

No tests added ...

Thanks for merging :-)
