### PR TITLE
Do not save page cache data when Varnish is active

### DIFF
--- a/app/code/Magento/PageCache/Model/Controller/Result/BuiltinPlugin.php
+++ b/app/code/Magento/PageCache/Model/Controller/Result/BuiltinPlugin.php
@@ -82,6 +82,11 @@ class BuiltinPlugin
         ResponseHttp $response
     ) {
         $proceed($response);
+
+        if (!$this->config->isEnabled() || $this->config->getType() != \Magento\PageCache\Model\Config::BUILT_IN) {
+            return $subject;
+        }
+
         if ($this->state->getMode() == \Magento\Framework\App\State::MODE_DEVELOPER) {
             $cacheControl = $response->getHeader('Cache-Control')['value'];
             $response->setHeader('X-Magento-Cache-Control', $cacheControl);


### PR DESCRIPTION
Here I describe and provide possible solution for issue where built in Magento 2 page cache does caching even when Varnish is enabled:

https://github.com/magento/magento2/blob/master/app/code/Magento/PageCache/Model/Controller/Result/BuiltinPlugin.php#L90

Since triggering built in caching code involves sending no cache headers:

https://github.com/magento/magento2/blob/master/lib/internal/Magento/Framework/App/PageCache/Kernel.php#L84

this results with 100% cache MISS after enabling Varnish, since with Magento2 provided .vcl it fully respects no cache headers:

https://github.com/magento/magento2/blob/master/lib/internal/Magento/Framework/App/Response/Http.php#L164-L166

and passes all requests directly to backend. This solution simply does check already implemented for fetching built in page cache data:

https://github.com/magento/magento2/blob/master/app/code/Magento/PageCache/Model/App/FrontController/BuiltinPlugin.php#L84-L86

to saving page data by built in cache code.
