### PR TITLE
Changed element to name for move action

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/layout/admin_login.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/admin_login.xml
@@ -20,9 +20,9 @@
         <remove name="notification.messages"/>
         <!-- @todo ui: - end -->
 
-        <move element="messages" destination="login.content" before="-"/>
-        <move element="copyright" destination="login.footer" before="-"/>
-        <move element="logo" destination="login.header" before="-"/>
+        <move name="messages" destination="login.content" before="-"/>
+        <move name="copyright" destination="login.footer" before="-"/>
+        <move name="logo" destination="login.header" before="-"/>
         <referenceBlock name="logo">
             <arguments>
                 <argument name="logo_image_src" xsi:type="string">images/magento-logo.svg</argument>

--- a/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view_type_bundle.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view_type_bundle.xml
@@ -38,9 +38,9 @@
         <referenceBlock name="product.info.form.options">
             <container name="bundle.product.options.wrapper" htmlTag="div" htmlClass="bundle-options-wrapper" after="product.info.form.options" />
         </referenceBlock> 
-        <move element="product.info.options.wrapper" destination="bundle.product.options.wrapper" before="-" />
-        <move element="product.info.options.wrapper.bottom" destination="bundle.product.options.wrapper" after="product.info.options.wrapper" />
-        <move element="product.price.tier" destination="product.info.options.wrapper.bottom" before="-" />
+        <move name="product.info.options.wrapper" destination="bundle.product.options.wrapper" before="-" />
+        <move name="product.info.options.wrapper.bottom" destination="bundle.product.options.wrapper" after="product.info.options.wrapper" />
+        <move name="product.price.tier" destination="product.info.options.wrapper.bottom" before="-" />
         <referenceBlock name="product.info.options.wrapper.bottom">
             <block class="Magento\CatalogInventory\Block\Qtyincrements" name="product.info.qtyincrements" before="-" template="qtyincrements.phtml"/>
             <action method="unsetChild">
@@ -63,6 +63,6 @@
         <referenceContainer name="product.info.main">
             <block class="Magento\Catalog\Block\Product\View" name="customize.button" as="customize_button" template="Magento_Bundle::catalog/product/view/customize.phtml" after="product.info.price" />
         </referenceContainer>
-        <move element="product.info" destination="bundle.options.container" before="-"/>
+        <move name="product.info" destination="bundle.options.container" before="-"/>
     </body>
 </page>

--- a/app/code/Magento/Downloadable/view/frontend/layout/catalog_product_view_type_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/catalog_product_view_type_downloadable.xml
@@ -40,7 +40,7 @@
         <referenceBlock name="head.components">
             <block class="Magento\Framework\View\Element\Js\Components" name="downloadable_page_head_components" template="Magento_Downloadable::js/components.phtml"/>
         </referenceBlock>
-        <move element="product.info" destination="content" after="product.info.media" />
-        <move element="product.info.social" destination="product.info.options.wrapper.bottom" after="-" />
+        <move name="product.info" destination="content" after="product.info.media" />
+        <move name="product.info.social" destination="product.info.options.wrapper.bottom" after="-" />
     </body>
 </page>

--- a/app/code/Magento/LayeredNavigation/view/frontend/layout/1column.xml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/layout/1column.xml
@@ -7,6 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd" label="All One-Column Layout Pages" design_abstraction="page_layout">
     <body>
-        <move element="catalog.leftnav" destination="content.top" after="-"/>
+        <move name="catalog.leftnav" destination="content.top" after="-"/>
     </body>
 </page>

--- a/app/code/Magento/LayeredNavigation/view/frontend/layout/2columns-left.xml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/layout/2columns-left.xml
@@ -7,6 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd" label="All Two-Column Layout Pages (Left Column)" design_abstraction="page_layout">
     <body>
-        <move element="catalog.leftnav" destination="sidebar.main" before="-"/>
+        <move name="catalog.leftnav" destination="sidebar.main" before="-"/>
     </body>
 </page>

--- a/app/code/Magento/LayeredNavigation/view/frontend/layout/2columns-right.xml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/layout/2columns-right.xml
@@ -7,6 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd" label="All Two-Column Layout Pages (Right Column)" design_abstraction="page_layout">
     <body>
