### PR TITLE
Added admin role id to backend menu cache key

### DIFF
--- a/app/code/Magento/Backend/Block/Menu.php
+++ b/app/code/Magento/Backend/Block/Menu.php
@@ -282,6 +282,7 @@ class Menu extends \Magento\Backend\Block\Template
             'admin_top_nav',
             $this->getActive(),
             $this->_authSession->getUser()->getId(),
+            $this->_authSession->getUser()->getRole()->getId(),
             $this->_localeResolver->getLocaleCode(),
         ];
         // Add additional key parameters if needed


### PR DESCRIPTION
**Problem:**
Given that there are 2 admin permission roles for regular admin users which have different menu items allowed, the following problem occurs: 
If an administrator now changes the admin role of an admin user, the admin user will see the old cached backend menu but if he clicks on a (now restricted) menu item, he will receive an "Permission denied" error - even after logging out and logging in again. This is very confusing for the admin user.

Under the current circumstances, the administrator has to clear the cache to make the changes in the backend menu visible and working properly. But clearing the cache can be risky on production environments and changes should be visible immediately.

**Solution:**
This commit adds the current admin role id to the cache key for the backend menu block. The administrator can now change the admin role of an admin user. If the user then logs out and logs in again, the new menu is immediately visible which out the need to clearing the cache.