### PR TITLE
Make Api\SearchResults implement Api\SearchResultsInterface

### DIFF
--- a/app/code/Magento/Catalog/Api/Data/CategoryAttributeSearchResultsInterface.php
+++ b/app/code/Magento/Catalog/Api/Data/CategoryAttributeSearchResultsInterface.php
@@ -24,5 +24,5 @@ interface CategoryAttributeSearchResultsInterface extends \Magento\Framework\Api
      * @param \Magento\Catalog\Api\Data\CategoryAttributeInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Catalog/Api/Data/ProductAttributeSearchResultsInterface.php
+++ b/app/code/Magento/Catalog/Api/Data/ProductAttributeSearchResultsInterface.php
@@ -24,5 +24,5 @@ interface ProductAttributeSearchResultsInterface extends \Magento\Framework\Api\
      * @param \Magento\Catalog\Api\Data\ProductAttributeInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Catalog/Api/Data/ProductSearchResultsInterface.php
+++ b/app/code/Magento/Catalog/Api/Data/ProductSearchResultsInterface.php
@@ -24,5 +24,5 @@ interface ProductSearchResultsInterface extends \Magento\Framework\Api\SearchRes
      * @param \Magento\Catalog\Api\Data\ProductInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/CatalogInventory/Api/Data/StockCollectionInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockCollectionInterface.php
@@ -30,5 +30,5 @@ interface StockCollectionInterface extends SearchResultsInterface
      * @param \Magento\CatalogInventory\Api\Data\StockInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/CatalogInventory/Api/Data/StockItemCollectionInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockItemCollectionInterface.php
@@ -30,7 +30,7 @@ interface StockItemCollectionInterface extends SearchResultsInterface
      * @param \Magento\CatalogInventory\Api\Data\StockItemInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 
     /**
      * Get search criteria.

--- a/app/code/Magento/CatalogInventory/Api/Data/StockStatusCollectionInterface.php
+++ b/app/code/Magento/CatalogInventory/Api/Data/StockStatusCollectionInterface.php
@@ -27,7 +27,7 @@ interface StockStatusCollectionInterface extends SearchResultsInterface
      * @param \Magento\CatalogInventory\Api\Data\StockStatusInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 
     /**
      * Get search criteria.

--- a/app/code/Magento/Cms/Api/Data/BlockSearchResultsInterface.php
+++ b/app/code/Magento/Cms/Api/Data/BlockSearchResultsInterface.php
@@ -26,5 +26,5 @@ interface BlockSearchResultsInterface extends SearchResultsInterface
      * @param \Magento\Cms\Api\Data\BlockInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Cms/Api/Data/PageSearchResultsInterface.php
+++ b/app/code/Magento/Cms/Api/Data/PageSearchResultsInterface.php
@@ -26,5 +26,5 @@ interface PageSearchResultsInterface extends SearchResultsInterface
      * @param \Magento\Cms\Api\Data\PageInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Customer/Api/Data/AddressSearchResultsInterface.php
+++ b/app/code/Magento/Customer/Api/Data/AddressSearchResultsInterface.php
@@ -26,5 +26,5 @@ interface AddressSearchResultsInterface extends \Magento\Framework\Api\SearchRes
      * @param \Magento\Customer\Api\Data\AddressInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Customer/Api/Data/CustomerSearchResultsInterface.php
+++ b/app/code/Magento/Customer/Api/Data/CustomerSearchResultsInterface.php
@@ -26,5 +26,5 @@ interface CustomerSearchResultsInterface extends \Magento\Framework\Api\SearchRe
      * @param \Magento\Customer\Api\Data\CustomerInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Customer/Api/Data/GroupSearchResultsInterface.php
+++ b/app/code/Magento/Customer/Api/Data/GroupSearchResultsInterface.php
@@ -26,5 +26,5 @@ interface GroupSearchResultsInterface extends \Magento\Framework\Api\SearchResul
      * @param \Magento\Customer\Api\Data\GroupInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Eav/Api/Data/AttributeGroupSearchResultsInterface.php
+++ b/app/code/Magento/Eav/Api/Data/AttributeGroupSearchResultsInterface.php
@@ -21,5 +21,5 @@ interface AttributeGroupSearchResultsInterface extends \Magento\Framework\Api\Se
      * @param \Magento\Eav\Api\Data\AttributeGroupInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Eav/Api/Data/AttributeSearchResultsInterface.php
+++ b/app/code/Magento/Eav/Api/Data/AttributeSearchResultsInterface.php
@@ -21,5 +21,5 @@ interface AttributeSearchResultsInterface extends \Magento\Framework\Api\SearchR
      * @param \Magento\Eav\Api\Data\AttributeInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Eav/Api/Data/AttributeSetSearchResultsInterface.php
+++ b/app/code/Magento/Eav/Api/Data/AttributeSetSearchResultsInterface.php
@@ -21,5 +21,5 @@ interface AttributeSetSearchResultsInterface extends \Magento\Framework\Api\Sear
      * @param \Magento\Eav\Api\Data\AttributeSetInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Quote/Api/Data/CartSearchResultsInterface.php
+++ b/app/code/Magento/Quote/Api/Data/CartSearchResultsInterface.php
@@ -35,7 +35,7 @@ interface CartSearchResultsInterface extends \Magento\Framework\Api\SearchResult
      * @param \Magento\Quote\Api\Data\CartInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 
     /**
      * Get search criteria.
@@ -50,7 +50,7 @@ interface CartSearchResultsInterface extends \Magento\Framework\Api\SearchResult
      * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
      * @return $this
      */
