### PR TITLE
fix typo in MAGE_MODE

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -13,7 +13,7 @@
 #    listen 80;
 #    server_name mage.dev;
 #    set $MAGE_ROOT /var/www/magento2;
-#    set $MAGE_MODE develop;
+#    set $MAGE_MODE developer;
 #    include /vagrant/magento2/nginx.conf.sample;
 # }
 


### PR DESCRIPTION
In the nginx sample configuration commented value of the MAGE_MODE variable is "develop". Magento will fail to start with this value, because correct one is "developer".