### PR TITLE
Fixed german translation "Warenkorbrn"

### DIFF
--- a/app/code/Magento/Catalog/i18n/de_DE.csv
+++ b/app/code/Magento/Catalog/i18n/de_DE.csv
@@ -14,7 +14,7 @@ Qty,Qty
 Action,Aktion
 Reset,Zurücksetzen
 Edit,Bearbeiten
-"Add to Cart","Zum Warenkobrn hinzufügen"
+"Add to Cart","Zum Warenkorb hinzufügen"
 "Images (.gif, .jpg, .png)","Images (.gif, .jpg, .png)"
 "First Name",Vorname
 "Last Name","Letzter Name"


### PR DESCRIPTION
"Warenkorbrn" is not really a german word. I corrected the translation. This phrase is also wrong in all Magento 1.x versions.
