### PR TITLE
Refactor bindRemoveButtons for improved performance

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -100,7 +100,6 @@ require([
             if (isNewOption && !this.isReadOnly) {
                 this.enableNewOptionDeleteButton(data.id);
             }
-            this.bindRemoveButton(data.id);
             this.itemCount++;
             this.totalItems++;
             this.updateItemsCountField();
@@ -139,14 +138,16 @@ require([
                 button.removeClassName('disabled');
             });
         },
-        bindRemoveButton: function(id) {
-            $('delete_button_' + id).observe('click', this.remove.bind(this));
-        }
     };
 
     if ($('add_new_option_button')) {
         Event.observe('add_new_option_button', 'click', attributeOption.add.bind(attributeOption));
     }
+    
+    $('manage-options-panel').on('click', '.delete-option', function(event, element) {
+        attributeOption.remove(event);
+    });
+
     <?php foreach ($block->getOptionValues() as $_value): ?>
     attributeOption.add(<?php echo $_value->toJson() ?>);
     <?php endforeach; ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -58,7 +58,7 @@
             <td id="delete_button_container_<%- data.id %>" class="col-delete">
                 <input type="hidden" class="delete-flag" name="option[delete][<%- data.id %>]" value="" />
                 <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()):?>
-                    <button title="<?php echo __('Delete') ?>" type="button"
+                    <button id="delete_button_<%- data.id %>" title="<?php echo __('Delete') ?>" type="button"
                         class="action- scalable delete delete-option"
                         >
                         <span><?php echo __('Delete') ?></span>
@@ -100,7 +100,7 @@ require([
             if (isNewOption && !this.isReadOnly) {
                 this.enableNewOptionDeleteButton(data.id);
             }
-            this.bindRemoveButtons();
+            this.bindRemoveButton(data.id);
             this.itemCount++;
             this.totalItems++;
             this.updateItemsCountField();
@@ -139,18 +139,10 @@ require([
                 button.removeClassName('disabled');
             });
         },
-        bindRemoveButtons: function() {
-            var buttons = $$('.delete-option');
-            for (var i = 0; i < buttons.length; i++) {
-                if (!$(buttons[i]).binded) {
-                    $(buttons[i]).binded = true;
-                    Event.observe(buttons[i], 'click', this.remove.bind(this));
-                }
-            }
+        bindRemoveButton: function(id) {
+            $('delete_button_' + id).observe('click', this.remove.bind(this));
         }
     };
-
-    attributeOption.bindRemoveButtons();
 
     if ($('add_new_option_button')) {
         Event.observe('add_new_option_button', 'click', attributeOption.add.bind(attributeOption));


### PR DESCRIPTION
There are known issues in Magento managing options with thousands of attributes.

It has been blogged about [here](http://www.sessiondigital.de/blog/magento-timeout-saving-attribute-options-type-multiple-select-dropdown/), where the author proposed [the following solution](https://github.com/Jarlssen/Jarlssen_FasterAttributeOptionEdit).

In my [my profiling](http://mpchadwick.github.io/blog/massive-magento-attributes/) I found that bindRemoveButtons is the culprit in terms of the inefficiency. Each time an option is appended to the DOM bindRemoveButtons checks every single delete button on the page. You can imagine how that could add up when working with attributes with thousands of options.

This PR refactors the options template implements bindRemoveButton (rather than bindRemoveButtons) so that when an option is appended to the DOM only the delete button for that option gets bound.