### PR TITLE
Empty system message

### DIFF
--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php
@@ -1,7 +1,7 @@
 <?php
 /**
  *
- * @copyright Copyright (c) 2014 X.commerce, Inc. (http://www.magentocommerce.com)
+ *@copyright Copyright(c) 2014 X.commerce, Inc. (http://www.magentocommerce.com)
  */
 namespace Magento\AdminNotification\Controller\Adminhtml\System\Message;
 
@@ -13,10 +13,11 @@ class ListAction extends \Magento\Backend\App\AbstractAction
     public function execute()
     {
         $severity = $this->getRequest()->getParam('severity');
-        $default = array(
+        $default = [
             'severity' => $severity,
-            'text' => 'All recent issues have been fixed. Please refresh the screen for an update.',
-        );
+            'text' => 'All recent issues have been fixed. '
+                .'Please refresh the screen for an update.',
+        ];
         $messageCollection = $this->_objectManager->get(
             'Magento\AdminNotification\Model\Resource\System\Message\Collection'
         );
@@ -25,13 +26,17 @@ class ListAction extends \Magento\Backend\App\AbstractAction
         }
         $result = [];
         foreach ($messageCollection->getItems() as $item) {
-            $result[] = ['severity' => $item->getSeverity(), 'text' => $item->getText()];
+            $result[] = [
+                'severity' => $item->getSeverity(),
+                'text' => $item->getText(),
+            ];
         }
         if (empty($result)) {
             $result[] = $default;
         }
         $this->getResponse()->representJson(
-            $this->_objectManager->get('Magento\Core\Helper\Data')->jsonEncode($result)
+            $this->_objectManager->get('Magento\Core\Helper\Data')
+                ->jsonEncode($result)
         );
     }
 }

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php
@@ -13,6 +13,10 @@ class ListAction extends \Magento\Backend\App\AbstractAction
     public function execute()
     {
         $severity = $this->getRequest()->getParam('severity');
+        $default = array(
+            'severity' => $severity,
+            'text' => 'All recent issues have been fixed. Please refresh the screen for an update.'
+            );
         $messageCollection = $this->_objectManager->get(
             'Magento\AdminNotification\Model\Resource\System\Message\Collection'
         );
@@ -22,6 +26,9 @@ class ListAction extends \Magento\Backend\App\AbstractAction
         $result = [];
         foreach ($messageCollection->getItems() as $item) {
             $result[] = ['severity' => $item->getSeverity(), 'text' => $item->getText()];
+        }
+        if (empty($result)) {
+            $result[] = $default;
         }
         $this->getResponse()->representJson(
             $this->_objectManager->get('Magento\Core\Helper\Data')->jsonEncode($result)

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php
@@ -15,8 +15,8 @@ class ListAction extends \Magento\Backend\App\AbstractAction
         $severity = $this->getRequest()->getParam('severity');
         $default = array(
             'severity' => $severity,
-            'text' => 'All recent issues have been fixed. Please refresh the screen for an update.'
-            );
+            'text' => 'All recent issues have been fixed. Please refresh the screen for an update.',
+        );
         $messageCollection = $this->_objectManager->get(
             'Magento\AdminNotification\Model\Resource\System\Message\Collection'
         );


### PR DESCRIPTION
Fixed issue with empty system message popup when issue has been fixed in the other window and current window wasn't refreshed.

Default message to display hard coded in controller.

Created separate pull request as from now on every single fix will be pushed to separate branches (as it should be) also fixed Coding standards issues.


If any Travis CI issues will appear due to coding standards it will be about differences between Windows and Unix environment (line endings). 