### PR TITLE
Replace UTF8 'en dash' with minus in error message

### DIFF
--- a/lib/internal/Magento/Framework/Module/Plugin/DbStatusValidator.php
+++ b/lib/internal/Magento/Framework/Module/Plugin/DbStatusValidator.php
@@ -52,7 +52,7 @@ class DbStatusValidator
             if ($errors) {
                 $formattedErrors = $this->formatErrors($errors);
                 throw new \Magento\Framework\Module\Exception(
-                    'Please update your database: Run "php –f index.php update" from the Magento root/setup directory.'
+                    'Please update your database: Run "php -f index.php update" from the Magento root/setup directory.'
                     . PHP_EOL . 'The following modules are outdated:' . PHP_EOL . implode(PHP_EOL, $formattedErrors)
                 );
             } else {


### PR DESCRIPTION
The character in the error message was the UTF8 character – `U+2013` (`&#8211;`)
also called "en dash", which is used e.g. to indicate a range of values.

For command line options the character - `U+002D` (`&#45;`) is used to specify
command options. This change should allow users who see the error message
to copy the command out of the browser and paste it into the shell.