### PR TITLE
Make composer.json optional as discussed in issue #840.

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Theme/XmlFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Theme/XmlFilesTest.php
@@ -113,7 +113,11 @@ class XmlFilesTest extends \PHPUnit_Framework_TestCase
         $result = $domConfig->validate($schemaFile, $errors);
         $message = "Invalid XML-file: {$file}\n";
         foreach ($errors as $error) {
-            $message .= "{$error->message} Line: {$error->line}\n";
+            if (is_string($error)) {
+                $message .= "$error\n";
+            } else {
+                $message .= "{$error->message} Line: {$error->line}\n";
+            }
         }
         $this->assertTrue($result, $message);
     }

--- a/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_composer_mismatch/parent-mismatch.json
+++ b/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_composer_mismatch/parent-mismatch.json
@@ -1,0 +1,12 @@
+{
+    "name": "magento/theme-area-test_parent_mismatch",
+    "description": "N/A",
+    "require": {
+        "php": "~5.4.11|~5.5.0",
+        "magento/framework": "0.1.0-alpha103",
+        "magento/theme-area-test_other": "0.1.0",
+        "magento/magento-composer-installer": "*"
+    },
+    "type": "magento2-theme",
+    "version": "1.0"
+}

--- a/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_composer_mismatch/parent-mismatch.xml
+++ b/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_composer_mismatch/parent-mismatch.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../../../../lib/internal/Magento/Framework/Config/etc/theme.xsd">
+    <title>Test</title>
+    <version>1.0</version>
+    <parent>Test/parent</parent>
+</theme>

--- a/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_composer_mismatch/version-mismatch.json
+++ b/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_composer_mismatch/version-mismatch.json
@@ -1,0 +1,11 @@
+{
+    "name": "magento/theme-area-test_version_mismatch",
+    "description": "N/A",
+    "require": {
+        "php": "~5.4.11|~5.5.0",
+        "magento/framework": "0.1.0-alpha103",
+        "magento/magento-composer-installer": "*"
+    },
+    "type": "magento2-theme",
+    "version": "2.0"
+}

--- a/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_composer_mismatch/version-mismatch.xml
+++ b/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_composer_mismatch/version-mismatch.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../../../../lib/internal/Magento/Framework/Config/etc/theme.xsd">
+    <title>Test</title>
+    <version>1.0</version>
+</theme>

--- a/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_xml_composer_match/composer.json
+++ b/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_xml_composer_match/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "magento/theme-area-test_test",
+    "description": "N/A",
+    "require": {
+        "php": "~5.4.11|~5.5.0",
+        "magento/framework": "0.1.0-alpha103",
+        "test/theme-area-parent": "0.1.0",
+        "magento/magento-composer-installer": "*"
+    },
+    "type": "magento2-theme",
+    "version": "1.0"
+}

--- a/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_xml_composer_match/theme.xml
+++ b/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_theme_xml_composer_match/theme.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../../../../lib/internal/Magento/Framework/Config/etc/theme.xsd">
+    <title>Test</title>
+    <version>1.0</version>
+    <parent>Test/parent</parent>
+</theme>

--- a/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_themexml_only/theme-only-title-version-parent.xml
+++ b/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_themexml_only/theme-only-title-version-parent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../../../../lib/internal/Magento/Framework/Config/etc/theme.xsd">
+    <title>Test</title>
+    <version>1.0</version>
+    <parent>Test/parent</parent>
+</theme>

--- a/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_themexml_only/theme-only-title-version.xml
+++ b/dev/tests/unit/testsuite/Magento/Framework/Config/_files/area/test_themexml_only/theme-only-title-version.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../../../../lib/internal/Magento/Framework/Config/etc/theme.xsd">
+    <title>Test</title>
+    <version>1.0</version>
+</theme>

--- a/lib/internal/Magento/Framework/Config/Theme.php
+++ b/lib/internal/Magento/Framework/Config/Theme.php
@@ -30,11 +30,13 @@ class Theme
      * @param string $configContent
      * @param string $composerContent
      */
