### PR TITLE
Fix for Textarea element cols and rows #675

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/Textarea.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Textarea.php
@@ -18,7 +18,7 @@ use Magento\Framework\Escaper;
  * @method mixed getCols()
  * @method Textarea setCols($cols)
  * @method mixed getRows()
- * @method mixed setRows($rows)
+ * @method Textarea setRows($rows)
  */
 class Textarea extends AbstractElement
 {

--- a/lib/internal/Magento/Framework/Data/Form/Element/Textarea.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Textarea.php
@@ -13,6 +13,13 @@ namespace Magento\Framework\Data\Form\Element;
 
 use Magento\Framework\Escaper;
 
+/**
+ * @method Textarea setExtType($extType)
+ * @method mixed getCols()
+ * @method Textarea setCols($cols)
+ * @method mixed getRows()
+ * @method mixed setRows($rows)
+ */
 class Textarea extends AbstractElement
 {
     /**
@@ -83,8 +90,8 @@ class Textarea extends AbstractElement
     {
         $this->addClass('textarea');
         $html = '<textarea id="' . $this->getHtmlId() . '" name="' . $this->getName() . '" ' . $this->serialize(
-            $this->getHtmlAttributes()
-        ) . $this->_getUiId() . ' >';
+                $this->getHtmlAttributes()
+            ) . $this->_getUiId() . ' >';
         $html .= $this->getEscapedValue();
         $html .= "</textarea>";
         $html .= $this->getAfterElementHtml();

--- a/lib/internal/Magento/Framework/Data/Form/Element/Textarea.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Textarea.php
@@ -16,6 +16,19 @@ use Magento\Framework\Escaper;
 class Textarea extends AbstractElement
 {
     /**
+     * default number of rows
+     *
+     * @var int
+     */
+    const DEFAULT_ROWS = 2;
+    /**
+     * default number of cols
+     *
+     * @var int
+     */
+    const DEFAULT_COLS = 15;
+
+    /**
      * @param Factory $factoryElement
      * @param CollectionFactory $factoryCollection
      * @param Escaper $escaper
@@ -30,8 +43,12 @@ class Textarea extends AbstractElement
         parent::__construct($factoryElement, $factoryCollection, $escaper, $data);
         $this->setType('textarea');
         $this->setExtType('textarea');
-        $this->setRows(2);
-        $this->setCols(15);
+        if (!$this->getRows()) {
+            $this->setRows(self::DEFAULT_ROWS);
+        }
+        if (!$this->getCols()) {
+            $this->setCols(self::DEFAULT_COLS);
+        }
     }
 
     /**


### PR DESCRIPTION
This should allow developers to set the number of cols and rows for a textarea in the admin forms. PR for issue #675 