### PR TITLE
Move Topmenu CategoryData creation to a public method to enable plugin ...

### DIFF
--- a/app/code/Magento/Catalog/Model/Observer.php
+++ b/app/code/Magento/Catalog/Model/Observer.php
@@ -136,7 +136,7 @@ class Observer
 
             $tree = $parentCategoryNode->getTree();
 
-            $categoryData = $this->getMenuCategoryData($category);
+            $categoryData = $this->_getMenuCategoryData($category);
 
             $categoryNode = new \Magento\Framework\Data\Tree\Node($categoryData, 'id', $tree, $parentCategoryNode);
             $parentCategoryNode->addChild($categoryNode);
@@ -158,7 +158,7 @@ class Observer
      * @param \Magento\Framework\Data\Tree\Node $category
      * @return array
      */
-    public function getMenuCategoryData($category)
+    protected function _getMenuCategoryData($category)
     {
 
         $nodeId = 'category-node-' . $category->getId();

--- a/app/code/Magento/Catalog/Model/Observer.php
+++ b/app/code/Magento/Catalog/Model/Observer.php
@@ -132,17 +132,12 @@ class Observer
                 continue;
             }
 
-            $nodeId = 'category-node-' . $category->getId();
-
             $block->addIdentity(\Magento\Catalog\Model\Category::CACHE_TAG . '_' . $category->getId());
 
             $tree = $parentCategoryNode->getTree();
-            $categoryData = [
-                'name' => $category->getName(),
-                'id' => $nodeId,
-                'url' => $this->_catalogCategory->getCategoryUrl($category),
-                'is_active' => $this->_isActiveMenuCategory($category),
-            ];
+
+            $categoryData = $this->getMenuCategoryData($category);
+
             $categoryNode = new \Magento\Framework\Data\Tree\Node($categoryData, 'id', $tree, $parentCategoryNode);
             $parentCategoryNode->addChild($categoryNode);
 
@@ -154,6 +149,28 @@ class Observer
 
             $this->_addCategoriesToMenu($subcategories, $categoryNode, $block);
         }
+    }
+
+
+    /**
+     * Get category data to be added to the Menu
+     *
+     * @param \Magento\Framework\Data\Tree\Node $category
+     * @return array
+     */
+    public function getMenuCategoryData($category)
+    {
+
+        $nodeId = 'category-node-' . $category->getId();
+
+        $categoryData = [
+            'name' => $category->getName(),
+            'id' => $nodeId,
+            'url' => $this->_catalogCategory->getCategoryUrl($category),
+            'is_active' => $this->_isActiveMenuCategory($category),
+        ];
+
+        return $categoryData;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Observer.php
+++ b/app/code/Magento/Catalog/Model/Observer.php
@@ -136,7 +136,7 @@ class Observer
 
             $tree = $parentCategoryNode->getTree();
 
-            $categoryData = $this->_getMenuCategoryData($category);
+            $categoryData = $this->getMenuCategoryData($category);
 
             $categoryNode = new \Magento\Framework\Data\Tree\Node($categoryData, 'id', $tree, $parentCategoryNode);
             $parentCategoryNode->addChild($categoryNode);
@@ -158,7 +158,7 @@ class Observer
      * @param \Magento\Framework\Data\Tree\Node $category
      * @return array
      */
-    protected function _getMenuCategoryData($category)
+    public function getMenuCategoryData($category)
     {
 
         $nodeId = 'category-node-' . $category->getId();


### PR DESCRIPTION
Magento provides a couple of nice observers that "Allow extensions to modify select (e.g. add custom category attributes to select)" namely catalog_category_flat_loadnodes_before and page_block_html_topmenu_gethtml_before. However once added to the select there is (I belive) no nice way to add the data to the topmenu.

Currently I need to disable catalog_add_topmenu_items and add my own observer to replace it, not very nice as only I can do this meaning other extensions cannot also add data. I propose moving the generation of $categoryData to a seperate public function so that I can add data with Plugins.