### PR TITLE
Fixed occurances of implode with wrong argument order

### DIFF
--- a/app/code/Magento/Fedex/Setup/InstallData.php
+++ b/app/code/Magento/Fedex/Setup/InstallData.php
@@ -96,7 +96,7 @@ class InstallData implements InstallDataInterface
                         $mapNew[] = $shippingMethod;
                     }
                 }
-                $mapNew = implode($mapNew, ',');
+                $mapNew = implode(',', $mapNew);
             } else {
                 continue;
             }

--- a/app/code/Magento/Payment/view/adminhtml/templates/info/default.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/info/default.phtml
@@ -19,7 +19,7 @@
 <?php foreach ($_specificInfo as $_label => $_value):?>
     <tr>
         <th><?php echo $block->escapeHtml($_label)?>:</th>
-        <td><?php echo nl2br(implode($block->getValueAsArray($_value, true), "\n"))?></td>
+        <td><?php echo nl2br(implode("\n", $block->getValueAsArray($_value, true)))?></td>
     </tr>
 <?php endforeach; ?>
 </table>

--- a/app/code/Magento/Payment/view/adminhtml/templates/info/pdf/default.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/info/pdf/default.phtml
@@ -16,8 +16,8 @@
 
 <?php if ($_specificInfo = $block->getSpecificInformation()):?>
 <?php foreach ($_specificInfo as $_label => $_value):?>
-<?php echo $_label ?>: <?php echo implode($block->getValueAsArray($_value), ' ')?>{{pdf_row_separator}}
+<?php echo $_label ?>: <?php echo implode(' ', $block->getValueAsArray($_value))?>{{pdf_row_separator}}
 <?php endforeach; ?>
 <?php endif;?>
 
-<?php echo implode($block->getChildPdfAsArray(), '{{pdf_row_separator}}') ?>
+<?php echo implode('{{pdf_row_separator}}', $block->getChildPdfAsArray()) ?>

--- a/app/code/Magento/Payment/view/frontend/templates/info/default.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/info/default.phtml
@@ -21,7 +21,7 @@
             <?php foreach ($_specificInfo as $_label => $_value):?>
                 <tr>
                     <th scope="row"><?php echo $block->escapeHtml($_label)?></th>
-                    <td><?php echo nl2br(implode($block->getValueAsArray($_value, true), "\n"))?></td>
+                    <td><?php echo nl2br(implode("\n", $block->getValueAsArray($_value, true)))?></td>
                 </tr>
             <?php endforeach; ?>
         </table>

--- a/app/code/Magento/Sales/Block/Adminhtml/Reorder/Renderer/Action.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Reorder/Renderer/Action.php
@@ -93,7 +93,7 @@ class Action extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstract
             $attributesObject->setData($action['@']);
             $html[] = '<a ' . $attributesObject->serialize() . '>' . $action['#'] . '</a>';
         }
-        return implode($html, '');
+        return implode('', $html);
     }
 
     /**

--- a/app/code/Magento/SalesRule/Model/Resource/Report/Collection.php
+++ b/app/code/Magento/SalesRule/Model/Resource/Report/Collection.php
@@ -170,7 +170,7 @@ class Collection extends \Magento\Sales\Model\Resource\Report\Collection\Abstrac
         }
 
         if (!empty($rulesFilterSqlParts)) {
-            $this->getSelect()->where(implode($rulesFilterSqlParts, ' OR '));
+            $this->getSelect()->where(implode(' OR ', $rulesFilterSqlParts));
         }
         return $this;
     }

--- a/app/code/Magento/Tax/Setup/InstallData.php
+++ b/app/code/Magento/Tax/Setup/InstallData.php
@@ -69,7 +69,7 @@ class InstallData implements InstallDataInterface
                 'visible_in_advanced_search' => true,
                 'used_in_product_listing' => true,
                 'unique' => false,
-                'apply_to' => implode($taxSetup->getTaxableItems(), ',')
+                'apply_to' => implode(',', $taxSetup->getTaxableItems())
             ]
         );
 

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertChildProductsInGrid.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertChildProductsInGrid.php
@@ -52,7 +52,7 @@ class AssertChildProductsInGrid extends AbstractConstraint
             }
         }
 
-        \PHPUnit_Framework_Assert::assertEmpty($errors, implode($errors, ' '));
+        \PHPUnit_Framework_Assert::assertEmpty($errors, implode(' ', $errors));
     }
 
     /**


### PR DESCRIPTION
Fix for issue #1116

Although implode accepts it's arguments in any order, the documented order should be used.

Searched the codebase for all occurrences of implode with incorrect argument order and corrected.