### PR TITLE
Fix test assertion and slight cleanup refactoring

### DIFF
--- a/dev/tests/unit/testsuite/Magento/Framework/View/Layout/Reader/UiComponentTest.php
+++ b/dev/tests/unit/testsuite/Magento/Framework/View/Layout/Reader/UiComponentTest.php
@@ -65,9 +65,9 @@ class UiComponentTest extends \PHPUnit_Framework_TestCase
      *
      * @param \Magento\Framework\View\Layout\Element $element
      *
-     * @dataProvider processDataProvider
+     * @dataProvider interpretDataProvider
      */
-    public function testProcess($element)
+    public function testInterpret($element)
     {
         $scope = $this->getMock('Magento\Framework\App\ScopeInterface', [], [], '', false);
         $this->scopeResolver->expects($this->any())->method('getScope')->will($this->returnValue($scope));
@@ -84,14 +84,14 @@ class UiComponentTest extends \PHPUnit_Framework_TestCase
             $element->getParent()
         )->willReturn($element->getAttribute('name'));
 
-        $this->helper->expects($this->any())->method('setStructureElementData')->with(
+        $scheduleStructure->expects($this->once())->method('setStructureElementData')->with(
             $element->getAttribute('name'),
             ['attributes' => ['group' => '', 'component' => 'listing']]
         );
         $this->model->interpret($this->context, $element);
     }
 
-    public function processDataProvider()
+    public function interpretDataProvider()
     {
         return [
             [


### PR DESCRIPTION
This PR against the develop branch replaces #755.

The PR fixes a test assertion in `Magento\Framework\View\Layout\Reader\UiComponentTest::testInterpret()`.
As can be seen in the diff, previously the code looked like follows:

```{.php}
    $this->helper->expects($this->any())->method('setStructureElementData')->...
```
Two things are wrong with it:

1. `->expects($this->any())` only stubs a return value for a method, no actual assertion takes place.
2. The method `setStructureElementData` does not exist on the helper instance. It has to be called on the `View\Layout\ScheduledStructure`.

So the previous method expectation effectively only tested that a non-existant method was called any number of times. 

The other thing this PR changes it the name of the test method to reflect the change in the interface, that is the method `process()` was renamed to `interpret()`, so the test `testProcess()` should also be renamed to `testInterpret()`.
