### PR TITLE
#720 fix for those issue

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
@@ -140,7 +140,7 @@ class Http extends File
      */
     public function fileOpen($path, $mode)
     {
-        $urlProp = parse_url($this->getScheme() . $path);
+        $urlProp = $this->parseUrl($this->getScheme() . $path);
 
         if (false === $urlProp) {
             throw new FilesystemException(__('Please correct the download URL.'));
@@ -235,5 +235,14 @@ class Http extends File
     {
         $scheme = $scheme ?: $this->scheme;
         return $scheme ? $scheme . '://' : '';
+    }
+
+    /**
+     * @param string $path
+     * @return array
+     */
+    protected function parseUrl($path)
+    {
+        return parse_url($path);
     }
 }

--- a/lib/internal/Magento/Framework/Filesystem/Driver/Https.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/Https.php
@@ -35,4 +35,21 @@ class Https extends Http
      * @var string
      */
     protected $scheme = 'https';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseUrl($path)
+    {
+        $urlProp = parent::parseUrl($path);
+
+        if ($urlProp['scheme'] === 'https') {
+            $urlProp['host'] = 'ssl://' . $urlProp['host'];
+            if (!isset($urlProp['port'])) {
+                $urlProp['port'] = 443;
+            }
+        }
+
+        return $urlProp;
+    }
 }


### PR DESCRIPTION
Hello,

I think it's a fix for issue #720 (if I fully understood description of those task).

Test cases for testing method "parseUrl" from this fix:
test input data:

```
geturl('https://ebay.com/test.txt'),
geturl('https://ebay.com:2000/test.txt'),
geturl('http://ebay.com:8080/test.txt'),
geturl('file://ebay.com/test.txt')
```

output data (used var_dump):

```
array(4) {
  'scheme' =>
  string(5) "https"
  'host' =>
  string(14) "ssl://ebay.com"
  'path' =>
  string(9) "/test.txt"
  'port' =>
  int(443)
}
array(4) {
  'scheme' =>
  string(5) "https"
  'host' =>
  string(14) "ssl://ebay.com"
  'port' =>
  int(2000)
  'path' =>
  string(9) "/test.txt"
}
array(4) {
  'scheme' =>
  string(4) "http"
  'host' =>
  string(8) "ebay.com"
  'port' =>
  int(8080)
  'path' =>
  string(9) "/test.txt"
}
array(3) {
  'scheme' =>
  string(4) "file"
  'host' =>
  string(8) "ebay.com"
  'path' =>
  string(9) "/test.txt"
}
```

Thanks, Anton