-    public function __construct(
-        $configContent = null,
-        $composerContent = null
-    ) {
-        $this->_data = $this->_extractData($configContent, $composerContent);
+    public function __construct($configContent = null, $composerContent = null)
+    {
+        $xmlData = $this->getValuesFromXmlConfig($configContent);
+        $composerData = $this->getValuesFromComposerConfig($composerContent);
+        $this->validateConfigurationData($xmlData, $composerData);
+
+        $this->_data = array_merge($this->getArrayWithAllConfigKeysSetToNull(), $xmlData, $composerData);
     }
 
     /**
@@ -48,44 +50,47 @@ class Theme
     }
 
     /**
-     * Extract configuration data from theme.xml and composer.json
+     * Extract configuration data from theme.xml and composer.json content
      *
      * @param string $configContent
      * @param string $composerContent
      * @return array
      */
-    protected function _extractData($configContent, $composerContent)
+    protected function extractData($configContent, $composerContent)
     {
-        $data = [
+        $xmlData = $this->getValuesFromXmlConfig($configContent);
+        $composerData = $this->getValuesFromComposerConfig($composerContent);
+        $this->validateConfigurationData($xmlData, $composerData);
+
+        return array_merge($this->getArrayWithAllConfigKeysSetToNull(), $xmlData, $composerData);
+    }
+
+    /**
+     * Check all required values are present and there is no mismatch should values be defined in both input sources
+     *
+     * @param array $xmlData
+     * @param array $composerData
+     * @return void
+     */
+    protected function validateConfigurationData(array $xmlData, array $composerData)
+    {
+        $this->checkForValueMismatches($xmlData, $composerData);
+        $this->checkRequiredValuesArePresent($xmlData, $composerData);
+    }
+    
+    /**
+     * Return an array with all possible configuration keys initialized to null
+     *
+     * @return array
+     */
+    protected function getArrayWithAllConfigKeysSetToNull()
+    {
+        return [
             'version' => null,
             'title' => null,
             'media' => null,
             'parent' => null,
         ];
-
-        if (!empty($configContent)) {
-            $dom = new \DOMDocument();
-            $dom->loadXML($configContent);
-            // todo: validation of the document
-            /** @var $themeNode \DOMElement */
-            $themeNode = $dom->getElementsByTagName('theme')->item(0);
-            $data['title'] = $themeNode->getElementsByTagName('title')->item(0)->nodeValue;
-            /** @var $mediaNode \DOMElement */
-            $mediaNode = $themeNode->getElementsByTagName('media')->item(0);
-            $previewImage = $mediaNode ? $mediaNode->getElementsByTagName('preview_image')->item(0)->nodeValue : '';
-            $data['media']['preview_image'] = $previewImage;
-        }
-
-        if (!empty($composerContent)) {
-            $json = json_decode($composerContent);
-            $package = new Package($json);
-            $data['version'] = $package->get('version');
-            $parents = (array)$package->get('require', '/.+\/theme-/');
-            $parents = empty($parents) ? null : array_keys($parents);
-            $data['parent'] = empty($parents) ? null : array_shift($parents);
-        }
-
-        return $data;
     }
 
     /**
@@ -126,31 +131,325 @@ class Theme
     public function getParentTheme()
     {
         $parentTheme = $this->_data['parent'];
-        if (!$parentTheme) {
-            return null;
-        }
-        $parent = $this->parseThemeName($parentTheme);
-        return [ucfirst($parent['vendor']), $parent['name']];
+        return $parentTheme
+            ? $this->formatComposerParentThemeParts($parentTheme)
+            : null;
+    }
+
+    /**
+     * Format the string parts of the parent theme array
+     *
+     * @param array $parentThemeParts
+     * @return array
+     */
+    protected function formatComposerParentThemeParts(array $parentThemeParts)
+    {
+        return [ucfirst($parentThemeParts['vendor']), $parentThemeParts['name']];
     }
 
     /**
      * Parse theme name
      *
-     * @param string $themeName
+     * @param string $themePackageName
      * @return array|null Return array if theme name is in the right format, otherwise null is returned, for example:
      *   [
      *     'vendor' => 'magento',
-     *     'area' => 'frontend',
      *     'name' => 'luma'
      *   ]
      */
-    private function parseThemeName($themeName)
+    protected function parseComposerThemeName($themePackageName)
     {
-        preg_match('/(?<vendor>.+)\/theme-(?<area>.+)-(?<name>.+)/', $themeName, $matches);
+        preg_match('/(?<vendor>.+)\/theme-(?<area>.+)-(?<name>.+)/', $themePackageName, $matches);
         return [
             'vendor' => $matches['vendor'],
-            'area' => $matches['area'],
             'name' => $matches['name'],
         ];
+    }
+
+    /**
+     * Parse the configuration values from the XML theme configuration
+     *
+     * @param string $xmlContent
+     * @return array
+     */
+    protected function getValuesFromXmlConfig($xmlContent)
+    {
+        $data = [];
+        if (!empty($xmlContent)) {
+            $dom = new \DOMDocument();
+            $dom->loadXML($xmlContent);
+            // todo: validation of the document
+            $data = $this->extractValuesFromConfigDom($dom);
+        }
+        $this->validateTitleIsPresentInConfigFromXml($data);
+        return $data;
+    }
+
+    /**
+     * Extract the theme config values from the passed dom document node
+     *
+     * @param \DOMDocument $dom
+     * @return array
+     */
+    protected function extractValuesFromConfigDom(\DOMDocument $dom)
+    {
+        return [
+            'title' => $this->getTitleFromXmlConfig($dom),
+            'version' => $this->getVersionFromXmlConfig($dom),
+            'parent' => $this->getParentFromXmlConfig($dom),
+            'media' => ['preview_image' => $this->getPreviewImageFromXmlConfig($dom)],
+        ];
+    }
+
+    /**
+     * Fetch the theme title from the given XML theme configuration
+     *
+     * @param \DOMDocument $dom
+     * @return string
+     */
+    protected function getTitleFromXmlConfig(\DOMDocument $dom)
+    {
+        return $this->getNodeValueFromThemeXmlConfigIfExists($dom, 'title');
+    }
+
+    /**
+     * Fetch the version title from the given XML theme configuration
+     *
+     * @param \DOMDocument $dom
+     * @return string
+     */
+    protected function getVersionFromXmlConfig(\DOMDocument $dom)
+    {
+        return $this->getNodeValueFromThemeXmlConfigIfExists($dom, 'version');
+    }
+
+    /**
+     * Fetch the theme parent from the given XML theme configuration
+     *
+     * @param \DOMDocument $dom
+     * @return array|null
+     */
+    protected function getParentFromXmlConfig(\DOMDocument $dom)
+    {
+        $parent = $this->getNodeValueFromThemeXmlConfigIfExists($dom, 'parent');
+        $pos = strpos($parent, '/');
+        return $parent
+            ? ['vendor' => substr($parent, 0, $pos), 'name' => substr($parent, $pos + 1)]
+            : null;
+    }
+
+    /**
+     * Fetch the theme preview image from the given XML theme configuration
+     *
+     * @param \DOMDocument $dom
+     * @return string
+     */
+    protected function getPreviewImageFromXmlConfig(\DOMDocument $dom)
+    {
+        $themeNode = $dom->getElementsByTagName('theme')->item(0);
+        $mediaNode = $themeNode->getElementsByTagName('media')->item(0);
+        $previewImage = $mediaNode ? $mediaNode->getElementsByTagName('preview_image')->item(0)->nodeValue : '';
+        return $previewImage;
+    }
+
+    /**
+     * Fetch a child node value from the given XML theme configuration
+     *
+     * @param \DOMDocument $dom
+     * @param string $nodeName
+     * @return string
+     */
+    protected function getNodeValueFromThemeXmlConfigIfExists(\DOMDocument $dom, $nodeName)
+    {
+        /** @var $themeNode \DOMElement */
+        $themeNode = $dom->getElementsByTagName('theme')->item(0);
+        $targetNode = $themeNode->getElementsByTagName($nodeName)->item(0);
+        return $targetNode ? $targetNode->nodeValue : null;
+    }
+
+    /**
+     * Check the title is present in XML configuration because it is the only way to identify them theme further errors
+     *
+     * @param array $data
+     * @return void
+     */
+    protected function validateTitleIsPresentInConfigFromXml(array $data)
+    {
+        if (!isset($data['title'])) {
+            throw new \RuntimeException('Theme title configuration is missing');
+        }
+    }
+
+    /**
+     * Parse the configuration values from the composer JSON theme configuration
+     *
+     * @param string $composerContent
+     * @return array
+     */
+    protected function getValuesFromComposerConfig($composerContent)
+    {
+        if (empty($composerContent)) {
+            return [];
+        }
+        $json = json_decode($composerContent);
+        $package = new Package($json);
+        return $this->extractValuesFromComposerPackage($package);
+    }
+
+    /**
+     * Compose the array with all relevant values from the composer package file
+     *
+     * @param Package $package
+     * @return array
+     */
+    protected function extractValuesFromComposerPackage(Package $package)
+    {
+        return [
+            'version' => $this->getVersionFromComposerConfig($package),
+            'parent' => $this->getParentThemeFromComposerConfig($package)
+        ];
+    }
+
+    /**
+     * Return the theme version configuration from the composer package
+     *
+     * @param Package $package
+     * @return string
+     */
+    protected function getVersionFromComposerConfig($package)
+    {
+        return $package->get('version');
+    }
+
+    /**
+     * Return the parent theme configuration from the composer package if present
+     *
+     * @param Package $package
+     * @return array|null
+     */
+    protected function getParentThemeFromComposerConfig(Package $package)
+    {
+        $parents = (array)$package->get('require', '/.+\/theme-/');
+        $parents = empty($parents) ? null : array_keys($parents);
+        return empty($parents) ? null : $this->parseComposerThemeName(array_shift($parents));
+    }
+
+    /**
+     * Check if version and parent configuration values in XML and JSON match
+     *
+     * @param array $xmlData
+     * @param array $composerData
+     * @return void
+     * @throws \UnexpectedValueException
+     */
+    protected function checkForValueMismatches(array $xmlData, array $composerData)
+    {
+        $this->checkForVersionMismatchIfDefinedInBoth($xmlData, $composerData);
+        $this->checkForParentMismatchIfDefinedInBoth($xmlData, $composerData);
+    }
+
+    /**
+     * If the version is defined in both the XML and the JSON config, check they are the same
+     *
+     * @param array $xmlData
+     * @param array $composerData
+     * @return void
+     */
+    protected function checkForVersionMismatchIfDefinedInBoth(array $xmlData, array $composerData)
+    {
+        if (isset($xmlData['version']) && isset($composerData['version'])) {
+            $this->checkForVersionMismatch($xmlData, $composerData);
+        }
+    }
+
+    /**
+     * Check the version configuration in XML and JSON config matches
+     *
+     * @param array $xmlData
+     * @param array $composerData
+     * @return void
+     */
+    protected function checkForVersionMismatch(array $xmlData, array $composerData)
+    {
+        if ($xmlData['version'] != $composerData['version']) {
+            $this->throwThemeVersionConfigMismatchException($xmlData['title']);
+        }
+    }
+
+    /**
+     * Throw exception with error message describing the theme config version mismatch
+     *
+     * @param string $themeTitle
+     * @return void
+     * @throws \UnexpectedValueException
+     */
+    protected function throwThemeVersionConfigMismatchException($themeTitle)
+    {
+        throw new \UnexpectedValueException(
+            'The specified versions do not match ' .
+            'between theme.xml and composer.json ' .
+            'in the theme ' . $themeTitle
+        );
+    }
+
+    /**
+     * If the parent configuration is present in the XML and JSON config, check its the same
+     *
+     * @param array $xmlData
+     * @param array $composerData
+     * @return void
+     */
+    protected function checkForParentMismatchIfDefinedInBoth(array $xmlData, array $composerData)
+    {
+        if (isset($xmlData['parent']) && isset($composerData['parent'])) {
+            $this->checkForParentMismatch($xmlData, $composerData);
+        }
+    }
+
+    /**
+     * Check the parent theme configuration in the XML and JSON config is the same
+     *
+     * @param array $xmlData
+     * @param array $composerData
+     * @return void
+     */
+    protected function checkForParentMismatch(array $xmlData, array $composerData)
+    {
+        $xmlParent = implode('/', $xmlData['parent']);
+        $composerParent = implode('/', $this->formatComposerParentThemeParts($composerData['parent']));
+        if ($xmlParent != $composerParent) {
+            $this->throwParentThemeConfigMismatch($xmlData['title'], $xmlParent, $composerParent);
+        }
+    }
+
+    /**
+     * Throw exception with error message describing the theme config parent theme mismatch
+     *
+     * @param string $themeTitle
+     * @param string $xmlParentName
+     * @param string $composerParentName
+     * @return void
+     * @throws \UnexpectedValueException
+     */
+    protected function throwParentThemeConfigMismatch($themeTitle, $xmlParentName, $composerParentName)
+    {
+        throw new \UnexpectedValueException(
+            'The specified parent themes do not match ' .
+            'between theme.xml and composer.json ' .
+            'in the theme ' . $themeTitle . ': ' .
+            $xmlParentName . ' != ' . $composerParentName
+        );
+    }
+
+    /**
+     * @param array $xmlData
+     * @param array $composerData
+     * @return void
+     */
+    protected function checkRequiredValuesArePresent(array $xmlData, array $composerData)
+    {
+        if (!isset($xmlData['version']) && !isset($composerData['version'])) {
+            throw new \RuntimeException('Version configuration is missing from theme');
+        }
     }
 }

--- a/lib/internal/Magento/Framework/Config/etc/theme.xsd
+++ b/lib/internal/Magento/Framework/Config/etc/theme.xsd
@@ -14,7 +14,9 @@
     <xs:element name="theme">
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="title" type="title"/>
+                <xs:element name="title" type="title" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="version" type="version" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="parent" type="parent" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="media" type="media" minOccurs="0"/>
             </xs:sequence>
         </xs:complexType>
@@ -26,6 +28,17 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="version">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]+(.[0-9]+)*(-([a-z0-9])+)*"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="parent">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z][a-zA-Z]*/[a-z]+"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="media">
         <xs:sequence>


### PR DESCRIPTION
The patch includes the following changes:

* Update theme.xsd to allow version
* Update theme.xsd to allow parent
* Update Config\Theme to parse version and parent from theme XML config
* Update Config\Theme to merge in composer.json config data
* Add validation to check parent and version match if specified in both files
* Add validation the title is present in XML theme config
* Add unit tests for changes

Please refer to the issue https://github.com/magento/magento2/issues/840 for further details.