### PR TITLE
Removing unused memory limit in htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -36,7 +36,6 @@
 ############################################
 ## adjust memory limit
 
-#    php_value memory_limit 64M
     php_value memory_limit 768M
     php_value max_execution_time 18000
 

--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -36,7 +36,6 @@
 ############################################
 ## adjust memory limit
 
-#    php_value memory_limit 64M
     php_value memory_limit 256M
     php_value max_execution_time 18000
 


### PR DESCRIPTION
I've never quite understood why Magento shipped with this commented out line.  Can we get rid of it?