### PR TITLE
Fix mod_expires dynamic content

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -167,6 +167,8 @@
 ## http://developer.yahoo.com/performance/rules.html#expires
 
     ExpiresDefault "access plus 1 year"
+    ExpiresByType text/html A0
+    ExpiresByType text/plain A0
 
 </IfModule>
 

--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -164,6 +164,8 @@
 ## http://developer.yahoo.com/performance/rules.html#expires
 
     ExpiresDefault "access plus 1 year"
+    ExpiresByType text/html A0
+    ExpiresByType text/plain A0
 
 </IfModule>
 

--- a/dev/tests/functional/.htaccess
+++ b/dev/tests/functional/.htaccess
@@ -170,6 +170,8 @@
 ## http://developer.yahoo.com/performance/rules.html#expires
 
     ExpiresDefault "access plus 1 year"
+    ExpiresByType text/html A0
+    ExpiresByType text/plain A0
 
 </IfModule>
 

--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -153,6 +153,8 @@
 ## http://developer.yahoo.com/performance/rules.html#expires
 
     ExpiresDefault "access plus 1 year"
+    ExpiresByType text/html A0
+    ExpiresByType text/plain A0
 
 </IfModule>
 


### PR DESCRIPTION
HTML, TXT and CSV files are allowed to be cached in the browser and proxies for one year with the mod_expires default setting in .htaccess files. This shouldn't be allowed by default as it doesn't allow you to control and refresh HTML content. The change sets "Cache-Control: max-age=0" header for HTML and other plain text content.