### PR TITLE
Improving documentation for jMeter performance tests

### DIFF
--- a/dev/tools/performance-toolkit/README.txt
+++ b/dev/tools/performance-toolkit/README.txt
@@ -24,7 +24,7 @@ to:
 Attempting to run with Performance Metrics Collector enabled without appropriately configuring it will result in a timeout error connecting to the collector and the test not running.
 
 1. Run via console
-Scenario can accept 5 parameters that are described bellow in format <parameter_name:default_value>:
+Scenario can accept parameters that are described bellow in format <parameter_name:default_value>:
 
 <host:''> URL component 'host' of application being tested (URL or IP).
 <base_path:'/'> Base path for tested site.
@@ -35,6 +35,15 @@ Scenario can accept 5 parameters that are described bellow in format <parameter_
 <admin_path:backend/> Admin backend path. Default is backend.
 <admin_user:admin/> Admin backend user. Default is admin.
 <admin_password:123123q/> Admin backend password. Default is 123123q.
+<view_product_add_to_cart_percent:62/> Percentage of users that will only reach the add to cart stage. Default is 62.
+<view_catalog_percent:30/> Percentage of users that will only reach the view catalog stage. Default is 30.
+<guest_checkout_percent:4/> Percentage of users that will reach the guest checkout stage. Default is 4.
+<customer_checkout_percent:4/> Percentage of users that will reach the (logged-in) customer checkout stage. Default is 4.
+<loops:1/> Number of loops to run. Default is 1.
+<jmeter_agent_port:3450/> jMeter agent port. Default is 3450.
+<db_server_ip:10.62.51.150/> DB Server IP (for jMeter Performance Metrics). Default is 10.62.51.150.
+<web_server_1_ip:10.62.51.185/> Web Server 1 IP (for jMeter Performance Metrics). Default is 10.62.51.185.
+<web_server_2_ip:10.62.51.186/> Web Server 2 IP (for jMeter Performance Metrics). Default is 10.62.51.186.
 
 All parameters must be passed to command line with "J" prefix: "-J<parameter_name>=<parameter_value>"
 

--- a/dev/tools/performance-toolkit/README.txt
+++ b/dev/tools/performance-toolkit/README.txt
@@ -4,16 +4,24 @@ Performance Toolkit
 Installation
 -----------
 jMeter:
--- go to http://jmeter.apache.org/download_jmeter.cgi and download jMeter in Source section (pay you attention that Java 6 or later is required)
+-- go to http://jmeter.apache.org/download_jmeter.cgi and download jMeter in Binary section (pay you attention that Java 6 or later is required)
 -- unzip archive
 
 Plugins (only if you want to use additional reports (like graphs)):
 -- go to http://jmeter-plugins.org/downloads/all/ and download JMeterPlugins-Standard and JMeterPlugins-Extras
 -- unzip them to appropriate ext directory of your jMeter instance.
+-- additional reports can now be enabled via GUI (right click them, then click Enable) or editing the jMeter JMX XML (set 'enabled="true"').
 
 
 Usage
 -----------
+Before running the jMeter tests for the first time, you will need to first use generate.php to generate the test data.
+
+If you do not wish to use performance metrics gathered from the server(s) (such as CPU / IO load), or do not wish to configure the jMeter metric gathering software on your server(s), you can disable that either via the GUI (right click on "Performance Metrics Collector" and click Disable) or by editing the jMeter JMX XML from:
+<kg.apc.jmeter.perfmon.PerfMonCollector guiclass="kg.apc.jmeter.vizualizers.PerfMonGui" testclass="kg.apc.jmeter.perfmon.PerfMonCollector" testname="Performance Metrics Collector" enabled="true">
+to:
+<kg.apc.jmeter.perfmon.PerfMonCollector guiclass="kg.apc.jmeter.vizualizers.PerfMonGui" testclass="kg.apc.jmeter.perfmon.PerfMonCollector" testname="Performance Metrics Collector" enabled="false">
+Attempting to run with Performance Metrics Collector enabled without appropriately configuring it will result in a timeout error connecting to the collector and the test not running.
 
 1. Run via console
 Scenario can accept 5 parameters that are described bellow in format <parameter_name:default_value>:
@@ -24,6 +32,9 @@ Scenario can accept 5 parameters that are described bellow in format <parameter_
 <ramp_period:300> Ramp period (seconds). Period the request will be distributed within.
 <orders:0> Number of orders in the period specified in the current allocation. If <orders> is specified, the <users> parameter will be recalculated.
 <report_save_path:./> Path where reports will be saved. Reports will be saved in current working directory by default.
+<admin_path:backend/> Admin backend path. Default is backend.
+<admin_user:admin/> Admin backend user. Default is admin.
+<admin_password:123123q/> Admin backend password. Default is 123123q.
 
 All parameters must be passed to command line with "J" prefix: "-J<parameter_name>=<parameter_value>"
 


### PR DESCRIPTION
While trying to play with the jMeter tests we discovered that the documentation was occasionally misleading / confusing, and also lacking some details.

* Source download of jMeter lacks the .jar for jMeter itself and thus is insufficient to work
* Once you install the additional libraries for graphing reports etc, you have to actually enable them for them to work
* Performance Metrics Collection will keep the jMeter test from completing if you do not have the agents set up / configured the jMeter settings for your server environment, etc.
* generate.php must be used to generate test data, at least in our experience, Sample Data did not work with jMeter test.
* There are a number of additional configurable parameters that were undocumented, such as specifying the admin username / password / path.