### PR TITLE
Non initialized log file fix

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Data/Form/Element/DateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Data/Form/Element/DateTest.php
@@ -56,14 +56,14 @@ class DateTest extends \PHPUnit_Framework_TestCase
                     'time_format' => \Magento\Framework\Stdlib\DateTime\TimezoneInterface::FORMAT_TYPE_SHORT,
                     'value' => $testTimestamp,
                 ],
-                date('n/j/y g:i A', $testTimestamp),
+                date('n/j/y g:i a', $testTimestamp),
             ],
             [
                 [
                     'time_format' => \Magento\Framework\Stdlib\DateTime\TimezoneInterface::FORMAT_TYPE_SHORT,
                     'value' => $testTimestamp,
                 ],
-                date('g:i A', $testTimestamp)
+                date('g:i a', $testTimestamp)
             ],
             [
                 [

--- a/setup/module/Magento/Setup/src/Model/WebLogger.php
+++ b/setup/module/Magento/Setup/src/Model/WebLogger.php
@@ -57,6 +57,11 @@ class WebLogger implements LoggerInterface
     private function open($mode)
     {
         $this->resource = fopen($this->logFile, $mode);
+        if (!file_exists($this->logFile) && !is_resource($this->resource)) {
+            $this->resource = fopen($this->logFile, 'w');
+        } else {
+            $this->resource = fopen($this->logFile, $mode);
+        }
     }
 
     /**
@@ -66,7 +71,10 @@ class WebLogger implements LoggerInterface
      */
     private function close()
     {
-        fclose($this->resource);
+        // Do a check to prevent warinig in console
+        if (is_resource($this->resource)) {
+            fclose($this->resource);
+        }
     }
 
     /**


### PR DESCRIPTION
Addition to #917 mentioned issue that prevent error with:

Warning: fopen(foo\bar\Local\Temp\install.log): failed to open stream: No such file or directory in foo\bar\Projects\magento2\setup\module\Magento\Setup\src\Model\WebLogger.php on line 59

Warning: fseek() expects parameter 1 to be resource, boolean given in foo\bar\magento2\setup\module\Magento\Setup\src\Model\WebLogger.php on line 148

Warning: fgets() expects parameter 1 to be resource, boolean given in foo\bar\magento2\setup\module\Magento\Setup\src\Model\WebLogger.php on line 150

Warning: fclose() expects parameter 1 to be resource, boolean given in foo\bar\magento2\setup\module\Magento\Setup\src\Model\WebLogger.php on line 69

Warning: fopen(foo\bar\Local\Temp\install.log): failed to open stream: No such file or directory in foo\bar\magento2\setup\module\Magento\Setup\src\Model\WebLogger.php on line 59

Warning: fseek() expects parameter 1 to be resource, boolean given in foo\bar\magento2\setup\module\Magento\Setup\src\Model\WebLogger.php on line 148

Warning: fgets() expects parameter 1 to be resource, boolean given in foo\bar\magento2\setup\module\Magento\Setup\src\Model\WebLogger.php on line 150

Warning: fclose() expects parameter 1 to be resource, boolean given in foo\bar\magento2\setup\module\Magento\Setup\src\Model\WebLogger.php on line 69

{"progress":"0","success":true,"console":[]}

To reproduce error just cause "installation not completed" error and then clear console and click "Try Again". The first action is "progress" with progress == 100 and multiple error due to not existing resource.

To prevent it I added simple is_resource check for fclose function and also on open() function to create file if doesn't exists.

I didn't have this issue during next 10 installation processes after this fix.