### PR TITLE
Change interpret() return value to conform with Layout\ReaderInterface

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/Reader/Remove.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Remove.php
@@ -36,6 +36,6 @@ class Remove implements Layout\ReaderInterface
     {
         $scheduledStructure = $readerContext->getScheduledStructure();
         $scheduledStructure->setElementToRemoveList((string)$currentElement->getAttribute('name'));
-        return false;
+        return $this;
     }
 }


### PR DESCRIPTION
This PR to the develop branch replaces #754.

The only change is the return type of the interpret() method so it conforms to the interface declaration.