### PR TITLE
Feature: Magento\Backend\Block\Widget\Grid\Column\Renderer

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Currency.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Currency.php
@@ -80,7 +80,7 @@ class Currency extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstra
      */
     public function render(\Magento\Framework\Object $row)
     {
-        if ($data = (string)$row->getData($this->getColumn()->getIndex())) {
+        if ($data = (string)$this->_getValue($row)) {
             $currency_code = $this->_getCurrencyCode($row);
             $data = floatval($data) * $this->_getRate($row);
             $sign = (bool)(int)$this->getColumn()->getShowNumberSign() && $data > 0 ? '+' : '';

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Price.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Price.php
@@ -48,7 +48,7 @@ class Price extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractR
      */
     public function render(\Magento\Framework\Object $row)
     {
-        if ($data = $row->getData($this->getColumn()->getIndex())) {
+        if ($data = $this->_getValue($row)) {
             $currencyCode = $this->_getCurrencyCode($row);
 
             if (!$currencyCode) {


### PR DESCRIPTION
Currency and Price Renderer: use _getValue() to be able to also
retrieve a calculated value instead of a fixed one via getData().

---

In Magento\Backend\Block\Widget\Grid\Column\Renderer\Currency the [render](https://github.com/magento/magento2/blob/master/app%2Fcode%2FMagento%2FBackend%2FBlock%2FWidget%2FGrid%2FColumn%2FRenderer%2FCurrency.php#L83) method is not using 
\Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRenderer::[_getValue](https://github.com/magento/magento2/blob/master/app%2Fcode%2FMagento%2FBackend%2FBlock%2FWidget%2FGrid%2FColumn%2FRenderer%2FAbstractRenderer.php#L76)(Object $row)

```
    public function render(\Magento\Framework\Object $row)
    {
        if ($data = (string)$row->getData($this->getColumn()->getIndex())) {
```

What is the particular reason for relying on the retrieval method above? ;-)

Would be great if you can implement the `_getValue(`) method as there are use cases for retrieving a computed value.

In `Magento\Backend\Block\Widget\Grid\Column\Renderer::Number` you have the correct useful implementation of `_getValue()` :-)

Thank you for merging!
