### PR TITLE
#865: add getParams/setParam to RequestInterface

### DIFF
--- a/dev/tests/unit/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/SaveTest.php
+++ b/dev/tests/unit/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/SaveTest.php
@@ -153,7 +153,7 @@ class SaveTest extends \PHPUnit_Framework_TestCase
 
         $this->request = $this->getMock(
             'Magento\Framework\App\RequestInterface',
-            ['getParam', 'getModuleName', 'setModuleName', 'getActionName', 'setActionName', 'getCookie'],
+            ['getParam', 'getModuleName', 'setModuleName', 'getActionName', 'setActionName', 'getCookie', 'getParams', 'setParams'],
             [],
             '',
             false

--- a/dev/tests/unit/testsuite/Magento/Checkout/Helper/CartTest.php
+++ b/dev/tests/unit/testsuite/Magento/Checkout/Helper/CartTest.php
@@ -73,7 +73,9 @@ class CartTest extends \PHPUnit_Framework_TestCase
                 'getActionName',
                 'setModuleName',
                 'getModuleName',
-                'getCookie'
+                'getCookie',
+                'getParams',
+                'setParams'
             ]
         );
         $contextMock = $this->getMock('\Magento\Framework\App\Helper\Context', [], [], '', false);

--- a/dev/tests/unit/testsuite/Magento/Checkout/Model/Type/OnepageTest.php
+++ b/dev/tests/unit/testsuite/Magento/Checkout/Model/Type/OnepageTest.php
@@ -134,7 +134,7 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
         $this->storeManagerMock = $this->getMock('Magento\Framework\Store\StoreManagerInterface');
         $this->requestMock = $this->getMock(
             'Magento\Framework\App\RequestInterface',
-            ['isAjax', 'getModuleName', 'setModuleName', 'getActionName', 'setActionName', 'getParam', 'getCookie']
+            ['isAjax', 'getModuleName', 'setModuleName', 'getActionName', 'setActionName', 'getParam', 'getCookie', 'getParams', 'setParams']
         );
         $this->addressFactoryMock = $this->getMock('Magento\Customer\Model\AddressFactory', [], [], '', false);
         $this->formFactoryMock = $this->getMock('Magento\Customer\Model\Metadata\FormFactory', [], [], '', false);

--- a/dev/tests/unit/testsuite/Magento/Core/App/Router/BaseTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/App/Router/BaseTest.php
@@ -70,6 +70,7 @@ class BaseTest extends \Magento\Test\BaseTestCase
             'getPost',
             'isSecure',
             'setParams',
+            'getParams'
         ];
 
         $this->requestMock = $this->getMock('Magento\Framework\App\RequestInterface', $requestMethods);

--- a/dev/tests/unit/testsuite/Magento/Core/App/Router/NoRouteHandlerTest.php
+++ b/dev/tests/unit/testsuite/Magento/Core/App/Router/NoRouteHandlerTest.php
@@ -39,6 +39,8 @@ class NoRouteHandlerTest extends \Magento\Test\BaseTestCase
             'setModuleName',
             'setControllerName',
             'getCookie',
+            'getParams',
+            'setParams'
         ];
         $this->requestMock = $this->getMock(
             'Magento\Framework\App\RequestInterface',

--- a/dev/tests/unit/testsuite/Magento/Customer/Controller/Account/CreateTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Controller/Account/CreateTest.php
@@ -65,7 +65,7 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $this->response = $this->getMock('Magento\Framework\App\ResponseInterface');
         $this->request = $this->getMock(
             'Magento\Framework\App\RequestInterface',
-            ['isPost', 'getModuleName', 'setModuleName', 'getActionName', 'setActionName', 'getParam', 'getCookie'],
+            ['isPost', 'getModuleName', 'setModuleName', 'getActionName', 'setActionName', 'getParam', 'getCookie', 'setParams', 'getParams'],
             [],
             '',
             false

--- a/dev/tests/unit/testsuite/Magento/Customer/Controller/Account/LoginPostTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Controller/Account/LoginPostTest.php
@@ -105,7 +105,7 @@ class LoginPostTest extends \PHPUnit_Framework_TestCase
     {
         $this->request = $this->getMock(
             'Magento\Framework\App\RequestInterface',
-            ['isPost', 'getModuleName', 'setModuleName', 'getActionName', 'setActionName', 'getParam', 'getCookie'],
+            ['isPost', 'getModuleName', 'setModuleName', 'getActionName', 'setActionName', 'getParam', 'getCookie', 'getParams', 'getParams'],
             [],
             '',
             false

--- a/dev/tests/unit/testsuite/Magento/Customer/Controller/Adminhtml/Index/IndexTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Controller/Adminhtml/Index/IndexTest.php
@@ -72,7 +72,9 @@ class IndexTest extends \PHPUnit_Framework_TestCase
                     'getActionName',
                     'setActionName',
                     'getParam',
-                    'getCookie'
+                    'getCookie',
+                    'getParams',
+                    'setParams'
                 ]
             )
             ->getMock();

--- a/dev/tests/unit/testsuite/Magento/Customer/Controller/Ajax/LoginTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Controller/Ajax/LoginTest.php
@@ -79,7 +79,9 @@ class LoginTest extends \PHPUnit_Framework_TestCase
                 'getCookie',
                 'getRawBody',
                 'getMethod',
-                'isXmlHttpRequest'
+                'isXmlHttpRequest',
+                'getParams',
+                'setParams'
             ],
             [],
             '',

--- a/dev/tests/unit/testsuite/Magento/Customer/Model/Metadata/Form/FileTest.php
+++ b/dev/tests/unit/testsuite/Magento/Customer/Model/Metadata/Form/FileTest.php
@@ -49,6 +49,7 @@ class FileTest extends AbstractFormTestCase
                     'getActionName',
                     'setActionName',
                     'getCookie',
+                    'setParams'
                 ]
             )
             ->getMock();

