### PR TITLE
Make it possible to exclude classes (directories) for compilation

### DIFF
--- a/dev/tools/Magento/Tools/Di/Code/Reader/ClassesScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Reader/ClassesScanner.php
@@ -11,6 +11,21 @@ use Zend\Code\Scanner\FileScanner;
 class ClassesScanner
 {
     /**
+     * @var array
+     */
+    protected $excludePatterns = [];
+
+    /**
+     * adds exclude patterns
+     *
+     * @param array $excludePatterns
+     */
+    public function addExcludePatterns(array $excludePatterns)
+    {
+        $this->excludePatterns = array_merge($this->excludePatterns, $excludePatterns);
+    }
+    
+    /**
      * Retrieves list of classes for given path
      *
      * @param string $path
@@ -36,6 +51,11 @@ class ClassesScanner
             /** @var $fileItem \SplFileInfo */
             if ($fileItem->getExtension() !== 'php') {
                 continue;
+            }
+            foreach ($this->excludePatterns as $excludePattern) {
+                if (preg_match($excludePattern, $fileItem->getRealPath())) {
+                    continue 2;
+                }
             }
             $fileScanner = new FileScanner($fileItem->getRealPath());
             $classNames = $fileScanner->getClassNames();

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/DirectoryScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/DirectoryScanner.php
@@ -26,8 +26,8 @@ class DirectoryScanner
                 continue;
             }
 
+            $filePath = str_replace('\\', '/', $file->getRealPath());
             foreach ($patterns as $type => $pattern) {
-                $filePath = str_replace('\\', '/', $file->getRealPath());
                 if (preg_match($pattern, $filePath)) {
                     $output[$type][] = $filePath;
                     break;

--- a/dev/tools/Magento/Tools/Di/Code/Scanner/DirectoryScanner.php
+++ b/dev/tools/Magento/Tools/Di/Code/Scanner/DirectoryScanner.php
@@ -12,9 +12,10 @@ class DirectoryScanner
      *
      * @param string $dir
      * @param array $patterns
+     * @param string[] $excludePatterns
      * @return array
      */
-    public function scan($dir, array $patterns = [])
+    public function scan($dir, array $patterns = [], array $excludePatterns = [])
     {
         $recursiveIterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($dir, \FilesystemIterator::FOLLOW_SYMLINKS)
@@ -27,6 +28,13 @@ class DirectoryScanner
             }
 
             $filePath = str_replace('\\', '/', $file->getRealPath());
+            if (!empty($excludePatterns)) {
+                foreach ($excludePatterns as $excludePattern) {
+                    if (preg_match($excludePattern, $filePath)) {
+                        continue 2;
+                    }
+                }
+            }
             foreach ($patterns as $type => $pattern) {
                 if (preg_match($pattern, $filePath)) {
                     $output[$type][] = $filePath;

--- a/dev/tools/Magento/Tools/Di/compiler.php
+++ b/dev/tools/Magento/Tools/Di/compiler.php
@@ -32,12 +32,15 @@ try {
             'extra-classes-file=s' => 'path to file with extra proxies and factories to generate',
             'generation=s'         => 'absolute path to generated classes, <magento_root>/var/generation by default',
             'di=s'                 => 'absolute path to DI definitions directory, <magento_root>/var/di by default',
+            'exclude-pattern=s'    => 'allows to exclude Paths from compilation (default is #[\\\\/]m1[\\\\/]#i)',
         ]
     );
     $opt->parse();
 
     $generationDir = $opt->getOption('generation') ? $opt->getOption('generation') : $rootDir . '/var/generation';
     $diDir = $opt->getOption('di') ? $opt->getOption('di') : $rootDir . '/var/di';
+    $fileExcludePatterns = $opt->getOption('exclude-pattern') ?
+        [$opt->getOption('exclude-pattern')] : ['#[\\\\/]M1[\\\\/]#i'];
     $relationsFile = $diDir . '/relations.ser';
     $pluginDefFile = $diDir . '/plugins.ser';
 
@@ -60,7 +63,7 @@ try {
     $filePatterns = ['php' => '/.*\.php$/', 'di' => '/\/etc\/([a-zA-Z_]*\/di|di)\.xml$/'];
     $codeScanDir = realpath($rootDir . '/app');
     $directoryScanner = new Scanner\DirectoryScanner();
-    $files = $directoryScanner->scan($codeScanDir, $filePatterns);
+    $files = $directoryScanner->scan($codeScanDir, $filePatterns, $fileExcludePatterns);
     $files['additional'] = [$opt->getOption('extra-classes-file')];
     $entities = [];
 
@@ -144,11 +147,13 @@ try {
     $validator = new \Magento\Framework\Code\Validator();
     $validator->add(new \Magento\Framework\Code\Validator\ConstructorIntegrity());
     $validator->add(new \Magento\Framework\Code\Validator\ContextAggregation());
+    $classesScanner = new \Magento\Tools\Di\Code\Reader\ClassesScanner();
+    $classesScanner->addExcludePatterns($fileExcludePatterns);
 
     $directoryInstancesNamesList = new \Magento\Tools\Di\Code\Reader\InstancesNamesList\Directory(
         $log,
         new \Magento\Framework\Code\Reader\ClassReader(),
-        new \Magento\Tools\Di\Code\Reader\ClassesScanner(),
+        $classesScanner,
         $validator,
         $generationDir
     );


### PR DESCRIPTION
Reason is:
A single module which is working for Magento 1.x and 2.x
the 2.x specific files are not problem for 1.x, but the 1.x specific files will get parsed from the compiler causing two errors.
1. they are not part of the autoloading, which causes a first error
2. they extend from classes not existent in 2.x anymore 

To prevent this errors this patch allows to specify an ignore pattern with `/m1/` as default, so everything a module places in a m1 directory, is not parsed from the compiler anymore.


I will provide documentation after this get merged, not sure about tests yet, but  will see later how to add some for it