### PR TITLE
Prevent a warning in activated developer mode when 'plugins' is no array

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
@@ -254,17 +254,19 @@ class Editor extends Textarea
             );
         }
 
-        foreach ($this->getConfig('plugins') as $plugin) {
-            if (isset($plugin['options']) && $this->_checkPluginButtonOptions($plugin['options'])) {
-                $buttonOptions = $this->_prepareButtonOptions($plugin['options']);
-                if (!$visible) {
-                    $configStyle = '';
-                    if (isset($buttonOptions['style'])) {
-                        $configStyle = $buttonOptions['style'];
+        if (is_array($this->getConfig('plugins'))) {
+            foreach ($this->getConfig('plugins') as $plugin) {
+                if (isset($plugin['options']) && $this->_checkPluginButtonOptions($plugin['options'])) {
+                    $buttonOptions = $this->_prepareButtonOptions($plugin['options']);
+                    if (!$visible) {
+                        $configStyle = '';
+                        if (isset($buttonOptions['style'])) {
+                            $configStyle = $buttonOptions['style'];
+                        }
+                        $buttonOptions = array_merge($buttonOptions, ['style' => 'display:none;' . $configStyle]);
                     }
-                    $buttonOptions = array_merge($buttonOptions, ['style' => 'display:none;' . $configStyle]);
+                    $buttonsHtml .= $this->_getButtonHtml($buttonOptions);
                 }
-                $buttonsHtml .= $this->_getButtonHtml($buttonOptions);
             }
         }
 


### PR DESCRIPTION
This exists also in Magento 1. A backport would be nice.