### PR TITLE
Specify date fixture and fix expectations

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Data/Form/Element/DateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Data/Form/Element/DateTest.php
@@ -48,29 +48,29 @@ class DateTest extends \PHPUnit_Framework_TestCase
      */
     public function getValueDataProvider()
     {
-        $currentTime = time();
+        $testTimestamp = strtotime('2014-05-18 12:08:16');
         return [
             [
                 [
                     'date_format' => \Magento\Framework\Stdlib\DateTime\TimezoneInterface::FORMAT_TYPE_SHORT,
                     'time_format' => \Magento\Framework\Stdlib\DateTime\TimezoneInterface::FORMAT_TYPE_SHORT,
-                    'value' => $currentTime,
+                    'value' => $testTimestamp,
                 ],
-                date('m/j/y g:i A', $currentTime),
+                date('n/j/y g:i A', $testTimestamp),
             ],
             [
                 [
                     'time_format' => \Magento\Framework\Stdlib\DateTime\TimezoneInterface::FORMAT_TYPE_SHORT,
-                    'value' => $currentTime,
+                    'value' => $testTimestamp,
                 ],
-                date('g:i A', $currentTime)
+                date('g:i A', $testTimestamp)
             ],
             [
                 [
                     'date_format' => \Magento\Framework\Stdlib\DateTime\TimezoneInterface::FORMAT_TYPE_SHORT,
-                    'value' => $currentTime,
+                    'value' => $testTimestamp,
                 ],
-                date('m/j/y', $currentTime)
+                date('n/j/y', $testTimestamp)
             ]
         ];
     }


### PR DESCRIPTION
The test passes if the current date is during October - December (10-12), but fails for January - September (1-9)

In the test `Magento\Framework\Data\Form\Element\DateTest::testGetValue()` the expected format for the month part for the format `Magento\Framework\Stdlib\DateTime\TimezoneInterface::FORMAT_TYPE_SHORT` is specifíed as `m` which is the [placeholder](](http://php.net/manual/en/function.date.php#refsect1-function.date-parameters)) for "Numeric representation of a month, with leading zeros".

However, in the file `vendor/magento/zendframework1/library/Zend/Locale/Data/en.xml` the code for the month part matching the [FORMAT_TYPE_SHORT](https://github.com/zendframework/zf1/blob/release-1.12.9/library/Zend/Locale/Data/en.xml#L1844-L1848) is `M`.

According to the [Zend Framework manual](http://framework.zend.com/manual/1.12/en/zend.date.constants.html#zend.date.constants.list), this placeholder stands for "Month (Number of the month, one or two digits)".
(That placeholder value `M` is represented by the [class constant](https://github.com/magento/zf1/blob/master/library/Zend/Date.php#L65) `Zend_Date::MONTH_SHORT`).

So the month values are expected to have a leading zero, but Zend_Date formats them without the leading zero.
