### PR TITLE
Add developer mode example to .htacess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,9 @@
 ############################################
+## uncomment the line below to enable developer mode
+
+#   SetEnv MAGE_MODE developer
+
+############################################
 ## uncomment these lines for CGI mode
 ## make sure to specify the correct cgi php binary file name
 ## it might be /cgi-bin/php-cgi

--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -1,4 +1,9 @@
 ############################################
+## uncomment the line below to enable developer mode
+
+#   SetEnv MAGE_MODE developer
+
+############################################
 ## uncomment these lines for CGI mode
 ## make sure to specify the correct cgi php binary file name
 ## it might be /cgi-bin/php-cgi

--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -1,4 +1,9 @@
 ############################################
+## uncomment the line below to enable developer mode
+
+#   SetEnv MAGE_MODE developer
+
+############################################
 ## uncomment these lines for CGI mode
 ## make sure to specify the correct cgi php binary file name
 ## it might be /cgi-bin/php-cgi


### PR DESCRIPTION
After years on M1 I allmost allways still google "Magento set developer mode" to get the Developer Mode snippet. I figure it would be nice to just have it there in .htacess as an example as 99% of the time that is why I am going to this file.