### PR TITLE
Logger is not always defined in Magento\Framework\Image\Adapter\Abstract...

### DIFF
--- a/lib/internal/Magento/Framework/Image/Adapter/AbstractAdapter.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/AbstractAdapter.php
@@ -675,7 +675,10 @@ abstract class AbstractAdapter implements AdapterInterface
             try {
                 $this->directoryWrite->create($this->directoryWrite->getRelativePath($destination));
             } catch (\Magento\Framework\Filesystem\FilesystemException $e) {
-                $this->logger->critical($e);
+                if (null !== $this->logger) {
+                    $this->logger->critical($e);   
+                }
+
                 throw new \Exception('Unable to write file into directory ' . $destination . '. Access forbidden.');
             }
         }


### PR DESCRIPTION
...Adapter

I got this on a clean install on OSX with PHP 5.5.18:

Fatal error: Call to a member function critical() on a non-object in .../lib/internal/Magento/Framework/Image/Adapter/AbstractAdapter.php on line 678