### PR TITLE
Missing URLDecode method

### DIFF
--- a/app/code/Magento/Core/Helper/Data.php
+++ b/app/code/Magento/Core/Helper/Data.php
@@ -255,4 +255,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         return $this->_dbCompatibleMode;
     }
+
+    /**
+     *  base64_dencode() for URLs dencoding
+     *
+     *  @param    string $url
+     *  @return   string
+     */
+    public function urlDecode($url)
+    {
+        $url = base64_decode(strtr($url, '-_,', '+/='));
+        return $url;
+    }
 }


### PR DESCRIPTION
When comparing products there is a call to a missing method urlDecode #807 

This is the method call from Magento 1 however I just return the parsed URL string. When testing in browser this is allowing the compare feature to function as expected. However I am not sure of any other use cases for urlDecode and if the expected return value should be modified. I will look at creating some tests if this PR is required. 
