### PR TITLE
Update regex in menu.xsd

### DIFF
--- a/app/code/Magento/Backend/etc/menu.xsd
+++ b/app/code/Magento/Backend/etc/menu.xsd
@@ -131,7 +131,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
+            <xs:pattern value="[A-Z]+[A-Za-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Regex should be equal to this https://github.com/magento/magento2/blob/develop/lib/internal/Magento/Framework/Module/etc/module.xsd#L76.

Otherwhise you are not able to use camelcase in your vendorname.