### PR TITLE
Prevent Varnish from creating cache variations of static files

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish.vcl
+++ b/app/code/Magento/PageCache/etc/varnish.vcl
@@ -46,6 +46,18 @@ sub vcl_recv {
     if (req.request != "GET" && req.request != "HEAD") {
         return (pass);
     }
+    
+    # normalize url in case of leading HTTP scheme and domain
+    set req.url = regsub(req.url, "^http[s]?://[^/]+", "");
+
+    # collect all cookies
+    std.collect(req.http.Cookie);
+
+    # static files are always cacheable. remove SSL flag and cookie
+    if (req.url ~ "^/(media|js|skin)/.*\.(png|jpg|jpeg|gif|css|js|swf|ico)$") {
+        unset req.http.Https;
+        unset req.http.Cookie;
+    }
 
     set req.grace = 1m;
 

--- a/app/code/Magento/PageCache/etc/varnish.vcl
+++ b/app/code/Magento/PageCache/etc/varnish.vcl
@@ -54,7 +54,7 @@ sub vcl_recv {
     std.collect(req.http.Cookie);
 
     # static files are always cacheable. remove SSL flag and cookie
-    if (req.url ~ "^/(media|js|skin)/.*\.(png|jpg|jpeg|gif|css|js|swf|ico)$") {
+    if (req.url ~ "^/pub/.*\.(png|jpg|jpeg|gif|css|js|swf|ico)$") {
         unset req.http.Https;
         unset req.http.Cookie;
     }

--- a/app/code/Magento/PageCache/etc/varnish.vcl
+++ b/app/code/Magento/PageCache/etc/varnish.vcl
@@ -54,7 +54,7 @@ sub vcl_recv {
     std.collect(req.http.Cookie);
 
     # static files are always cacheable. remove SSL flag and cookie
-    if (req.url ~ "^/pub/.*\.(png|jpg|jpeg|gif|css|js|swf|ico)$") {
+    if (req.url ~ "^/(pub/)?(media|static)/.*\.(png|jpg|jpeg|gif|css|js|swf|ico|woff|svg)$") {
         unset req.http.Https;
         unset req.http.Cookie;
     }


### PR DESCRIPTION
In the vcl_hash routine cookie values are read to create cache variations of the same URL which makes only sense for HTML pages. Static files will never change and therefore shouldn't be stored in variations.
The VCL change removes schema and cookies for static files before calling vcl_hash to ensure only one cache element is created.