### PR TITLE
Add integration test for View\Page\Config\Reader\Html

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/View/Page/Config/Reader/HtmlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Page/Config/Reader/HtmlTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Magento\Framework\View\Page\Config\Reader;
+
+
+class HtmlTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInterpret()
+    {
+        /** @var \Magento\Framework\View\Layout\Reader\Context $readerContext */
+        $readerContext = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            'Magento\Framework\View\Layout\Reader\Context'
+        );
+        $pageXml = new \Magento\Framework\View\Layout\Element(__DIR__ . '/_files/_layout_update.xml', 0, true);
+        $parentElement = new \Magento\Framework\View\Layout\Element('<page></page>');
+
+        $html = new Html();
+        foreach ($pageXml->xpath('html') as $htmlElement) {
+            $html->interpret($readerContext, $htmlElement, $parentElement);
+        }
+        
+        $structure = $readerContext->getPageConfigStructure();
+        $this->assertEquals(['html' => ['test-name' => 'test-value']], $structure->getElementAttributes());
+    }
+} 

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Page/Config/Reader/_files/_layout_update.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Page/Config/Reader/_files/_layout_update.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd">
+    <html>
+        <attribute name="test-name" value="test-value"/>
+    </html>
+</page>


### PR DESCRIPTION
This PR to the develop branch replaces #749
Since the main issue is now already resolved this PR now only contains the integration test, because as far as I can see there is no other test for Magento\Framework\View\Page\Config\Reader\Html.