### PR TITLE
Change process() return value to conform with Layout\ReaderInterface

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/Reader/Container.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Container.php
@@ -86,7 +86,8 @@ class Container implements Layout\ReaderInterface
             default:
                 break;
         }
-        return $this->readerPool->interpret($readerContext, $currentElement);
+        $this->readerPool->interpret($readerContext, $currentElement);
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Minor change.
No tests added since the return value of process() is used nowhere.