### PR TITLE
avoid wrong exception results

### DIFF
--- a/bin/magento
+++ b/bin/magento
@@ -7,14 +7,15 @@
 
 try {
     require __DIR__ . '/../app/bootstrap.php';
-    if (PHP_SAPI == 'cli') {
-        $application = new Magento\Framework\Console\Cli('Magento CLI');
-        $application->run();
-    }
-
 } catch (\Exception $e) {
     if (PHP_SAPI == 'cli') {
         echo 'Autoload error: ' . $e->getMessage();
     }
     exit(1);
 }
+
+if (PHP_SAPI == 'cli') {
+    $application = new Magento\Framework\Console\Cli('Magento CLI');
+    $application->run();
+}
+


### PR DESCRIPTION
makes the exception handling analog to the on in index.php

fixes: #1219

to make the difference clear.

before the Patch:
```
Autoload error: An abstract factory could not create an instance of magentosetupconsolecommandconfigsetcommand(alias: Magento\Setup\Console\Command\ConfigSetCommand).
```

after the Patch:
```
PHP Fatal error:  Uncaught exception 'Exception' with message 'Attribute 'setup_version' is missing for module 'Cotya_Authentication'.' in /srv/magento_beta_full/lib/internal/Magento/Framework/Module/Declaration/Converter/Dom.php:32
Stack trace:
#0 /srv/magento_beta_full/lib/internal/Magento/Framework/Module/ModuleList/Loader.php(80): Magento\Framework\Module\Declaration\Converter\Dom->convert(Object(DOMDocument))
#1 /srv/magento_beta_full/lib/internal/Magento/Framework/Module/FullModuleList.php(46): Magento\Framework\Module\ModuleList\Loader->load()
#2 /srv/magento_beta_full/lib/internal/Magento/Framework/Module/FullModuleList.php(66): Magento\Framework\Module\FullModuleList->getAll()
#3 /srv/magento_beta_full/setup/src/Magento/Setup/Model/ConfigOptionsListCollector.php(88): Magento\Framework\Module\FullModuleList->getNames()
#4 /srv/magento_beta_full/setup/src/Magento/Setup/Model/ConfigModel.php(67): Magento\Setup\Model\ConfigOptionsListCollector->collectOptionsLists()
#5 /srv/magento_beta_full/setup/src/Magento/Setup/Consol in /srv/magento_beta_full/vendor/zendframework/zend-servicemanager/src/ServiceManager.php on line 1135

```