### PR TITLE
Add 7.0 and HHVM to Travis-CI as allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
+  - hhvm
 env:
   - TEST_SUITE=unit
   - TEST_SUITE=integration
@@ -14,6 +16,17 @@ matrix:
       env: TEST_SUITE=static_phpcs
     - php: 5.6
       env: TEST_SUITE=static_annotation
+    - php: hhvm
+      env: TEST_SUITE=static_phpcs
+    - php: hhvm
+      env: TEST_SUITE=static_annotation
+    - php: 7.0
+      env: TEST_SUITE=static_phpcs
+    - php: 7.0
+      env: TEST_SUITE=static_annotation
+  allow_failures:
+    - php: hhvm
+    - php: 7.0
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq postfix


### PR DESCRIPTION
This pull request allows developers and contributors to track how Magento tests are faring against hhvm and 7.0; while not raising a red flag for any failures.

It's best to track this data early on so that supporting them can be considered in the future. There's no harm to include them, so why not do so?