--- a/dev/tests/unit/testsuite/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/LinkTest.php
+++ b/dev/tests/unit/testsuite/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/LinkTest.php
@@ -58,7 +58,9 @@ class LinkTest extends \PHPUnit_Framework_TestCase
                 'setModuleName',
                 'getActionName',
                 'setActionName',
-                'getCookie'
+                'getCookie',
+                'getParams',
+                'setParams'
             ]
         );
         $this->response = $this->getMock(

--- a/dev/tests/unit/testsuite/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/SampleTest.php
+++ b/dev/tests/unit/testsuite/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/SampleTest.php
@@ -58,7 +58,9 @@ class SampleTest extends \PHPUnit_Framework_TestCase
                 'setModuleName',
                 'getActionName',
                 'setActionName',
-                'getCookie'
+                'getCookie',
+                'getParams',
+                'setParams'
             ]
         );
         $this->response = $this->getMock(

--- a/dev/tests/unit/testsuite/Magento/Downloadable/Controller/Download/LinkTest.php
+++ b/dev/tests/unit/testsuite/Magento/Downloadable/Controller/Download/LinkTest.php
@@ -90,7 +90,9 @@ class LinkTest extends \PHPUnit_Framework_TestCase
                 'setModuleName',
                 'getActionName',
                 'setActionName',
-                'getCookie'
+                'getCookie',
+                'getParams',
+                'setParams'
             ]
         );
         $this->response = $this->getMock(

--- a/dev/tests/unit/testsuite/Magento/Framework/App/Action/ActionTest.php
+++ b/dev/tests/unit/testsuite/Magento/Framework/App/Action/ActionTest.php
@@ -100,7 +100,8 @@ class ActionTest extends \PHPUnit_Framework_TestCase
                 'getActionName',
                 'setActionName',
                 'getParam',
-                'getCookie'
+                'getCookie',
+                'getParams'
             ],
             [],
             '',

--- a/dev/tests/unit/testsuite/Magento/Framework/Controller/Result/ForwardTest.php
+++ b/dev/tests/unit/testsuite/Magento/Framework/Controller/Result/ForwardTest.php
@@ -35,7 +35,8 @@ class ForwardTest extends \PHPUnit_Framework_TestCase
                 'getCookie',
                 'setDispatched',
                 'setParams',
-                'setControllerName'
+                'setControllerName',
+                'getParams'
             ],
             [],
             '',

--- a/dev/tests/unit/testsuite/Magento/Framework/UrlTest.php
+++ b/dev/tests/unit/testsuite/Magento/Framework/UrlTest.php
@@ -96,7 +96,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     protected function getRequestMock($mockMethods = [])
     {
         $interfaceMethods =
-            ['getModuleName', 'setModuleName', 'getActionName', 'setActionName', 'getParam', 'getCookie'];
+            ['getModuleName', 'setModuleName', 'getActionName', 'setActionName', 'getParam', 'getCookie', 'getParams', 'setParams'];
         return $this->getMock('Magento\Framework\App\RequestInterface', array_merge($interfaceMethods, $mockMethods));
     }
 
