### PR TITLE
Apply pattern matching datasource config files

### DIFF
--- a/app/code/Magento/Ui/DataProvider/Config/FileResolver.php
+++ b/app/code/Magento/Ui/DataProvider/Config/FileResolver.php
@@ -45,7 +45,7 @@ class FileResolver implements \Magento\Framework\Config\FileResolverInterface
     {
         $iterator = $this->iteratorFactory->create(
             $this->directoryRead,
-            $this->directoryRead->search('/*/*/etc/data_source/*')
+            $this->directoryRead->search('/*/*/etc/data_source/' . $filename)
         );
         return $iterator;
     }

--- a/dev/tests/unit/testsuite/Magento/Ui/DataProvider/Config/FileResolverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Ui/DataProvider/Config/FileResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Magento\Ui\DataProvider\Config;
+
+use Magento\Framework\Filesystem;
+use Magento\Ui\DataProvider\Config\FileResolver;
+use Magento\Framework\Config\FileIteratorFactory;
+
+class FileResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Magento\Framework\Filesystem\Directory\Read | \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockDirectoryRead;
+
+    /**
+     * @var FileResolver
+     */
+    private $fileResolver;
+
+    public function setUp()
+    {
+        $this->mockDirectoryRead = $this->getMockBuilder('Magento\Framework\Filesystem\Directory\Read')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $stubFileIteratorFactory = $this->getMockBuilder('Magento\Framework\Config\FileIteratorFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $stubFilesystem = $this->getMockBuilder('Magento\Framework\Filesystem')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $stubFilesystem->expects($this->any())
+            ->method('getDirectoryRead')
+            ->willReturn($this->mockDirectoryRead);
+        $this->fileResolver = new FileResolver($stubFilesystem, $stubFileIteratorFactory);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldApplyTheFilenamePattern()
+    {
+        $this->mockDirectoryRead->expects($this->once())
+            ->method('search')
+            ->with($this->matchesRegularExpression('#\*\.xml$#'))
+            ->willReturn([]);
+        
+        $this->fileResolver->get('*.xml', '');
+    }
+}

--- a/dev/tests/unit/testsuite/Magento/Ui/DataProvider/Config/FileResolverTest.php
+++ b/dev/tests/unit/testsuite/Magento/Ui/DataProvider/Config/FileResolverTest.php
@@ -35,10 +35,7 @@ class FileResolverTest extends \PHPUnit_Framework_TestCase
         $this->fileResolver = new FileResolver($stubFilesystem, $stubFileIteratorFactory);
     }
 
-    /**
-     * @test
-     */
-    public function itShouldApplyTheFilenamePattern()
+    public function testItAppliesTheFilenamePattern()
     {
         $this->mockDirectoryRead->expects($this->once())
             ->method('search')


### PR DESCRIPTION
The `Magento\Ui\DataProvider\Config\FileResolver` class currently uses the hardcoded pattern `'/*/*/etc/data_source/*'` to search for data source configuration files.
The method argument `$filename`, which contains the file pattern that should be matched, is not used.
Due to this temorarily excludng files by renaming them with a different file type ending is not possible.
For example

    etc/data_source/customer.xml -> etc/data_source/customer.xml.off

This patch applies the specified file name pattern to the pattern.