### PR TITLE
Default Accept header.

### DIFF
--- a/app/code/Magento/Webapi/Controller/Rest/Request.php
+++ b/app/code/Magento/Webapi/Controller/Rest/Request.php
@@ -75,7 +75,14 @@ class Request extends \Magento\Webapi\Controller\Request
         $qualityToTypes = [];
         $orderedTypes = [];
 
-        foreach (preg_split('/,\s*/', $this->getHeader('Accept')) as $definition) {
+        $headerAccept  = $this->getHeader('Accept');
+        $defaultAccept = \Magento\Webapi\Controller\Rest\Response\Renderer\Json::MIME_TYPE;
+
+        if(false === $headerAccept) {
+            $headerAccept = $defaultAccept;
+        }
+
+        foreach (preg_split('/,\s*/', $headerAccept) as $definition) {
             $typeWithQ = explode(';', $definition);
             $mimeType = trim(array_shift($typeWithQ));
 


### PR DESCRIPTION
According to the documentation http://devdocs.magento.com/guides/v1.0/get-started/gs-web-api-request.html#http-headers json should be the default for Accept header but if you don't send the Accept header at all an error is thrown saying "Server cannot understand Accept HTTP header media type.", this commit intention is to make application/json the default Accept for REST requests.