-    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null);
+    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria);
 
     /**
      * Get total count.

--- a/app/code/Magento/Sales/Api/Data/CreditmemoCommentSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/CreditmemoCommentSearchResultInterface.php
@@ -29,5 +29,5 @@ interface CreditmemoCommentSearchResultInterface extends \Magento\Framework\Api\
      * @param \Magento\Sales\Api\Data\CreditmemoCommentInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/CreditmemoItemSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/CreditmemoItemSearchResultInterface.php
@@ -29,5 +29,5 @@ interface CreditmemoItemSearchResultInterface extends \Magento\Framework\Api\Sea
      * @param \Magento\Sales\Api\Data\CreditmemoItemInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/CreditmemoSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/CreditmemoSearchResultInterface.php
@@ -28,5 +28,5 @@ interface CreditmemoSearchResultInterface extends \Magento\Framework\Api\SearchR
      * @param \Magento\Sales\Api\Data\CreditmemoInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/InvoiceCommentSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/InvoiceCommentSearchResultInterface.php
@@ -27,5 +27,5 @@ interface InvoiceCommentSearchResultInterface extends \Magento\Framework\Api\Sea
      * @param \Magento\Sales\Api\Data\InvoiceCommentInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/InvoiceItemSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/InvoiceItemSearchResultInterface.php
@@ -26,5 +26,5 @@ interface InvoiceItemSearchResultInterface extends \Magento\Framework\Api\Search
      * @param \Magento\Sales\Api\Data\InvoiceItemInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/InvoiceSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/InvoiceSearchResultInterface.php
@@ -26,5 +26,5 @@ interface InvoiceSearchResultInterface extends \Magento\Framework\Api\SearchResu
      * @param \Magento\Sales\Api\Data\InvoiceInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/OrderAddressSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderAddressSearchResultInterface.php
@@ -28,5 +28,5 @@ interface OrderAddressSearchResultInterface extends \Magento\Framework\Api\Searc
      * @param \Magento\Sales\Api\Data\OrderAddressInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/OrderItemSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderItemSearchResultInterface.php
@@ -28,5 +28,5 @@ interface OrderItemSearchResultInterface extends \Magento\Framework\Api\SearchRe
      * @param \Magento\Sales\Api\Data\OrderItemInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/OrderPaymentSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderPaymentSearchResultInterface.php
@@ -28,5 +28,5 @@ interface OrderPaymentSearchResultInterface extends \Magento\Framework\Api\Searc
      * @param \Magento\Sales\Api\Data\OrderPaymentInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/OrderStatusHistorySearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderStatusHistorySearchResultInterface.php
@@ -28,5 +28,5 @@ interface OrderStatusHistorySearchResultInterface extends \Magento\Framework\Api
      * @param \Magento\Sales\Api\Data\OrderStatusHistoryInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/ShipmentCommentSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/ShipmentCommentSearchResultInterface.php
@@ -27,5 +27,5 @@ interface ShipmentCommentSearchResultInterface extends \Magento\Framework\Api\Se
      * @param \Magento\Sales\Api\Data\ShipmentCommentInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/ShipmentItemSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/ShipmentItemSearchResultInterface.php
@@ -27,5 +27,5 @@ interface ShipmentItemSearchResultInterface extends \Magento\Framework\Api\Searc
      * @param \Magento\Sales\Api\Data\ShipmentItemInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/ShipmentSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/ShipmentSearchResultInterface.php
@@ -29,5 +29,5 @@ interface ShipmentSearchResultInterface extends SearchResultsInterface
      * @param \Magento\Sales\Api\Data\ShipmentInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/ShipmentTrackSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/ShipmentTrackSearchResultInterface.php
@@ -28,5 +28,5 @@ interface ShipmentTrackSearchResultInterface extends \Magento\Framework\Api\Sear
      * @param \Magento\Sales\Api\Data\ShipmentTrackInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Sales/Api/Data/TransactionSearchResultInterface.php
+++ b/app/code/Magento/Sales/Api/Data/TransactionSearchResultInterface.php
@@ -26,5 +26,5 @@ interface TransactionSearchResultInterface extends \Magento\Framework\Api\Search
      * @param \Magento\Sales\Api\Data\TransactionInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Tax/Api/Data/TaxClassSearchResultsInterface.php
+++ b/app/code/Magento/Tax/Api/Data/TaxClassSearchResultsInterface.php
@@ -25,5 +25,5 @@ interface TaxClassSearchResultsInterface extends \Magento\Framework\Api\SearchRe
      * @param \Magento\Tax\Api\Data\TaxClassInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Tax/Api/Data/TaxRateSearchResultsInterface.php
+++ b/app/code/Magento/Tax/Api/Data/TaxRateSearchResultsInterface.php
@@ -28,5 +28,5 @@ interface TaxRateSearchResultsInterface extends SearchResultsInterface
      * @param \Magento\Tax\Api\Data\TaxRateInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Tax/Api/Data/TaxRuleSearchResultsInterface.php
+++ b/app/code/Magento/Tax/Api/Data/TaxRuleSearchResultsInterface.php
@@ -25,5 +25,5 @@ interface TaxRuleSearchResultsInterface extends \Magento\Framework\Api\SearchRes
      * @param \Magento\Tax\Api\Data\TaxRuleInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxClass/RepositoryTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxClass/RepositoryTest.php
@@ -222,6 +222,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
 
         $collection->expects($this->any())->method('getSize')->willReturn(2);
         $collection->expects($this->any())->method('setItems')->with([$taxClassOne, $taxClassTwo]);
+        $collection->expects($this->any())->method('getItems')->willReturn([$taxClassOne, $taxClassTwo]);
         $collection->expects($this->once())->method('setCurPage')->with(0);
         $collection->expects($this->once())->method('setPageSize')->with(20);
 

--- a/app/code/Magento/Ui/Api/Data/BookmarkSearchResultsInterface.php
+++ b/app/code/Magento/Ui/Api/Data/BookmarkSearchResultsInterface.php
@@ -26,5 +26,5 @@ interface BookmarkSearchResultsInterface extends \Magento\Framework\Api\SearchRe
      * @param \Magento\Ui\Api\Data\BookmarkInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 }

--- a/lib/internal/Magento/Framework/Api/SearchResults.php
+++ b/lib/internal/Magento/Framework/Api/SearchResults.php
@@ -9,7 +9,7 @@ namespace Magento\Framework\Api;
 /**
  * SearchResults Service Data Object used for the search service requests
  */
