### PR TITLE
Allow custom config files with virtual types only by adding generic schema locator

### DIFF
--- a/lib/internal/Magento/Framework/Config/GenericSchemaLocator.php
+++ b/lib/internal/Magento/Framework/Config/GenericSchemaLocator.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Magento\Framework\Config;
+
+use Magento\Framework\Module\Dir\Reader as ModuleDirReader;
+
+/**
+ * Class GenericSchemaLocator
+ */
+class GenericSchemaLocator implements SchemaLocatorInterface
+{
+    /**
+     * @var ModuleDirReader
+     */
+    private $moduleDirReader;
+    
+    /**
+     * @var string
+     */
+    private $moduleName;
+    
+    /**
+     * @var string
+     */
+    private $perFileSchema;
+    
+    /**
+     * @var string|null
+     */
+    private $schema;
+
+    /**
+     * @param ModuleDirReader $reader
+     * @param string $moduleName
+     * @param string $schema
+     * @param string|null $perFileSchema
+     */
+    public function __construct(ModuleDirReader $reader, $moduleName, $schema, $perFileSchema = null)
+    {
+        $this->moduleDirReader = $reader;
+        $this->moduleName = $moduleName;
+        $this->schema = $schema;
+        $this->perFileSchema = $perFileSchema;
+    }
+
+    /**
+     * Get path to merged config schema
+     *
+     * @return string|null
+     */
+    public function getSchema()
+    {
+        return $this->moduleDirReader->getModuleDir('etc', $this->moduleName) . '/' . $this->schema;
+    }
+
+    /**
+     * Get path to per file validation schema
+     *
+     * @return string|null
+     */
+    public function getPerFileSchema()
+    {
+        return is_null($this->perFileSchema) ?
+            null :
+            $this->moduleDirReader->getModuleDir('etc', $this->moduleName) . '/' . $this->perFileSchema;
+    }
+}

--- a/lib/internal/Magento/Framework/Config/Test/Unit/GenericSchemaLocatorTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/GenericSchemaLocatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace Magento\Framework\Config\Test\Unit;
+
+use Magento\Framework\Config\GenericSchemaLocator;
+use Magento\Framework\Config\SchemaLocatorInterface;
+use Magento\Framework\Module\Dir\Reader as ModuleDirReader;
+
+/**
+ * @covers \Magento\Framework\Config\GenericSchemaLocator
+ */
+class GenericSchemaLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string
+     */
+    private $testSchemaFileName = 'test-example.xsd';
+
+    /**
+     * @var GenericSchemaLocator
+     */
+    private $schemaLocator;
+
+    /**
+     * @var ModuleDirReader|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $moduleReaderMock;
+
+    private function createNewSchemaLocatorInstance(ModuleDirReader $reader, $moduleName, $mergeSchema, $perFileSchema)
+    {
+        return new GenericSchemaLocator($reader, $moduleName, $mergeSchema, $perFileSchema);
+    }
+
+    protected function setUp()
+    {
+        $this->moduleReaderMock = $this->getMock(ModuleDirReader::class, [], [], '', false);
+        $this->schemaLocator = $this->createNewSchemaLocatorInstance(
+            $this->moduleReaderMock,
+            'Test_ModuleName',
+            $this->testSchemaFileName,
+            null
+        );
+    }
+
+    public function testItIsAnInstanceOfSchemaLocatorInterface()
+    {
+        $this->assertInstanceOf(SchemaLocatorInterface::class, $this->schemaLocator);
+    }
+
+    public function testItReturnsThePathToTheSpecifiedModuleXsd()
+    {
+        $this->moduleReaderMock->expects($this->any())->method('getModuleDir')->willReturn('....');
+        $this->assertSame('..../' . $this->testSchemaFileName, $this->schemaLocator->getSchema());
+    }
+
+    public function testItReturnsNullAsTheDefaultPerFileSchema()
+    {
+        $this->assertNull($this->schemaLocator->getPerFileSchema());
+    }
+
+    public function testItReturnsThePathToThePerFileSchema()
+    {
+        $this->moduleReaderMock->expects($this->any())->method('getModuleDir')->willReturn('....');
+        $schemaLocator = $this->createNewSchemaLocatorInstance(
+            $this->moduleReaderMock,
+            'Test_ModuleName',
+            'some other file name',
+            $this->testSchemaFileName
+        );
+        $this->assertSame('..../' . $this->testSchemaFileName, $schemaLocator->getPerFileSchema());
+    }
+}


### PR DESCRIPTION
Using custom configuration files requires a number of class implementations.
Most of these can be satisfied by using generic implementations found within the `Magento\Framework\Config` namespace and injectable parameters.

* `Magento\Framework\Config\DataInterface` => `Magento\Framework\Config\Data`
* `Magento\Framework\Config\ReaderInterface` => `Magento\Framework\Config\Reader\Filesystem`
* `Magento\Framework\Config\ConverterInterface` => `Magento\Framework\Config\Converter\Dom`

The one that is missing is a generic implementation of the schema locator interface `Magento\Framework\Config\SchemaLocatorInterface`
The implementation always is very simple, it only returns the names of the schema files. Not a lot of work but just another bit of annoying boilerplate to write.

This PR adds a generic schema locator implementation.
Here is an example di.xml how that might be used:
```xml
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="../../../../../../lib/internal/Magento/Framework/ObjectManager/etc/config.xsd">
    <type name="Example\DiConfig\Controller\Index\Index">
        <arguments>
            <argument name="config" xsi:type="object">Example\DiConfig\Model\ConfigData\Virtual</argument>
        </arguments>
    </type>
    <virtualType name="Example\DiConfig\Model\ConfigData\Virtual"
                 type="Magento\Framework\Config\Data">
        <arguments>
            <argument name="reader" xsi:type="object">Example\DiConfig\Model\Config\Reader\Virtual</argument>
            <argument name="cacheId" xsi:type="string">example_config</argument>
        </arguments>
    </virtualType>
    <virtualType name="Example\DiConfig\Model\Config\Reader\Virtual"
                 type="Magento\Framework\Config\Reader\Filesystem">
        <arguments>
            <argument name="converter" xsi:type="object">Example\DiConfig\Model\Config\Converter\Virtual</argument>
            <argument name="schemaLocator" xsi:type="object">Example\DiConfig\Model\Config\SchemaLocator\Virtual</argument>
            <argument name="fileName" xsi:type="string">example.xml</argument>
        </arguments>
    </virtualType>
    
    <virtualType name="Example\DiConfig\Model\Config\Converter\Virtual"
                 type="Magento\Framework\Config\Converter\Dom"/>

    <virtualType name="Example\DiConfig\Model\Config\SchemaLocator\Virtual"
                 type="Magento\Framework\Config\GenericSchemaLocator">
        <arguments>
            <argument name="moduleName" xsi:type="string">Example_DiConfig</argument>
            <argument name="schema" xsi:type="string">example.xsd</argument>
        </arguments>
    </virtualType>
</config>
```
No custom class implementations are required anymore to use custom configuration files. Of course they still should be used if it makes sense though, mostly for the `DataInterface` to provide readable getters.