### PR TITLE
Avoid following error:

### DIFF
--- a/lib/internal/Magento/Framework/Console/README.md
+++ b/lib/internal/Magento/Framework/Console/README.md
@@ -8,7 +8,7 @@ For example we can introduce new command in module using di.xml:
 <type name="Magento\Framework\Console\CommandList">
     <arguments>
         <argument name="commands" xsi:type="array">
-            <item name="test_me" xsi:type="string">Magento\MyModule\Console\TestMeCommand</item>
+            <item name="test_me" xsi:type="object">Magento\MyModule\Console\TestMeCommand</item>
         </argument>
     </arguments>
 </type>


### PR DESCRIPTION
Autoload error: Recoverable Error: Argument 1 passed to Symfony\Component\Console\Application::add() must be an instance of Symfony\Component\Console\Command\Command, string given,
called in /var/www/html/magento2/lib/internal/Magento/Framework/Console/Cli.php on line 27 and defined in /var/www/html/magento2/vendor/symfony/console/Symfony/Component/Console/Application.php on line 384