### PR TITLE
Fix for the missed trailing end of line in indexer.php usage help text

### DIFF
--- a/app/code/Magento/Indexer/Model/Shell.php
+++ b/app/code/Magento/Indexer/Model/Shell.php
@@ -241,6 +241,7 @@ Usage:  php -f {$this->_entryPoint} -- [options]
   help                          This help
 
   <indexer>     Comma separated indexer codes or value "all" for all indexers
+
 USAGE;
     }
 }


### PR DESCRIPTION
This fix just adds a missing trailing end of line at the indexer.php usage help text.

Before the fix, it appears as this:
```bash
vagrant@packer-virtualbox-iso:/var/www/magento/dev/shell$ php indexer.php
Usage:  php -f indexer.php -- [options]

  --status <indexer>            Show Indexer(s) Status
  --mode <indexer>              Show Indexer(s) Index Mode
  --mode-realtime <indexer>     Set index mode type "Update on Save"
  --mode-schedule <indexer>     Set index mode type "Update by Schedule"
  --reindex <indexer>           Reindex Data
  info                          Show allowed indexers
  reindexall                    Reindex Data by all indexers
  help                          This help

  <indexer>     Comma separated indexer codes or value "all" for all indexersvagrant@packer-virtualbox-iso:/var/www/magento/dev/shell$
```

After the fix:
```bash
vagrant@packer-virtualbox-iso:/var/www/magento/dev/shell$ php indexer.php
Usage:  php -f indexer.php -- [options]

  --status <indexer>            Show Indexer(s) Status
  --mode <indexer>              Show Indexer(s) Index Mode
  --mode-realtime <indexer>     Set index mode type "Update on Save"
  --mode-schedule <indexer>     Set index mode type "Update by Schedule"
  --reindex <indexer>           Reindex Data
  info                          Show allowed indexers
  reindexall                    Reindex Data by all indexers
  help                          This help

  <indexer>     Comma separated indexer codes or value "all" for all indexers
vagrant@packer-virtualbox-iso:/var/www/magento/dev/shell$
```