### PR TITLE
Specify `Magento_Catalog` module on template for sorting

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_category_view.xml
@@ -21,7 +21,7 @@
                     <block class="Magento\Framework\View\Element\RendererList" name="category.product.type.details.renderers" as="details.renderers">
                         <block class="Magento\Framework\View\Element\Template" as="default"/>
                     </block>
-                    <block class="Magento\Catalog\Block\Product\ProductList\Toolbar" name="product_list_toolbar" template="product/list/toolbar.phtml">
+                    <block class="Magento\Catalog\Block\Product\ProductList\Toolbar" name="product_list_toolbar" template="Magento_Catalog::product/list/toolbar.phtml">
                         <block class="Magento\Theme\Block\Html\Pager" name="product_list_toolbar_pager"/>
                         <!-- The following code shows how to set your own pager increments -->
                         <!--


### PR DESCRIPTION
I am trying to create an extension that enhances the sort order on product lists.

### Problem ###
To extend the sorting feature, I had extend the block `Magento\Catalog\Block\Product\ProductList\Toolbar`. Without specifying that the template is on `Magento_Catalog`, the module that extends this block also needs a copy of the template.

### What I tried ###

First, I tried using a plugin for this block and adding an `afterSetCollection()` method.
> `setCollection()` method handles the sorting algorithm

Unfortunately, my plugin did not work. This block had no interceptor (I am still interested in this and open to answers why). 

So, I did a rewrite using `<preference>` tag, then I made my changes in the block class from my module. After this, the toolbar was gone from the frontend! That is because it is searching for the template file (in my module) and not found. I worked it around by copying the `product/list/toolbar.phtml` file on my module.