### PR TITLE
Add Failured-Allowed PHP 5.6 testing to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 5.4
   - 5.5
+  - 5.6
 env:
   - TEST_SUITE=unit
   - TEST_SUITE=integration
@@ -14,6 +15,12 @@ matrix:
       env: TEST_SUITE=static_phpcs
     - php: 5.4
       env: TEST_SUITE=static_annotation
+    - php: 5.6
+      env: TEST_SUITE=static_phpcs
+    - php: 5.6
+      env: TEST_SUITE=static_annotation
+  allow_failures:
+    - php: 5.6
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq postfix

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "AFL-3.0"
     ],
     "require": {
-        "php": "~5.4.11|~5.5.0",
+        "php": ">=5.4.11",
         "zendframework/zend-stdlib": "2.3.1",
         "zendframework/zend-code": "2.3.1",
         "zendframework/zend-server": "2.3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -3035,7 +3035,7 @@
     },
     "prefer-stable": false,
     "platform": {
-        "php": "~5.4.11|~5.5.0"
+        "php": ">=5.4.11"
     },
     "platform-dev": {
         "lib-libxml": "*",


### PR DESCRIPTION
While PHP 5.6 is not officially supported by Magento proper, allowing
Magento 2 to be installed and tested under that environment will allow
tests to be constructed so that features or functionality broken in these
versions may be understood and potentially fixed.  If the tests are
failing for these environments it also warns developers of the
reprecussions of using Magento in them.