### PR TITLE
Fix for missed cronjobs history cleanup

### DIFF
--- a/app/code/Magento/Cron/Model/Observer.php
+++ b/app/code/Magento/Cron/Model/Observer.php
@@ -353,7 +353,8 @@ class Observer
         $now = time();
         /** @var Schedule $record */
         foreach ($history as $record) {
-            if (strtotime($record->getExecutedAt()) < $now - $historyLifetimes[$record->getStatus()]) {
+            $checkTime = strtotime($record->getExecutedAt() ? $record->getExecutedAt() : $record->getScheduledAt());
+            if ($checkTime < $now - $historyLifetimes[$record->getStatus()]) {
                 $record->delete();
             }
         }


### PR DESCRIPTION
This is Magento 1 legacy code, so the same issue exists in Magento 1.

Magento clean up mechanism for scheduled cronjobs has two options:
1. Clean success history after x seconds
2. Clean failure history after y seconds

Success job is the one with status Success.
Failure job is the one with statuses Missed or Error.

Unfortunately, when Magento cleans up job's history, the script will clean jobs with status Missed, ignoring option "Clean success/failure history after some seconds".

Scheduled cronjobs with status Missed do not have executed time field filled. So Missed cronjob will be erased besides of Clean success/failure history after some seconds option.

I propose to use "ScheduledAt" time (because it is always filled when schedule is generated) if job was not executed ("ExecutedAt" field is empty).

Testing scenario for this case:

1. Set cronjob configuration:
 * "Generate Schedules Every" to '15'
 * "Schedule Ahead for" to '20'
 * "Missed if Not Run Within" to '3'
 * "History Cleanup Every" to '10'
 * "Success History Lifetime" to '60'
 * "Failure History Lifetime" to '600'
3. Add job to cron job with interval of * * * * * (every minute)
4. Run ./pub/cron.php in Magento 2 directory (scheduler should generate jobs for new task in every minute)
5. Run ./pub/cron.php after 5 minutes (scheduler will mark some of new jobs as missed)
6. Run ./pub/cron.php after 15 - history will be cleaned up, jobs marked as missed will be erased (while they should not be erased, in my opinion)