### PR TITLE
Add check to see if PHP > 5.6 and always_populate_raw_post_data = -1

### DIFF
--- a/setup/pub/magento/setup/readiness-check.js
+++ b/setup/pub/magento/setup/readiness-check.js
@@ -32,6 +32,11 @@ angular.module('readiness-check', [])
             processed: false,
             expanded: false
         };
+        $scope.rawpost = {
+            visible: false,
+            processed: false,
+            expanded: false
+        };
         $scope.extensions = {
             visible: false,
             processed: false,
@@ -54,6 +59,19 @@ angular.module('readiness-check', [])
                     $scope.version.processed = true;
                     angular.extend($scope.version, data);
                     $scope.updateOnProcessed($scope.version.responseType);
+                    $scope.stopProgress();
+                }
+            },
+            'php-rawpost': {
+                url:'index.php/environment/php-rawpost',
+                show: function() {
+                    $scope.startProgress();
+                    $scope.rawpost.visible = true;
+                },
+                process: function(data) {
+                    $scope.rawpost.processed = true;
+                    angular.extend($scope.rawpost, data);
+                    $scope.updateOnProcessed($scope.rawpost.responseType);
                     $scope.stopProgress();
                 }
             },

--- a/setup/src/Magento/Setup/Controller/Environment.php
+++ b/setup/src/Magento/Setup/Controller/Environment.php
@@ -82,6 +82,29 @@ class Environment extends AbstractActionController
     }
 
     /**
+     * Checks if PHP version >= 5.6.0 and always_populate_raw_post_data is set
+     *
+     * @return JsonModel
+     */
+    public function phpRawpostAction()
+    {
+        $iniSetting = ini_get('always_populate_raw_post_data');
+        $responseType = ResponseTypeInterface::RESPONSE_TYPE_SUCCESS;
+        if (version_compare(PHP_VERSION, '5.6.0') >= 0 && (int)$iniSetting > -1) {
+            $responseType = ResponseTypeInterface::RESPONSE_TYPE_ERROR;
+        }
+        $data = [
+            'responseType' => $responseType,
+            'data' => [
+                'version' => PHP_VERSION,
+                'ini' => ini_get('always_populate_raw_post_data')
+            ]
+        ];
+
+        return new JsonModel($data);
+    }
+
+    /**
      * Verifies php verifications
      *
      * @return JsonModel

--- a/setup/src/Magento/Setup/Controller/Environment.php
+++ b/setup/src/Magento/Setup/Controller/Environment.php
@@ -97,7 +97,7 @@ class Environment extends AbstractActionController
             'responseType' => $responseType,
             'data' => [
                 'version' => PHP_VERSION,
-                'ini' => ini_get('always_populate_raw_post_data')
+                'ini' => $iniSetting
             ]
         ];
 

--- a/setup/view/magento/setup/readiness-check/progress.phtml
+++ b/setup/view/magento/setup/readiness-check/progress.phtml
@@ -85,6 +85,59 @@
 
 </div>
 
+<div id="php-rawpost" class="rediness-check-item" ng-show="rawpost.visible">
+
+    <h3 class="readiness-check-title" ng-hide="version.processed">
+        Checking PHP Version and PHP Raw Post Data Settings...
+    </h3>
+
+    <div ng-show="rawpost.processed" ng-switch="rawpost.responseType">
+
+        <div ng-switch-when="success" ng-init="updateOnSuccess(rawpost)">
+
+            <span class="readiness-check-icon icon-success-round"></span>
+
+            <div class="readiness-check-content">
+                <h3 class="readiness-check-title">PHP Raw Post Data Check</h3>
+                <p>
+                    You are not populating raw_post_data or your PHP version is less than 5.6.0
+                </p>
+            </div>
+
+        </div>
+
+        <div class="readiness-check-item" ng-switch-default ng-init="updateOnError(rawpost)">
+
+            <div class="rediness-check-side">
+                <p class="side-title">Need Help?</p>
+                <a href="http://www.php.net/docs.php" target="_blank">PHP Documentation</a>
+            </div>
+
+            <span class="readiness-check-icon icon-failed-round"></span>
+
+            <div class="readiness-check-content">
+                <h3 class="readiness-check-title">PHP Raw Post Data Check</h3>
+                <p>
+                    Your PHP Version is {{rawpost.data.version}}<br />
+                    always_populate_raw_post_data = {{rawpost.data.ini}}.
+                    <a href="#php-rawpost" ng-click="updateOnExpand(rawpost)">
+                        <span ng-hide="rawpost.expanded">Show detail</span>
+                        <span ng-show="rawpost.expanded">Hide detail</span>
+                    </a>
+                </p>
+                <p ng-show="rawpost.expanded">
+                    $HTTP_RAW_POST_DATA is deprecated from PHP 5.6 onwards and will stop the installer from running,
+                    please open your php.ini file and set always_populate_raw_post_data to -1 (uncomment if necessary)
+                </p>
+                <p ng-show="rawpost.expanded">If you need more help please call your hosting provider.</p>
+            </div>
+
+        </div>
+
+    </div>
+
+</div>
+
 <div id="php-extensions" class="rediness-check-item" ng-show="extensions.visible">
 
     <h3 ng-hide="extensions.processed" class="readiness-check-title">


### PR DESCRIPTION
Fix for issue [#1057](https://github.com/magento/magento2/issues/1057)

$HTTP_RAW_POST_DATA has been deprecated in PHP 5.6 the ini setting is commented out by default however this causes PHP to throw an E_DEPRECATED notice whenever it receives post data that isn't `application/x-www-form-urlencoded` (e.g. `application\json`).

This is causing the database check to fail during Web Setup as Angular JS posts `application\json` by default. This fix checks the users PHP version and the value of `always_populate_raw_post_data` and warns if they are using PHP >= 5.6.0 and `always_populate_raw_post_data` isn't explicitly set to -1