### PR TITLE
Add tests for View\Layout\Reader\Block and slight refactoring

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/Reader/BlockTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/Reader/BlockTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Magento\Framework\View\Layout\Reader;
+
+class BlockTest extends \PHPUnit_Framework_TestCase
+{
+    const IDX_TYPE = 0;
+    const IDX_PARENT = 2;
+
+    /**
+     * @var Block
+     */
+    private $block;
+
+    /**
+     * @var Context
+     */
+    private $readerContext;
+
+    private $blockName = 'test.block';
+    private $childBlockName = 'test.child.block';
+
+    public function setUp()
+    {
+        $this->block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            'Magento\Framework\View\Layout\Reader\Block'
+        );
+        
+        $this->readerContext = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            'Magento\Framework\View\Layout\Reader\Context'
+        );
+    }
+
+    public function testInterpretBlockDirective()
+    {
+        $pageXml = new \Magento\Framework\View\Layout\Element(__DIR__ . '/_files/_layout_update_block.xml', 0, true);
+        $parentElement = new \Magento\Framework\View\Layout\Element('<page></page>');
+
+        foreach ($pageXml->xpath('body/block') as $blockElement) {
+            $this->assertTrue(in_array($blockElement->getName(), $this->block->getSupportedNodes()));
+
+            $this->block->interpret($this->readerContext, $blockElement, $parentElement);
+        }
+
+        $structure = $this->readerContext->getScheduledStructure();
+        $this->assertArrayHasKey($this->blockName, $structure->getStructure());
+        $this->assertEquals('block', $structure->getStructure()[$this->blockName][self::IDX_TYPE]);
+
+        $resultElementData = $structure->getStructureElementData($this->blockName);
+
+        $this->assertEquals(
+            ['group' => 'test.group', 'class' => 'Dummy\Class', 'template' => 'test.phtml', 'ttl' => 3],
+            $resultElementData['attributes']
+        );
+        $this->assertEquals(
+            ['test_arg' => ['name' => 'test_arg', 'xsi:type' => 'string', 'value' => 'test-argument-value']],
+            $resultElementData['arguments']
+        );
+
+        $this->assertEquals('block', $structure->getStructure()[$this->childBlockName][self::IDX_TYPE]);
+        $this->assertEquals($this->blockName, $structure->getStructure()[$this->childBlockName][self::IDX_PARENT]);
+    }
+
+    /**
+     * @depends testInterpretBlockDirective
+     */
+    public function testInterpretReferenceBlockDirective()
+    {
+        $pageXml = new \Magento\Framework\View\Layout\Element(
+            __DIR__ . '/_files/_layout_update_reference.xml', 0, true
+        );
+        $parentElement = new \Magento\Framework\View\Layout\Element('<page></page>');
+
+        foreach ($pageXml->xpath('body/*') as $element) {
+            $this->assertTrue(in_array($element->getName(), $this->block->getSupportedNodes()));
+
+            $this->block->interpret($this->readerContext, $element, $parentElement);
+        }
+
+        $structure = $this->readerContext->getScheduledStructure();
+        $this->assertArrayHasKey($this->blockName, $structure->getStructure());
+        $this->assertEquals('block', $structure->getStructure()[$this->blockName][self::IDX_TYPE]);
+
+        $resultElementData = $structure->getStructureElementData($this->blockName);
+
+        $this->assertEquals(
+            ['test_arg' => ['name' => 'test_arg', 'xsi:type' => 'string', 'value' => 'test-argument-value']],
+            $resultElementData['arguments']
+        );
+    }
+} 

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/Reader/_files/_layout_update_block.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/Reader/_files/_layout_update_block.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="../../../../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd">
+    <body>
+        <block class="Dummy\Class"
+               name="test.block"
+               group="test.group"
+               template="test.phtml"
+               ttl="3">
+            <arguments>
+                <argument name="test_arg" xsi:type="string">test-argument-value</argument>
+            </arguments>
+            <block class="Dummy\Class" name="test.child.block"/>
+        </block>
+    </body>
+</page>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/Reader/_files/_layout_update_reference.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/Reader/_files/_layout_update_reference.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="../../../../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd">
+    <body>
+        <block class="Dummy\Class" name="test.block"/>
+        <referenceBlock name="test.block">
+            <arguments>
+                <argument name="test_arg" xsi:type="string">test-argument-value</argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/lib/internal/Magento/Framework/View/Layout/Reader/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Block.php
@@ -120,7 +120,8 @@ class Block implements Layout\ReaderInterface
             default:
                 break;
         }
-        return $this->readerPool->interpret($readerContext, $currentElement);
+        $this->readerPool->interpret($readerContext, $currentElement);
+        return $this;
     }
 
     /**
@@ -173,7 +174,7 @@ class Block implements Layout\ReaderInterface
      * Update data for scheduled element
      *
      * @param Layout\Element $currentElement
-     * @param array $data
+     * @param array &$data
      * @return array
      */
     protected function updateScheduledData($currentElement, array &$data)


### PR DESCRIPTION
This PR to the develop branch replaces the PR #752.

It contains the following refactorings and additions:
* Add integration test for View\Layout\Reader\Block
* Change interpret() return value to conform with Layout\ReaderInterface