### PR TITLE
Change interpret() return value to conform with Layout\ReaderInterface

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/Reader/Move.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Move.php
@@ -34,7 +34,7 @@ class Move implements Layout\ReaderInterface
     public function interpret(Context $readerContext, Layout\Element $currentElement)
     {
         $this->scheduleMove($readerContext->getScheduledStructure(), $currentElement);
-        return false;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This PR to the develop branch replaces #753.

The only thing changed is that the return value of interpret() now matches the type `$this` as specified in the interface.