-        <move element="catalog.leftnav" destination="sidebar.main" before="-"/>
+        <move name="catalog.leftnav" destination="sidebar.main" before="-"/>
     </body>
 </page>

--- a/app/code/Magento/LayeredNavigation/view/frontend/layout/3columns.xml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/layout/3columns.xml
@@ -7,6 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd" label="All Three-Column Layout Pages" design_abstraction="page_layout">
     <body>
-        <move element="catalog.leftnav" destination="sidebar.main" before="-"/>
+        <move name="catalog.leftnav" destination="sidebar.main" before="-"/>
     </body>
 </page>

--- a/app/code/Magento/LayeredNavigation/view/frontend/layout/page_empty.xml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/layout/page_empty.xml
@@ -7,6 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd" label="All Empty Layout Pages" design_abstraction="page_layout">
     <body>
-        <move element="catalog.leftnav" destination="category.product.list.additional" before="-"/>
+        <move name="catalog.leftnav" destination="category.product.list.additional" before="-"/>
     </body>
 </page>

--- a/app/code/Magento/Theme/view/frontend/layout/print.xml
+++ b/app/code/Magento/Theme/view/frontend/layout/print.xml
@@ -11,8 +11,8 @@
         <remove name="header.container" />
         <remove name="catalog.topnav" />
         <remove name="footer-container" />
-        <move element="logo" destination="main.content" before="-" />
-        <move element="copyright" destination="main.content" after="-" />
+        <move name="logo" destination="main.content" before="-" />
+        <move name="copyright" destination="main.content" after="-" />
         <referenceContainer name="before.body.end">
             <block class="Magento\Framework\View\Element\Template" name="sales.order.print.js" template="Magento_Theme::html/print.phtml" />
         </referenceContainer>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_bundle.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_bundle.xml
@@ -33,7 +33,7 @@
                 <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Checkbox" name="product.info.bundle.options.checkbox" as="checkbox"/>
             </block>
         </referenceBlock>
-        <move element="product.price.tier" destination="product.info.options.wrapper.bottom" before="-" />
+        <move name="product.price.tier" destination="product.info.options.wrapper.bottom" before="-" />
         <referenceBlock name="product.info.options.wrapper.bottom">
             <block class="Magento\CatalogInventory\Block\Qtyincrements" name="product.info.qtyincrements" before="-" template="qtyincrements.phtml"/>
             <action method="unsetChild">
@@ -56,6 +56,6 @@
         <referenceContainer name="product.info.main">
             <block class="Magento\Catalog\Block\Product\View" name="customize.button" as="customize_button" template="Magento_Bundle::catalog/product/view/customize.phtml" after="product.info.price" />
         </referenceContainer>
-        <move element="product.info" destination="bundle.options.container" before="-"/>
+        <move name="product.info" destination="bundle.options.container" before="-"/>
     </body>
 </page>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_downloadable.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_downloadable.xml
@@ -41,7 +41,7 @@
                 </arguments>
             </block>
         </referenceContainer>
-        <move element="product.info" destination="content" after="product.info.media" />
-        <move element="product.info.social" destination="product.info.options.wrapper.bottom" after="-" />
+        <move name="product.info" destination="content" after="product.info.media" />
+        <move name="product.info.social" destination="product.info.options.wrapper.bottom" after="-" />
     </body>
 </page>

--- a/app/design/adminhtml/Magento/backend/Magento_Backend/layout/default.xml
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/layout/default.xml
@@ -22,13 +22,13 @@
             <container name="header.inner.right" after="header.inner.left" htmlTag="div" htmlClass="page-header-actions col-l-4 col-m-6"/>
         </referenceContainer>
 
-        <move element="page.menu" destination="menu.wrapper" />
-        <move element="logo" before="-" destination="menu.wrapper" />
+        <move name="page.menu" destination="menu.wrapper" />
+        <move name="logo" before="-" destination="menu.wrapper" />
 
-        <move element="page.title" before="-" destination="header.inner.left" />
-        <move element="user" before="-" destination="header.inner.right" />
-        <move element="notification.messages" after="user" destination="header.inner.right" />
-        <move element="global.search" after="notification.messages" destination="header.inner.right" />
+        <move name="page.title" before="-" destination="header.inner.left" />
+        <move name="user" before="-" destination="header.inner.right" />
+        <move name="notification.messages" after="user" destination="header.inner.right" />
+        <move name="global.search" after="notification.messages" destination="header.inner.right" />
 
     </body>
 </page>

