### PR TITLE
fix incorrect js filename

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -8,7 +8,8 @@ define([
     'ko',
     'Magento_Customer/js/section-config',
     'jquery/jquery-storageapi',
-    'jquery/jquery-cookie'
+    'jquery/jquery.cookie'
+
 ], function ($, _, ko, sectionConfig) {
     'use strict';
 


### PR DESCRIPTION
A one-liner that fixes issue #1360 and issue #1319. This *customer-data.js* file is currently the only place in the codebase requiring the incorrect path ``jquery/jquery-cookie``, so this is an easy fix.

It seems that the error with retrieving ``jquery/jquery-storageapi``has been resolved, probably due to the *requirejs-config.js* defining the path

    "jquery/jquery-storageapi": "jquery/jquery.storageapi.min"