-class SearchResults extends AbstractSimpleObject
+class SearchResults extends AbstractSimpleObject implements SearchResultsInterface
 {
     const KEY_ITEMS = 'items';
     const KEY_SEARCH_CRITERIA = 'search_criteria';
@@ -49,10 +49,10 @@ class SearchResults extends AbstractSimpleObject
     /**
      * Set search criteria
      *
-     * @param \Magento\Framework\Api\SearchCriteria $searchCriteria
+     * @param SearchCriteriaInterface $searchCriteria
      * @return $this
      */
-    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteria $searchCriteria)
+    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria)
     {
         return $this->setData(self::KEY_SEARCH_CRITERIA, $searchCriteria);
     }

--- a/lib/internal/Magento/Framework/Api/SearchResultsInterface.php
+++ b/lib/internal/Magento/Framework/Api/SearchResultsInterface.php
@@ -26,7 +26,7 @@ interface SearchResultsInterface
      * @param \Magento\Framework\Api\ExtensibleDataInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null);
+    public function setItems(array $items);
 
     /**
      * Get search criteria.
@@ -41,7 +41,7 @@ interface SearchResultsInterface
      * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
      * @return $this
      */
-    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria = null);
+    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria);
 
     /**
      * Get total count.


### PR DESCRIPTION
Purpose
==

Make the implementation actually fulfill the contract defined by the interface.

Background
==

The return type hints of almost all the repository implementations of the `getList()`
method indicate a return type of `\Magento\Framework\Api\SearchResultsInterface` or
one of its sub-interfaces.

One example of many is `\Magento\Catalog\Api\ProductRepositoryInterface::getList()`.
The return type hint states it returns `\Magento\Catalog\Api\Data\ProductSearchResultsInterface`,
which in turn extends `\Magento\Framework\Api\SearchResultsInterface`.

However, the concrete implementation preference for that interface is
`\Magento\Framework\Api\SearchResults`, which does not implement
`\Magento\Framework\Api\SearchResultsInterface` (or any interface for that matter).

Reasons for this PR
==

This PR makes `Api\SearchResults` actually implement `Api\SearchResultsInterface`,
forcing all implementations to match the contract.
It also improves developer experience because this is pretty much what should be expected
of the code.
It also makes the preference configuration technically more correct, because the configured
concrete class is guaranteed to at least partially fulfill the contract defined by the
interface.