### PR TITLE
Fix test assertion

### DIFF
--- a/dev/tests/unit/testsuite/Magento/Framework/View/Layout/Reader/UiComponentTest.php
+++ b/dev/tests/unit/testsuite/Magento/Framework/View/Layout/Reader/UiComponentTest.php
@@ -65,9 +65,9 @@ class UiComponentTest extends \PHPUnit_Framework_TestCase
      *
      * @param \Magento\Framework\View\Layout\Element $element
      *
-     * @dataProvider processDataProvider
+     * @dataProvider interpretDataProvider
      */
-    public function testProcess($element)
+    public function testInterpret($element)
     {
         $scope = $this->getMock('Magento\Framework\App\ScopeInterface', [], [], '', false);
         $this->scopeResolver->expects($this->any())->method('getScope')->will($this->returnValue($scope));
@@ -84,14 +84,14 @@ class UiComponentTest extends \PHPUnit_Framework_TestCase
             $element->getParent()
         )->willReturn($element->getAttribute('name'));
 
-        $this->helper->expects($this->any())->method('setStructureElementData')->with(
+        $scheduleStructure->expects($this->once())->method('setStructureElementData')->with(
             $element->getAttribute('name'),
             ['attributes' => ['group' => '', 'component' => 'listing']]
         );
         $this->model->interpret($this->context, $element);
     }
 
-    public function processDataProvider()
+    public function interpretDataProvider()
     {
         return [
             [


### PR DESCRIPTION
The original assertion simply stubbed the setStructureElementData method on the View\Layout\ScheduledStructure\Helper mock. The method in question is not part of the helper interface but of the View\Layout\ScheduledStructure interface.
The change moves the assertion to the scheduled structure mock and changes the expectation from any() to once().