### PR TITLE
SalesSequence: Fixed composer installer dependency

### DIFF
--- a/app/code/Magento/SalesSequence/composer.json
+++ b/app/code/Magento/SalesSequence/composer.json
@@ -4,7 +4,7 @@
   "require": {
     "php": "~5.5.0|~5.6.0",
     "magento/framework": "0.74.0-beta4",
-    "magento/magento-composer-installer": "0.74.0-beta4"
+    "magento/magento-composer-installer": "*"
   },
   "type": "magento2-module",
   "version": "0.74.0-beta4",


### PR DESCRIPTION
**Problem:**
The dependency in the SalesSequence module for the Magento composer installer is set to "0.74.0-beta4". Unfortunately, this tag does not exist in https://github.com/magento/magento-composer-installer

When trying to install Magento2 via https://github.com/magento/magento2-community-edition this leads to the following error:

```
  Problem 1
    - Installation request for magento/module-sales-sequence 0.74.0-beta4 -> satisfiable by magento/module-sales-sequence[0.74.0-beta4].
    - magento/module-sales-sequence 0.74.0-beta4 requires magento/magento-composer-installer 0.74.0-beta4 -> no matching package found.
```

**Solution:**
Set the dependency to "*" like in every other Magento2 module as well.