### PR TITLE
Mail transport abstraction

### DIFF
--- a/app/code/Magento/Checkout/Helper/Data.php
+++ b/app/code/Magento/Checkout/Helper/Data.php
@@ -270,14 +270,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $total = $checkout->getStoreCurrencyCode() . ' ' . $checkout->getGrandTotal();
 
         foreach ($sendTo as $recipient) {
+            $from = $this->_transportBuilder->getFrom($this->scopeConfig->getValue(
+                'checkout/payment_failed/identity',
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $checkout->getStoreId()
+            ));
             $this->_transportBuilder->getMessage()
-                ->setFrom(
-                    $this->scopeConfig->getValue(
-                            'checkout/payment_failed/identity',
-                            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                            $checkout->getStoreId()
-                        )
-                    )
+                ->setFrom($from['email'],$from['name'])
                 ->addTo($recipient['email'],
                         $recipient['name'])
                 ->addBcc($bcc);

--- a/app/code/Magento/Checkout/Helper/Data.php
+++ b/app/code/Magento/Checkout/Helper/Data.php
@@ -270,6 +270,17 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $total = $checkout->getStoreCurrencyCode() . ' ' . $checkout->getGrandTotal();
 
         foreach ($sendTo as $recipient) {
+            $this->_transportBuilder->getMessage()
+                ->setFrom(
+                    $this->scopeConfig->getValue(
+                            'checkout/payment_failed/identity',
+                            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                            $checkout->getStoreId()
+                        )
+                    )
+                ->addTo($recipient['email'],
+                        $recipient['name'])
+                ->addBcc($bcc);
             $transport = $this->_transportBuilder->setTemplateIdentifier(
                 $template
             )->setTemplateOptions(
@@ -298,17 +309,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                     'items' => nl2br($items),
                     'total' => $total,
                 ]
-            )->setFrom(
-                $this->scopeConfig->getValue(
-                    'checkout/payment_failed/identity',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                    $checkout->getStoreId()
-                )
-            )->addTo(
-                $recipient['email'],
-                $recipient['name']
-            )->addBcc(
-                $bcc
             )->getTransport();
 
             $transport->sendMessage();

--- a/app/code/Magento/Contact/Controller/Index/Post.php
+++ b/app/code/Magento/Contact/Controller/Index/Post.php
@@ -46,6 +46,11 @@ class Post extends \Magento\Contact\Controller\Index
             }
 
             $storeScope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
+            $this->_transportBuilder->getMessage()
+                ->setFrom($this->scopeConfig->getValue(self::XML_PATH_EMAIL_SENDER, $storeScope))
+                ->addTo($this->scopeConfig->getValue(self::XML_PATH_EMAIL_RECIPIENT, $storeScope))
+                ->setReplyTo($post['email']);
+
             $transport = $this->_transportBuilder
                 ->setTemplateIdentifier($this->scopeConfig->getValue(self::XML_PATH_EMAIL_TEMPLATE, $storeScope))
                 ->setTemplateOptions(
@@ -55,9 +60,6 @@ class Post extends \Magento\Contact\Controller\Index
                     ]
                 )
                 ->setTemplateVars(['data' => $postObject])
-                ->setFrom($this->scopeConfig->getValue(self::XML_PATH_EMAIL_SENDER, $storeScope))
-                ->addTo($this->scopeConfig->getValue(self::XML_PATH_EMAIL_RECIPIENT, $storeScope))
-                ->setReplyTo($post['email'])
                 ->getTransport();
 
             $transport->sendMessage();

--- a/app/code/Magento/Contact/Controller/Index/Post.php
+++ b/app/code/Magento/Contact/Controller/Index/Post.php
@@ -46,8 +46,9 @@ class Post extends \Magento\Contact\Controller\Index
             }
 
             $storeScope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
+            $from = $this->_transportBuilder->getFrom($this->scopeConfig->getValue(self::XML_PATH_EMAIL_SENDER, $storeScope));
             $this->_transportBuilder->getMessage()
-                ->setFrom($this->scopeConfig->getValue(self::XML_PATH_EMAIL_SENDER, $storeScope))
+                ->setFrom($from['email'],$from['name'])
                 ->addTo($this->scopeConfig->getValue(self::XML_PATH_EMAIL_RECIPIENT, $storeScope))
                 ->setReplyTo($post['email']);
 

--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -840,6 +840,17 @@ class AccountManagement implements AccountManagementInterface
         }
 
         $customerEmailData = $this->getFullCustomerObject($customer);
