### PR TITLE
Removes .js and .css files robots.txt disallow rules

### DIFF
--- a/app/code/Magento/Theme/etc/config.xml
+++ b/app/code/Magento/Theme/etc/config.xml
@@ -22,11 +22,8 @@
 User-agent: *
 Disallow: /index.php/
 Disallow: /*?
-Disallow: /*.js$
-Disallow: /*.css$
 Disallow: /checkout/
 Disallow: /app/
-Disallow: /js/
 Disallow: /lib/
 Disallow: /*.php$
 Disallow: /pkginfo/


### PR DESCRIPTION
Per [this page] (http://googlewebmastercentral.blogspot.com/2014/10/updating-our-technical-webmaster.html) on Google's Webmaster Central Blog restricting Googlebot from crawling these harms their algorithms and can result in lower rankings.