### PR TITLE
Add Event for sales_order_state_change_before during Order->saveState()

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -919,6 +919,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Order state setter.
      * If status is specified, will add order status history with specified comment
      * the setData() cannot be overridden because of compatibility issues with resource model
+     * By default allows to set any state. Can also update status to default or specified value
+     * Complete and closed states are encapsulated intentionally
      *
      * @param string $state
      * @param string|bool $status
@@ -926,6 +928,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param bool $isCustomerNotified
      * @param bool $shouldProtectState
      * @return \Magento\Sales\Model\Order
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function setState(
         $state,
@@ -934,29 +937,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         $isCustomerNotified = null,
         $shouldProtectState = true
     ) {
-        return $this->_setState($state, $status, $comment, $isCustomerNotified, $shouldProtectState);
-    }
 
-    /**
-     * Order state protected setter.
-     * By default allows to set any state. Can also update status to default or specified value
-     * Complete and closed states are encapsulated intentionally, see the _checkState()
-     *
-     * @param string $state
-     * @param string|bool $status
-     * @param string $comment
-     * @param bool $isCustomerNotified
-     * @param bool $shouldProtectState
-     * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
-     */
-    protected function _setState(
-        $state,
-        $status = false,
-        $comment = '',
-        $isCustomerNotified = null,
-        $shouldProtectState = false
-    ) {
         // attempt to set the specified state
         if ($shouldProtectState) {
             if ($this->isStateProtected($state)) {
@@ -965,17 +946,29 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
                 );
             }
         }
-        $this->setData('state', $state);
+
+        $transport = new \Magento\Framework\Object(
+            [
+                'state'     => $state,
+                'status'    => $status,
+                'comment'   => $comment,
+                'isCustomerNotified'    => $isCustomerNotified
+            ]
+        );
+
+        $this->_eventManager->dispatch('sales_order_state_change_before', array('order' => $this, 'transport' => $transport));
+        $status = $transport->getStatus();
+        $this->setData('state', $transport->getState());
 
         // add status history
         if ($status) {
             if ($status === true) {
-                $status = $this->getConfig()->getStateDefaultStatus($state);
+                $status = $this->getConfig()->getStateDefaultStatus($transport->getState());
             }
             $this->setStatus($status);
-            $history = $this->addStatusHistoryComment($comment, false);
+            $history = $this->addStatusHistoryComment($transport->getComment(), false);
             // no sense to set $status again
-            $history->setIsCustomerNotified($isCustomerNotified);
+            $history->setIsCustomerNotified($transport->getIsCustomerNotified());
         }
         return $this;
     }
@@ -1166,7 +1159,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             $this->setTotalCanceled($this->getGrandTotal() - $this->getTotalPaid());
             $this->setBaseTotalCanceled($this->getBaseGrandTotal() - $this->getBaseTotalPaid());
 
-            $this->_setState($cancelState, true, $comment);
+            $this->setState($cancelState, true, $comment);
         } elseif (!$graceful) {
             throw new \Magento\Framework\Exception\LocalizedException(__('We cannot cancel this order.'));
         }

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1159,7 +1159,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             $this->setTotalCanceled($this->getGrandTotal() - $this->getTotalPaid());
             $this->setBaseTotalCanceled($this->getBaseGrandTotal() - $this->getBaseTotalPaid());
 
-            $this->setState($cancelState, true, $comment);
+            $this->setState($cancelState, true, $comment, null, false);
         } elseif (!$graceful) {
             throw new \Magento\Framework\Exception\LocalizedException(__('We cannot cancel this order.'));
         }

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -952,7 +952,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
                 'state'     => $state,
                 'status'    => $status,
                 'comment'   => $comment,
-                'isCustomerNotified'    => $isCustomerNotified
+                'is_customer_notified'    => $isCustomerNotified
             ]
         );
 


### PR DESCRIPTION
Additionally refactored to remove unnecessary protected function
Refactored only call to the protected function to call the public function
Fixed up the docblock as well.

After looking through 6000 Magento 1.x extensions (https://gist.github.com/dfry22/474f727495228baccf28), noticed that the most common model rewrite in all of them (1 in 100 approx.) was `Mage_Sales_Model_Order`. After analyzing a large sample of these modules, noticed that the most common occurrence was a dispatch of `sales_order_status_change`.

If this event can be worked into Magento 2, we can remove the need for superfluous plugins looking to intercept the `setState()` function.

Also refactored the formerly protected `_saveState()` function, which was only being called once in the class itself, and also had no differences with the public function aside from one default parameter - so combined them into one function, and removed some outdated docblock comments.

Used a transport object in dispatching the event so any modifications in observers are passed back into the function.