### PR TITLE
Render menu via template file.

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -42,11 +42,11 @@ class Topmenu extends Template implements IdentityInterface
      *
      * @param string $outermostClass
      * @param string $childrenWrapClass
-     * @param int $limit
      * @return string
      */
-    public function getHtml($outermostClass = '', $childrenWrapClass = '', $limit = 0)
+    public function getHtml($outermostClass = '', $childrenWrapClass = '')
     {
+
         $this->_eventManager->dispatch(
             'page_block_html_topmenu_gethtml_before',
             ['menu' => $this->_menu, 'block' => $this]
@@ -55,9 +55,17 @@ class Topmenu extends Template implements IdentityInterface
         $this->_menu->setOutermostClass($outermostClass);
         $this->_menu->setChildrenWrapClass($childrenWrapClass);
 
-        $html = $this->_getHtml($this->_menu, $childrenWrapClass, $limit);
+        $renderer = $this->getChildBlock('catalog.topnav.renderer');
+
+        if(!$renderer){
+            $renderer = $this->getLayout()->createBlock('Magento\Theme\Block\Html\Topmenu\Renderer');
+        }
+
+        $renderer->setMenuTree($this->_menu)->setChildrenWrapClass($childrenWrapClass);
+        $html = $renderer->toHtml();
 
         $transportObject = new \Magento\Framework\Object(['html' => $html]);
+
         $this->_eventManager->dispatch(
             'page_block_html_topmenu_gethtml_after',
             ['menu' => $this->_menu, 'transportObject' => $transportObject]
@@ -129,109 +137,12 @@ class Topmenu extends Template implements IdentityInterface
     }
 
     /**
-     * Add sub menu HTML code for current menu item
-     *
-     * @param \Magento\Framework\Data\Tree\Node $child
-     * @param string $childLevel
-     * @param string $childrenWrapClass
-     * @param int $limit
-     * @return string HTML code
-     */
-    protected function _addSubMenu($child, $childLevel, $childrenWrapClass, $limit)
-    {
-        $html = '';
-        if (!$child->hasChildren()) {
-            return $html;
-        }
-
-        $colStops = null;
-        if ($childLevel == 0 && $limit) {
-            $colStops = $this->_columnBrake($child->getChildren(), $limit);
-        }
-
-        $html .= '<ul class="level' . $childLevel . ' submenu">';
-        $html .= $this->_getHtml($child, $childrenWrapClass, $limit, $colStops);
-        $html .= '</ul>';
-
-        return $html;
-    }
-
-    /**
-     * Recursively generates top menu html from data that is specified in $menuTree
-     *
-     * @param \Magento\Framework\Data\Tree\Node $menuTree
-     * @param string $childrenWrapClass
-     * @param int $limit
-     * @param array $colBrakes
-     * @return string
-     *
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-     * @SuppressWarnings(PHPMD.NPathComplexity)
-     */
-    protected function _getHtml(
-        \Magento\Framework\Data\Tree\Node $menuTree,
-        $childrenWrapClass,
-        $limit,
-        $colBrakes = []
-    ) {
-        $html = '';
-
-        $children = $menuTree->getChildren();
-        $parentLevel = $menuTree->getLevel();
-        $childLevel = $parentLevel === null ? 0 : $parentLevel + 1;
-
-        $counter = 1;
-        $itemPosition = 1;
-        $childrenCount = $children->count();
-
-        $parentPositionClass = $menuTree->getPositionClass();
-        $itemPositionClassPrefix = $parentPositionClass ? $parentPositionClass . '-' : 'nav-';
-
-        foreach ($children as $child) {
-            $child->setLevel($childLevel);
-            $child->setIsFirst($counter == 1);
-            $child->setIsLast($counter == $childrenCount);
-            $child->setPositionClass($itemPositionClassPrefix . $counter);
-
-            $outermostClassCode = '';
-            $outermostClass = $menuTree->getOutermostClass();
-
-            if ($childLevel == 0 && $outermostClass) {
-                $outermostClassCode = ' class="' . $outermostClass . '" ';
-                $child->setClass($outermostClass);
-            }
-
-            if (count($colBrakes) && $colBrakes[$counter]['colbrake']) {
-                $html .= '</ul></li><li class="column"><ul>';
-            }
-
-            $html .= '<li ' . $this->_getRenderedMenuItemAttributes($child) . '>';
-            $html .= '<a href="' . $child->getUrl() . '" ' . $outermostClassCode . '><span>' . $this->escapeHtml(
-                $child->getName()
-            ) . '</span></a>' . $this->_addSubMenu(
-                $child,
-                $childLevel,
-                $childrenWrapClass,
-                $limit
-            ) . '</li>';
-            $itemPosition++;
-            $counter++;
-        }
-
-        if (count($colBrakes) && $limit) {
-            $html = '<li class="column"><ul>' . $html . '</ul></li>';
-        }
-
-        return $html;
-    }
-
-    /**
      * Generates string with all attributes that should be present in menu item element
      *
      * @param \Magento\Framework\Data\Tree\Node $item
      * @return string
      */
-    protected function _getRenderedMenuItemAttributes(\Magento\Framework\Data\Tree\Node $item)
+    public function _getRenderedMenuItemAttributes(\Magento\Framework\Data\Tree\Node $item)
     {
         $html = '';
         $attributes = $this->_getMenuItemAttributes($item);

--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -142,7 +142,7 @@ class Topmenu extends Template implements IdentityInterface
      * @param \Magento\Framework\Data\Tree\Node $item
      * @return string
      */
-    public function _getRenderedMenuItemAttributes(\Magento\Framework\Data\Tree\Node $item)
+    public function getRenderedMenuItemAttributes(\Magento\Framework\Data\Tree\Node $item)
     {
         $html = '';
         $attributes = $this->_getMenuItemAttributes($item);

--- a/app/code/Magento/Theme/Block/Html/Topmenu/Renderer.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu/Renderer.php
@@ -27,7 +27,7 @@ class Renderer extends Topmenu
         }
 
         if (!$this->isTemplateFileValid($this->getTemplateFile())) {
-            throw new \Magento\Framework\Exception('Not valid template file:' . $this->_templateFile);
+            throw new \Magento\Framework\Exception('Not valid template file:' . $this->getTemplateFile());
         }
 
         return $this->render($menuTree,$childrenWrapClass);

--- a/app/code/Magento/Theme/Block/Html/Topmenu/Renderer.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu/Renderer.php
@@ -46,7 +46,7 @@ class Renderer extends Topmenu
      * @param int $limit
      * @return string HTML code
      */
-    public function _addSubMenu($child, $childLevel, $childrenWrapClass, $limit)
+    public function addSubMenu($child, $childLevel, $childrenWrapClass, $limit)
     {
         $html = '';
         if (!$child->hasChildren()) {

--- a/app/code/Magento/Theme/Block/Html/Topmenu/Renderer.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu/Renderer.php
@@ -74,9 +74,7 @@ class Renderer extends Topmenu
             $colStops = $this->_columnBrake($child->getChildren(), $limit);
         }
 
-        $html .= '<ul class="level' . $childLevel . ' submenu">';
         $html .= $this->render($child, $childrenWrapClass, $limit, $colStops);
-        $html .= '</ul>';
 
         return $html;
     }

--- a/app/code/Magento/Theme/Block/Html/Topmenu/Renderer.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu/Renderer.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Theme\Block\Html\Topmenu;
+
+use Magento\Theme\Block\Html\Topmenu;
+
+class Renderer extends Topmenu
+{
+    protected $_template = 'html/topmenu/renderer.phtml';
+
+    protected function _toHtml()
+    {
+        $menuTree = $this->getMenuTree();
+        $childrenWrapClass = $this->getChildrenWrapClass();
+
+        if(!$this->getTemplate() || is_null($menuTree) || is_null($childrenWrapClass)) {
+            throw new \Magento\Framework\Exception("Top-menu renderer isn't fully configured.");
+        }
+
+        if (!$this->isTemplateFileValid($this->getTemplateFile())) {
+            throw new \Magento\Framework\Exception('Not valid template file:' . $this->_templateFile);
+        }
+
+        return $this->render($menuTree,$childrenWrapClass);
+    }
+
+    public function render($menuTree,$childrenWrapClass,$limit=0,$colBreaks = [])
+    {
+        $this->assign('menuTree',$menuTree);
+        $this->assign('childrenWrapClass',$childrenWrapClass);
+        $this->assign('colBrakes',$colBreaks);
+        $this->assign('limit',$limit);
+
+        return $this->fetchView($this->getTemplateFile());
+    }
+
+    /**
+     * Add sub menu HTML code for current menu item
+     *
+     * @param \Magento\Framework\Data\Tree\Node $child
+     * @param string $childLevel
+     * @param string $childrenWrapClass
+     * @param int $limit
+     * @return string HTML code
+     */
+    public function _addSubMenu($child, $childLevel, $childrenWrapClass, $limit)
+    {
+        $html = '';
+        if (!$child->hasChildren()) {
+            return $html;
+        }
+
+        $colStops = null;
+        if ($childLevel == 0 && $limit) {
+            $colStops = $this->_columnBrake($child->getChildren(), $limit);
+        }
+
+        $html .= '<ul class="level' . $childLevel . ' submenu">';
+        $html .= $this->render($child, $childrenWrapClass, $limit, $colStops);
+        $html .= '</ul>';
+
+        return $html;
+    }
+}

--- a/app/code/Magento/Theme/Block/Html/Topmenu/Renderer.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu/Renderer.php
@@ -11,6 +11,12 @@ class Renderer extends Topmenu
 {
     protected $_template = 'html/topmenu/renderer.phtml';
 
+    /**
+     * Renders block html
+     *
+     * @return string
+     * @throws \Magento\Framework\Exception
+     */
     protected function _toHtml()
     {
         $menuTree = $this->getMenuTree();
@@ -27,6 +33,16 @@ class Renderer extends Topmenu
         return $this->render($menuTree,$childrenWrapClass);
     }
 
+    /**
+     * Render menu node via a template file
+     *
+     * @param       $menuTree
+     * @param       $childrenWrapClass
+     * @param int   $limit
+     * @param array $colBreaks
+     *
+     * @return string
+     */
     public function render($menuTree,$childrenWrapClass,$limit=0,$colBreaks = [])
     {
         $this->assign('menuTree',$menuTree);

--- a/app/code/Magento/Theme/view/frontend/layout/default.xml
+++ b/app/code/Magento/Theme/view/frontend/layout/default.xml
@@ -48,7 +48,9 @@
             </container>
         </referenceContainer>
         <referenceContainer name="page.top">
-            <block class="Magento\Theme\Block\Html\Topmenu" name="catalog.topnav" template="html/topmenu.phtml" ttl="3600"/>
+            <block class="Magento\Theme\Block\Html\Topmenu" name="catalog.topnav" template="html/topmenu.phtml" ttl="3600">
+                <block class="Magento\Theme\Block\Html\Topmenu\Renderer" name="catalog.topnav.renderer" template="html/topmenu/renderer.phtml"/>
+            </block>
             <container name="top.container" as="topContainer" label="After Page Header Top" htmlTag="div" htmlClass="top-container"/>
             <block class="Magento\Theme\Block\Html\Breadcrumbs" name="breadcrumbs" as="breadcrumbs"/>
         </referenceContainer>

--- a/app/code/Magento/Theme/view/frontend/templates/html/topmenu/renderer.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/topmenu/renderer.phtml
@@ -42,12 +42,22 @@ foreach ($children as $child) {
     $html .= '<li ' . $block->getRenderedMenuItemAttributes($child) . '>';
     $html .= '<a href="' . $child->getUrl() . '" ' . $outermostClassCode . '><span>' . $block->escapeHtml(
             $child->getName()
-        ) . '</span></a>' . $block->addSubMenu(
+        ) . '</span></a>';
+
+    if ($child->hasChildren()) {
+
+        $html .= '<ul class="level' . $childLevel . ' submenu">';
+        $html .= $block->addSubMenu(
             $child,
             $childLevel,
             $childrenWrapClass,
             $limit
-        ) . '</li>';
+        );
+        $html .= '</ul>';
+
+    }
+
+    $html .= '</li>';
     $itemPosition++;
     $counter++;
 }

--- a/app/code/Magento/Theme/view/frontend/templates/html/topmenu/renderer.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/topmenu/renderer.phtml
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * @var \Magento\Theme\Block\Html\Topmenu\Renderer $block
+ */
+
+$html = '';
+
+$children = $menuTree->getChildren();
+$parentLevel = $menuTree->getLevel();
+$childLevel = $parentLevel === null ? 0 : $parentLevel + 1;
+
+$counter = 1;
+$itemPosition = 1;
+$childrenCount = $children->count();
+
+$parentPositionClass = $menuTree->getPositionClass();
+$itemPositionClassPrefix = $parentPositionClass ? $parentPositionClass . '-' : 'nav-';
+
+foreach ($children as $child) {
+    $child->setLevel($childLevel);
+    $child->setIsFirst($counter == 1);
+    $child->setIsLast($counter == $childrenCount);
+    $child->setPositionClass($itemPositionClassPrefix . $counter);
+
+    $outermostClassCode = '';
+    $outermostClass = $menuTree->getOutermostClass();
+
+    if ($childLevel == 0 && $outermostClass) {
+        $outermostClassCode = ' class="' . $outermostClass . '" ';
+        $child->setClass($outermostClass);
+    }
+
+    if (count($colBrakes) && $colBrakes[$counter]['colbrake']) {
+        $html .= '</ul></li><li class="column"><ul>';
+    }
+
+    $html .= '<li ' . $block->_getRenderedMenuItemAttributes($child) . '>';
+    $html .= '<a href="' . $child->getUrl() . '" ' . $outermostClassCode . '><span>' . $block->escapeHtml(
+            $child->getName()
+        ) . '</span></a>' . $block->_addSubMenu(
+            $child,
+            $childLevel,
+            $childrenWrapClass,
+            $limit
+        ) . '</li>';
+    $itemPosition++;
+    $counter++;
+}
+
+if (count($colBrakes) && $limit) {
+    $html = '<li class="column"><ul>' . $html . '</ul></li>';
+}
+
+echo $html;
+
+?>

--- a/app/code/Magento/Theme/view/frontend/templates/html/topmenu/renderer.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/topmenu/renderer.phtml
@@ -39,10 +39,10 @@ foreach ($children as $child) {
         $html .= '</ul></li><li class="column"><ul>';
     }
 
-    $html .= '<li ' . $block->_getRenderedMenuItemAttributes($child) . '>';
+    $html .= '<li ' . $block->getRenderedMenuItemAttributes($child) . '>';
     $html .= '<a href="' . $child->getUrl() . '" ' . $outermostClassCode . '><span>' . $block->escapeHtml(
             $child->getName()
-        ) . '</span></a>' . $block->_addSubMenu(
+        ) . '</span></a>' . $block->addSubMenu(
             $child,
             $childLevel,
             $childrenWrapClass,


### PR DESCRIPTION
Newer versions of Magento 1.x use .phtml to render the main topMenu files, making it much easier for themes to tweak the menu html.

I have implemented this in a similar way to 1.x and since _getHtml was depreciated in the latest 1.x version I have completely dropped that and set a default template and block incase one was not found in the theme.

The .phtml still needs work as I have just copied that directly from the .php file for now. Happy to continue and attempt to redo that if this pull request is of use, but mabey that is better done by a frontend dev internally.

Undecided on the use of $this->assign( rather than $this->setVariable to set menuTree etc but using this just means I didn't need to edit the .phtml so much.