### PR TITLE
Allow multiple caplitalized words (like typical vendor names) in ACL resource IDs

### DIFF
--- a/app/code/Magento/Config/Test/Unit/Model/Config/_files/invalidSystemXmlArray.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/_files/invalidSystemXmlArray.php
@@ -118,7 +118,7 @@ return [
             "Element 'resource': [facet 'minLength'] The value has a length of '4'; this underruns the allowed " .
             "minimum length of '8'.",
             "Element 'resource': [facet 'pattern'] The value 'One:' is not accepted by the " .
-            "pattern '[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
+            "pattern '([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
             "Element 'resource': 'One:' is not " . "a valid value of the atomic type 'typeAclResourceId'."
         ],
     ],

--- a/app/code/Magento/Config/etc/system.xsd
+++ b/app/code/Magento/Config/etc/system.xsd
@@ -414,7 +414,7 @@
         </xs:annotation>
 
         <xs:restriction base="xs:string">
-            <xs:pattern value="([A-Z]+[a-z0-9]{1,})+_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
+            <xs:pattern value="([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
             <xs:minLength value="8" />
         </xs:restriction>
     </xs:simpleType>

--- a/app/code/Magento/Config/etc/system.xsd
+++ b/app/code/Magento/Config/etc/system.xsd
@@ -414,7 +414,7 @@
         </xs:annotation>
 
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
+            <xs:pattern value="([A-Z]+[a-z0-9]{1,})+_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
             <xs:minLength value="8" />
         </xs:restriction>
     </xs:simpleType>

--- a/app/code/Magento/Config/etc/system_file.xsd
+++ b/app/code/Magento/Config/etc/system_file.xsd
@@ -427,7 +427,7 @@
         </xs:annotation>
 
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
+            <xs:pattern value="([A-Z]+[a-z0-9]{1,})+_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
             <xs:minLength value="8" />
         </xs:restriction>
     </xs:simpleType>

--- a/app/code/Magento/Config/etc/system_file.xsd
+++ b/app/code/Magento/Config/etc/system_file.xsd
@@ -427,7 +427,7 @@
         </xs:annotation>
 
         <xs:restriction base="xs:string">
-            <xs:pattern value="([A-Z]+[a-z0-9]{1,})+_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
+            <xs:pattern value="([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
             <xs:minLength value="8" />
         </xs:restriction>
     </xs:simpleType>

--- a/lib/internal/Magento/Framework/Acl/Test/Unit/Resource/Config/_files/invalidAclXmlArray.php
+++ b/lib/internal/Magento/Framework/Acl/Test/Unit/Resource/Config/_files/invalidAclXmlArray.php
@@ -49,7 +49,7 @@ return [
         '</resources></acl></config>',
         [
             "Element 'resource', attribute 'id': [facet 'pattern'] The value 'test_Value::show_toolbar' is " .
-            "not accepted by the pattern '[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
+            "not accepted by the pattern '([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
             "Element 'resource', attribute 'id': 'test_Value::show_toolbar' is not a valid value of the atomic type " .
             "'typeId'.",
             "Element 'resource', attribute 'id': Warning: No precomputed value available, " .
@@ -62,7 +62,7 @@ return [
         '</resources></acl></config>',
         [
             "Element 'resource', attribute 'id': [facet 'pattern'] The value 'Test_value::show_toolbar' is not " .
-            "accepted by the pattern '[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
+            "accepted by the pattern '([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
             "Element 'resource', attribute 'id': 'Test_value::show_toolbar' is not a valid value of the atomic type " .
             "'typeId'.",
             "Element 'resource', attribute 'id': Warning: No precomputed value available, " .
@@ -75,7 +75,7 @@ return [
         '</resources></acl></config>',
         [
             "Element 'resource', attribute 'id': [facet 'pattern'] The value 'M@#$%^*_Value::show_toolbar' is not " .
-            "accepted by the pattern '[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
+            "accepted by the pattern '([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
             "Element 'resource', attribute 'id': 'M@#$%^*_Value::show_toolbar' " .
             "is not a valid value of the atomic type " .
             "'typeId'.",
@@ -89,7 +89,7 @@ return [
         '</resources></acl></config>',
         [
             "Element 'resource', attribute 'id': [facet 'pattern'] The value '_Value::show_toolbar' is not " .
-            "accepted by the pattern '[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
+            "accepted by the pattern '([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
             "Element 'resource', attribute 'id': '_Value::show_toolbar' " .
             "is not a valid value of the atomic type 'typeId'.",
             "Element 'resource', attribute 'id': " .
@@ -102,7 +102,7 @@ return [
         '</acl></config>',
         [
             "Element 'resource', attribute 'id': [facet 'pattern'] The value 'Value_::show_toolbar' is not " .
-            "accepted by the pattern '[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
+            "accepted by the pattern '([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
             "Element 'resource', attribute 'id': 'Value_::show_toolbar' " .
             "is not a valid value of the atomic type 'typeId'.",
             "Element 'resource', attribute 'id': " .
@@ -115,7 +115,7 @@ return [
         '</resources></acl></config>',
         [
             "Element 'resource', attribute 'id': [facet 'pattern'] The value 'Test_value:show_toolbar' is not " .
-            "accepted by the pattern '[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
+            "accepted by the pattern '([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
             "Element 'resource', attribute 'id': 'Test_value:show_toolbar' is not a valid value of the atomic " .
             "type 'typeId'.",
             "Element 'resource', attribute 'id': " .
@@ -127,7 +127,7 @@ return [
         '<?xml version="1.0"?><config><acl><resources><resource id="Test_Value::"/></resources>' . '</acl></config>',
         [
             "Element 'resource', attribute 'id': [facet 'pattern'] The value 'Test_Value::' is not accepted by " .
-            "the pattern '[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
+            "the pattern '([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'.",
             "Element 'resource', attribute 'id': 'Test_Value::' is not a valid value of the atomic type 'typeId'.",
             "Element 'resource', attribute 'id': " .
             "Warning: No precomputed value available, the value was either invalid " .

--- a/lib/internal/Magento/Framework/Acl/etc/acl.xsd
+++ b/lib/internal/Magento/Framework/Acl/etc/acl.xsd
@@ -61,7 +61,7 @@
         </xs:annotation>
 
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Z]+[a-z0-9]{1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
+            <xs:pattern value="([A-Z]+[a-z0-9]{1,})+_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
         </xs:restriction>
     </xs:simpleType>
 

--- a/lib/internal/Magento/Framework/Acl/etc/acl.xsd
+++ b/lib/internal/Magento/Framework/Acl/etc/acl.xsd
@@ -61,7 +61,7 @@
         </xs:annotation>
 
         <xs:restriction base="xs:string">
-            <xs:pattern value="([A-Z]+[a-z0-9]{1,})+_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
+            <xs:pattern value="([A-Z]+[a-z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}" />
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
The current xsd schema allows for a single capitalized word, followed by an underscore, followed by any mix of lowercase and uppercase letters. All of this is followed by ``::`` and another, more specific string that can contain a mix of lowercase and uppercase letters. For example,

    <resource id="Magento_Catalog::attributes_attributes" title="Product" sortOrder="30" />

However, it seems that common practice will be to use the module name Vendor_Module as that first section of the ``id`` attribute. Since it is very common for vendor names to be two capitalized words, I've updated the schema to allow for something like below.

    <resource id="BlueAcorn_UrlTracker::urltracker" title="URL Tracker" />

To be clear, with the original xsd, the resource ID would have to be ``Blueacorn_UrlTracker::urltracker``, which would cause inconsistent naming across the application.