### PR TITLE
Make Browser configurable with command line option

### DIFF
--- a/dev/tests/js/run_js_tests.php
+++ b/dev/tests/js/run_js_tests.php
@@ -32,9 +32,9 @@ if (isset($config['Browser'])) {
     } else {
         $browser = exec('which firefox');
     }
-}
-if (!file_exists($browser)) {
-    reportError('Browser executable not found: ' . $browser);
+    if (!file_exists($browser)) {
+        reportError('Browser executable not found: ' . $browser);
+    }
 }
 
 $server = isset($config['server']) ? $config['server'] : "http://localhost:9876";


### PR DESCRIPTION
Move the check if the browser binary exists into the block with the default
discovery. This makes it possible to configure the Browser in the jsTestDriver.php
file with command line arguments.
For example:

```{.php}
    'Browser' => '/Applications/Firefox.app/Contents/MacOS/firefox -P "selenium"',
```

Without the change the check would fail, since the value is not an existing
file name, but rather a file name including command line options.