### PR TITLE
Fix issue where it isn't possible to skip url validation when using cons...

### DIFF
--- a/app/code/Magento/Install/Model/Installer/Console.php
+++ b/app/code/Magento/Install/Model/Installer/Console.php
@@ -251,12 +251,6 @@ class Console
             }
 
             /**
-             * Skip URL validation, if set
-             */
-            $this->_installerData->setSkipUrlValidation($options['skip_url_validation']);
-            $this->_installerData->setSkipBaseUrlValidation($options['skip_url_validation']);
-
-            /**
              * Locale settings
              */
             $this->_installerData->setLocaleData(
@@ -287,6 +281,7 @@ class Console
                     'backend_frontname' => $this->_checkBackendFrontname($options['backend_frontname']),
                     'admin_no_form_key' => $this->_getFlagValue($options['admin_no_form_key']),
                     'skip_url_validation' => $this->_getFlagValue($options['skip_url_validation']),
+                    'skip_base_url_validation' => $this->_getFlagValue($options['skip_url_validation']),
                     'enable_charts' => $this->_getFlagValue($options['enable_charts']),
                     'order_increment_prefix' => $options['order_increment_prefix']
                 ]


### PR DESCRIPTION
With current alpha 100 there is a regression due to which it currently isn't possible to skip URL validation using -"--skip_url_validation yes" console parameter when using console installer. This commit fixes the issue for current alpha, but since goals of code creating regression are unclear to me, this might require additional attention.
