### PR TITLE
Fix email template creation date not being persisted

### DIFF
--- a/app/code/Magento/Email/Model/Resource/Template.php
+++ b/app/code/Magento/Email/Model/Resource/Template.php
@@ -99,7 +99,7 @@ class Template extends \Magento\Framework\Model\Resource\Db\AbstractDb
     protected function _beforeSave(AbstractModel $object)
     {
         if ($object->isObjectNew()) {
-            $object->setCreatedAt($this->dateTime->formatDate(true));
+            $object->setAddedAt($this->dateTime->formatDate(true));
         }
         $object->setModifiedAt($this->dateTime->formatDate(true));
         $object->setTemplateType((int)$object->getTemplateType());


### PR DESCRIPTION
The database schema from https://github.com/magento/magento2/blob/develop/app/code/Magento/Email/sql/email_setup/install-2.0.0.php#L62-L67 uses the column `added_at` for storing the date the email template creation date. When `setCreatedAt` is used, that date is not persisted to the database, leaving the column `NULL` in the database.
