### PR TITLE
Small improvement to the eval() call

### DIFF
--- a/lib/internal/Magento/Framework/Data/Collection/Filesystem.php
+++ b/lib/internal/Magento/Framework/Data/Collection/Filesystem.php
@@ -466,7 +466,7 @@ class Filesystem extends \Magento\Framework\Data\Collection
         }
         $result = false;
         if ($this->_filterEvalRendered) {
-            eval('$result = ' . $this->_filterEvalRendered . ';');
+            $result = eval('return ' . $this->_filterEvalRendered . ';');
         }
         return $result;
     }


### PR DESCRIPTION
http://php.net/manual/en/function.eval.php

> eval() returns NULL unless return is called in the evaluated code,
> in which case the value passed to return is returned.
> If there is a parse error in the evaluated code,
> eval() returns FALSE and execution of the following code continues normally.

A 'return' statement seems a more elegant way of handling this than using `$result = `. The behavior remains unchanged. If an error happens eval() will return `False` so $return will retain it's `False` if that happens,