### PR TITLE
Fixes issue with reading store config for store with code of 'default'

### DIFF
--- a/app/code/Magento/Store/Model/Config/Reader/Store.php
+++ b/app/code/Magento/Store/Model/Config/Reader/Store.php
@@ -75,8 +75,6 @@ class Store implements \Magento\Framework\App\Config\Scope\ReaderInterface
     {
         if (empty($code)) {
             $store = $this->_storeManager->getStore();
-        } elseif (($code == ScopeConfigInterface::SCOPE_TYPE_DEFAULT)) {
-            $store = $this->_storeManager->getDefaultStoreView();
         } else {
             $store = $this->_storeFactory->create();
             $store->load($code);


### PR DESCRIPTION
Fixes bug where if you setup a store with a store code of 'default' and also have another store configured as the default store on the given website, the config values for the configured default store would be loaded when requesting the config for the `store|default` scope code. This results in the system displaying and using incorrect config values.

I've update the unit test to guarantee that this does not happen happen again within the affected method by mocking a default store, which if by the tested method will break the test. Also corrected the method so it correctly loads the correct config based on the passed in store code regardless of what that code may be.