### PR TITLE
Prevent special characters finding their way into layout handle due to SKU being used

### DIFF
--- a/app/code/Magento/Catalog/Helper/Product/View.php
+++ b/app/code/Magento/Catalog/Helper/Product/View.php
@@ -116,24 +116,26 @@ class View extends \Magento\Framework\App\Helper\AbstractHelper
             $pageConfig->setPageLayout($settings->getPageLayout());
         }
 
+        $urlSafeSku = rawurlencode($product->getSku());
+
         // Load default page handles and page configurations
         if ($params && $params->getBeforeHandles()) {
             foreach ($params->getBeforeHandles() as $handle) {
                 $resultPage->addPageLayoutHandles(
-                    ['id' => $product->getId(), 'sku' => $product->getSku(), 'type' => $product->getTypeId()],
+                    ['id' => $product->getId(), 'sku' => $urlSafeSku, 'type' => $product->getTypeId()],
                     $handle
                 );
             }
         }
 
         $resultPage->addPageLayoutHandles(
-            ['id' => $product->getId(), 'sku' => $product->getSku(), 'type' => $product->getTypeId()]
+            ['id' => $product->getId(), 'sku' => $urlSafeSku, 'type' => $product->getTypeId()]
         );
 
         if ($params && $params->getAfterHandles()) {
             foreach ($params->getAfterHandles() as $handle) {
                 $resultPage->addPageLayoutHandles(
-                    ['id' => $product->getId(), 'sku' => $product->getSku(), 'type' => $product->getTypeId()],
+                    ['id' => $product->getId(), 'sku' => $urlSafeSku, 'type' => $product->getTypeId()],
                     $handle
                 );
             }

--- a/app/code/Magento/PageCache/Model/Observer/ProcessLayoutRenderElement.php
+++ b/app/code/Magento/PageCache/Model/Observer/ProcessLayoutRenderElement.php
@@ -37,7 +37,7 @@ class ProcessLayoutRenderElement
             'page_cache/block/esi',
             [
                 'blocks' => json_encode([$block->getNameInLayout()]),
-                'handles' => urlencode(json_encode($layout->getUpdate()->getHandles()))
+                'handles' => json_encode($layout->getUpdate()->getHandles())
             ]
         );
         return sprintf('<esi:include src="%s" />', $url);

--- a/app/code/Magento/Review/Controller/Product/ListAction.php
+++ b/app/code/Magento/Review/Controller/Product/ListAction.php
@@ -25,8 +25,10 @@ class ListAction extends \Magento\Review\Controller\Product
             $pageConfig->setPageLayout($product->getPageLayout());
         }
         $update = $this->_view->getLayout()->getUpdate();
+
+        $urlSafeSku = rawurlencode($product->getSku());
         $this->_view->addPageLayoutHandles(
-            ['id' => $product->getId(), 'sku' => $product->getSku(), 'type' => $product->getTypeId()]
+            ['id' => $product->getId(), 'sku' => $urlSafeSku, 'type' => $product->getTypeId()]
         );
 
         $this->_view->loadLayoutUpdates();


### PR DESCRIPTION
Prevent special characters finding their way into layout handle due to SKU being used.

This avoids page cache issue when Varnish tries to retrieve ESI with invalid URL on
product page.