### PR TITLE
Use correct column name for creation date on Email Template

### DIFF
--- a/app/code/Magento/Email/Model/Resource/Template.php
+++ b/app/code/Magento/Email/Model/Resource/Template.php
@@ -99,7 +99,7 @@ class Template extends \Magento\Framework\Model\Resource\Db\AbstractDb
     protected function _beforeSave(AbstractModel $object)
     {
         if ($object->isObjectNew()) {
-            $object->setCreatedAt($this->dateTime->formatDate(true));
+            $object->setAddedAt($this->dateTime->formatDate(true));
         }
         $object->setModifiedAt($this->dateTime->formatDate(true));
         $object->setTemplateType((int)$object->getTemplateType());


### PR DESCRIPTION
The install script uses `added_at` as the column for persisting the date a template is created.