+        $this->transportBuilder->getMessage()
+            ->setFrom(
+            $this->scopeConfig->getValue(
+                self::XML_PATH_FORGOT_EMAIL_IDENTITY,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $storeId
+            )
+            )->addTo(
+                $customer->getEmail(),
+                $this->customerViewHelper->getCustomerName($customer)
+            );
         /** @var \Magento\Framework\Mail\TransportInterface $transport */
         $transport = $this->transportBuilder->setTemplateIdentifier(
             $this->scopeConfig->getValue(
@@ -851,15 +862,6 @@ class AccountManagement implements AccountManagementInterface
             ['area' => \Magento\Framework\App\Area::AREA_FRONTEND, 'store' => $storeId]
         )->setTemplateVars(
             ['customer' => $customerEmailData, 'store' => $this->storeManager->getStore($storeId)]
-        )->setFrom(
-            $this->scopeConfig->getValue(
-                self::XML_PATH_FORGOT_EMAIL_IDENTITY,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                $storeId
-            )
-        )->addTo(
-            $customer->getEmail(),
-            $this->customerViewHelper->getCustomerName($customer)
         )->getTransport();
         $transport->sendMessage();
 
@@ -913,6 +915,13 @@ class AccountManagement implements AccountManagementInterface
      */
     protected function sendEmailTemplate($customer, $template, $sender, $templateParams = [], $storeId = null)
     {
+        $this->transportBuilder->getMessage()
+            ->setFrom(
+                $this->scopeConfig->getValue($sender, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId)
+            )->addTo(
+                $customer->getEmail(),
+                $this->customerViewHelper->getCustomerName($customer)
+            );
         /** @var \Magento\Framework\Mail\TransportInterface $transport */
         $transport = $this->transportBuilder->setTemplateIdentifier(
             $this->scopeConfig->getValue($template, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId)
@@ -920,11 +929,6 @@ class AccountManagement implements AccountManagementInterface
             ['area' => \Magento\Framework\App\Area::AREA_FRONTEND, 'store' => $storeId]
         )->setTemplateVars(
             $templateParams
-        )->setFrom(
-            $this->scopeConfig->getValue($sender, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId)
-        )->addTo(
-            $customer->getEmail(),
-            $this->customerViewHelper->getCustomerName($customer)
         )->getTransport();
         $transport->sendMessage();
 

--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -840,14 +840,16 @@ class AccountManagement implements AccountManagementInterface
         }
 
         $customerEmailData = $this->getFullCustomerObject($customer);
-        $this->transportBuilder->getMessage()
-            ->setFrom(
-            $this->scopeConfig->getValue(
+        $from = $this->transportBuilder->getFrom(
+                $this->scopeConfig->getValue(
                 self::XML_PATH_FORGOT_EMAIL_IDENTITY,
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
                 $storeId
             )
-            )->addTo(
+        );
+        $this->transportBuilder->getMessage()
+            ->setFrom($from['email'],$from['name'])
+            ->addTo(
                 $customer->getEmail(),
                 $this->customerViewHelper->getCustomerName($customer)
             );
@@ -915,9 +917,10 @@ class AccountManagement implements AccountManagementInterface
      */
     protected function sendEmailTemplate($customer, $template, $sender, $templateParams = [], $storeId = null)
     {
+        $from = $this->transportBuilder->getFrom($this->scopeConfig->getValue($sender, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId));
         $this->transportBuilder->getMessage()
             ->setFrom(
-                $this->scopeConfig->getValue($sender, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId)
+                $from['email'],$from['name']
             )->addTo(
                 $customer->getEmail(),
                 $this->customerViewHelper->getCustomerName($customer)

--- a/app/code/Magento/Customer/Model/Customer.php
+++ b/app/code/Magento/Customer/Model/Customer.php
@@ -855,6 +855,13 @@ class Customer extends \Magento\Framework\Model\AbstractModel
      */
     protected function _sendEmailTemplate($template, $sender, $templateParams = [], $storeId = null)
     {
+        $this->_transportBuilder->getMessage()
+            ->setFrom(
+                $this->_scopeConfig->getValue($sender, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId)
+            )->addTo(
+                $this->getEmail(),
+                $this->getName()
+            );
         /** @var \Magento\Framework\Mail\TransportInterface $transport */
         $transport = $this->_transportBuilder->setTemplateIdentifier(
             $this->_scopeConfig->getValue($template, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId)
@@ -862,11 +869,6 @@ class Customer extends \Magento\Framework\Model\AbstractModel
             ['area' => \Magento\Framework\App\Area::AREA_FRONTEND, 'store' => $storeId]
         )->setTemplateVars(
             $templateParams
-        )->setFrom(
-            $this->_scopeConfig->getValue($sender, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId)
-        )->addTo(
-            $this->getEmail(),
-            $this->getName()
         )->getTransport();
         $transport->sendMessage();
 

--- a/app/code/Magento/Customer/Model/Customer.php
+++ b/app/code/Magento/Customer/Model/Customer.php
@@ -855,9 +855,10 @@ class Customer extends \Magento\Framework\Model\AbstractModel
      */
     protected function _sendEmailTemplate($template, $sender, $templateParams = [], $storeId = null)
     {
+        $from = $this->_transportBuilder->getFrom($this->_scopeConfig->getValue($sender, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId));
         $this->_transportBuilder->getMessage()
             ->setFrom(
-                $this->_scopeConfig->getValue($sender, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId)
+                $from['email'],$from['name']
             )->addTo(
                 $this->getEmail(),
                 $this->getName()

--- a/app/code/Magento/Directory/Model/Observer.php
+++ b/app/code/Magento/Directory/Model/Observer.php
@@ -128,13 +128,15 @@ class Observer
             $this->_currencyFactory->create()->saveRates($rates);
         } else {
             $this->inlineTranslation->suspend();
+            $from = $this->_transportBuilder->getFrom(
+                $this->_scopeConfig->getValue(
+                    self::XML_PATH_ERROR_IDENTITY,
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                )
+            );
             $this->_transportBuilder->getMessage()
-                ->setFrom(
-                    $this->_scopeConfig->getValue(
-                        self::XML_PATH_ERROR_IDENTITY,
-                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                    )
-                )->addTo(
+                ->setFrom($from['email'],$from['name'])
+                ->addTo(
                     $this->_scopeConfig->getValue(
                         self::XML_PATH_ERROR_RECIPIENT,
                         \Magento\Store\Model\ScopeInterface::SCOPE_STORE

--- a/app/code/Magento/Directory/Model/Observer.php
+++ b/app/code/Magento/Directory/Model/Observer.php
@@ -128,7 +128,18 @@ class Observer
             $this->_currencyFactory->create()->saveRates($rates);
         } else {
             $this->inlineTranslation->suspend();
-
+            $this->_transportBuilder->getMessage()
+                ->setFrom(
+                    $this->_scopeConfig->getValue(
+                        self::XML_PATH_ERROR_IDENTITY,
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                    )
+                )->addTo(
+                    $this->_scopeConfig->getValue(
+                        self::XML_PATH_ERROR_RECIPIENT,
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                    )
+                );
             $this->_transportBuilder->setTemplateIdentifier(
                 $this->_scopeConfig->getValue(
                     self::XML_PATH_ERROR_TEMPLATE,
@@ -141,16 +152,6 @@ class Observer
                 ]
             )->setTemplateVars(
                 ['warnings' => join("\n", $importWarnings)]
-            )->setFrom(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_ERROR_IDENTITY,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
-            )->addTo(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_ERROR_RECIPIENT,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
             );
             $transport = $this->_transportBuilder->getTransport();
             $transport->sendMessage();

--- a/app/code/Magento/Log/Model/Cron.php
+++ b/app/code/Magento/Log/Model/Cron.php
@@ -107,13 +107,15 @@ class Cron extends \Magento\Framework\Model\AbstractModel
         }
 
         $this->inlineTranslation->suspend();
+        $from = $this->_transportBuilder->getFrom(
+            $this->_scopeConfig->getValue(
+                self::XML_PATH_EMAIL_LOG_CLEAN_IDENTITY,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            )
+        );
         $this->_transportBuilder->getMessage()
-            ->setFrom(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_EMAIL_LOG_CLEAN_IDENTITY,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
-            )->addTo(
+            ->setFrom($from['email'],$from['name'])
+            ->addTo(
                 $this->_scopeConfig->getValue(
                     self::XML_PATH_EMAIL_LOG_CLEAN_RECIPIENT,
                     \Magento\Store\Model\ScopeInterface::SCOPE_STORE

--- a/app/code/Magento/Log/Model/Cron.php
+++ b/app/code/Magento/Log/Model/Cron.php
@@ -107,6 +107,18 @@ class Cron extends \Magento\Framework\Model\AbstractModel
         }
 
         $this->inlineTranslation->suspend();
+        $this->_transportBuilder->getMessage()
+            ->setFrom(
+                $this->_scopeConfig->getValue(
+                    self::XML_PATH_EMAIL_LOG_CLEAN_IDENTITY,
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                )
+            )->addTo(
+                $this->_scopeConfig->getValue(
+                    self::XML_PATH_EMAIL_LOG_CLEAN_RECIPIENT,
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                )
+            );
         $transport = $this->_transportBuilder->setTemplateIdentifier(
             $this->_scopeConfig->getValue(
                 self::XML_PATH_EMAIL_LOG_CLEAN_TEMPLATE,
@@ -119,16 +131,6 @@ class Cron extends \Magento\Framework\Model\AbstractModel
             ]
         )->setTemplateVars(
             ['warnings' => join("\n", $this->_errors)]
-        )->setFrom(
-            $this->_scopeConfig->getValue(
-                self::XML_PATH_EMAIL_LOG_CLEAN_IDENTITY,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-            )
-        )->addTo(
-            $this->_scopeConfig->getValue(
-                self::XML_PATH_EMAIL_LOG_CLEAN_RECIPIENT,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-            )
         )->getTransport();
 
         $transport->sendMessage();

--- a/app/code/Magento/Newsletter/Model/Queue.php
+++ b/app/code/Magento/Newsletter/Model/Queue.php
@@ -226,15 +226,17 @@ class Queue extends \Magento\Email\Model\AbstractTemplate
 
         /** @var \Magento\Newsletter\Model\Subscriber $item */
         foreach ($collection->getItems() as $item) {
+            $this->_transportBuilder->getMessage()
+                ->setFrom(
+                    ['name' => $this->getNewsletterSenderEmail(), 'email' => $this->getNewsletterSenderName()]
+                )->addTo(
+                    $item->getSubscriberEmail(),
+                    $item->getSubscriberFullName()
+                );
             $transport = $this->_transportBuilder->setTemplateOptions(
                 ['area' => \Magento\Framework\App\Area::AREA_FRONTEND, 'store' => $item->getStoreId()]
             )->setTemplateVars(
                 ['subscriber' => $item]
-            )->setFrom(
-                ['name' => $this->getNewsletterSenderEmail(), 'email' => $this->getNewsletterSenderName()]
-            )->addTo(
-                $item->getSubscriberEmail(),
-                $item->getSubscriberFullName()
             )->getTransport();
 
             try {

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -646,13 +646,15 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
         }
 
         $this->inlineTranslation->suspend();
+        $from = $this->_transportBuilder->getFrom(
+            $this->_scopeConfig->getValue(
+                self::XML_PATH_CONFIRM_EMAIL_IDENTITY,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            )
+        );
         $this->_transportBuilder->getMessage()
-            ->setFrom(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_CONFIRM_EMAIL_IDENTITY,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
-            )->addTo(
+            ->setFrom($from['email'],$from['name'])
+            ->addTo(
                 $this->getEmail(),
                 $this->getName()
             );
@@ -700,13 +702,15 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
         }
 
         $this->inlineTranslation->suspend();
+        $from = $this->_transportBuilder->getFrom(
+            $this->_scopeConfig->getValue(
+                self::XML_PATH_SUCCESS_EMAIL_IDENTITY,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            )
+        );
         $this->_transportBuilder->getMessage()
-            ->setFrom(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_SUCCESS_EMAIL_IDENTITY,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
-            )->addTo(
+            ->setFrom($from['email'],$from['name'])
+            ->addTo(
                 $this->getEmail(),
                 $this->getName()
             );
@@ -753,13 +757,15 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
         }
 
         $this->inlineTranslation->suspend();
+        $from = $this->_transportBuilder->getFrom(
+            $this->_scopeConfig->getValue(
+                self::XML_PATH_UNSUBSCRIBE_EMAIL_IDENTITY,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            )
+        );
         $this->_transportBuilder->getMessage()
-            ->setFrom(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_UNSUBSCRIBE_EMAIL_IDENTITY,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
-            )->addTo(
+            ->setFrom($from['email'],$from['name'])
+            ->addTo(
                 $this->getEmail(),
                 $this->getName()
             );

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -646,7 +646,16 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
         }
 
         $this->inlineTranslation->suspend();
-
+        $this->_transportBuilder->getMessage()
+            ->setFrom(
+                $this->_scopeConfig->getValue(
+                    self::XML_PATH_CONFIRM_EMAIL_IDENTITY,
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                )
+            )->addTo(
+                $this->getEmail(),
+                $this->getName()
+            );
         $this->_transportBuilder->setTemplateIdentifier(
             $this->_scopeConfig->getValue(
                 self::XML_PATH_CONFIRM_EMAIL_TEMPLATE,
@@ -659,14 +668,6 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
             ]
         )->setTemplateVars(
             ['subscriber' => $this, 'store' => $this->_storeManager->getStore()]
-        )->setFrom(
-            $this->_scopeConfig->getValue(
-                self::XML_PATH_CONFIRM_EMAIL_IDENTITY,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-            )
-        )->addTo(
-            $this->getEmail(),
-            $this->getName()
         );
         $transport = $this->_transportBuilder->getTransport();
         $transport->sendMessage();
@@ -699,7 +700,16 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
         }
 
         $this->inlineTranslation->suspend();
-
+        $this->_transportBuilder->getMessage()
+            ->setFrom(
+                $this->_scopeConfig->getValue(
+                    self::XML_PATH_SUCCESS_EMAIL_IDENTITY,
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                )
+            )->addTo(
+                $this->getEmail(),
+                $this->getName()
+            );
         $this->_transportBuilder->setTemplateIdentifier(
             $this->_scopeConfig->getValue(
                 self::XML_PATH_SUCCESS_EMAIL_TEMPLATE,
@@ -712,14 +722,6 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
             ]
         )->setTemplateVars(
             ['subscriber' => $this]
-        )->setFrom(
-            $this->_scopeConfig->getValue(
-                self::XML_PATH_SUCCESS_EMAIL_IDENTITY,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-            )
-        )->addTo(
-            $this->getEmail(),
-            $this->getName()
         );
         $transport = $this->_transportBuilder->getTransport();
         $transport->sendMessage();
@@ -751,7 +753,16 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
         }
 
         $this->inlineTranslation->suspend();
-
+        $this->_transportBuilder->getMessage()
+            ->setFrom(
+                $this->_scopeConfig->getValue(
+                    self::XML_PATH_UNSUBSCRIBE_EMAIL_IDENTITY,
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                )
+            )->addTo(
+                $this->getEmail(),
+                $this->getName()
+            );
         $this->_transportBuilder->setTemplateIdentifier(
             $this->_scopeConfig->getValue(
                 self::XML_PATH_UNSUBSCRIBE_EMAIL_TEMPLATE,
@@ -764,14 +775,6 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
             ]
         )->setTemplateVars(
             ['subscriber' => $this]
-        )->setFrom(
-            $this->_scopeConfig->getValue(
-                self::XML_PATH_UNSUBSCRIBE_EMAIL_IDENTITY,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-            )
-        )->addTo(
-            $this->getEmail(),
-            $this->getName()
         );
         $transport = $this->_transportBuilder->getTransport();
         $transport->sendMessage();

--- a/app/code/Magento/ProductAlert/Model/Email.php
+++ b/app/code/Magento/ProductAlert/Model/Email.php
@@ -364,7 +364,17 @@ class Email extends \Magento\Framework\Model\AbstractModel
             [$block, 'toHtml']
         );
         $this->_appEmulation->stopEnvironmentEmulation();
-
+        $this->_transportBuilder->getMessage()
+            ->setFrom(
+                $this->_scopeConfig->getValue(
+                    self::XML_PATH_EMAIL_IDENTITY,
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                    $storeId
+                )
+            )->addTo(
+                $this->_customer->getEmail(),
+                $this->_customerHelper->getCustomerName($this->_customer)
+            );
         $transport = $this->_transportBuilder->setTemplateIdentifier(
             $templateId
         )->setTemplateOptions(
@@ -374,15 +384,6 @@ class Email extends \Magento\Framework\Model\AbstractModel
                 'customerName' => $this->_customerHelper->getCustomerName($this->_customer),
                 'alertGrid' => $alertGrid,
             ]
-        )->setFrom(
-            $this->_scopeConfig->getValue(
-                self::XML_PATH_EMAIL_IDENTITY,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                $storeId
-            )
-        )->addTo(
-            $this->_customer->getEmail(),
-            $this->_customerHelper->getCustomerName($this->_customer)
         )->getTransport();
 
         $transport->sendMessage();

--- a/app/code/Magento/ProductAlert/Model/Email.php
+++ b/app/code/Magento/ProductAlert/Model/Email.php
@@ -364,14 +364,16 @@ class Email extends \Magento\Framework\Model\AbstractModel
             [$block, 'toHtml']
         );
         $this->_appEmulation->stopEnvironmentEmulation();
+        $from = $this->_transportBuilder->getFrom(
+            $this->_scopeConfig->getValue(
+                self::XML_PATH_EMAIL_IDENTITY,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $storeId
+            )
+        );
         $this->_transportBuilder->getMessage()
-            ->setFrom(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_EMAIL_IDENTITY,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                    $storeId
-                )
-            )->addTo(
+            ->setFrom($from['email'],$from['name'])
+            ->addTo(
                 $this->_customer->getEmail(),
                 $this->_customerHelper->getCustomerName($this->_customer)
             );

--- a/app/code/Magento/ProductAlert/Model/Observer.php
+++ b/app/code/Magento/ProductAlert/Model/Observer.php
@@ -363,13 +363,15 @@ class Observer
             }
 
             $this->inlineTranslation->suspend();
+            $from = $this->_transportBuilder->getFrom(
+                $this->_scopeConfig->getValue(
+                    self::XML_PATH_ERROR_IDENTITY,
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                )
+            );
             $this->_transportBuilder->getMessage()
-                ->setFrom(
-                    $this->_scopeConfig->getValue(
-                        self::XML_PATH_ERROR_IDENTITY,
-                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                    )
-                )->addTo(
+                ->setFrom($from['email'],$from['name'])
+                ->addTo(
                     $this->_scopeConfig->getValue(
                         self::XML_PATH_ERROR_RECIPIENT,
                         \Magento\Store\Model\ScopeInterface::SCOPE_STORE

--- a/app/code/Magento/ProductAlert/Model/Observer.php
+++ b/app/code/Magento/ProductAlert/Model/Observer.php
@@ -363,7 +363,18 @@ class Observer
             }
 
             $this->inlineTranslation->suspend();
-
+            $this->_transportBuilder->getMessage()
+                ->setFrom(
+                    $this->_scopeConfig->getValue(
+                        self::XML_PATH_ERROR_IDENTITY,
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                    )
+                )->addTo(
+                    $this->_scopeConfig->getValue(
+                        self::XML_PATH_ERROR_RECIPIENT,
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                    )
+                );
             $transport = $this->_transportBuilder->setTemplateIdentifier(
                 $this->_scopeConfig->getValue(
                     self::XML_PATH_ERROR_TEMPLATE,
@@ -376,16 +387,6 @@ class Observer
                 ]
             )->setTemplateVars(
                 ['warnings' => join("\n", $this->_errors)]
-            )->setFrom(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_ERROR_IDENTITY,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
-            )->addTo(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_ERROR_RECIPIENT,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
             )->getTransport();
 
             $transport->sendMessage();

--- a/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
+++ b/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
@@ -98,6 +98,7 @@ class SenderBuilder
         $this->transportBuilder->setTemplateIdentifier($this->templateContainer->getTemplateId());
         $this->transportBuilder->setTemplateOptions($this->templateContainer->getTemplateOptions());
         $this->transportBuilder->setTemplateVars($this->templateContainer->getTemplateVars());
-        $this->transportBuilder->getMessage()->setFrom($this->identityContainer->getEmailIdentity());
+        $from = $this->transportBuilder->getFrom($this->identityContainer->getEmailIdentity());
+        $this->transportBuilder->getMessage()->setFrom($from['email'],$from['name']);
     }
 }

--- a/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
+++ b/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
@@ -50,7 +50,7 @@ class SenderBuilder
     {
         $this->configureEmailTemplate();
 
-        $this->transportBuilder->addTo(
+        $this->transportBuilder->getMessage()->addTo(
             $this->identityContainer->getCustomerEmail(),
             $this->identityContainer->getCustomerName()
         );
@@ -59,7 +59,7 @@ class SenderBuilder
 
         if (!empty($copyTo) && $this->identityContainer->getCopyMethod() == 'bcc') {
             foreach ($copyTo as $email) {
-                $this->transportBuilder->addBcc($email);
+                $this->transportBuilder->getMessage()->addBcc($email);
             }
         }
 
@@ -80,7 +80,7 @@ class SenderBuilder
             foreach ($copyTo as $email) {
                 $this->configureEmailTemplate();
 
-                $this->transportBuilder->addTo($email);
+                $this->transportBuilder->getMessage()->addTo($email);
 
                 $transport = $this->transportBuilder->getTransport();
                 $transport->sendMessage();
@@ -98,6 +98,6 @@ class SenderBuilder
         $this->transportBuilder->setTemplateIdentifier($this->templateContainer->getTemplateId());
         $this->transportBuilder->setTemplateOptions($this->templateContainer->getTemplateOptions());
         $this->transportBuilder->setTemplateVars($this->templateContainer->getTemplateVars());
-        $this->transportBuilder->setFrom($this->identityContainer->getEmailIdentity());
+        $this->transportBuilder->getMessage()->setFrom($this->identityContainer->getEmailIdentity());
     }
 }

--- a/app/code/Magento/Sendfriend/Model/Sendfriend.php
+++ b/app/code/Magento/Sendfriend/Model/Sendfriend.php
@@ -182,14 +182,10 @@ class Sendfriend extends \Magento\Framework\Model\AbstractModel
 
         foreach ($this->getRecipients()->getEmails() as $k => $email) {
             $name = $this->getRecipients()->getNames($k);
+            $from = $this->_transportBuilder->getFrom($sender);
             $this->_transportBuilder->getMessage()
-                ->setFrom(
-                    $sender
-                )
-                ->addTo(
-                    $email,
-                    $name
-                );
+                ->setFrom($from['email'],$from['name'])
+                ->addTo($email,$name);
             $this->_transportBuilder->setTemplateIdentifier(
                 $this->_sendfriendData->getEmailTemplate()
             )->setTemplateOptions(

--- a/app/code/Magento/Sendfriend/Model/Sendfriend.php
+++ b/app/code/Magento/Sendfriend/Model/Sendfriend.php
@@ -182,6 +182,14 @@ class Sendfriend extends \Magento\Framework\Model\AbstractModel
 
         foreach ($this->getRecipients()->getEmails() as $k => $email) {
             $name = $this->getRecipients()->getNames($k);
+            $this->_transportBuilder->getMessage()
+                ->setFrom(
+                    $sender
+                )
+                ->addTo(
+                    $email,
+                    $name
+                );
             $this->_transportBuilder->setTemplateIdentifier(
                 $this->_sendfriendData->getEmailTemplate()
             )->setTemplateOptions(
@@ -189,8 +197,6 @@ class Sendfriend extends \Magento\Framework\Model\AbstractModel
                     'area' => \Magento\Framework\App\Area::AREA_FRONTEND,
                     'store' => $this->_storeManager->getStore()->getId(),
                 ]
-            )->setFrom(
-                $sender
             )->setTemplateVars(
                 [
                     'name' => $name,
@@ -202,9 +208,6 @@ class Sendfriend extends \Magento\Framework\Model\AbstractModel
                     'sender_email' => $sender['email'],
                     'product_image' => $this->_catalogImage->init($this->getProduct(), 'small_image')->resize(75),
                 ]
-            )->addTo(
-                $email,
-                $name
             );
             $transport = $this->_transportBuilder->getTransport();
             $transport->sendMessage();

--- a/app/code/Magento/Sitemap/Model/Observer.php
+++ b/app/code/Magento/Sitemap/Model/Observer.php
@@ -125,7 +125,18 @@ class Observer
         ) {
             $translate = $this->_translateModel->getTranslateInline();
             $this->_translateModel->setTranslateInline(false);
-
+            $this->_transportBuilder->getMessage()
+                ->setFrom(
+                    $this->_scopeConfig->getValue(
+                        self::XML_PATH_ERROR_IDENTITY,
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                    )
+                )->addTo(
+                    $this->_scopeConfig->getValue(
+                        self::XML_PATH_ERROR_RECIPIENT,
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                    )
+                );
             $this->_transportBuilder->setTemplateIdentifier(
                 $this->_scopeConfig->getValue(
                     self::XML_PATH_ERROR_TEMPLATE,
@@ -138,16 +149,6 @@ class Observer
                 ]
             )->setTemplateVars(
                 ['warnings' => join("\n", $errors)]
-            )->setFrom(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_ERROR_IDENTITY,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
-            )->addTo(
-                $this->_scopeConfig->getValue(
-                    self::XML_PATH_ERROR_RECIPIENT,
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                )
             );
             $transport = $this->_transportBuilder->getTransport();
             $transport->sendMessage();

--- a/app/code/Magento/Sitemap/Model/Observer.php
+++ b/app/code/Magento/Sitemap/Model/Observer.php
@@ -125,13 +125,15 @@ class Observer
         ) {
             $translate = $this->_translateModel->getTranslateInline();
             $this->_translateModel->setTranslateInline(false);
+            $from = $this->_transportBuilder->getFrom(
+                $this->_scopeConfig->getValue(
+                    self::XML_PATH_ERROR_IDENTITY,
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                )
+            );
             $this->_transportBuilder->getMessage()
-                ->setFrom(
-                    $this->_scopeConfig->getValue(
-                        self::XML_PATH_ERROR_IDENTITY,
-                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                    )
-                )->addTo(
+                ->setFrom($from['email'],$from['name'])
+                ->addTo(
                     $this->_scopeConfig->getValue(
                         self::XML_PATH_ERROR_RECIPIENT,
                         \Magento\Store\Model\ScopeInterface::SCOPE_STORE

--- a/app/code/Magento/User/Model/User.php
+++ b/app/code/Magento/User/Model/User.php
@@ -458,10 +458,10 @@ class User extends AbstractModel implements StorageInterface
     public function sendPasswordResetConfirmationEmail()
     {
         // Set all required params and send emails
+        $from = $this->_transportBuilder->getFrom($this->_config->getValue(self::XML_PATH_FORGOT_EMAIL_IDENTITY));
         $this->_transportBuilder->getMessage()
-            ->setFrom(
-                $this->_config->getValue(self::XML_PATH_FORGOT_EMAIL_IDENTITY)
-            )->addTo(
+            ->setFrom($from['email'],$from['name'])
+            ->addTo(
                 $this->getEmail(),
                 $this->getName()
             );
@@ -486,10 +486,10 @@ class User extends AbstractModel implements StorageInterface
     public function sendPasswordResetNotificationEmail()
     {
         // Set all required params and send emails
+        $from = $this->_transportBuilder->getFrom($this->_config->getValue(self::XML_PATH_FORGOT_EMAIL_IDENTITY));
         $this->_transportBuilder->getMessage()
-            ->setFrom(
-                $this->_config->getValue(self::XML_PATH_FORGOT_EMAIL_IDENTITY)
-            )->addTo(
+            ->setFrom($from['email'],$from['name'])
+            ->addTo(
                 $this->getEmail(),
                 $this->getName()
             );

--- a/app/code/Magento/User/Model/User.php
+++ b/app/code/Magento/User/Model/User.php
@@ -458,6 +458,13 @@ class User extends AbstractModel implements StorageInterface
     public function sendPasswordResetConfirmationEmail()
     {
         // Set all required params and send emails
+        $this->_transportBuilder->getMessage()
+            ->setFrom(
+                $this->_config->getValue(self::XML_PATH_FORGOT_EMAIL_IDENTITY)
+            )->addTo(
+                $this->getEmail(),
+                $this->getName()
+            );
         /** @var \Magento\Framework\Mail\TransportInterface $transport */
         $transport = $this->_transportBuilder->setTemplateIdentifier(
             $this->_config->getValue(self::XML_PATH_FORGOT_EMAIL_TEMPLATE)
@@ -465,11 +472,6 @@ class User extends AbstractModel implements StorageInterface
             ['area' => \Magento\Framework\App\Area::AREA_FRONTEND, 'store' => 0]
         )->setTemplateVars(
             ['user' => $this, 'store' => $this->_storeManager->getStore(0)]
-        )->setFrom(
-            $this->_config->getValue(self::XML_PATH_FORGOT_EMAIL_IDENTITY)
-        )->addTo(
-            $this->getEmail(),
-            $this->getName()
         )->getTransport();
 
         $transport->sendMessage();
@@ -484,6 +486,13 @@ class User extends AbstractModel implements StorageInterface
     public function sendPasswordResetNotificationEmail()
     {
         // Set all required params and send emails
+        $this->_transportBuilder->getMessage()
+            ->setFrom(
+                $this->_config->getValue(self::XML_PATH_FORGOT_EMAIL_IDENTITY)
+            )->addTo(
+                $this->getEmail(),
+                $this->getName()
+            );
         /** @var \Magento\Framework\Mail\TransportInterface $transport */
         $transport = $this->_transportBuilder->setTemplateIdentifier(
             $this->_config->getValue(self::XML_PATH_RESET_PASSWORD_TEMPLATE)
@@ -491,11 +500,6 @@ class User extends AbstractModel implements StorageInterface
             ['area' => \Magento\Framework\App\Area::AREA_FRONTEND, 'store' => 0]
         )->setTemplateVars(
             ['user' => $this, 'store' => $this->_storeManager->getStore(0)]
-        )->setFrom(
-            $this->_config->getValue(self::XML_PATH_FORGOT_EMAIL_IDENTITY)
-        )->addTo(
-            $this->getEmail(),
-            $this->getName()
         )->getTransport();
 
         $transport->sendMessage();

--- a/app/code/Magento/Wishlist/Controller/Index/Send.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Send.php
@@ -157,6 +157,15 @@ class Send extends Action\Action implements IndexInterface
                 $scopeConfig = $this->_objectManager->get('Magento\Framework\App\Config\ScopeConfigInterface');
                 $storeManager = $this->_objectManager->get('Magento\Store\Model\StoreManagerInterface');
                 foreach ($emails as $email) {
+                    $this->_transportBuilder->getMessage()
+                        ->setFrom(
+                            $scopeConfig->getValue(
+                                'wishlist/email/email_identity',
+                                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                            )
+                        )->addTo(
+                            $email
+                        );
                     $transport = $this->_transportBuilder->setTemplateIdentifier(
                         $scopeConfig->getValue(
                             'wishlist/email/email_template',
@@ -178,13 +187,6 @@ class Send extends Action\Action implements IndexInterface
                             'message' => $message,
                             'store' => $storeManager->getStore(),
                         ]
-                    )->setFrom(
-                        $scopeConfig->getValue(
-                            'wishlist/email/email_identity',
-                            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                        )
-                    )->addTo(
-                        $email
                     )->getTransport();
 
                     $transport->sendMessage();

--- a/app/code/Magento/Wishlist/Controller/Index/Send.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Send.php
@@ -157,13 +157,15 @@ class Send extends Action\Action implements IndexInterface
                 $scopeConfig = $this->_objectManager->get('Magento\Framework\App\Config\ScopeConfigInterface');
                 $storeManager = $this->_objectManager->get('Magento\Store\Model\StoreManagerInterface');
                 foreach ($emails as $email) {
+                    $from = $this->_transportBuilder->getFrom(
+                        $scopeConfig->getValue(
+                            'wishlist/email/email_identity',
+                            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                        )
+                    );
                     $this->_transportBuilder->getMessage()
-                        ->setFrom(
-                            $scopeConfig->getValue(
-                                'wishlist/email/email_identity',
-                                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                            )
-                        )->addTo(
+                        ->setFrom($from['email'],$from['name'])
+                        ->addTo(
                             $email
                         );
                     $transport = $this->_transportBuilder->setTemplateIdentifier(

--- a/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
+++ b/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
@@ -57,7 +57,7 @@ class TransportBuilder
     /**
      * Message
      *
-     * @var \Magento\Framework\Mail\Message
+     * @var \Magento\Framework\Mail\MessageInterface
      */
     protected $message;
 
@@ -75,14 +75,14 @@ class TransportBuilder
 
     /**
      * @param FactoryInterface $templateFactory
-     * @param \Magento\Framework\Mail\Message $message
+     * @param \Magento\Framework\Mail\MessageInterface $message
      * @param \Magento\Framework\Mail\Template\SenderResolverInterface $senderResolver
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Framework\Mail\TransportInterfaceFactory $mailTransportFactory
      */
     public function __construct(
         \Magento\Framework\Mail\Template\FactoryInterface $templateFactory,
-        \Magento\Framework\Mail\Message $message,
+        \Magento\Framework\Mail\MessageInterface $message,
         \Magento\Framework\Mail\Template\SenderResolverInterface $senderResolver,
         \Magento\Framework\ObjectManagerInterface $objectManager,
         \Magento\Framework\Mail\TransportInterfaceFactory $mailTransportFactory
@@ -95,69 +95,22 @@ class TransportBuilder
     }
 
     /**
-     * Add cc address
-     *
-     * @param array|string $address
-     * @param string $name
-     * @return $this
+     * @return \Magento\Framework\Mail\MessageInterface
      */
-    public function addCc($address, $name = '')
+    public function getMessage()
     {
-        $this->message->addCc($address, $name);
-        return $this;
+        return $this->message;
     }
 
     /**
-     * Add to address
-     *
-     * @param array|string $address
-     * @param string $name
+     * @param \Magento\Framework\Mail\MessageInterface $message
      * @return $this
      */
-    public function addTo($address, $name = '')
+    public function setMessage(\Magento\Framework\Mail\MessageInterface $message)
     {
-        $this->message->addTo($address, $name);
+        $this->message  = $message;
         return $this;
     }
-
-    /**
-     * Add bcc address
-     *
-     * @param array|string $address
-     * @return $this
-     */
-    public function addBcc($address)
-    {
-        $this->message->addBcc($address);
-        return $this;
-    }
-
-    /**
-     * Set Reply-To Header
-     *
-     * @param string $email
-     * @param string|null $name
-     * @return $this
-     */
-    public function setReplyTo($email, $name = null)
-    {
-        $this->message->setReplyTo($email, $name);
-        return $this;
-    }
-
-    /**
-     * Set mail from address
-     *
-     * @param string|array $from
-     * @return $this
-     */
-    public function setFrom($from)
-    {
-        $result = $this->_senderResolver->resolve($from);
-        $this->message->setFrom($result['email'], $result['name']);
-        return $this;
-    }
-
     /**
      * Set template identifier
      *

--- a/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
+++ b/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
@@ -192,6 +192,15 @@ class TransportBuilder
     }
 
     /**
+     * @param $from
+     * @return array
+     */
+    public function getFrom($from)
+    {
+        return $this->_senderResolver->resolve($from);
+    }
+
+    /**
      * Prepare message
      *
      * @return $this

--- a/lib/internal/Magento/Framework/Mail/TransportInterfaceFactory.php
+++ b/lib/internal/Magento/Framework/Mail/TransportInterfaceFactory.php
@@ -49,4 +49,14 @@ class TransportInterfaceFactory
     {
         return $this->_objectManager->create($this->_instanceName, $data);
     }
+
+    /**
+     * @param $name
+     * @return $this
+     */
+    public function setInstanceName($name)
+    {
+        $this->_instanceName    = $name;
+        return $this;
+    }
 }


### PR DESCRIPTION
We changed the constructor on lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php so its possible to have $message as an interface  \Magento\Framework\Mail\MessageInterface, before it was an instance of \Magento\Framework\Mail\Message which we consider wrong.

Also we removed all methods that dont belong to the transport: addCc, addTo, addBcc, setReplyTo and setFrom, we consider these message operations.

We added a getter and one setter so its possible to change the message via an interceptor on the fly.

On lib/internal/Magento/Framework/Mail/TransportInterfaceFactory.php we added a getter for $_instanceName, this allows an interceptor to change the transport instead of needing a rewrite for this.