### PR TITLE
Date Test additional fix

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Data/Form/Element/DateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Data/Form/Element/DateTest.php
@@ -56,14 +56,14 @@ class DateTest extends \PHPUnit_Framework_TestCase
                     'time_format' => \Magento\Framework\Stdlib\DateTime\TimezoneInterface::FORMAT_TYPE_SHORT,
                     'value' => $testTimestamp,
                 ],
-                date('n/j/y g:i A', $testTimestamp),
+                date('n/j/y g:i a', $testTimestamp),
             ],
             [
                 [
                     'time_format' => \Magento\Framework\Stdlib\DateTime\TimezoneInterface::FORMAT_TYPE_SHORT,
                     'value' => $testTimestamp,
                 ],
-                date('g:i A', $testTimestamp)
+                date('g:i a', $testTimestamp)
             ],
             [
                 [

--- a/dev/tests/integration/testsuite/Magento/Framework/Data/Form/Element/DateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Data/Form/Element/DateTest.php
@@ -49,6 +49,7 @@ class DateTest extends \PHPUnit_Framework_TestCase
     public function getValueDataProvider()
     {
         $testTimestamp = strtotime('2014-05-18 12:08:16');
+
         return [
             [
                 [


### PR DESCRIPTION
DateTest.php still failed because of difference between capital and lowercase AM/PM

One generated by Magento core was lowercase and date() function returned capital PM (or AM).
After test 100% ok now in my case.