@@ -118,7 +118,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetCurrentUrl($port, $url)
     {
-        $requestMock = $this->getRequestMock(['getServer', 'getScheme', 'getHttpHost']);
+        $requestMock = $this->getRequestMock(['getServer', 'getScheme', 'getHttpHost', 'getParams', 'setParams']);
         $requestMock->expects($this->at(0))->method('getServer')->with('SERVER_PORT')
             ->will($this->returnValue($port));
         $requestMock->expects($this->at(1))->method('getServer')->with('REQUEST_URI')
@@ -182,7 +182,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetUrl($query, $queryResult, $returnUri)
     {
-        $requestMock = $this->getRequestMock(['isDirectAccessFrontendName', 'getAlias']);
+        $requestMock = $this->getRequestMock(['isDirectAccessFrontendName', 'getAlias', 'getParams', 'setParams']);
         $routeConfigMock = $this->getMock('Magento\Framework\App\Route\ConfigInterface');
         $model = $this->getUrlModel(
             ['scopeResolver' => $this->scopeResolverMock, 'routeParamsResolver' => $this->getRouteParamsResolver(),
@@ -267,7 +267,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     {
         $this->routeParamsResolverMock->expects($this->any())->method('getRouteParams')
             ->will($this->returnValue(['foo' => 'bar']));
-        $request = $this->getRequestMock(['isDirectAccessFrontendName', 'getAlias']);
+        $request = $this->getRequestMock(['isDirectAccessFrontendName', 'getAlias', 'getParams', 'setParams']);
         $request->expects($this->once())->method('getAlias')->will($this->returnValue('/catalog/product/view/'));
         $model = $this->getUrlModel([
             'scopeResolver' => $this->scopeResolverMock,
@@ -303,6 +303,8 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             'getRequestedRouteName',
             'getRequestedControllerName',
             'getRequestedActionName',
+            'getParams',
+            'setParams'
         ]);
         $routeConfigMock = $this->getMock('Magento\Framework\App\Route\ConfigInterface');
         $model = $this->getUrlModel(
@@ -336,7 +338,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDirectUrl()
     {
-        $requestMock = $this->getRequestMock(['isDirectAccessFrontendName', 'getAlias']);
+        $requestMock = $this->getRequestMock(['isDirectAccessFrontendName', 'getAlias', 'getParams', 'setParams']);
         $routeConfigMock = $this->getMock('Magento\Framework\App\Route\ConfigInterface');
         $model = $this->getUrlModel(
             ['scopeResolver' => $this->scopeResolverMock, 'routeParamsResolver' => $this->getRouteParamsResolver(),
@@ -364,7 +366,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetRebuiltUrl($url)
     {
-        $requestMock = $this->getRequestMock(['getHttpHost']);
+        $requestMock = $this->getRequestMock(['getHttpHost', 'getParams', 'setParams']);
         $model = $this->getUrlModel([
             'session' => $this->sessionMock,
             'request' => $requestMock,
@@ -459,7 +461,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsOwnOriginUrl($result, $baseUrl, $referrer)
     {
-        $requestMock = $this->getRequestMock(['setServer', 'getServer']);
+        $requestMock = $this->getRequestMock(['setServer', 'getServer', 'getParams', 'setParams']);
         $model = $this->getUrlModel(['scopeResolver' => $this->scopeResolverMock, 'request' => $requestMock]);
 
         $this->scopeMock->expects($this->any())->method('getBaseUrl')->will($this->returnValue($baseUrl));
@@ -567,7 +569,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testSessionUrlVarWithMatchedHostsAndBaseUrl($html, $result)
     {
-        $requestMock = $this->getRequestMock(['getHttpHost']);
+        $requestMock = $this->getRequestMock(['getHttpHost', 'setParams', 'getParams']);
         $model = $this->getUrlModel(
             ['session' => $this->sessionMock, 'request' => $requestMock, 'sidResolver' => $this->sidResolverMock,
                 'scopeResolver' => $this->scopeResolverMock, 'routeParamsResolver' => $this->getRouteParamsResolver(), ]
@@ -590,7 +592,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     public function testSessionUrlVarWithoutMatchedHostsAndBaseUrl()
     {
-        $requestMock = $this->getRequestMock(['getHttpHost']);
+        $requestMock = $this->getRequestMock(['getHttpHost', 'getParams', 'setParams']);
         $model = $this->getUrlModel(
             ['session' => $this->sessionMock, 'request' => $requestMock, 'sidResolver' => $this->sidResolverMock,
                 'scopeResolver' => $this->scopeResolverMock, 'routeParamsResolver' => $this->getRouteParamsResolver(), ]
@@ -638,7 +640,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     public function testSetRequest()
     {
-        $requestMethods = ['getServer', 'getScheme', 'getHttpHost'];
+        $requestMethods = ['getServer', 'getScheme', 'getHttpHost', 'getParams', 'setParams'];
         $initRequestMock = $this->getRequestMock($requestMethods);
         $requestMock = $this->getRequestMock($requestMethods);
         $initRequestMock->expects($this->any())->method('getScheme')->will($this->returnValue('fake'));


### PR DESCRIPTION
As per issue #865, the getParams and setParams method is missing from the RequestInterface. Which are methods relied upon heavily in app/code/Magento/*.