### PR TITLE
use 127.0.0.1 instead of localhost for db host parameter

### DIFF
--- a/dev/tests/integration/etc/install-config-mysql.php.dist
+++ b/dev/tests/integration/etc/install-config-mysql.php.dist
@@ -4,7 +4,7 @@
  */
 
 return [
-    'db_host' => 'localhost',
+    'db_host' => '127.0.0.1',
     'db_user' => 'root',
     'db_pass' => '',
     'db_name' => 'magento_integration_tests',

--- a/dev/tests/performance/config.php.dist
+++ b/dev/tests/performance/config.php.dist
@@ -12,7 +12,7 @@ return array(
                 'language'                   => 'en_US',
                 'timezone'                   => 'America/Los_Angeles',
                 'currency'                   => 'USD',
-                'db_host'                    => 'localhost',
+                'db_host'                    => '127.0.0.1',
                 'db_name'                    => 'magento',
                 'db_user'                    => 'root',
                 'db_pass'                    => '',

--- a/setup/pub/magento/setup/add-database.js
+++ b/setup/pub/magento/setup/add-database.js
@@ -8,7 +8,7 @@ angular.module('add-database', ['ngStorage'])
         $scope.db = {
             useExistingDb: 1,
             useAccess: 1,
-            host: 'localhost',
+            host: '127.0.0.1',
             user: 'root',
             name: 'magento'
         };


### PR DESCRIPTION
localhost means connect via socket, which is in some cases not available
or wrong configured or differs from the place php assumes it.

known Downsides: there may be performance impacts, but I never had something noticeable

Reason: It happens regularly that people have connection problems with localhost, which nearly always got resolved by changing to 127.0.0.1