### PR TITLE
Change interpret() return value to conform with Layout\ReaderInterface

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/Reader/Container.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Container.php
@@ -86,7 +86,8 @@ class Container implements Layout\ReaderInterface
             default:
                 break;
         }
-        return $this->readerPool->interpret($readerContext, $currentElement);
+        $this->readerPool->interpret($readerContext, $currentElement);
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This PR to the develop branch replaces #751.

In the interface Layout\ReaderInterface the return value for the interpret() method is listed as $this.
This PR changes the actual return value to conform to the interface.