### PR TITLE
Never seed a RNG with a timestamp!

### DIFF
--- a/lib/internal/Magento/Framework/Math/Random.php
+++ b/lib/internal/Magento/Framework/Math/Random.php
@@ -72,7 +72,6 @@ class Random
             fclose($fp);
         } else {
             // fallback to mt_rand() if all else fails
-            mt_srand(10000000 * (double)microtime());
             for ($i = 0, $lc = strlen($chars) - 1; $i < $length; $i++) {
                 $rand = mt_rand(0, $lc); // random integer from 0 to $lc
                 $str .= $chars[$rand]; // random character in $chars
@@ -110,7 +109,6 @@ class Random
             fclose($fp);
         } else {
             // fallback to mt_rand() if all else fails
-            mt_srand(mt_rand() + (100000000 * microtime()) % PHP_INT_MAX);
             return mt_rand($min, $max); // random integer from $min to $max
         }
 


### PR DESCRIPTION
Seeding a random number generator with a timestamp allows an attacker with knowledge about when the secret was generated to greatly reduce the amount of work needed to crack the secret. PHP automatically seeds the RNG with a random number, so seeding is not necessary in the first place.

In this case only the microsecond portion of microtime is used and an attacker would probably not know the microtime, so theoretically there are 1 million possible seeds best case. While 1 million is still a big number, it is much smaller than PHP_INT_MAX (2.14 billion).

This should also be fixed in Magento 1 (actually far more important since Magento 1 _always_ uses mt_rand).
