### PR TITLE
[BUGFIX] Fixed german translation "Warenkorbrn"

### DIFF
--- a/app/code/Magento/Catalog/i18n/de_DE.csv
+++ b/app/code/Magento/Catalog/i18n/de_DE.csv
@@ -14,7 +14,7 @@ Qty,Qty
 Action,Aktion
 Reset,Zurücksetzen
 Edit,Bearbeiten
-"Add to Cart","Zum Warenkobrn hinzufügen"
+"Add to Cart","Zum Warenkorb hinzufügen"
 "Images (.gif, .jpg, .png)","Images (.gif, .jpg, .png)"
 "First Name",Vorname
 "Last Name","Letzter Name"

--- a/app/code/Magento/Reports/i18n/de_DE.csv
+++ b/app/code/Magento/Reports/i18n/de_DE.csv
@@ -11,7 +11,7 @@ Subtotal,Zwischensumme
 Discount,Discount
 Action,Aktion
 Total,Gesamtbetrag
-"Add to Cart","Zum Warenkobrn hinzufügen"
+"Add to Cart","Zum Warenkorb hinzufügen"
 Orders,Aufträge
 Bestsellers,Bestseller
 Customer,Kundenname

--- a/app/code/Magento/Sales/i18n/de_DE.csv
+++ b/app/code/Magento/Sales/i18n/de_DE.csv
@@ -33,7 +33,7 @@ Total,Gesamt
 "Move to Wishlist","Auf Wunschzettel schreiben"
 Edit,Bearbeiten
 Item,Objekt
-"Add to Cart","Zum Warenkobrn hinzufügen"
+"Add to Cart","Zum Warenkorb hinzufügen"
 Sku,SKU
 "Order saving error: %1","Order saving error: %1"
 "You created the order.","You created the order."

--- a/app/code/Magento/Wishlist/i18n/de_DE.csv
+++ b/app/code/Magento/Wishlist/i18n/de_DE.csv
@@ -7,7 +7,7 @@ Action,Action
 "Are you sure that you want to remove this item?","Are you sure that you want to remove this item?"
 Edit,Bearbeiten
 "Remove item","Artikel löschen"
-"Add to Cart","Zum Warenkobrn hinzufügen"
+"Add to Cart","Zum Warenkorb hinzufügen"
 Delete,Delete
 Enabled,Enabled
 "We cannot add this item to your shopping cart.","We cannot add this item to your shopping cart."


### PR DESCRIPTION
Warenkorbrn" is not really a german word. I corrected the translation. This phrase is also wrong in all Magento 1.x versions.