--- a/app/design/frontend/Magento/blank/Magento_Catalog/layout/catalog_product_view.xml
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/layout/catalog_product_view.xml
@@ -8,6 +8,6 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd">
     <body>
-        <move element="page.main.title" destination="product.info.main" before="-"/>
+        <move name="page.main.title" destination="product.info.main" before="-"/>
     </body>
 </page>

--- a/app/design/frontend/Magento/blank/Magento_Checkout/layout/checkout_cart_index.xml
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/layout/checkout_cart_index.xml
@@ -23,12 +23,12 @@
                 </container>
             </container>
         </referenceContainer>
-        <move element="checkout.cart.form.before" destination="checkout.cart.container" before="cart.summary"/>
-        <move element="checkout.cart.form" destination="checkout.cart.container" after="cart.summary"/>
-        <move element="checkout.cart.widget" destination="checkout.cart.container" after="checkout.cart.form"/>
-        <move element="checkout.cart.shipping" destination="cart.summary" after="checkout.cart.summary.title"/>
-        <move element="checkout.cart.coupon" destination="cart.summary"/>
-        <move element="checkout.cart.totals.container" destination="cart.summary"/>
-        <move element="checkout.cart.methods.bottom" destination="cart.summary"/>
+        <move name="checkout.cart.form.before" destination="checkout.cart.container" before="cart.summary"/>
+        <move name="checkout.cart.form" destination="checkout.cart.container" after="cart.summary"/>
+        <move name="checkout.cart.widget" destination="checkout.cart.container" after="checkout.cart.form"/>
+        <move name="checkout.cart.shipping" destination="cart.summary" after="checkout.cart.summary.title"/>
+        <move name="checkout.cart.coupon" destination="cart.summary"/>
+        <move name="checkout.cart.totals.container" destination="cart.summary"/>
+        <move name="checkout.cart.methods.bottom" destination="cart.summary"/>
     </body>
 </page>

--- a/app/design/frontend/Magento/blank/Magento_Customer/layout/customer_account.xml
+++ b/app/design/frontend/Magento/blank/Magento_Customer/layout/customer_account.xml
@@ -38,6 +38,6 @@
                 </block>
             </block>
         </referenceContainer>
-        <move element="page.main.title" destination="content.top" before="-"/>
+        <move name="page.main.title" destination="content.top" before="-"/>
     </body>
 </page>

--- a/app/design/frontend/Magento/blank/Magento_Theme/layout/default.xml
+++ b/app/design/frontend/Magento/blank/Magento_Theme/layout/default.xml
@@ -10,9 +10,9 @@
         <referenceContainer name="header.container">
             <container name="header.panel.wrapper" htmlClass="panel wrapper" htmlTag="div" before="-"/>
         </referenceContainer>
-        <move element="header.panel" destination="header.panel.wrapper"/>
-        <move element="top.links" destination="header.panel" after="-"/>
-        <move element="catalog.topnav" destination="store.menu" before="-"/>
+        <move name="header.panel" destination="header.panel.wrapper"/>
+        <move name="top.links" destination="header.panel" after="-"/>
+        <move name="catalog.topnav" destination="store.menu" before="-"/>
         <referenceContainer name="page.top">
             <block class="Magento\Framework\View\Element\Template" name="navigation.sections" before="-" template="Magento_Theme::html/sections.phtml">
                 <arguments>

--- a/app/design/frontend/Magento/luma/Magento_Catalog/layout/catalog_product_view.xml
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/layout/catalog_product_view.xml
@@ -7,7 +7,7 @@
 -->
 <page layout="1column" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd">
     <body>
-        <move element="product.info.stock.sku" destination="product.info.price" after="product.price.final"/>
-        <move element="product.info.review" destination="product.info.main" before="product.info.price"/>
+        <move name="product.info.stock.sku" destination="product.info.price" after="product.price.final"/>
+        <move name="product.info.review" destination="product.info.main" before="product.info.price"/>
     </body>
 </page>

