### PR TITLE
Group by on collections don't work

### DIFF
--- a/lib/internal/Magento/Framework/Data/Collection/Db.php
+++ b/lib/internal/Magento/Framework/Data/Collection/Db.php
@@ -224,7 +224,14 @@ class Db extends \Magento\Framework\Data\Collection
         $countSelect->reset(\Zend_Db_Select::LIMIT_OFFSET);
         $countSelect->reset(\Zend_Db_Select::COLUMNS);
 
-        $countSelect->columns('COUNT(*)');
+        if(count($this->getSelect()->getPart(\Zend_Db_Select::GROUP)) > 0) {
+            $countSelect->reset(\Zend_Db_Select::GROUP);
+            $countSelect->distinct(true);
+            $group = $this->getSelect()->getPart(\Zend_Db_Select::GROUP);
+            $countSelect->columns('COUNT(DISTINCT '.implode(', ', $group).')');
+        } else {
+            $countSelect->columns('COUNT(*)');
+        }
 
         return $countSelect;
     }


### PR DESCRIPTION
This will allow joins on collections using group by and aggregate functions while still returning the correct record count. In Magento 1, pagination and record counts were broken when group by was used in a collection.