### PR TITLE
Added ignore rule for media assets in wysiwyg directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ atlassian*
 /pub/media/theme/*
 /pub/media/theme_customization/*
 !/pub/media/theme_customization/.htaccess
+/pub/media/wysiwyg/*
+!/pub/media/wysiwyg/.htaccess
 /pub/media/tmp/*
 !/pub/media/tmp/.htaccess
 /pub/static/*


### PR DESCRIPTION
Simply installing the sample data causes this directory to show up in the list of untracked files, but it should not be versioned.