--- a/app/design/frontend/Magento/luma/Magento_Checkout/layout/checkout_cart_index.xml
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/layout/checkout_cart_index.xml
@@ -11,8 +11,8 @@
         <referenceContainer name="checkout.cart.container">
             <container name="cart.discount" label="Cart Discount Container" htmlTag="div" htmlClass="cart-discount" after="-" />
         </referenceContainer>
-        <move element="checkout.cart.crosssell" destination="checkout.cart.container" after="-" />
-        <move element="checkout.cart.coupon" destination="cart.discount" />
-        <move element="checkout.cart.shortcut.buttons" destination="checkout.cart.methods" after="checkout.cart.methods.onepage.bottom"/>
+        <move name="checkout.cart.crosssell" destination="checkout.cart.container" after="-" />
+        <move name="checkout.cart.coupon" destination="cart.discount" />
+        <move name="checkout.cart.shortcut.buttons" destination="checkout.cart.methods" after="checkout.cart.methods.onepage.bottom"/>
     </body>
 </page>

--- a/app/design/frontend/Magento/luma/Magento_Customer/layout/default.xml
+++ b/app/design/frontend/Magento/luma/Magento_Customer/layout/default.xml
@@ -16,9 +16,9 @@
                 <argument name="show_part" xsi:type="string">welcome</argument>
             </arguments>
         </block>
-        <move element="header" destination="header.links" before="-"/>
-        <move element="register-link" destination="header.links"/>
-        <move element="top.links" destination="customer"/>
-        <move element="authorization-link" destination="top.links" after="-"/>
+        <move name="header" destination="header.links" before="-"/>
+        <move name="register-link" destination="header.links"/>
+        <move name="top.links" destination="customer"/>
+        <move name="authorization-link" destination="top.links" after="-"/>
     </body>
 </page>

--- a/app/design/frontend/Magento/luma/Magento_Theme/layout/default.xml
+++ b/app/design/frontend/Magento/luma/Magento_Theme/layout/default.xml
@@ -24,6 +24,6 @@
             <block class="Magento\Store\Block\Switcher" name="store_switcher" as="store_switcher" after="footer_links" template="switch/stores.phtml"/>
         </referenceContainer>
         <remove name="report.bugs"/>
-        <move element="copyright" destination="before.body.end"/>
+        <move name="copyright" destination="before.body.end"/>
     </body>
 </page>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/move.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/move.xml
@@ -10,7 +10,7 @@
         <block class="Magento\Framework\View\Element\Text" name="no.name2" as="no.name2"/>
     </container>
     <container name="container2" label="Container 2"/>
-    <move element="container1" destination="container2"/>
+    <move name="container1" destination="container2"/>
     <block class="Magento\Framework\View\Element\Text" name="block_container" as="block.container">
         <block class="Magento\Framework\View\Element\Text" name="child_block1"/>
         <block class="Magento\Framework\View\Element\Text" name="child_block2"/>
@@ -18,9 +18,9 @@
     <container name="container3" label="Container 3">
         <block class="Magento\Framework\View\Element\Text" name="no_name"/>
     </container>
-    <move element="no_name" destination="block_container" after="child_block1"/>
+    <move name="no_name" destination="block_container" after="child_block1"/>
     <block class="Magento\Framework\View\Element\Text" name="no_name4"/>
-    <move element="no_name4" destination="block_container" before="child_block2"/>
-    <move element="no_name3" destination="block_container"/>
+    <move name="no_name4" destination="block_container" before="child_block2"/>
+    <move name="no_name3" destination="block_container"/>
     <block class="Magento\Framework\View\Element\Text" name="no_name3"/>
 </layout>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/move_alias_broken.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/move_alias_broken.xml
@@ -9,6 +9,6 @@
     <container name="container1" label="Container 1">
         <block class="Magento\Framework\View\Element\Text" name="no_name1" as="same_alias"/>
     </container>
-    <move element="no_name3" destination="container1" as="same_alias"/>
+    <move name="no_name3" destination="container1" as="same_alias"/>
     <block class="Magento\Framework\View\Element\Text" name="no_name3" as="same_alias"/>
 </layout>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/move_broken.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/move_broken.xml
@@ -7,6 +7,6 @@
 -->
 <layout>
     <container name="container1" label="Container 1"/>
