### PR TITLE
Change wording for long operation warning

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/edit/form.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/edit/form.phtml
@@ -54,7 +54,7 @@ $categoryId = $block->getCategoryId();
 
 <div data-id="information-dialog-category" class="messages admin__scope" style="display: none;">
     <div class="message message-notice">
-        <div><?php echo __('This operation can take much time'); ?></div>
+        <div><?php echo __('This operation can take a long time'); ?></div>
     </div>
 </div>
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/tree.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/tree.phtml
@@ -32,7 +32,7 @@
 
 <div data-id="information-dialog-tree" class="messages admin__scope" style="display: none;">
     <div class="message message-notice">
-       <div><?php echo __('This operation can take much time'); ?></div>
+       <div><?php echo __('This operation can take a long time'); ?></div>
     </div>
 </div>
 <!--[if IE]>


### PR DESCRIPTION
Changed working for long operation warning that for me occured when moving a category from one parent to another.