### PR TITLE
Bug: Database name not quoted

### DIFF
--- a/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Eav/AbstractEav.php
+++ b/app/code/Magento/Catalog/Model/Resource/Product/Indexer/Eav/AbstractEav.php
@@ -170,11 +170,11 @@ abstract class AbstractEav extends \Magento\Catalog\Model\Resource\Product\Index
     protected function _removeNotVisibleEntityFromIndex()
     {
         $write = $this->_getWriteAdapter();
-
         $idxTable = $this->getIdxTable();
-        $idxTable = $write->quoteIdentifier($idxTable);
 
         $select = $write->select()->from($idxTable, null);
+
+        $idxTable = $write->quoteIdentifier($idxTable);
 
         $condition = $write->quoteInto('=?', \Magento\Catalog\Model\Product\Visibility::VISIBILITY_NOT_VISIBLE);
         $this->_addAttributeToSelect(


### PR DESCRIPTION
Hello,

In bug #718 wrote about does not quoted table name and field name, fix in this pull request.
Example with same code: [AbstractDb](https://github.com/magento/magento2/blob/c8b7223139366e8030b0b8ae43406495e46ec95e/lib/internal/Magento/Framework/Model/Resource/Db/AbstractDb.php#L380)

Thanks, Anton
