### PR TITLE
Bug fix for issue 1035

### DIFF
--- a/dev/tests/unit/testsuite/Magento/Framework/Simplexml/ElementTest.php
+++ b/dev/tests/unit/testsuite/Magento/Framework/Simplexml/ElementTest.php
@@ -72,12 +72,12 @@ XML;
         $baseXml = simplexml_load_string('<root/>', 'Magento\Framework\Simplexml\Element');
         /** @var \Magento\Framework\Simplexml\Element $appendXml */
         $appendXml = simplexml_load_string(
-            '<node_a attr="abc"><node_b>text</node_b></node_a>',
+            '<node_a attr="abc"><node_b innerAttribute="xyz">text</node_b></node_a>',
             'Magento\Framework\Simplexml\Element'
         );
         $baseXml->appendChild($appendXml);
 
-        $expectedXml = '<root><node_a attr="abc"><node_b>text</node_b></node_a></root>';
+        $expectedXml = '<root><node_a attr="abc"><node_b innerAttribute="xyz">text</node_b></node_a></root>';
         $this->assertXmlStringEqualsXmlString($expectedXml, $baseXml->asNiceXml());
     }
 

--- a/lib/internal/Magento/Framework/Simplexml/Element.php
+++ b/lib/internal/Magento/Framework/Simplexml/Element.php
@@ -326,7 +326,7 @@ class Element extends \SimpleXMLElement
      */
     public function appendChild($source)
     {
-        if ($source->children()) {
+        if ($source->count()) {
             $child = $this->addChild($source->getName());
         } else {
             $child = $this->addChild($source->getName(), $this->xmlentities($source));


### PR DESCRIPTION
https://github.com/magento/magento2/issues/1035

A bug in the appendChild method of Magento\Framework\Simplexml\Element.php causes values to be lost in very specific cases. This will fix it. The existing unit test for appendChild has been updated as well.

Bug: When appending a node that has an attribute and no child nodes, the code will take the code path for having children. This is because the result of $source->children() evaluates to TRUE when a node has attributes and no children.
Example: 
```php
$root = simplexml_load_string('<root/>', 'Magento\Framework\Simplexml\Element');
$append = simplexml_load_string('<child attr="abc">Text</child>', 'Magento\Framework\Simplexml\Element');
$root->appendChild($append);
echo $root->asNiceXml();
```
Should output:
```xml
<root>
    <child attr="abc">Text</child>
</root>
```
Actually outputs:
```xml
<root>
    <child attr="abc" />
</root>
```

Fix: Changing to call from [children()] to [count()] fixes the issue.