### PR TITLE
Fixed a bug where type attribute for tag button was missing

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/extended.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/extended.phtml
@@ -116,7 +116,7 @@ $numColumns = sizeof($block->getColumns());
                             <?php echo __('of %1', '<span>' . $block->getCollection()->getLastPageNumber() . '</span>') ?>
                         </label>
                         <?php if ($_curPage < $_lastPage): ?>
-                            <button href="#"
+                            <button type="button"
                                     title="<?php echo __('Next page') ?>"
                                     class="action-next"
                                     onclick="<?php echo $block->getJsObjectName() ?>.setPage('<?php echo($_curPage + 1) ?>');return false;">


### PR DESCRIPTION
The bug breaks extended grid in certain cases because without type="button" the behaviour of a 'button' will fall back to default type which is 'submit', if this happens the ancestor 'form' will automatically submit creating unexpected problems.