### PR TITLE
Wrong parameter for getting base url for 'media' path in "Image" form element.

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/Image.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Image.php
@@ -50,7 +50,7 @@ class Image extends \Magento\Framework\Data\Form\Element\AbstractElement
             $url = $this->_getUrl();
 
             if (!preg_match("/^http\:\/\/|https\:\/\//", $url)) {
-                $url = $this->_urlBuilder->getBaseUrl('media') . $url;
+                $url = $this->_urlBuilder->getBaseUrl(['_type' => \Magento\Framework\UrlInterface::URL_TYPE_MEDIA]) . $url;
             }
 
             $html = '<a href="' .


### PR DESCRIPTION
Form element "image" doesn't load 'media' path.
http://dl1.joxi.net/drive/0000/0178/12466/150206/57a3f0519b.jpg

\Magento\Framework\UrlInterface::getBaseUrl accepts an array instead of a string.