-    <move element="no_name3"/>
+    <move name="no_name3"/>
     <block class="Magento\Framework\View\Element\Text" name="no_name3"/>
 </layout>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/move_new_alias.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/move_new_alias.xml
@@ -9,6 +9,6 @@
     <container name="container1" label="Container 1">
         <block class="Magento\Framework\View\Element\Text" name="no_name1" as="same_alias"/>
     </container>
-    <move element="no_name3" destination="container1" as="new_alias"/>
+    <move name="no_name3" destination="container1" as="new_alias"/>
     <block class="Magento\Framework\View\Element\Text" name="no_name3" as="same_alias"/>
 </layout>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/move_the_same_alias.xml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/layout_directives_test/move_the_same_alias.xml
@@ -9,6 +9,6 @@
     <container name="container1" label="Container 1">
         <block class="Magento\Framework\View\Element\Text" name="no_name1" as="same_alias"/>
     </container>
-    <move element="no_name3" destination="container1"/>
+    <move name="no_name3" destination="container1"/>
     <block class="Magento\Framework\View\Element\Text" name="no_name3" as="same_alias"/>
 </layout>

--- a/lib/internal/Magento/Framework/View/Layout/Reader/Move.php
+++ b/lib/internal/Magento/Framework/View/Layout/Reader/Move.php
@@ -48,7 +48,7 @@ class Move implements Layout\ReaderInterface
      */
     protected function scheduleMove(Layout\ScheduledStructure $scheduledStructure, Layout\Element $currentElement)
     {
-        $elementName = (string)$currentElement->getAttribute('element');
+        $elementName = (string)$currentElement->getAttribute('name');
         $destination = (string)$currentElement->getAttribute('destination');
         $alias = (string)$currentElement->getAttribute('as') ?: '';
         if ($elementName && $destination) {

--- a/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
@@ -296,7 +296,7 @@
                 Move Element directive.
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute type="elementNameType" name="element" use="required"/>
+        <xs:attribute type="elementNameType" name="name" use="required"/>
         <xs:attribute type="elementNameType" name="destination" use="required"/>
         <xs:attribute type="elementAliasType" name="as" use="optional"/>
         <xs:attribute type="elementPositionType" name="after" use="optional"/>

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/Reader/MoveTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/Reader/MoveTest.php
@@ -64,7 +64,7 @@ class MoveTest extends \PHPUnit_Framework_TestCase
         $this->scheduledStructureMock->expects($this->any())
             ->method('setElementToMove')
             ->with(
-                (string)$currentElement->getAttribute('element'),
+                (string)$currentElement->getAttribute('name'),
                 [$destination, $siblingName, $isAfter, $alias]
             );
         $this->move->interpret($this->contextMock, $currentElement, $parentElement);
@@ -78,7 +78,7 @@ class MoveTest extends \PHPUnit_Framework_TestCase
         return [
             'move_before' => [
                 'element' => new \Magento\Framework\View\Layout\Element('
-                    <move element="product" destination="product.info" before="before.block" as="as.product.info"/>
+                    <move name="product" destination="product.info" before="before.block" as="as.product.info"/>
                 '),
                 'destination' => 'product.info',
                 'siblingName' => 'before.block',
@@ -88,7 +88,7 @@ class MoveTest extends \PHPUnit_Framework_TestCase
             ],
             'move_after' => [
                 'element' => new \Magento\Framework\View\Layout\Element('
-                    <move element="product" destination="product.info" after="after.block" as="as.product.info"/>
+                    <move name="product" destination="product.info" after="after.block" as="as.product.info"/>
                 '),
                 'destination' => 'product.info',
                 'siblingName' => 'after.block',
@@ -104,7 +104,7 @@ class MoveTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcessInvalidData()
     {
-        $invalidElement = new \Magento\Framework\View\Layout\Element('<move element="product" into="product.info"/>');
+        $invalidElement = new \Magento\Framework\View\Layout\Element('<move name="product" into="product.info"/>');
         $this->move->interpret($this->contextMock, $invalidElement, $invalidElement);
     }
 }


### PR DESCRIPTION
Changed <move> layout command to use name instead of element for referencing
which block to move.  This is for consistency with other layout commands (and to make @annarudko happy).  I did update the unit tests and they ran successfully on my local machine.