### PR TITLE
Hide the outline when clicking on a tab in admin

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/admin.less
+++ b/app/design/adminhtml/Magento/backend/web/css/admin.less
@@ -2622,6 +2622,7 @@ address {
     background: #e0dacf;
     padding: 11px 15px 13px;
     border-radius: 2px 2px 0 0;
+    outline: 0;
 }
 
 .tabs-horiz > .ui-state-active .ui-tabs-anchor {


### PR DESCRIPTION
Tabbing through the tabs still works with indication