### PR TITLE
Checked users status before applying during newsletter edit from my accont

### DIFF
--- a/app/code/Magento/Newsletter/Controller/Manage/Save.php
+++ b/app/code/Magento/Newsletter/Controller/Manage/Save.php
@@ -49,10 +49,11 @@ class Save extends \Magento\Newsletter\Controller\Manage
                     ->create();
                 $this->_customerAccountService->updateCustomer($customerId, $customerDetails);
 
-                if ((boolean)$this->getRequest()->getParam('is_subscribed', false)) {
+                $isAlreadySubscribed = $this->_subscriberFactory->create()->loadByCustomerId($customerId)->isSubscribed();
+                if (!$isAlreadySubscribed && (boolean) $this->getRequest()->getParam('is_subscribed', false)) {
                     $this->_subscriberFactory->create()->subscribeCustomerById($customerId);
                     $this->messageManager->addSuccess(__('We saved the subscription.'));
-                } else {
+                } elseif ($isAlreadySubscribed && !(boolean) $this->getRequest()->getParam('is_subscribed', false)) {
                     $this->_subscriberFactory->create()->unsubscribeCustomerById($customerId);
                     $this->messageManager->addSuccess(__('We removed the subscription.'));
                 }


### PR DESCRIPTION
When users go to the edit Manage Newsletter section from their Account. After clicking on the Submit button the message is shown regarding "changes are saved" even if they never change anything. Just added a condition before making changes to avoid unnecessary messages and transactions. 