### PR TITLE
Add abstract method execute() to \Magento\Framework\App\Action\Action

### DIFF
--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification.php
@@ -7,7 +7,7 @@
  */
 namespace Magento\AdminNotification\Controller\Adminhtml;
 
-class Notification extends \Magento\Backend\App\AbstractAction
+abstract class Notification extends \Magento\Backend\App\AbstractAction
 {
     /**
      * @return bool

--- a/app/code/Magento/Backend/App/Action.php
+++ b/app/code/Magento/Backend/App/Action.php
@@ -12,6 +12,6 @@ namespace Magento\Backend\App;
 /**
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class Action extends \Magento\Backend\App\AbstractAction
+abstract class Action extends \Magento\Backend\App\AbstractAction
 {
 }

--- a/app/code/Magento/Backend/Controller/Adminhtml/Auth.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Auth.php
@@ -10,7 +10,7 @@ use Magento\Backend\App\AbstractAction;
 /**
  * Auth backend controller
  */
-class Auth extends AbstractAction
+abstract class Auth extends AbstractAction
 {
     /**
      * Check if user has permissions to access this controller

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache.php
@@ -8,7 +8,7 @@ namespace Magento\Backend\Controller\Adminhtml;
 use Magento\Backend\App\Action;
 use Magento\Framework\Exception\LocalizedException;
 
-class Cache extends Action
+abstract class Cache extends Action
 {
     /**
      * @var \Magento\Framework\App\Cache\TypeListInterface

--- a/app/code/Magento/Backend/Controller/Adminhtml/Dashboard.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Dashboard.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Backend\Controller\Adminhtml;
 
-class Dashboard extends \Magento\Backend\App\Action
+abstract class Dashboard extends \Magento\Backend\App\Action
 {
     /**
      * @return bool

--- a/app/code/Magento/Backend/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Index.php
@@ -10,7 +10,7 @@ use Magento\Backend\App\AbstractAction;
 /**
  * Index backend controller
  */
-class Index extends AbstractAction
+abstract class Index extends AbstractAction
 {
     /**
      * Check if user has permissions to access this controller

--- a/app/code/Magento/Backend/Controller/Adminhtml/System.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System.php
@@ -12,7 +12,7 @@ use Magento\Backend\App\AbstractAction;
  *
  * @author     Magento Core Team <core@magentocommerce.com>
  */
-class System extends AbstractAction
+abstract class System extends AbstractAction
 {
     /**
      * @return bool

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Account.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Account.php
@@ -12,7 +12,7 @@ use Magento\Backend\App\Action;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Account extends Action
+abstract class Account extends Action
 {
     /**
      * @return bool

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Design.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Design.php
@@ -7,7 +7,7 @@ namespace Magento\Backend\Controller\Adminhtml\System;
 
 use Magento\Backend\App\Action;
 
-class Design extends Action
+abstract class Design extends Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
@@ -17,7 +17,7 @@ use Magento\Framework\Filesystem;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Store extends Action
+abstract class Store extends Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Backup/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Backup/Controller/Adminhtml/Index.php
@@ -10,7 +10,7 @@ namespace Magento\Backup\Controller\Adminhtml;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Index extends \Magento\Backend\App\Action
+abstract class Index extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category.php
@@ -8,7 +8,7 @@ namespace Magento\Catalog\Controller\Adminhtml;
 /**
  * Catalog category controller
  */
-class Category extends \Magento\Backend\App\Action
+abstract class Category extends \Magento\Backend\App\Action
 {
     /**
      * Initialize requested category and put it into registry.

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Widget.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Widget.php
@@ -12,7 +12,7 @@ use Magento\Framework\View\Element\BlockInterface;
  *
  * @author     Magento Core Team <core@magentocommerce.com>
  */
-class Widget extends \Magento\Backend\App\Action
+abstract class Widget extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\View\LayoutFactory

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product.php
@@ -11,7 +11,7 @@ use Magento\Backend\App\Action;
  * Catalog product controller
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class Product extends \Magento\Backend\App\Action
+abstract class Product extends \Magento\Backend\App\Action
 {
     /**
      * @var Product\Builder

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/AbstractProductGrid.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/AbstractProductGrid.php
@@ -10,7 +10,7 @@ use Magento\Backend\App\Action;
 use Magento\Catalog\Controller\Adminhtml\Product;
 use Magento\Framework\Controller\Result;
 
-class AbstractProductGrid extends Product
+abstract class AbstractProductGrid extends Product
 {
     /**
      * @var \Magento\Framework\View\Result\LayoutFactory

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
@@ -13,7 +13,7 @@ use Magento\Backend\App\Action;
 /**
  * Adminhtml catalog product action attribute update controller
  */
-class Attribute extends Action
+abstract class Attribute extends Action
 {
     /**
      *  @var \Magento\Catalog\Helper\Product\Edit\Action\Attribute

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute.php
@@ -12,7 +12,7 @@ namespace Magento\Catalog\Controller\Adminhtml\Product;
 use Magento\Framework\Controller\Result;
 use Magento\Framework\View\Result\PageFactory;
 
-class Attribute extends \Magento\Backend\App\Action
+abstract class Attribute extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\Cache\FrontendInterface

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set.php
@@ -10,7 +10,7 @@ namespace Magento\Catalog\Controller\Adminhtml\Product;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Set extends \Magento\Backend\App\Action
+abstract class Set extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Catalog/Controller/Product.php
+++ b/app/code/Magento/Catalog/Controller/Product.php
@@ -10,7 +10,7 @@ namespace Magento\Catalog\Controller;
 use Magento\Catalog\Controller\Product\View\ViewInterface;
 use Magento\Catalog\Model\Product as ModelProduct;
 
-class Product extends \Magento\Framework\App\Action\Action implements ViewInterface
+abstract class Product extends \Magento\Framework\App\Action\Action implements ViewInterface
 {
     /**
      * Initialize requested product object

--- a/app/code/Magento/Catalog/Controller/Product/Compare.php
+++ b/app/code/Magento/Catalog/Controller/Product/Compare.php
@@ -15,7 +15,7 @@ use Magento\Framework\View\Result\PageFactory;
  * @SuppressWarnings(PHPMD.LongVariable)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Compare extends \Magento\Framework\App\Action\Action
+abstract class Compare extends \Magento\Framework\App\Action\Action
 {
     /**
      * Customer id

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog.php
@@ -18,7 +18,7 @@ use Magento\Backend\App\Action\Context;
 use Magento\Framework\Registry;
 use Magento\Framework\Stdlib\DateTime\Filter\Date;
 
-class Catalog extends Action
+abstract class Catalog extends Action
 {
     /**
      * Dirty rules notice message

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Widget.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Widget.php
@@ -7,7 +7,7 @@ namespace Magento\CatalogRule\Controller\Adminhtml\Promo;
 
 use Magento\Backend\App\Action;
 
-class Widget extends Action
+abstract class Widget extends Action
 {
     /**
      * @return bool

--- a/app/code/Magento/CatalogWidget/Controller/Adminhtml/Product/Widget.php
+++ b/app/code/Magento/CatalogWidget/Controller/Adminhtml/Product/Widget.php
@@ -10,7 +10,7 @@ use Magento\Backend\App\Action;
 /**
  * Class Widget
  */
-class Widget extends Action
+abstract class Widget extends Action
 {
     /**
      * @return bool

--- a/app/code/Magento/Checkout/Controller/Cart.php
+++ b/app/code/Magento/Checkout/Controller/Cart.php
@@ -12,7 +12,7 @@ use Magento\Store\Model\ScopeInterface;
 /**
  * Shopping cart controller
  */
-class Cart extends \Magento\Framework\App\Action\Action implements ViewInterface
+abstract class Cart extends \Magento\Framework\App\Action\Action implements ViewInterface
 {
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface

--- a/app/code/Magento/Checkout/Controller/Onepage.php
+++ b/app/code/Magento/Checkout/Controller/Onepage.php
@@ -13,7 +13,7 @@ use Magento\Framework\App\RequestInterface;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Onepage extends Action
+abstract class Onepage extends Action
 {
     /**
      * @var array

--- a/app/code/Magento/Checkout/Test/Unit/Controller/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/OnepageTest.php
@@ -85,9 +85,9 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
         $context->expects($this->once())
             ->method('getEventManager')
             ->willReturn($this->eventManager);
-
+        
         $this->controller = $objectManager->getObject(
-            'Magento\Checkout\Controller\Onepage',
+            'Magento\Checkout\Test\Unit\Controller\Stub\OnepageStub',
             [
                 'context' => $context
             ]

--- a/app/code/Magento/Checkout/Test/Unit/Controller/Stub/OnepageStub.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/Stub/OnepageStub.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Magento\Checkout\Test\Unit\Controller\Stub;
+
+class OnepageStub extends \Magento\Checkout\Controller\Onepage
+{
+    protected function execute()
+    {
+        // Empty method stub for test
+    }
+}

--- a/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement.php
+++ b/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\CheckoutAgreements\Controller\Adminhtml;
 
-class Agreement extends \Magento\Backend\App\Action
+abstract class Agreement extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block.php
@@ -10,7 +10,7 @@ namespace Magento\Cms\Controller\Adminhtml;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Block extends \Magento\Backend\App\Action
+abstract class Block extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images.php
@@ -10,7 +10,7 @@ namespace Magento\Cms\Controller\Adminhtml\Wysiwyg;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Images extends \Magento\Backend\App\Action
+abstract class Images extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Contact/Controller/Index.php
+++ b/app/code/Magento/Contact/Controller/Index.php
@@ -12,7 +12,7 @@ use Magento\Store\Model\ScopeInterface;
 /**
  * Contact index controller
  */
-class Index extends \Magento\Framework\App\Action\Action
+abstract class Index extends \Magento\Framework\App\Action\Action
 {
     /**
      * Recipient email config path

--- a/app/code/Magento/Contact/Test/Unit/Controller/IndexTest.php
+++ b/app/code/Magento/Contact/Test/Unit/Controller/IndexTest.php
@@ -51,7 +51,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->_controller = new \Magento\Contact\Controller\Index(
+        $this->_controller = new \Magento\Contact\Test\Unit\Controller\Stub\IndexStub(
             $context,
             $this->getMock('\Magento\Framework\Mail\Template\TransportBuilder', [], [], '', false),
             $this->getMockForAbstractClass('\Magento\Framework\Translate\Inline\StateInterface', [], '', false),

--- a/app/code/Magento/Contact/Test/Unit/Controller/Stub/IndexStub.php
+++ b/app/code/Magento/Contact/Test/Unit/Controller/Stub/IndexStub.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Magento\Contact\Test\Unit\Controller\Stub;
+
+class IndexStub extends \Magento\Contact\Controller\Index
+{
+    protected function execute()
+    {
+        // Empty method stub for test
+    }
+}

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\CurrencySymbol\Controller\Adminhtml\System;
 
-class Currency extends \Magento\Backend\App\Action
+abstract class Currency extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\CurrencySymbol\Controller\Adminhtml\System;
 
-class Currencysymbol extends \Magento\Backend\App\Action
+abstract class Currencysymbol extends \Magento\Backend\App\Action
 {
     /**
      * Check the permission to run it

--- a/app/code/Magento/Customer/Controller/Account.php
+++ b/app/code/Magento/Customer/Controller/Account.php
@@ -16,7 +16,7 @@ use Magento\Framework\View\Result\PageFactory;
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Account extends \Magento\Framework\App\Action\Action
+abstract class Account extends \Magento\Framework\App\Action\Action
 {
     /**
      * List of actions that are allowed for not authorized users

--- a/app/code/Magento/Customer/Controller/Address.php
+++ b/app/code/Magento/Customer/Controller/Address.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\RequestInterface;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Address extends \Magento\Framework\App\Action\Action
+abstract class Address extends \Magento\Framework\App\Action\Action
 {
     /**
      * @var \Magento\Customer\Model\Session

--- a/app/code/Magento/Customer/Controller/Adminhtml/Cart/Product/Composite/Cart.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Cart/Product/Composite/Cart.php
@@ -13,7 +13,7 @@ use Magento\Framework\Exception\LocalizedException;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Cart extends \Magento\Backend\App\Action
+abstract class Cart extends \Magento\Backend\App\Action
 {
     /**
      * Customer we're working with

--- a/app/code/Magento/Customer/Controller/Adminhtml/Group.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Group.php
@@ -11,7 +11,7 @@ use Magento\Customer\Api\GroupRepositoryInterface;
 /**
  * Customer groups controller
  */
-class Group extends \Magento\Backend\App\Action
+abstract class Group extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index.php
@@ -24,7 +24,7 @@ use Magento\Framework\Api\DataObjectHelper;
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class Index extends \Magento\Backend\App\Action
+abstract class Index extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\Validator

--- a/app/code/Magento/Customer/Controller/Adminhtml/System/Config/Validatevat.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/System/Config/Validatevat.php
@@ -10,7 +10,7 @@ namespace Magento\Customer\Controller\Adminhtml\System\Config;
  *
  * @author     Magento Core Team <core@magentocommerce.com>
  */
-class Validatevat extends \Magento\Backend\App\Action
+abstract class Validatevat extends \Magento\Backend\App\Action
 {
     /**
      * Perform customer VAT ID validation

--- a/app/code/Magento/Customer/Controller/Adminhtml/Wishlist/Product/Composite/Wishlist.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Wishlist/Product/Composite/Wishlist.php
@@ -10,7 +10,7 @@ use Magento\Framework\Exception\LocalizedException as CoreException;
 /**
  * Catalog composite product configuration controller
  */
-class Wishlist extends \Magento\Backend\App\Action
+abstract class Wishlist extends \Magento\Backend\App\Action
 {
     /**
      * Wishlist we're working with.

--- a/app/code/Magento/DesignEditor/Controller/Adminhtml/System/Design/Editor.php
+++ b/app/code/Magento/DesignEditor/Controller/Adminhtml/System/Design/Editor.php
@@ -14,7 +14,7 @@ use Magento\Store\Model\Store;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Editor extends \Magento\Backend\App\Action
+abstract class Editor extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Theme\Model\Config

--- a/app/code/Magento/DesignEditor/Controller/Adminhtml/System/Design/Editor/Tools.php
+++ b/app/code/Magento/DesignEditor/Controller/Adminhtml/System/Design/Editor/Tools.php
@@ -10,7 +10,7 @@ namespace Magento\DesignEditor\Controller\Adminhtml\System\Design\Editor;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Tools extends \Magento\Backend\App\Action
+abstract class Tools extends \Magento\Backend\App\Action
 {
     /**
      * Initialize theme context model

--- a/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/File.php
+++ b/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/File.php
@@ -10,7 +10,7 @@ namespace Magento\Downloadable\Controller\Adminhtml\Downloadable;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class File extends \Magento\Backend\App\Action
+abstract class File extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Downloadable\Model\Link

--- a/app/code/Magento/Downloadable/Controller/Download.php
+++ b/app/code/Magento/Downloadable/Controller/Download.php
@@ -12,7 +12,7 @@ use Magento\Downloadable\Helper\Download as DownloadHelper;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Download extends \Magento\Framework\App\Action\Action
+abstract class Download extends \Magento\Framework\App\Action\Action
 {
     /**
      * Prepare response to output resource contents

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template.php
@@ -10,7 +10,7 @@ namespace Magento\Email\Controller\Adminhtml\Email;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Template extends \Magento\Backend\App\Action
+abstract class Template extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/GoogleShopping/Controller/Adminhtml/Googleshopping/Items.php
+++ b/app/code/Magento/GoogleShopping/Controller/Adminhtml/Googleshopping/Items.php
@@ -12,7 +12,7 @@ use Magento\Framework\Controller\ResultFactory;
 /**
  * GoogleShopping Admin Items Controller
  */
-class Items extends \Magento\Backend\App\Action
+abstract class Items extends \Magento\Backend\App\Action
 {
     /**
      * @var NotifierInterface

--- a/app/code/Magento/GoogleShopping/Controller/Adminhtml/Googleshopping/Types.php
+++ b/app/code/Magento/GoogleShopping/Controller/Adminhtml/Googleshopping/Types.php
@@ -10,7 +10,7 @@ use Magento\Framework\App\RequestInterface;
 /**
  * GoogleShopping Admin Item Types Controller
  */
-class Types extends \Magento\Backend\App\Action
+abstract class Types extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export.php
@@ -10,7 +10,7 @@ use Magento\Backend\App\Action;
 /**
  * Export controller
  */
-class Export extends Action
+abstract class Export extends Action
 {
     /**
      * Check access (in the ACL) for current user

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import.php
@@ -10,7 +10,7 @@ use Magento\Backend\App\Action;
 /**
  * Import controller
  */
-class Import extends Action
+abstract class Import extends Action
 {
     /**
      * Check access (in the ACL) for current user.

--- a/app/code/Magento/Indexer/Controller/Adminhtml/Indexer.php
+++ b/app/code/Magento/Indexer/Controller/Adminhtml/Indexer.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Indexer\Controller\Adminhtml;
 
-class Indexer extends \Magento\Backend\App\Action
+abstract class Indexer extends \Magento\Backend\App\Action
 {
     /**
      * Check ACL permissions

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration.php
@@ -13,7 +13,7 @@ use Magento\Integration\Api\OauthServiceInterface as IntegrationOauthService;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Integration extends Action
+abstract class Integration extends Action
 {
     /** Param Key for extracting integration id from Request */
     const PARAM_INTEGRATION_ID = 'id';

--- a/app/code/Magento/MediaStorage/Controller/Adminhtml/System/Config/System/Storage.php
+++ b/app/code/Magento/MediaStorage/Controller/Adminhtml/System/Config/System/Storage.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\MediaStorage\Controller\Adminhtml\System\Config\System;
 
-class Storage extends \Magento\Backend\App\Action
+abstract class Storage extends \Magento\Backend\App\Action
 {
     /**
      * Return file storage singleton

--- a/app/code/Magento/Multishipping/Controller/Checkout.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout.php
@@ -13,7 +13,7 @@ use Magento\Framework\App\RequestInterface;
  * Multishipping checkout controller
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class Checkout extends \Magento\Checkout\Controller\Action implements
+abstract class Checkout extends \Magento\Checkout\Controller\Action implements
     \Magento\Checkout\Controller\Express\RedirectLoginInterface
 {
     /**

--- a/app/code/Magento/Multishipping/Controller/Checkout/Address.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Address.php
@@ -8,7 +8,7 @@ namespace Magento\Multishipping\Controller\Checkout;
 /**
  * Multishipping checkout address manipulation controller
  */
-class Address extends \Magento\Framework\App\Action\Action
+abstract class Address extends \Magento\Framework\App\Action\Action
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Problem.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Problem.php
@@ -8,7 +8,7 @@ namespace Magento\Newsletter\Controller\Adminhtml;
 /**
  * Newsletter subscribers controller
  */
-class Problem extends \Magento\Backend\App\Action
+abstract class Problem extends \Magento\Backend\App\Action
 {
     /**
      * Check if user has enough privileges

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Queue.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Queue.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Newsletter\Controller\Adminhtml;
 
-class Queue extends \Magento\Backend\App\Action
+abstract class Queue extends \Magento\Backend\App\Action
 {
     /**
      * Check if user has enough privileges

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber.php
@@ -8,7 +8,7 @@ namespace Magento\Newsletter\Controller\Adminhtml;
 /**
  * Newsletter subscribers controller
  */
-class Subscriber extends \Magento\Backend\App\Action
+abstract class Subscriber extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\App\Response\Http\FileFactory

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Template.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Template.php
@@ -10,7 +10,7 @@
  */
 namespace Magento\Newsletter\Controller\Adminhtml;
 
-class Template extends \Magento\Backend\App\Action
+abstract class Template extends \Magento\Backend\App\Action
 {
     /**
      * Check is allowed access

--- a/app/code/Magento/Newsletter/Controller/Manage.php
+++ b/app/code/Magento/Newsletter/Controller/Manage.php
@@ -10,7 +10,7 @@ use Magento\Framework\App\RequestInterface;
 /**
  * Customers newsletter subscription controller
  */
-class Manage extends \Magento\Framework\App\Action\Action
+abstract class Manage extends \Magento\Framework\App\Action\Action
 {
     /**
      * Customer session

--- a/app/code/Magento/Newsletter/Controller/Subscriber.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber.php
@@ -15,7 +15,7 @@ use Magento\Customer\Model\Session;
 use Magento\Newsletter\Model\SubscriberFactory;
 use Magento\Customer\Model\Url as CustomerUrl;
 
-class Subscriber extends \Magento\Framework\App\Action\Action
+abstract class Subscriber extends \Magento\Framework\App\Action\Action
 {
     /**
      * Customer session

--- a/app/code/Magento/PageCache/Controller/Block.php
+++ b/app/code/Magento/PageCache/Controller/Block.php
@@ -7,7 +7,7 @@
  */
 namespace Magento\PageCache\Controller;
 
-class Block extends \Magento\Framework\App\Action\Action
+abstract class Block extends \Magento\Framework\App\Action\Action
 {
     /**
      * @var \Magento\Framework\Translate\InlineInterface

--- a/app/code/Magento/Persistent/Controller/Index.php
+++ b/app/code/Magento/Persistent/Controller/Index.php
@@ -15,7 +15,7 @@ use Magento\Persistent\Helper\Session as SessionHelper;
 /**
  * Persistent front controller
  */
-class Index extends Action
+abstract class Index extends Action
 {
     /**
      * Persistent observer

--- a/app/code/Magento/ProductAlert/Controller/Add.php
+++ b/app/code/Magento/ProductAlert/Controller/Add.php
@@ -10,7 +10,7 @@ use Magento\Framework\App\Action\Context;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\App\RequestInterface;
 
-class Add extends Action
+abstract class Add extends Action
 {
     /**
      * @var \Magento\Customer\Model\Session

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe.php
@@ -5,6 +5,6 @@
  */
 namespace Magento\ProductAlert\Controller;
 
-class Unsubscribe extends Add
+abstract class Unsubscribe extends Add
 {
 }

--- a/app/code/Magento/Reports/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Index.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Reports\Controller\Adminhtml;
 
-class Index extends \Magento\Backend\App\Action
+abstract class Index extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\App\Response\Http\FileFactory

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Customer.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Customer.php
@@ -12,7 +12,7 @@
  */
 namespace Magento\Reports\Controller\Adminhtml\Report;
 
-class Customer extends \Magento\Backend\App\Action
+abstract class Customer extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\App\Response\Http\FileFactory

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Reports\Controller\Adminhtml\Report;
 
-class Product extends AbstractReport
+abstract class Product extends AbstractReport
 {
     /**
      * Add report/products breadcrumbs

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Review.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Review.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Reports\Controller\Adminhtml\Report;
 
-class Review extends \Magento\Backend\App\Action
+abstract class Review extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\App\Response\Http\FileFactory

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Sales.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Sales.php
@@ -14,7 +14,7 @@ namespace Magento\Reports\Controller\Adminhtml\Report;
 /**
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class Sales extends AbstractReport
+abstract class Sales extends AbstractReport
 {
     /**
      * Add report/sales breadcrumbs

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart.php
@@ -11,7 +11,7 @@
  */
 namespace Magento\Reports\Controller\Adminhtml\Report;
 
-class Shopcart extends \Magento\Backend\App\Action
+abstract class Shopcart extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\App\Response\Http\FileFactory

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics.php
@@ -14,7 +14,7 @@ namespace Magento\Reports\Controller\Adminhtml\Report;
 use Magento\Backend\Model\Auth\Session as AuthSession;
 use Magento\Backend\Model\Session;
 
-class Statistics extends \Magento\Backend\App\Action
+abstract class Statistics extends \Magento\Backend\App\Action
 {
     /**
      * Admin session model

--- a/app/code/Magento/Review/Controller/Adminhtml/Product.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product.php
@@ -14,7 +14,7 @@ use Magento\Review\Model\RatingFactory;
 /**
  * Reviews admin controller
  */
-class Product extends Action
+abstract class Product extends Action
 {
     /**
      * Array of actions which can be processed without secret key validation

--- a/app/code/Magento/Review/Controller/Adminhtml/Rating.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Rating.php
@@ -12,7 +12,7 @@ use Magento\Framework\Registry;
 /**
  * Admin ratings controller
  */
-class Rating extends Action
+abstract class Rating extends Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Review/Controller/Customer.php
+++ b/app/code/Magento/Review/Controller/Customer.php
@@ -13,7 +13,7 @@ use Magento\Framework\App\RequestInterface;
 /**
  * Customer reviews controller
  */
-class Customer extends Action
+abstract class Customer extends Action
 {
     /**
      * Customer session model

--- a/app/code/Magento/Review/Controller/Product.php
+++ b/app/code/Magento/Review/Controller/Product.php
@@ -15,7 +15,7 @@ use Magento\Review\Model\Review;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Product extends \Magento\Framework\App\Action\Action
+abstract class Product extends \Magento\Framework\App\Action\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Rss/Controller/Adminhtml/Feed.php
+++ b/app/code/Magento/Rss/Controller/Adminhtml/Feed.php
@@ -9,7 +9,7 @@ namespace Magento\Rss\Controller\Adminhtml;
  * Class Feed
  * @package Magento\Rss\Controller
  */
-class Feed extends \Magento\Backend\App\Action
+abstract class Feed extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Rss\Model\RssManager

--- a/app/code/Magento/Rss/Controller/Feed.php
+++ b/app/code/Magento/Rss/Controller/Feed.php
@@ -8,7 +8,7 @@ namespace Magento\Rss\Controller;
 /**
  * Class Feed
  */
-class Feed extends \Magento\Framework\App\Action\Action
+abstract class Feed extends \Magento\Framework\App\Action\Action
 {
     /**
      * @var \Magento\Customer\Model\Session

--- a/app/code/Magento/Rss/Controller/Index.php
+++ b/app/code/Magento/Rss/Controller/Index.php
@@ -9,7 +9,7 @@ namespace Magento\Rss\Controller;
  * Class Index
  * @package Magento\Rss\Controller
  */
-class Index extends \Magento\Framework\App\Action\Action
+abstract class Index extends \Magento\Framework\App\Action\Action
 {
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order.php
@@ -13,7 +13,7 @@ use Magento\Backend\App\Action;
  * @author      Magento Core Team <core@magentocommerce.com>
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class Order extends \Magento\Backend\App\Action
+abstract class Order extends \Magento\Backend\App\Action
 {
     /**
      * Array of actions which can be processed without secret key validation

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Create.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Create.php
@@ -15,7 +15,7 @@ use Magento\Backend\Model\View\Result\ForwardFactory;
  * @author      Magento Core Team <core@magentocommerce.com>
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class Create extends \Magento\Backend\App\Action
+abstract class Create extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\Escaper

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status.php
@@ -8,7 +8,7 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 /**
  * Order status management controller
  */
-class Status extends \Magento\Backend\App\Action
+abstract class Status extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/View/Giftmessage.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/View/Giftmessage.php
@@ -10,7 +10,7 @@ namespace Magento\Sales\Controller\Adminhtml\Order\View;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Giftmessage extends \Magento\Backend\App\Action
+abstract class Giftmessage extends \Magento\Backend\App\Action
 {
     /**
      * Retrieve gift message save model

--- a/app/code/Magento/Sales/Controller/Adminhtml/Transactions.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Transactions.php
@@ -15,7 +15,7 @@ use Magento\Framework\View\Result\LayoutFactory;
  *
  * @author Magento Core Team <core@magentocommerce.com>
  */
-class Transactions extends \Magento\Backend\App\Action
+abstract class Transactions extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\SalesRule\Controller\Adminhtml\Promo;
 
-class Quote extends \Magento\Backend\App\Action
+abstract class Quote extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Search/Controller/Adminhtml/Term.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term.php
@@ -8,7 +8,7 @@ namespace Magento\Search\Controller\Adminhtml;
 use Magento\Backend\App\Action;
 use Magento\Framework\Controller\ResultFactory;
 
-class Term extends Action
+abstract class Term extends Action
 {
     /**
      * @return \Magento\Backend\Model\View\Result\Page

--- a/app/code/Magento/SendFriend/Controller/Product.php
+++ b/app/code/Magento/SendFriend/Controller/Product.php
@@ -14,7 +14,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Product extends \Magento\Framework\App\Action\Action
+abstract class Product extends \Magento\Framework\App\Action\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap.php
@@ -8,7 +8,7 @@ namespace Magento\Sitemap\Controller\Adminhtml;
 /**
  * XML sitemap controller
  */
-class Sitemap extends \Magento\Backend\App\Action
+abstract class Sitemap extends \Magento\Backend\App\Action
 {
     /**
      * Init actions

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rate.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rate.php
@@ -13,7 +13,7 @@ use Magento\Framework\Controller\ResultFactory;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Rate extends \Magento\Backend\App\Action
+abstract class Rate extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\Registry

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rule.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rule.php
@@ -14,7 +14,7 @@ namespace Magento\Tax\Controller\Adminhtml;
 use Magento\Backend\App\Action;
 use Magento\Framework\Controller\ResultFactory;
 
-class Rule extends \Magento\Backend\App\Action
+abstract class Rule extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Tax/Controller/Adminhtml/Tax.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Tax.php
@@ -13,7 +13,7 @@ use Magento\Framework\Exception\InputException;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Tax extends \Magento\Backend\App\Action
+abstract class Tax extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Tax\Api\TaxClassRepositoryInterface

--- a/app/code/Magento/Tax/Test/Unit/App/Action/ContextPluginTest.php
+++ b/app/code/Magento/Tax/Test/Unit/App/Action/ContextPluginTest.php
@@ -123,7 +123,7 @@ class ContextPluginTest extends \PHPUnit_Framework_TestCase
             ->method('setValue')
             ->with('tax_rates', [], 0);
 
-        $action = $this->objectManager->getObject('Magento\Framework\App\Action\Action');
+        $action = $this->objectManager->getObject('Magento\Tax\Test\Unit\App\Action\Stub\ActionStub');
         $request = $this->getMock('\Magento\Framework\App\Request\Http', ['getActionName'], [], '', false);
         $expectedResult = 'expectedResult';
         $proceed = function ($request) use ($expectedResult) {

--- a/app/code/Magento/Tax/Test/Unit/App/Action/Stub/ActionStub.php
+++ b/app/code/Magento/Tax/Test/Unit/App/Action/Stub/ActionStub.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Magento\Tax\Test\Unit\App\Action\Stub;
+
+class ActionStub extends \Magento\Framework\App\Action\Action
+{
+    protected function execute()
+    {
+        // Empty method stub for test
+    }
+}

--- a/app/code/Magento/TaxImportExport/Controller/Adminhtml/Rate.php
+++ b/app/code/Magento/TaxImportExport/Controller/Adminhtml/Rate.php
@@ -8,7 +8,7 @@ namespace Magento\TaxImportExport\Controller\Adminhtml;
 /**
  * Adminhtml tax rate controller
  */
-class Rate extends \Magento\Backend\App\Action
+abstract class Rate extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\App\Response\Http\FileFactory

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme.php
@@ -9,7 +9,7 @@
  */
 namespace Magento\Theme\Controller\Adminhtml\System\Design;
 
-class Theme extends \Magento\Backend\App\Action
+abstract class Theme extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Wysiwyg/Files.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Wysiwyg/Files.php
@@ -9,7 +9,7 @@
  */
 namespace Magento\Theme\Controller\Adminhtml\System\Design\Wysiwyg;
 
-class Files extends \Magento\Backend\App\Action
+abstract class Files extends \Magento\Backend\App\Action
 {
     /**
      * @var \Magento\Framework\App\Response\Http\FileFactory

--- a/app/code/Magento/Ui/Controller/Adminhtml/AbstractAction.php
+++ b/app/code/Magento/Ui/Controller/Adminhtml/AbstractAction.php
@@ -31,13 +31,6 @@ abstract class AbstractAction extends Action implements UiActionInterface
     }
 
     /**
-     * Execute action
-     *
-     * @return mixed
-     */
-    abstract public function execute();
-
-    /**
      * Getting name
      *
      * @return mixed
@@ -55,5 +48,15 @@ abstract class AbstractAction extends Action implements UiActionInterface
     protected function getComponent()
     {
         return $this->_request->getParam('component');
+    }
+
+    /**
+     * Action for AJAX request
+     *
+     * @return void
+     */
+    public function executeAjaxRequest()
+    {
+        $this->execute();
     }
 }

--- a/app/code/Magento/Ui/Controller/Adminhtml/Bookmark/Delete.php
+++ b/app/code/Magento/Ui/Controller/Adminhtml/Bookmark/Delete.php
@@ -48,7 +48,7 @@ class Delete extends AbstractAction
      *
      * @return void
      */
-    public function execute()
+    protected function execute()
     {
         $viewIds = explode('.', $this->_request->getParam('data'));
         $bookmark = $this->bookmarkManagement->getByIdentifierNamespace(

--- a/app/code/Magento/Ui/Controller/Adminhtml/Bookmark/Save.php
+++ b/app/code/Magento/Ui/Controller/Adminhtml/Bookmark/Save.php
@@ -71,7 +71,7 @@ class Save extends AbstractAction
      *
      * @return void
      */
-    public function execute()
+    protected function execute()
     {
         $bookmark = $this->bookmarkFactory->create();
         $data = $this->_request->getParam('data');

--- a/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php
+++ b/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php
@@ -20,7 +20,7 @@ class Render extends AbstractAction
      *
      * @return void
      */
-    public function execute()
+    protected function execute()
     {
         $component = $this->factory->create($this->_request->getParam('namespace'));
         $this->prepareComponent($component);

--- a/app/code/Magento/Ui/Controller/UiActionInterface.php
+++ b/app/code/Magento/Ui/Controller/UiActionInterface.php
@@ -15,5 +15,5 @@ interface UiActionInterface
      *
      * @return mixed
      */
-    public function execute();
+    public function executeAjaxRequest();
 }

--- a/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php
@@ -56,7 +56,7 @@ class RenderTest extends \PHPUnit_Framework_TestCase
         $this->render = new Render($contextMock, $this->uiFactoryMock);
     }
 
-    public function testExecute()
+    public function testExecuteAjaxRequest()
     {
         $name = 'test-name';
         $renderedData = '<html>data</html>';
@@ -94,6 +94,6 @@ class RenderTest extends \PHPUnit_Framework_TestCase
             ->method('create')
             ->willReturn($viewMock);
 
-        $this->render->execute();
+        $this->render->executeAjaxRequest();
     }
 }

--- a/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite.php
+++ b/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite.php
@@ -12,7 +12,7 @@ use Magento\Catalog\Model\Product;
 /**
  * URL rewrite adminhtml controller
  */
-class Rewrite extends Action
+abstract class Rewrite extends Action
 {
     /**#@+
      * Entity types

--- a/app/code/Magento/User/Controller/Adminhtml/Auth.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Auth.php
@@ -8,7 +8,7 @@ namespace Magento\User\Controller\Adminhtml;
 /**
  * \Magento\User Auth controller
  */
-class Auth extends \Magento\Backend\App\AbstractAction
+abstract class Auth extends \Magento\Backend\App\AbstractAction
 {
     /**
      * User model factory

--- a/app/code/Magento/User/Controller/Adminhtml/User.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\User\Controller\Adminhtml;
 
-class User extends \Magento\Backend\App\AbstractAction
+abstract class User extends \Magento\Backend\App\AbstractAction
 {
     /**
      * Core registry

--- a/app/code/Magento/User/Controller/Adminhtml/User/Role.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Role.php
@@ -7,7 +7,7 @@ namespace Magento\User\Controller\Adminhtml\User;
 
 use Magento\Authorization\Model\Acl\Role\Group as RoleGroup;
 
-class Role extends \Magento\Backend\App\AbstractAction
+abstract class Role extends \Magento\Backend\App\AbstractAction
 {
     /**
      * Core registry

--- a/app/code/Magento/Variable/Controller/Adminhtml/System/Variable.php
+++ b/app/code/Magento/Variable/Controller/Adminhtml/System/Variable.php
@@ -12,7 +12,7 @@ use Magento\Backend\App\Action;
  *
  * @author     Magento Core Team <core@magentocommerce.com>
  */
-class Variable extends Action
+abstract class Variable extends Action
 {
     /**
      * Core registry

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance.php
@@ -9,7 +9,7 @@
  */
 namespace Magento\Widget\Controller\Adminhtml\Widget;
 
-class Instance extends \Magento\Backend\App\Action
+abstract class Instance extends \Magento\Backend\App\Action
 {
     /**
      * Core registry

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/Stub/ProductControllerStub.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/Stub/ProductControllerStub.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Magento\Catalog\Helper\Product\Stub;
+
+class ProductControllerStub extends \Magento\Catalog\Controller\Product
+{
+    protected function execute()
+    {
+        // Empty method stub for test
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/ViewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/ViewTest.php
@@ -50,7 +50,7 @@ class ViewTest extends \PHPUnit_Framework_TestCase
         ];
         $context = $this->objectManager->create('Magento\Framework\App\Action\Context', $arguments);
         $this->_controller = $this->objectManager->create(
-            'Magento\Catalog\Controller\Product',
+            'Magento\Catalog\Helper\Product\Stub\ProductControllerStub',
             ['context' => $context]
         );
         $resultPageFactory = $this->objectManager->get('Magento\Framework\View\Result\PageFactory');
@@ -126,7 +126,7 @@ class ViewTest extends \PHPUnit_Framework_TestCase
     public function testPrepareAndRenderWrongController()
     {
         $objectManager = $this->objectManager;
-        $controller = $objectManager->create('Magento\Catalog\Controller\Product');
+        $controller = $objectManager->create('Magento\Catalog\Helper\Product\Stub\ProductControllerStub');
         $this->_helper->prepareAndRender($this->page, 10, $controller);
     }
 

--- a/dev/tests/integration/testsuite/Magento/Cms/Helper/PageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Helper/PageTest.php
@@ -38,7 +38,7 @@ class PageTest extends \PHPUnit_Framework_TestCase
         $pageHelper = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get('Magento\Cms\Helper\Page');
         $result = $pageHelper->prepareResultPage(
             \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-                'Magento\Framework\App\Action\Action',
+                'Magento\Cms\Helper\Stub\ActionStub',
                 ['context' => $context]
             ),
             $page->getId()

--- a/dev/tests/integration/testsuite/Magento/Cms/Helper/Stub/ActionStub.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Helper/Stub/ActionStub.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Magento\Cms\Helper\Stub;
+
+class ActionStub extends \Magento\Framework\App\Action\Action
+{
+    protected function execute()
+    {
+        // Empty method stub for test
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/CreateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/CreateTest.php
@@ -110,7 +110,9 @@ class CreateTest extends \Magento\Backend\Utility\Controller
     public function testGetAclResource($actionName, $reordered, $expectedResult)
     {
         $this->_objectManager->get('Magento\Backend\Model\Session\Quote')->setReordered($reordered);
-        $orderController = $this->_objectManager->get('Magento\Sales\Controller\Adminhtml\Order\Create');
+        $orderController = $this->_objectManager->get(
+            'Magento\Sales\Controller\Adminhtml\Order\Stub\OrderCreateStub'
+        );
 
         $this->getRequest()->setActionName($actionName);
 

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Stub/OrderCreateStub.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Stub/OrderCreateStub.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Magento\Sales\Controller\Adminhtml\Order\Stub;
+
+class OrderCreateStub extends \Magento\Sales\Controller\Adminhtml\Order\Create
+{
+    protected function execute()
+    {
+        // Empty method stub for test
+    }
+}

--- a/lib/internal/Magento/Framework/App/Action/Action.php
+++ b/lib/internal/Magento/Framework/App/Action/Action.php
@@ -7,6 +7,7 @@ namespace Magento\Framework\App\Action;
 
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\Exception\NotFoundException;
 
 /**
@@ -15,7 +16,7 @@ use Magento\Framework\Exception\NotFoundException;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class Action extends AbstractAction
+abstract class Action extends AbstractAction
 {
     /**
      * @var \Magento\Framework\ObjectManagerInterface
@@ -118,6 +119,11 @@ class Action extends AbstractAction
         \Magento\Framework\Profiler::stop($profilerKey);
         return $result ?: $this->_response;
     }
+
+    /**
+     * @return ResultInterface
+     */
+    abstract protected function execute();
 
     /**
      * Throw control to different action (control and module if was specified).


### PR DESCRIPTION
## Purpose

Make implementing Actions more developer friendly via self-documenting code.

## Background

The existing method `\Magento\Framework\App\Action\Action::dispatch()` calls an `execute()` method without actually implementing it.

```php
$result = $this->execute();
```

Any subclass actions simply need to implement that method and it will be called automatically when the superclass method is `dispatch()` is called.

Without the changes in this PR, the `execute()` method in effect was part of an implicit interface exposed by the `Action` class.
  
Because of this the `Action` class could never be instantiated and used (that is, dispatched), without first subclassing it.  
This in turn makes the `Action` class an implicitly abstract class.  

All this PR does it that it makes the class interface explicit by adding the execute method as an abstract method to `\Magento\Framework\App\Action\Action`.
  
All the other changes in this PR are just follow-up changes to accommodate for this one update.

## Follow up changes

Because concrete classes can't have abstract methods, the `Action` class itself also had to be made abstract.  

A number of subclasses of `Action` that did not implement `execute()`, because they themselves also needed to be extended, had to be declared as abstract classes now, too, because they inherit the abstract method from the `Action` superclass.  

There where some tests that instantiated these implicitly abstract classes.
This PR adds stub implementations for each of these.  

* `Magento\Checkout\Test\Unit\Controller\OnepageTest`   in app/code/Magento/Checkout/Test/Unit/Controller/
* `Magento\Contact\Test\Unit\Controller\IndexTest`  in app/code/Magento/Contact/Test/Unit/Controller/
* `Magento\Tax\Test\Unit\App\Action\ContextPluginTest`  in app/code/Magento/Tax/Test/Unit/App/Action/
* `Magento\Catalog\Helper\Product\ViewTest`  in dev/tests/integration/testsuite/Magento/Catalog/Helper/Product/
* `Magento\Cms\Helper\PageTest`  in dev/tests/integration/testsuite/Magento/Cms/Helper/Stub/
* `Magento\Sales\Controller\Adminhtml\Order\CreateTest`  in dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/

Finally, the `Magento\Ui\Controller\UiActionInterface` class, which was implemented by an abstract subclass of `Action`, namely `\Magento\Ui\Controller\Adminhtml\AbstractAction`, contained a
`public function execute();` itself.
This explicit interface contract was in conflict with the implicit interface of the `Action` class, which did defined the same method, but implicitly.  

To resolve this conflict this PR changes the method exposed by the `UiActionInterface` to `public function executeAjaxRequest();`. This seemed the most fitting when looking at the code implementing the interface method. Internally it only calls the now explicit `execute()` method inherited from the `Action` interface.

Also, it seems as if the `UiActionInterface::execute()` method was only called by a single test. However, I realize the method might be used a lot more in the non-public EE code, which will also need to be adjusted to be compatible with this PR.

## Reasons for this PR

As stated above, the purpose of this PR is to make the developer experience better. This is done by making an implicit interface explicit. This has a whole number of benefits, besides being good OOP practice:

* It is clear which classes should be instantiated and which should not
* It is clear which method needs to be implemented when subclassing `Action`
* The expected return type of `execute()` is documented in the phpdoc block
* When subclassing `Action` the IDE can be used to quickly a method stub

Allover the changes lead to more self-documenting code that tells developers to they should use it.

## Potential reasons against this PR
  
The explicit abstract `execute()` method added in this PR is declared with protected visibility.  
This basically removes it as a valid extension point for plugins. However, since the method was not declared as public previously (in fact, is wasn't declared at all), it should not have been used as an extension point for plugins anyway.

So the main reason against this PR I can think of is that the EE code will need to be adjusted (plus, I might be missing many obvious reasons).  
Of course I'd be happy to make the required updates, but I realize that is problematic due to the commercial licenced, non-open code.  
I've got a bunch of hacky shell scripts to find and update any controllers needed to be declared abstract, but I'd rather not share them as they are just one-time hacks.  
All the other changes - updating the ui action interface and the test stubs - where done manually and didn't take long.

## Additional notes
This PR would resolve issue #771.