### PR TITLE
Update static URL rewrite rule to use QSA flag 

### DIFF
--- a/pub/static/.htaccess
+++ b/pub/static/.htaccess
@@ -10,5 +10,5 @@ php_flag engine 0
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-l
 
-    RewriteRule .* ../static.php?resource=$0 [L]
+    RewriteRule .* ../static.php?resource=$0 [L,QSA]
 </IfModule>


### PR DESCRIPTION
Using the [QSA](http://httpd.apache.org/docs/trunk/rewrite/flags.html#flag_qsa) flag in the RewriteRule will allow parameters to be passed down to the rewritten URL. One use case for this is when using Xdebug's profiler trigger. It makes it possible so that `http://mage2.dev/pub/static/frontend/Magento/blank/en_US/mage/calendar.css?XDEBUG_PROFILE=1` will generate the profile file otherwise the `XDEBUG_PROFILE` parameter is essentially ignored. 
