### PR TITLE
Add customer_validate event

### DIFF
--- a/app/code/Magento/Customer/Model/Customer.php
+++ b/app/code/Magento/Customer/Model/Customer.php
@@ -1034,6 +1034,12 @@ class Customer extends \Magento\Framework\Model\AbstractModel
             $errors[] = __('Gender is required.');
         }
 
+        $transport = new \Magento\Framework\Object(
+            ['errors' => $errors]
+        );
+        $this->_eventManager->dispatch('customer_validate' , ['customer' => $this, 'transport' => $transport]);
+        $errors = $transport->getErrors();
+
         if (empty($errors)) {
             return true;
         }


### PR DESCRIPTION
Intended to try to minimize need for rewrites when custom validation is required for the customer.

**Motivation**
Analyzed 5996 Magento 1.x Extensions and determined the most common rewrites and hope to add events to Magento2 to make these rewrites unnecessary (https://gist.github.com/dfry22/474f727495228baccf28).
Nearly 1 in 100 extensions was rewriting Mage_Customer_Model_Customer, and after analyzing a large sample, found that many were rewriting the validation.

**Solution**
Dispatch customer_validate event and pass the errors array so it can be modified by custom validators and passed back into the function. This allows for localized validation and any other custom customer validation