### PR TITLE
Rename Api\SearchCriteriaBuilder::addFilter() to addFilters()

### DIFF
--- a/app/code/Magento/Backend/Model/Search/Customer.php
+++ b/app/code/Magento/Backend/Model/Search/Customer.php
@@ -96,7 +96,7 @@ class Customer extends \Magento\Framework\Object
                 ->setValue($this->getQuery() . '%')
                 ->create();
         }
-        $this->searchCriteriaBuilder->addFilter($filters);
+        $this->searchCriteriaBuilder->addFilters($filters);
         $searchCriteria = $this->searchCriteriaBuilder->create();
         $searchResults = $this->customerRepository->getList($searchCriteria);
 

--- a/app/code/Magento/Catalog/Model/Category/AttributeRepository.php
+++ b/app/code/Magento/Catalog/Model/Category/AttributeRepository.php
@@ -73,7 +73,7 @@ class AttributeRepository implements CategoryAttributeRepositoryInterface
         $defaultAttributeSetId = $this->eavConfig
             ->getEntityType(\Magento\Catalog\Api\Data\CategoryAttributeInterface::ENTITY_TYPE_CODE)
             ->getDefaultAttributeSetId();
-        $searchCriteria = $this->searchCriteriaBuilder->addFilter(
+        $searchCriteria = $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder
                     ->setField('attribute_set_id')

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -212,7 +212,7 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
         $defaultAttributeSetId = $this->eavConfig
             ->getEntityType(\Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE)
             ->getDefaultAttributeSetId();
-        $searchCriteria = $this->searchCriteriaBuilder->addFilter(
+        $searchCriteria = $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder
                     ->setField('attribute_set_id')

--- a/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/SetRepository.php
@@ -62,7 +62,7 @@ class SetRepository implements \Magento\Catalog\Api\AttributeSetRepositoryInterf
      */
     public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria)
     {
-        $this->searchCriteriaBuilder->addFilter(
+        $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder
                     ->setField('entity_type_code')

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -652,7 +652,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $defaultAttributeSetId = $this->eavConfig
             ->getEntityType(\Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE)
             ->getDefaultAttributeSetId();
-        $extendedSearchCriteria = $this->searchCriteriaBuilder->addFilter(
+        $extendedSearchCriteria = $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder
                     ->setField('attribute_set_id')

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/AttributeRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/AttributeRepositoryTest.php
@@ -114,7 +114,7 @@ class AttributeRepositoryTest extends \PHPUnit_Framework_TestCase
             3
         )->willReturnSelf();
         $this->filterBuilderMock->expects($this->once())->method('create')->willReturn($filterMock);
-        $this->searchBuilderMock->expects($this->once())->method('addFilter')->with([$filterMock])->willReturnSelf();
+        $this->searchBuilderMock->expects($this->once())->method('addFilters')->with([$filterMock])->willReturnSelf();
         $searchCriteriaMock = $this->getMock('Magento\Framework\Api\SearchCriteria', [], [], '', false);
         $this->searchBuilderMock->expects($this->once())->method('create')->willReturn($searchCriteriaMock);
         $itemMock = $this->getMock('Magento\Framework\Object', [], [], '', false);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/RepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/RepositoryTest.php
@@ -180,7 +180,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
             ->willReturnSelf();
         $this->filterBuilderMock->expects($this->once())->method('create')->willReturn($filterMock);
         $this->searchCriteriaBuilderMock->expects($this->once())
-            ->method('addFilter')
+            ->method('addFilters')
             ->with([$filterMock])
             ->willReturnSelf();
         $searchCriteriaMock = $this->getMock('Magento\Framework\Api\SearchCriteria', [], [], '', false);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/SetRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/SetRepositoryTest.php
@@ -181,7 +181,7 @@ class SetRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->filterBuilderMock->expects($this->once())->method('create')->willReturn($filterMock);
 
         $this->searchCriteriaBuilderMock->expects($this->once())
-            ->method('addFilter')
+            ->method('addFilters')
             ->with([$filterMock])
             ->willReturnSelf();
         $this->searchCriteriaBuilderMock->expects($this->once())

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
@@ -573,7 +573,7 @@ class ProductRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->filterBuilderMock->expects($this->once())->method('setValue')
             ->with(4)
             ->willReturn($this->filterBuilderMock);
-        $this->searchCriteriaBuilderMock->expects($this->once())->method('addFilter')->with([$filterMock])
+        $this->searchCriteriaBuilderMock->expects($this->once())->method('addFilters')->with([$filterMock])
             ->willReturn($searchCriteriaBuilderMock);
         $searchCriteriaBuilderMock->expects($this->once())->method('create')->willReturn($extendedSearchCriteriaMock);
         $this->metadataServiceMock->expects($this->once())->method('getList')->with($extendedSearchCriteriaMock)

--- a/app/code/Magento/Customer/Model/GroupManagement.php
+++ b/app/code/Magento/Customer/Model/GroupManagement.php
@@ -154,8 +154,8 @@ class GroupManagement implements \Magento\Customer\Api\GroupManagementInterface
             ->setValue(self::CUST_GROUP_ALL)
             ->create();
         $searchCriteria = $this->searchCriteriaBuilder
-            ->addFilter($notLoggedInFilter)
-            ->addFilter($groupAll)
+            ->addFilters($notLoggedInFilter)
+            ->addFilters($groupAll)
             ->create();
         return $this->groupRepository->getList($searchCriteria)->getItems();
     }

--- a/app/code/Magento/Customer/Test/Unit/Model/Resource/Group/Grid/ServiceCollectionTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Resource/Group/Grid/ServiceCollectionTest.php
@@ -88,7 +88,7 @@ class ServiceCollectionTest extends \PHPUnit_Framework_TestCase
             ->setCurrentPage(1)
             ->setPageSize(false)
             ->addSortOrder($sortOrder)
-            ->addFilter(
+            ->addFilters(
                 [$this->filterBuilder->setField('name')->setConditionType('eq')->setValue('Magento')->create()]
             )->create();
 
@@ -119,7 +119,7 @@ class ServiceCollectionTest extends \PHPUnit_Framework_TestCase
             ->setCurrentPage(1)
             ->setPageSize(0)
             ->addSortOrder($sortOrder)
-            ->addFilter([$filter])
+            ->addFilters([$filter])
             ->create();
 
         // Verifies that the search criteria Data Object created by the serviceCollection matches expected
@@ -150,7 +150,7 @@ class ServiceCollectionTest extends \PHPUnit_Framework_TestCase
             ->setCurrentPage(1)
             ->setPageSize(0)
             ->addSortOrder($sortOrder)
-            ->addFilter(
+            ->addFilters(
                 [
                     $this->filterBuilder->setField($fieldA)->setConditionType('eq')->setValue($value)->create(),
                     $this->filterBuilder->setField($fieldB)->setConditionType('eq')->setValue($value)->create(),
@@ -186,13 +186,13 @@ class ServiceCollectionTest extends \PHPUnit_Framework_TestCase
             ->setCurrentPage(1)
             ->setPageSize(0)
             ->addSortOrder($sortOrder)
-            ->addFilter(
+            ->addFilters(
                 [
                     $this->filterBuilder->setField($fieldA)->setConditionType('gt')
                         ->setValue($value)->create(),
                 ]
             )
-            ->addFilter(
+            ->addFilters(
                 [
                     $this->filterBuilder->setField($fieldB)->setConditionType('gt')
                         ->setValue($value)->create(),

--- a/app/code/Magento/Multishipping/Block/Checkout/Address/Select.php
+++ b/app/code/Magento/Multishipping/Block/Checkout/Address/Select.php
@@ -101,7 +101,7 @@ class Select extends \Magento\Multishipping\Block\Checkout\AbstractMultishipping
                     ->setConditionType('eq')
                     ->create();
                 $addresses = (array)($this->addressRepository->getList(
-                    $this->searchCriteriaBuilder->addFilter([$filter])->create()
+                    $this->searchCriteriaBuilder->addFilters([$filter])->create()
                 )->getItems());
             } catch (NoSuchEntityException $e) {
                 return [];

--- a/app/code/Magento/Multishipping/Controller/Checkout/Address/ShippingSaved.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Address/ShippingSaved.php
@@ -61,7 +61,7 @@ class ShippingSaved extends Address
         $filter = $this->filterBuilder->setField('parent_id')->setValue($this->_getCheckout()->getCustomer()->getId())
             ->setConditionType('eq')->create();
         $addresses = (array)($this->addressRepository->getList(
-            $this->searchCriteriaBuilder->addFilter([$filter])->create()
+            $this->searchCriteriaBuilder->addFilters([$filter])->create()
         )->getItems());
 
         /**

--- a/app/code/Magento/Multishipping/Model/Checkout/Type/Multishipping.php
+++ b/app/code/Magento/Multishipping/Model/Checkout/Type/Multishipping.php
@@ -878,7 +878,7 @@ class Multishipping extends \Magento\Framework\Object
                     ->setConditionType('eq')
                     ->create();
                 $addresses = (array)($this->addressRepository->getList(
-                    $this->searchCriteriaBuilder->addFilter([$filter])->create()
+                    $this->searchCriteriaBuilder->addFilters([$filter])->create()
                 )->getItems());
                 if ($addresses) {
                     $address = reset($addresses);

--- a/app/code/Magento/Multishipping/Test/Unit/Block/Checkout/Address/SelectTest.php
+++ b/app/code/Magento/Multishipping/Test/Unit/Block/Checkout/Address/SelectTest.php
@@ -130,7 +130,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $this->filterBuilderMock->expects($this->once())->method('create')->willReturn($this->filterMock);
         $this->searchCriteriaBuilderMock
             ->expects($this->once())
-            ->method('addFilter')
+            ->method('addFilters')
             ->with([$this->filterMock])
             ->willReturnSelf();
         $this->searchCriteriaBuilderMock
@@ -176,7 +176,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $this->filterBuilderMock->expects($this->once())->method('create')->willReturn($this->filterMock);
         $this->searchCriteriaBuilderMock
             ->expects($this->once())
-            ->method('addFilter')
+            ->method('addFilters')
             ->with([$this->filterMock])
             ->willReturnSelf();
         $this->searchCriteriaBuilderMock

--- a/app/code/Magento/Multishipping/Test/Unit/Controller/Checkout/Address/ShippingSavedTest.php
+++ b/app/code/Magento/Multishipping/Test/Unit/Controller/Checkout/Address/ShippingSavedTest.php
@@ -138,7 +138,7 @@ class ShippingSavedTest extends \PHPUnit_Framework_TestCase
         $this->filterBuilderMock->expects($this->once())->method('create')->willReturn($filterMock);
 
         $searchCriteriaMock = $this->getMock('Magento\Framework\Api\SearchCriteria', [], [], '', false);
-        $this->criteriaBuilderMock->expects($this->once())->method('addFilter')->with([$filterMock])->willReturnSelf();
+        $this->criteriaBuilderMock->expects($this->once())->method('addFilters')->with([$filterMock])->willReturnSelf();
         $this->criteriaBuilderMock->expects($this->once())->method('create')->willReturn($searchCriteriaMock);
 
         $searchResultMock = $this->getMock('Magento\Customer\Api\Data\AddressSearchResultsInterface');

--- a/app/code/Magento/Multishipping/Test/Unit/Model/Checkout/Type/MultishippingTest.php
+++ b/app/code/Magento/Multishipping/Test/Unit/Model/Checkout/Type/MultishippingTest.php
@@ -149,7 +149,7 @@ class MultishippingTest extends \PHPUnit_Framework_TestCase
         $this->filterBuilderMock->expects($this->atLeastOnce())->method('create')->willReturnSelf();
 
         $searchCriteriaMock = $this->getMock('\Magento\Framework\Api\SearchCriteria', [], [], '', false);
-        $this->searchCriteriaBuilderMock->expects($this->atLeastOnce())->method('addFilter')->willReturnSelf();
+        $this->searchCriteriaBuilderMock->expects($this->atLeastOnce())->method('addFilters')->willReturnSelf();
         $this->searchCriteriaBuilderMock->expects($this->atLeastOnce())->method('create')
             ->willReturn($searchCriteriaMock);
 

--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -268,7 +268,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
      *
      * @var \Magento\Framework\Api\SearchCriteriaBuilder
      */
-    protected $criteriaBuilder;
+    protected $searchCriteriaBuilder;
 
     /**
      * Filter builder
@@ -421,7 +421,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
         $this->_quotePaymentCollectionFactory = $quotePaymentCollectionFactory;
         $this->_objectCopyService = $objectCopyService;
         $this->addressRepository = $addressRepository;
-        $this->criteriaBuilder = $criteriaBuilder;
+        $this->searchCriteriaBuilder = $criteriaBuilder;
         $this->filterBuilder = $filterBuilder;
         $this->stockRegistry = $stockRegistry;
         $this->itemProcessor = $itemProcessor;

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Form/Address.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Form/Address.php
@@ -61,7 +61,7 @@ class Address extends \Magento\Sales\Block\Adminhtml\Order\Create\Form\AbstractF
      *
      * @var \Magento\Framework\Api\SearchCriteriaBuilder
      */
-    protected $criteriaBuilder;
+    protected $searchCriteriaBuilder;
 
     /**
      * Filter builder
@@ -121,7 +121,7 @@ class Address extends \Magento\Sales\Block\Adminhtml\Order\Create\Form\AbstractF
         $this->_customerFormFactory = $customerFormFactory;
         $this->_addressHelper = $addressHelper;
         $this->addressService = $addressService;
-        $this->criteriaBuilder = $criteriaBuilder;
+        $this->searchCriteriaBuilder = $criteriaBuilder;
         $this->filterBuilder = $filterBuilder;
         $this->addressMapper = $addressMapper;
         parent::__construct(
@@ -159,8 +159,8 @@ class Address extends \Magento\Sales\Block\Adminhtml\Order\Create\Form\AbstractF
                 ->setValue($this->getCustomerId())
                 ->setConditionType('eq')
                 ->create();
-            $this->criteriaBuilder->addFilter([$filter]);
-            $criteria = $this->criteriaBuilder->create();
+            $this->searchCriteriaBuilder->addFilters([$filter]);
+            $criteria = $this->searchCriteriaBuilder->create();
             $result = $this->addressService->getList($criteria);
             return $result->getItems();
         }

--- a/app/code/Magento/Sales/Model/Order/Payment/TransactionRepository.php
+++ b/app/code/Magento/Sales/Model/Order/Payment/TransactionRepository.php
@@ -81,7 +81,7 @@ class TransactionRepository
         }
         if (!isset($this->registry[$id])) {
             $filter = $this->filterBuilder->setField('transaction_id')->setValue($id)->setConditionType('eq')->create();
-            $this->searchCriteriaBuilder->addFilter([$filter]);
+            $this->searchCriteriaBuilder->addFilters([$filter]);
             $this->find($this->searchCriteriaBuilder->create());
 
             if (!isset($this->registry[$id])) {

--- a/app/code/Magento/Sales/Model/Service/CreditmemoService.php
+++ b/app/code/Magento/Sales/Model/Service/CreditmemoService.php
@@ -75,8 +75,8 @@ class CreditmemoService implements \Magento\Sales\Api\CreditmemoManagementInterf
      */
     public function getCommentsList($id)
     {
-        $this->searchCriteriaBuilder->addFilter(
-            ['eq' => $this->filterBuilder->setField('parent_id')->setValue($id)->create()]
+        $this->searchCriteriaBuilder->addFilters(
+            [$this->filterBuilder->setField('parent_id')->setValue($id)->setConditionType('eq')->create()]
         );
         $criteria = $this->searchCriteriaBuilder->create();
         return $this->creditmemoCommentRepository->getList($criteria);

--- a/app/code/Magento/Sales/Model/Service/InvoiceService.php
+++ b/app/code/Magento/Sales/Model/Service/InvoiceService.php
@@ -88,8 +88,8 @@ class InvoiceService implements InvoiceManagementInterface
      */
     public function getCommentsList($id)
     {
-        $this->criteriaBuilder->addFilter(
-            ['eq' => $this->filterBuilder->setField('parent_id')->setValue($id)->create()]
+        $this->criteriaBuilder->addFilters(
+            [$this->filterBuilder->setField('parent_id')->setValue($id)->setConditionType('eq')->create()]
         );
         $criteria = $this->criteriaBuilder->create();
         return $this->commentRepository->getList($criteria);

--- a/app/code/Magento/Sales/Model/Service/OrderService.php
+++ b/app/code/Magento/Sales/Model/Service/OrderService.php
@@ -89,8 +89,8 @@ class OrderService implements OrderManagementInterface
      */
     public function getCommentsList($id)
     {
-        $this->criteriaBuilder->addFilter(
-            ['eq' => $this->filterBuilder->setField('parent_id')->setValue($id)->create()]
+        $this->criteriaBuilder->addFilters(
+            [$this->filterBuilder->setField('parent_id')->setValue($id)->setConditionType('eq')->create()]
         );
         $criteria = $this->criteriaBuilder->create();
         return $this->historyRepository->getList($criteria);

--- a/app/code/Magento/Sales/Model/Service/ShipmentService.php
+++ b/app/code/Magento/Sales/Model/Service/ShipmentService.php
@@ -88,8 +88,8 @@ class ShipmentService implements ShipmentManagementInterface
      */
     public function getCommentsList($id)
     {
-        $this->criteriaBuilder->addFilter(
-            ['eq' => $this->filterBuilder->setField('parent_id')->setValue($id)->create()]
+        $this->criteriaBuilder->addFilters(
+            [$this->filterBuilder->setField('parent_id')->setValue($id)->setConditionType('eq')->create()]
         );
         $criteria = $this->criteriaBuilder->create();
         return $this->commentRepository->getList($criteria);

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/TransactionRepositoryTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/TransactionRepositoryTest.php
@@ -112,7 +112,7 @@ class TransactionRepositoryTest extends \PHPUnit_Framework_TestCase
             ->method('getFilterGroups')
             ->willReturn([$filterGroup]);
         $this->searchCriteriaBuilder->expects($this->once())
-            ->method('addFilter')
+            ->method('addFilters')
             ->with([$filter]);
         $this->searchCriteriaBuilder->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
@@ -63,14 +63,14 @@ class CreditmemoServiceTest extends \PHPUnit_Framework_TestCase
         );
         $this->searchCriteriaBuilderMock = $this->getMock(
             'Magento\Framework\Api\SearchCriteriaBuilder',
-            ['create', 'addFilter'],
+            ['create', 'addFilters'],
             [],
             '',
             false
         );
         $this->filterBuilderMock = $this->getMock(
             'Magento\Framework\Api\FilterBuilder',
-            ['setField', 'setValue', 'create'],
+            ['setField', 'setValue', 'setConditionType', 'create'],
             [],
             '',
             false
@@ -151,11 +151,15 @@ class CreditmemoServiceTest extends \PHPUnit_Framework_TestCase
             ->with($id)
             ->will($this->returnSelf());
         $this->filterBuilderMock->expects($this->once())
+            ->method('setConditionType')
+            ->with('eq')
+            ->will($this->returnSelf());
+        $this->filterBuilderMock->expects($this->once())
             ->method('create')
             ->will($this->returnValue($filterMock));
         $this->searchCriteriaBuilderMock->expects($this->once())
-            ->method('addFilter')
-            ->with(['eq' => $filterMock]);
+            ->method('addFilters')
+            ->with([$filterMock]);
         $this->searchCriteriaBuilderMock->expects($this->once())
             ->method('create')
             ->will($this->returnValue($searchCriteriaMock));

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/InvoiceServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/InvoiceServiceTest.php
@@ -31,7 +31,7 @@ class InvoiceServiceTest extends \PHPUnit_Framework_TestCase
      *
      * @var \Magento\Framework\Api\SearchCriteriaBuilder|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $criteriaBuilderMock;
+    protected $searchCriteriaBuilderMock;
 
     /**
      * Filter Builder
@@ -71,16 +71,16 @@ class InvoiceServiceTest extends \PHPUnit_Framework_TestCase
             '',
             false
         );
-        $this->criteriaBuilderMock = $this->getMock(
+        $this->searchCriteriaBuilderMock = $this->getMock(
             'Magento\Framework\Api\SearchCriteriaBuilder',
-            ['create', 'addFilter'],
+            ['create', 'addFilters'],
             [],
             '',
             false
         );
         $this->filterBuilderMock = $this->getMock(
             'Magento\Framework\Api\FilterBuilder',
-            ['setField', 'setValue', 'create'],
+            ['setField', 'setValue', 'setConditionType', 'create'],
             [],
             '',
             false
@@ -98,7 +98,7 @@ class InvoiceServiceTest extends \PHPUnit_Framework_TestCase
             [
                 'repository' => $this->repositoryMock,
                 'commentRepository' => $this->commentRepositoryMock,
-                'criteriaBuilder' => $this->criteriaBuilderMock,
+                'criteriaBuilder' => $this->searchCriteriaBuilderMock,
                 'filterBuilder' => $this->filterBuilderMock,
                 'notifier' => $this->invoiceNotifierMock
             ]
@@ -164,12 +164,16 @@ class InvoiceServiceTest extends \PHPUnit_Framework_TestCase
             ->with($id)
             ->will($this->returnSelf());
         $this->filterBuilderMock->expects($this->once())
+            ->method('setConditionType')
+            ->with('eq')
+            ->will($this->returnSelf());
+        $this->filterBuilderMock->expects($this->once())
             ->method('create')
             ->will($this->returnValue($filterMock));
-        $this->criteriaBuilderMock->expects($this->once())
-            ->method('addFilter')
-            ->with(['eq' => $filterMock]);
-        $this->criteriaBuilderMock->expects($this->once())
+        $this->searchCriteriaBuilderMock->expects($this->once())
+            ->method('addFilters')
+            ->with([$filterMock]);
+        $this->searchCriteriaBuilderMock->expects($this->once())
             ->method('create')
             ->will($this->returnValue($searchCriteriaMock));
         $this->commentRepositoryMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/OrderServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/OrderServiceTest.php
@@ -152,11 +152,15 @@ class OrderServiceTest extends \PHPUnit_Framework_TestCase
             ->with(123)
             ->willReturnSelf();
         $this->filterBuilderMock->expects($this->once())
+            ->method('setConditionType')
+            ->with('eq')
+            ->willReturnSelf();
+        $this->filterBuilderMock->expects($this->once())
             ->method('create')
             ->willReturn($this->filterMock);
         $this->searchCriteriaBuilderMock->expects($this->once())
-            ->method('addFilter')
-            ->with(['eq' => $this->filterMock])
+            ->method('addFilters')
+            ->with([$this->filterMock])
             ->willReturn($this->filterBuilderMock);
         $this->searchCriteriaBuilderMock->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/ShipmentServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/ShipmentServiceTest.php
@@ -24,7 +24,7 @@ class ShipmentServiceTest extends \PHPUnit_Framework_TestCase
      *
      * @var \Magento\Framework\Api\SearchCriteriaBuilder|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $criteriaBuilderMock;
+    protected $searchCriteriaBuilderMock;
 
     /**
      * Filter Builder
@@ -65,16 +65,16 @@ class ShipmentServiceTest extends \PHPUnit_Framework_TestCase
             '',
             false
         );
-        $this->criteriaBuilderMock = $this->getMock(
+        $this->searchCriteriaBuilderMock = $this->getMock(
             'Magento\Framework\Api\SearchCriteriaBuilder',
-            ['create', 'addFilter'],
+            ['create', 'addFilters'],
             [],
             '',
             false
         );
         $this->filterBuilderMock = $this->getMock(
             'Magento\Framework\Api\FilterBuilder',
-            ['setField', 'setValue', 'create'],
+            ['setField', 'setValue', 'setConditionType', 'create'],
             [],
             '',
             false
@@ -97,7 +97,7 @@ class ShipmentServiceTest extends \PHPUnit_Framework_TestCase
             'Magento\Sales\Model\Service\ShipmentService',
             [
                 'commentRepository' => $this->commentRepositoryMock,
-                'criteriaBuilder' => $this->criteriaBuilderMock,
+                'criteriaBuilder' => $this->searchCriteriaBuilderMock,
                 'filterBuilder' => $this->filterBuilderMock,
                 'repository' => $this->repositoryMock,
                 'notifier' => $this->notifierMock,
@@ -164,12 +164,16 @@ class ShipmentServiceTest extends \PHPUnit_Framework_TestCase
             ->with($id)
             ->will($this->returnSelf());
         $this->filterBuilderMock->expects($this->once())
+            ->method('setConditionType')
+            ->with('eq')
+            ->will($this->returnSelf());
+        $this->filterBuilderMock->expects($this->once())
             ->method('create')
             ->will($this->returnValue($filterMock));
-        $this->criteriaBuilderMock->expects($this->once())
-            ->method('addFilter')
-            ->with(['eq' => $filterMock]);
-        $this->criteriaBuilderMock->expects($this->once())
+        $this->searchCriteriaBuilderMock->expects($this->once())
+            ->method('addFilters')
+            ->with([$filterMock]);
+        $this->searchCriteriaBuilderMock->expects($this->once())
             ->method('create')
             ->will($this->returnValue($searchCriteriaMock));
         $this->commentRepositoryMock->expects($this->once())

--- a/app/code/Magento/Tax/Model/Calculation.php
+++ b/app/code/Magento/Tax/Model/Calculation.php
@@ -698,7 +698,7 @@ class Calculation extends \Magento\Framework\Model\AbstractModel
         }
         $rateRequest = $this->getRateRequest($shippingAddressObj, $billingAddressObj, $customerTaxClassId);
 
-        $searchCriteria = $this->searchCriteriaBuilder->addFilter(
+        $searchCriteria = $this->searchCriteriaBuilder->addFilters(
             [$this->filterBuilder->setField(ClassModel::KEY_TYPE)
                  ->setValue(\Magento\Tax\Api\TaxClassManagementInterface::TYPE_PRODUCT)
                  ->create()]

--- a/app/code/Magento/Tax/Model/TaxClass/Management.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Management.php
@@ -60,9 +60,9 @@ class Management implements \Magento\Tax\Api\TaxClassManagementInterface
                 case TaxClassKeyInterface::TYPE_ID:
                     return $taxClassKey->getValue();
                 case TaxClassKeyInterface::TYPE_NAME:
-                    $searchCriteria = $this->searchCriteriaBuilder->addFilter(
+                    $searchCriteria = $this->searchCriteriaBuilder->addFilters(
                         [$this->filterBuilder->setField(ClassModel::KEY_TYPE)->setValue($taxClassType)->create()]
-                    )->addFilter(
+                    )->addFilters(
                         [
                             $this->filterBuilder->setField(ClassModel::KEY_NAME)
                                 ->setValue($taxClassKey->getValue())

--- a/app/code/Magento/Tax/Model/TaxClass/Source/Customer.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Source/Customer.php
@@ -60,7 +60,7 @@ class Customer extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
             $filter = $this->filterBuilder->setField(ClassModel::KEY_TYPE)
                 ->setValue(TaxClassManagementInterface::TYPE_CUSTOMER)
                 ->create();
-            $searchCriteria = $this->searchCriteriaBuilder->addFilter([$filter])->create();
+            $searchCriteria = $this->searchCriteriaBuilder->addFilters([$filter])->create();
             $searchResults = $this->taxClassRepository->getList($searchCriteria);
             foreach ($searchResults->getItems() as $taxClass) {
                 $options[] = [

--- a/app/code/Magento/Tax/Model/TaxClass/Source/Product.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Source/Product.php
@@ -71,7 +71,7 @@ class Product extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
                 ->setField(ClassModel::KEY_TYPE)
                 ->setValue(TaxClassManagementInterface::TYPE_PRODUCT)
                 ->create();
-            $searchCriteria = $this->_searchCriteriaBuilder->addFilter([$filter])->create();
+            $searchCriteria = $this->_searchCriteriaBuilder->addFilters([$filter])->create();
             $searchResults = $this->_taxClassRepository->getList($searchCriteria);
             foreach ($searchResults->getItems() as $taxClass) {
                 $this->_options[] = [

--- a/app/code/Magento/Tax/Model/TaxClass/Type/Customer.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Type/Customer.php
@@ -61,7 +61,7 @@ class Customer extends \Magento\Tax\Model\TaxClass\AbstractType
     public function isAssignedToObjects()
     {
         $searchCriteria = $this->searchCriteriaBuilder
-            ->addFilter(
+            ->addFilters(
                 [
                     $this->filterBuilder->setField(CustomerGroup::TAX_CLASS_ID)->setValue($this->getId())->create(),
                 ]

--- a/app/code/Magento/Tax/Model/TaxRateManagement.php
+++ b/app/code/Magento/Tax/Model/TaxRateManagement.php
@@ -57,7 +57,7 @@ class TaxRateManagement implements TaxRateManagementInterface
      */
     public function getRatesByCustomerAndProductTaxClassId($customerTaxClassId, $productTaxClassId)
     {
-        $this->searchCriteriaBuilder->addFilter(
+        $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder
                     ->setField('customer_tax_class_ids')
@@ -66,7 +66,7 @@ class TaxRateManagement implements TaxRateManagementInterface
             ]
         );
 
-        $this->searchCriteriaBuilder->addFilter(
+        $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder
                     ->setField('product_tax_class_ids')

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxClass/ManagementTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxClass/ManagementTest.php
@@ -98,7 +98,7 @@ class ManagementTest extends \PHPUnit_Framework_TestCase
         $this->filterBuilder->expects($this->exactly(2))->method('create')->willReturn($filter);
         $this->searchCriteriaBuilder
             ->expects($this->exactly(2))
-            ->method('addFilter')
+            ->method('addFilters')
             ->with([$filter])
             ->willReturnSelf();
 

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxClass/Source/CustomerTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxClass/Source/CustomerTest.php
@@ -54,7 +54,7 @@ class CustomerTest extends \PHPUnit_Framework_TestCase
         );
         $this->searchCriteriaBuilderMock = $this->getMock(
             'Magento\Framework\Api\SearchCriteriaBuilder',
-            ['addFilter', 'create'],
+            ['addFilters', 'create'],
             [],
             '',
             false
@@ -130,7 +130,7 @@ class CustomerTest extends \PHPUnit_Framework_TestCase
             ->method('create')
             ->willReturn($filterMock);
         $this->searchCriteriaBuilderMock->expects($this->once())
-            ->method('addFilter')
+            ->method('addFilters')
             ->with([$filterMock])
             ->willReturnSelf();
         $this->searchCriteriaBuilderMock->expects($this->once())
@@ -234,7 +234,7 @@ class CustomerTest extends \PHPUnit_Framework_TestCase
             ->method('create')
             ->willReturn($filterMock);
         $this->searchCriteriaBuilderMock->expects($this->once())
-            ->method('addFilter')
+            ->method('addFilters')
             ->with([$filterMock])
             ->willReturnSelf();
         $this->searchCriteriaBuilderMock->expects($this->once())

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxClass/Source/ProductTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxClass/Source/ProductTest.php
@@ -49,7 +49,7 @@ class ProductTest extends \PHPUnit_Framework_TestCase
         );
         $this->searchCriteriaBuilderMock = $this->getMock(
             'Magento\Framework\Api\SearchCriteriaBuilder',
-            ['addFilter', 'create'],
+            ['addFilters', 'create'],
             [],
             '',
             false
@@ -152,7 +152,7 @@ class ProductTest extends \PHPUnit_Framework_TestCase
             ->method('create')
             ->willReturn($filterMock);
         $this->searchCriteriaBuilderMock->expects($this->once())
-            ->method('addFilter')
+            ->method('addFilters')
             ->with([$filterMock])
             ->willReturnSelf();
         $this->searchCriteriaBuilderMock->expects($this->once())

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxClass/Type/CustomerTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxClass/Type/CustomerTest.php
@@ -19,10 +19,13 @@ class CustomerTest extends \PHPUnit_Framework_TestCase
             ->method('getItems')
             ->will($this->returnValue(['randomValue']));
 
+        /** @var \Magento\Framework\Api\FilterBuilder $filterBuilder */
         $filterBuilder = $objectManagerHelper
             ->getObject('Magento\Framework\Api\FilterBuilder');
+        /** @var \Magento\Framework\Api\Search\FilterGroupBuilder $filterGroupBuilder */
         $filterGroupBuilder = $objectManagerHelper
             ->getObject('Magento\Framework\Api\Search\FilterGroupBuilder');
+        /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder */
         $searchCriteriaBuilder = $objectManagerHelper->getObject(
             'Magento\Framework\Api\SearchCriteriaBuilder',
             [
@@ -30,7 +33,7 @@ class CustomerTest extends \PHPUnit_Framework_TestCase
             ]
         );
         $expectedSearchCriteria = $searchCriteriaBuilder
-            ->addFilter([$filterBuilder->setField('tax_class_id')->setValue(5)->create()])
+            ->addFilters([$filterBuilder->setField('tax_class_id')->setValue(5)->create()])
             ->create();
 
         $customerGroupServiceMock = $this->getMockBuilder('Magento\Customer\Api\GroupRepositoryInterface')

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxRateManagementTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxRateManagementTest.php
@@ -76,7 +76,7 @@ class TaxRateManagementTest extends \PHPUnit_Framework_TestCase
             $customerFilterMock,
             $productFilterMock
         );
-        $this->searchCriteriaBuilderMock->expects($this->exactly(2))->method('addFilter')->withConsecutive(
+        $this->searchCriteriaBuilderMock->expects($this->exactly(2))->method('addFilters')->withConsecutive(
             [[$customerFilterMock]],
             [[$productFilterMock]]
         );

--- a/app/code/Magento/Ui/Model/BookmarkManagement.php
+++ b/app/code/Magento/Ui/Model/BookmarkManagement.php
@@ -51,7 +51,7 @@ class BookmarkManagement implements \Magento\Ui\Api\BookmarkManagementInterface
      */
     public function loadByNamespace($namespace)
     {
-        $this->searchCriteriaBuilder->addFilter(
+        $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder
                     ->setField('user_id')
@@ -77,7 +77,7 @@ class BookmarkManagement implements \Magento\Ui\Api\BookmarkManagementInterface
      */
     public function getByIdentifierNamespace($identifier, $namespace)
     {
-        $this->searchCriteriaBuilder->addFilter(
+        $this->searchCriteriaBuilder->addFilters(
             [
                 $this->filterBuilder
                     ->setField('user_id')

--- a/dev/tests/api-functional/testsuite/Magento/Cms/Api/BlockRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Cms/Api/BlockRepositoryTest.php
@@ -222,13 +222,14 @@ class BlockRepositoryTest extends WebapiAbstract
         $this->currentBlock = $this->blockRepository->save($blockDataObject);
 
         $filterBuilder = Bootstrap::getObjectManager()->create('Magento\Framework\Api\FilterBuilder');
+        /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder */
         $searchCriteriaBuilder = Bootstrap::getObjectManager()
             ->create('Magento\Framework\Api\SearchCriteriaBuilder');
         $filter = $filterBuilder
             ->setField(BlockInterface::IDENTIFIER)
             ->setValue($blockIdentifier)
             ->create();
-        $searchCriteriaBuilder->addFilter([$filter]);
+        $searchCriteriaBuilder->addFilters([$filter]);
 
         $searchData = $searchCriteriaBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchData];

--- a/dev/tests/api-functional/testsuite/Magento/Cms/Api/PageRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Cms/Api/PageRepositoryTest.php
@@ -222,13 +222,14 @@ class PageRepositoryTest extends WebapiAbstract
         $this->currentPage = $this->pageRepository->save($pageDataObject);
 
         $filterBuilder = Bootstrap::getObjectManager()->create('Magento\Framework\Api\FilterBuilder');
+        /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder */
         $searchCriteriaBuilder = Bootstrap::getObjectManager()
             ->create('Magento\Framework\Api\SearchCriteriaBuilder');
         $filter = $filterBuilder
             ->setField(PageInterface::IDENTIFIER)
             ->setValue($pageIdentifier)
             ->create();
-        $searchCriteriaBuilder->addFilter([$filter]);
+        $searchCriteriaBuilder->addFilters([$filter]);
 
         $searchData = $searchCriteriaBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchData];

--- a/dev/tests/api-functional/testsuite/Magento/Customer/Api/CustomerRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Customer/Api/CustomerRepositoryTest.php
@@ -357,7 +357,7 @@ class CustomerRepositoryTest extends WebapiAbstract
             ->setField(Customer::EMAIL)
             ->setValue($customerData[Customer::EMAIL])
             ->create();
-        $this->searchCriteriaBuilder->addFilter([$filter]);
+        $this->searchCriteriaBuilder->addFilters([$filter]);
         $searchData = $this->dataObjectProcessor->buildOutputDataArray(
             $this->searchCriteriaBuilder->create(),
             'Magento\Framework\Api\SearchCriteriaInterface'
@@ -391,7 +391,7 @@ class CustomerRepositoryTest extends WebapiAbstract
             ->setField(Customer::EMAIL)
             ->setValue($customerData[Customer::EMAIL])
             ->create();
-        $this->searchCriteriaBuilder->addFilter([$filter]);
+        $this->searchCriteriaBuilder->addFilters([$filter]);
 
         $searchData = $this->searchCriteriaBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchData];
@@ -451,8 +451,8 @@ class CustomerRepositoryTest extends WebapiAbstract
         $filter3 = $builder->setField(Customer::LASTNAME)
             ->setValue($customerData1[Customer::LASTNAME])
             ->create();
-        $this->searchCriteriaBuilder->addFilter([$filter1, $filter2]);
-        $this->searchCriteriaBuilder->addFilter([$filter3]);
+        $this->searchCriteriaBuilder->addFilters([$filter1, $filter2]);
+        $this->searchCriteriaBuilder->addFilters([$filter3]);
 
         /**@var \Magento\Framework\Api\SortOrderBuilder $sortOrderBuilder */
         $sortOrderBuilder = Bootstrap::getObjectManager()->create(
@@ -500,8 +500,8 @@ class CustomerRepositoryTest extends WebapiAbstract
         $filter3 = $builder->setField(Customer::LASTNAME)
             ->setValue($customerData1[Customer::LASTNAME])
             ->create();
-        $this->searchCriteriaBuilder->addFilter([$filter1, $filter2]);
-        $this->searchCriteriaBuilder->addFilter([$filter3]);
+        $this->searchCriteriaBuilder->addFilters([$filter1, $filter2]);
+        $this->searchCriteriaBuilder->addFilters([$filter3]);
         $this->searchCriteriaBuilder->setSortOrders([Customer::EMAIL => SearchCriteria::SORT_ASC]);
         $searchCriteria = $this->searchCriteriaBuilder->create();
         $searchData = $searchCriteria->__toArray();
@@ -536,8 +536,8 @@ class CustomerRepositoryTest extends WebapiAbstract
         $filter3 = $builder->setField(Customer::LASTNAME)
             ->setValue('INVALID')
             ->create();
-        $this->searchCriteriaBuilder->addFilter([$filter1, $filter2]);
-        $this->searchCriteriaBuilder->addFilter([$filter3]);
+        $this->searchCriteriaBuilder->addFilters([$filter1, $filter2]);
+        $this->searchCriteriaBuilder->addFilters([$filter3]);
         $searchCriteria = $this->searchCriteriaBuilder->create();
         $searchData = $searchCriteria->__toArray();
         $requestData = ['searchCriteria' => $searchData];
@@ -574,8 +574,8 @@ class CustomerRepositoryTest extends WebapiAbstract
         $filter3 = $builder->setField(Customer::LASTNAME)
             ->setValue('INVALID')
             ->create();
-        $this->searchCriteriaBuilder->addFilter([$filter1, $filter2]);
-        $this->searchCriteriaBuilder->addFilter([$filter3]);
+        $this->searchCriteriaBuilder->addFilters([$filter1, $filter2]);
+        $this->searchCriteriaBuilder->addFilters([$filter3]);
         $searchCriteria = $this->searchCriteriaBuilder->create();
         $searchData = $searchCriteria->__toArray();
         $requestData = ['searchCriteria' => $searchData];
@@ -612,9 +612,9 @@ class CustomerRepositoryTest extends WebapiAbstract
             ->setValue($customerData1[Customer::LASTNAME])
             ->create();
 
-        $this->searchCriteriaBuilder->addFilter([$filter1]);
-        $this->searchCriteriaBuilder->addFilter([$filter2, $filter3]);
-        $this->searchCriteriaBuilder->addFilter([$filter4]);
+        $this->searchCriteriaBuilder->addFilters([$filter1]);
+        $this->searchCriteriaBuilder->addFilters([$filter2, $filter3]);
+        $this->searchCriteriaBuilder->addFilters([$filter4]);
         $searchCriteria = $this->searchCriteriaBuilder->setCurrentPage(1)->setPageSize(10)->create();
         $searchData = $searchCriteria->__toArray();
         $requestData = ['searchCriteria' => $searchData];
@@ -638,9 +638,9 @@ class CustomerRepositoryTest extends WebapiAbstract
             ->setValue('invalid')
             ->create();
 
-        $this->searchCriteriaBuilder->addFilter([$filter1]);
-        $this->searchCriteriaBuilder->addFilter([$filter2, $filter3]);
-        $this->searchCriteriaBuilder->addFilter([$filter4]);
+        $this->searchCriteriaBuilder->addFilters([$filter1]);
+        $this->searchCriteriaBuilder->addFilters([$filter2, $filter3]);
+        $this->searchCriteriaBuilder->addFilters([$filter4]);
         $searchCriteria = $this->searchCriteriaBuilder->create();
         $searchData = $searchCriteria->__toArray();
         $requestData = ['searchCriteria' => $searchData];

--- a/dev/tests/api-functional/testsuite/Magento/Customer/Api/GroupRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Customer/Api/GroupRepositoryTest.php
@@ -921,13 +921,14 @@ class GroupRepositoryTest extends WebapiAbstract
     public function testSearchGroups($filterField, $filterValue, $expectedResult)
     {
         $filterBuilder = Bootstrap::getObjectManager()->create('Magento\Framework\Api\FilterBuilder');
+        /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder */
         $searchCriteriaBuilder =  Bootstrap::getObjectManager()
             ->create('Magento\Framework\Api\SearchCriteriaBuilder');
         $filter = $filterBuilder
                     ->setField($filterField)
                     ->setValue($filterValue)
                     ->create();
-        $searchCriteriaBuilder->addFilter([$filter]);
+        $searchCriteriaBuilder->addFilters([$filter]);
 
         $searchData = $searchCriteriaBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchData];
@@ -968,13 +969,14 @@ class GroupRepositoryTest extends WebapiAbstract
     {
         $this->_markTestAsRestOnly('SOAP is covered in ');
         $filterBuilder = Bootstrap::getObjectManager()->create('Magento\Framework\Api\FilterBuilder');
+        /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder */
         $searchCriteriaBuilder =  Bootstrap::getObjectManager()
             ->create('Magento\Framework\Api\SearchCriteriaBuilder');
         $filter = $filterBuilder
             ->setField($filterField)
             ->setValue($filterValue)
             ->create();
-        $searchCriteriaBuilder->addFilter([$filter]);
+        $searchCriteriaBuilder->addFilters([$filter]);
         $searchData = $searchCriteriaBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchData];
         $searchQueryString = http_build_query($requestData);

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartRepositoryTest.php
@@ -23,7 +23,7 @@ class CartRepositoryTest extends WebapiAbstract
     /**
      * @var SearchCriteriaBuilder
      */
-    private $searchBuilder;
+    private $searchCriteriaBuilder;
 
     /**
      * @var SortOrderBuilder
@@ -44,7 +44,7 @@ class CartRepositoryTest extends WebapiAbstract
         $this->sortOrderBuilder = $this->objectManager->create(
             'Magento\Framework\Api\SortOrderBuilder'
         );
-        $this->searchBuilder = $this->objectManager->create(
+        $this->searchCriteriaBuilder = $this->objectManager->create(
             'Magento\Framework\Api\SearchCriteriaBuilder'
         );
     }
@@ -174,13 +174,13 @@ class CartRepositoryTest extends WebapiAbstract
             ->setValue($tomorrowDate)
             ->create();
 
-        $this->searchBuilder->addFilter([$grandTotalFilter, $subtotalFilter]);
-        $this->searchBuilder->addFilter([$minCreatedAtFilter]);
-        $this->searchBuilder->addFilter([$maxCreatedAtFilter]);
+        $this->searchCriteriaBuilder->addFilters([$grandTotalFilter, $subtotalFilter]);
+        $this->searchCriteriaBuilder->addFilters([$minCreatedAtFilter]);
+        $this->searchCriteriaBuilder->addFilters([$maxCreatedAtFilter]);
         /** @var SortOrder $sortOrder */
         $sortOrder = $this->sortOrderBuilder->setField('subtotal')->setDirection(SearchCriteria::SORT_ASC)->create();
-        $this->searchBuilder->setSortOrders([$sortOrder]);
-        $searchCriteria = $this->searchBuilder->create()->__toArray();
+        $this->searchCriteriaBuilder->setSortOrders([$sortOrder]);
+        $searchCriteria = $this->searchCriteriaBuilder->create()->__toArray();
 
         $requestData = ['searchCriteria' => $searchCriteria];
         $serviceInfo = [
@@ -233,8 +233,8 @@ class CartRepositoryTest extends WebapiAbstract
             ->setValue(0)
             ->create();
 
-        $this->searchBuilder->addFilter([$invalidFilter]);
-        $searchCriteria = $this->searchBuilder->create()->__toArray();
+        $this->searchCriteriaBuilder->addFilters([$invalidFilter]);
+        $searchCriteria = $this->searchCriteriaBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchCriteria];
         $this->_webApiCall($serviceInfo, $requestData);
     }

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartTotalRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartTotalRepositoryTest.php
@@ -23,7 +23,7 @@ class CartTotalRepositoryTest extends WebapiAbstract
     /**
      * @var SearchCriteriaBuilder
      */
-    private $searchBuilder;
+    private $searchCriteriaBuilder;
 
     /**
      * @var FilterBuilder
@@ -33,7 +33,7 @@ class CartTotalRepositoryTest extends WebapiAbstract
     protected function setUp()
     {
         $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $this->searchBuilder = $this->objectManager->create(
+        $this->searchCriteriaBuilder = $this->objectManager->create(
             'Magento\Framework\Api\SearchCriteriaBuilder'
         );
         $this->filterBuilder = $this->objectManager->create(

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/GuestCartTotalRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/GuestCartTotalRepositoryTest.php
@@ -23,7 +23,7 @@ class GuestCartTotalRepositoryTest extends WebapiAbstract
     /**
      * @var SearchCriteriaBuilder
      */
-    private $searchBuilder;
+    private $searchCriteriaBuilder;
 
     /**
      * @var FilterBuilder
@@ -33,7 +33,7 @@ class GuestCartTotalRepositoryTest extends WebapiAbstract
     protected function setUp()
     {
         $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $this->searchBuilder = $this->objectManager->create(
+        $this->searchCriteriaBuilder = $this->objectManager->create(
             'Magento\Framework\Api\SearchCriteriaBuilder'
         );
         $this->filterBuilder = $this->objectManager->create(

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/CreditmemoListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/CreditmemoListTest.php
@@ -58,7 +58,7 @@ class CreditmemoListTest extends WebapiAbstract
             'Magento\Framework\Api\FilterBuilder'
         );
 
-        $searchCriteriaBuilder->addFilter(
+        $searchCriteriaBuilder->addFilters(
             [
                 $filterBuilder
                     ->setField('state')

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/InvoiceListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/InvoiceListTest.php
@@ -43,7 +43,7 @@ class InvoiceListTest extends WebapiAbstract
             'Magento\Framework\Api\FilterBuilder'
         );
 
-        $searchCriteriaBuilder->addFilter(
+        $searchCriteriaBuilder->addFilters(
             [
                 $filterBuilder
                     ->setField('state')

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderListTest.php
@@ -44,7 +44,7 @@ class OrderListTest extends WebapiAbstract
             'Magento\Framework\Api\FilterBuilder'
         );
 
-        $searchCriteriaBuilder->addFilter(
+        $searchCriteriaBuilder->addFilters(
             [
                 $filterBuilder
                     ->setField('status')

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/ShipmentListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/ShipmentListTest.php
@@ -43,7 +43,7 @@ class ShipmentListTest extends WebapiAbstract
             'Magento\Framework\Api\FilterBuilder'
         );
 
-        $searchCriteriaBuilder->addFilter([$filterBuilder->setField('shipment_status')->setValue(1)->create()]);
+        $searchCriteriaBuilder->addFilters([$filterBuilder->setField('shipment_status')->setValue(1)->create()]);
         $searchData = $searchCriteriaBuilder->create()->__toArray();
 
         $requestData = ['criteria' => $searchData];

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/TransactionTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/TransactionTest.php
@@ -105,7 +105,7 @@ class TransactionTest extends WebapiAbstract
             'Magento\Framework\Api\SearchCriteriaBuilder'
         );
 
-        $searchCriteriaBuilder->addFilter($filters);
+        $searchCriteriaBuilder->addFilters($filters);
         $searchData = $searchCriteriaBuilder->create()->__toArray();
 
         $requestData = ['criteria' => $searchData];

--- a/dev/tests/api-functional/testsuite/Magento/Tax/Api/TaxClassRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Tax/Api/TaxClassRepositoryTest.php
@@ -225,7 +225,7 @@ class TaxClassRepositoryTest extends WebapiAbstract
         $filter = $this->filterBuilder->setField($taxClassNameField)
             ->setValue($taxClassName)
             ->create();
-        $this->searchCriteriaBuilder->addFilter([$filter]);
+        $this->searchCriteriaBuilder->addFilters([$filter]);
         $searchData = $this->searchCriteriaBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchData];
         $serviceInfo = [
@@ -273,8 +273,8 @@ class TaxClassRepositoryTest extends WebapiAbstract
          * (class_name == 'Retail Customer' || class_name == 'Taxable Goods)
          * && ( class_type == 'CUSTOMER' || class_type == 'PRODUCT')
          */
-        $this->searchCriteriaBuilder->addFilter([$filter1, $filter2]);
-        $this->searchCriteriaBuilder->addFilter([$filter3, $filter4]);
+        $this->searchCriteriaBuilder->addFilters([$filter1, $filter2]);
+        $this->searchCriteriaBuilder->addFilters([$filter3, $filter4]);
         $searchCriteria = $this->searchCriteriaBuilder->setCurrentPage(1)->setPageSize(10)->create();
         $searchData = $searchCriteria->__toArray();
         $requestData = ['searchCriteria' => $searchData];
@@ -301,8 +301,8 @@ class TaxClassRepositoryTest extends WebapiAbstract
         );
 
         /** class_name == 'Retail Customer' && ( class_type == 'CUSTOMER' || class_type == 'PRODUCT') */
-        $this->searchCriteriaBuilder->addFilter([$filter2]);
-        $this->searchCriteriaBuilder->addFilter([$filter3, $filter4]);
+        $this->searchCriteriaBuilder->addFilters([$filter2]);
+        $this->searchCriteriaBuilder->addFilters([$filter3, $filter4]);
         $searchCriteria = $this->searchCriteriaBuilder->create();
         $searchData = $searchCriteria->__toArray();
         $requestData = ['searchCriteria' => $searchData];

--- a/dev/tests/api-functional/testsuite/Magento/Tax/Api/TaxRateRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Tax/Api/TaxRateRepositoryTest.php
@@ -437,7 +437,7 @@ class TaxRateRepositoryTest extends WebapiAbstract
             ->setValue('codeUs12')
             ->create();
 
-        $this->searchCriteriaBuilder->addFilter([$filter]);
+        $this->searchCriteriaBuilder->addFilters([$filter]);
 
         $searchData = $this->searchCriteriaBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchData];
@@ -488,7 +488,7 @@ class TaxRateRepositoryTest extends WebapiAbstract
             ->setDirection(SearchCriteria::SORT_DESC)
             ->create();
         // Order them by descending postcode (not the default order)
-        $this->searchCriteriaBuilder->addFilter([$filter])
+        $this->searchCriteriaBuilder->addFilters([$filter])
             ->addSortOrder($sortOrder);
         $searchData = $this->searchCriteriaBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchData];

--- a/dev/tests/api-functional/testsuite/Magento/Tax/Api/TaxRuleRepositoryInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Tax/Api/TaxRuleRepositoryInterfaceTest.php
@@ -269,7 +269,7 @@ class TaxRuleRepositoryInterfaceTest extends WebapiAbstract
             ->setValue('Test Rule')
             ->create();
 
-        $this->searchCriteriaBuilder->addFilter([$filter]);
+        $this->searchCriteriaBuilder->addFilters([$filter]);
 
         $fixtureRule = $this->getFixtureTaxRules()[1];
 
@@ -324,7 +324,7 @@ class TaxRuleRepositoryInterfaceTest extends WebapiAbstract
             ->setValue(0)
             ->create();
 
-        $this->searchCriteriaBuilder->addFilter([$filter, $sortFilter]);
+        $this->searchCriteriaBuilder->addFilters([$filter, $sortFilter]);
 
         $fixtureRule = $this->getFixtureTaxRules()[1];
 
@@ -522,7 +522,7 @@ class TaxRuleRepositoryInterfaceTest extends WebapiAbstract
         $filter = $this->filterBuilder->setField('code')
             ->setValue($fixtureRule->getCode())
             ->create();
-        $this->searchCriteriaBuilder->addFilter([$filter]);
+        $this->searchCriteriaBuilder->addFilters([$filter]);
         $searchData = $this->searchCriteriaBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchData];
         $serviceInfo = [

--- a/dev/tests/api-functional/testsuite/Magento/Webapi/JoinDirectivesTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Webapi/JoinDirectivesTest.php
@@ -89,7 +89,7 @@ class JoinDirectivesTest extends \Magento\TestFramework\TestCase\WebapiAbstract
         /** @var SortOrder $sortOrder */
         $sortOrder = $this->sortOrderBuilder->setField('store_id')->setDirection(SearchCriteria::SORT_ASC)->create();
         $this->searchBuilder->setSortOrders([$sortOrder]);
-        $this->searchBuilder->addFilter([$this->filterBuilder->setField('state')->setValue(2)->create()]);
+        $this->searchBuilder->addFilters([$this->filterBuilder->setField('state')->setValue(2)->create()]);
         $searchCriteria = $this->searchBuilder->create()->__toArray();
         $requestData = ['criteria' => $searchCriteria];
 

--- a/dev/tests/integration/testsuite/Magento/Customer/Api/AddressRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Api/AddressRepositoryTest.php
@@ -306,10 +306,10 @@ class AddressRepositoryTest extends \PHPUnit_Framework_TestCase
         /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchBuilder */
         $searchBuilder = $this->_objectManager->create('Magento\Framework\Api\SearchCriteriaBuilder');
         foreach ($filters as $filter) {
-            $searchBuilder->addFilter([$filter]);
+            $searchBuilder->addFilters([$filter]);
         }
         if ($filterGroup !== null) {
-            $searchBuilder->addFilter($filterGroup);
+            $searchBuilder->addFilters($filterGroup);
         }
 
         $searchResults = $this->repository->getList($searchBuilder->create());

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Adminhtml/Group/Edit/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Adminhtml/Group/Edit/FormTest.php
@@ -100,7 +100,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
         /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteria */
         $searchCriteria = Bootstrap::getObjectManager()
             ->create('Magento\Framework\Api\SearchCriteriaBuilder')
-            ->addFilter([$builder->setField('code')->setValue('custom_group')->create()]);
+            ->addFilters([$builder->setField('code')->setValue('custom_group')->create()]);
         /** @var GroupInterface $customerGroup */
         $customerGroup = $this->groupRepository->getList($searchCriteria->create())->getItems()[0];
         $this->registry->register(RegistryConstants::CURRENT_GROUP_ID, $customerGroup->getId());

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Adminhtml/Group/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Adminhtml/Group/EditTest.php
@@ -85,7 +85,7 @@ class EditTest extends AbstractController
         /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteria */
         $searchCriteria = Bootstrap::getObjectManager()
             ->create('Magento\Framework\Api\SearchCriteriaBuilder')
-            ->addFilter([$builder->setField('code')->setValue('custom_group')->create()])->create();
+            ->addFilters([$builder->setField('code')->setValue('custom_group')->create()])->create();
         $customerGroup = $this->groupRepository->getList($searchCriteria)->getItems()[0];
         $this->getRequest()->setParam('id', $customerGroup->getId());
         $this->registry->register(RegistryConstants::CURRENT_GROUP_ID, $customerGroup->getId());

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/AddressRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/AddressRepositoryTest.php
@@ -308,10 +308,10 @@ class AddressRepositoryTest extends \PHPUnit_Framework_TestCase
         /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchBuilder */
         $searchBuilder = $this->_objectManager->create('Magento\Framework\Api\SearchCriteriaBuilder');
         foreach ($filters as $filter) {
-            $searchBuilder->addFilter([$filter]);
+            $searchBuilder->addFilters([$filter]);
         }
         if ($filterGroup !== null) {
-            $searchBuilder->addFilter($filterGroup);
+            $searchBuilder->addFilters($filterGroup);
         }
         if ($filterOrders !== null) {
             foreach ($filterOrders as $order) {

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/CustomerRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/CustomerRepositoryTest.php
@@ -299,14 +299,14 @@ class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testSearchCustomers($filters, $filterGroup, $expectedResult)
     {
-        /** @var \Magento\Framework\Api\SearchCriteriBuilder $searchBuilder */
+        /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchBuilder */
         $searchBuilder = Bootstrap::getObjectManager()
             ->create('Magento\Framework\Api\SearchCriteriaBuilder');
         foreach ($filters as $filter) {
-            $searchBuilder->addFilter([$filter]);
+            $searchBuilder->addFilters([$filter]);
         }
         if ($filterGroup !== null) {
-            $searchBuilder->addFilter($filterGroup);
+            $searchBuilder->addFilters($filterGroup);
         }
 
         $searchResults = $this->customerRepository->getList($searchBuilder->create());
@@ -338,7 +338,7 @@ class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
             ->setConditionType('like')
             ->setValue('First%')
             ->create();
-        $searchBuilder->addFilter([$firstnameFilter]);
+        $searchBuilder->addFilters([$firstnameFilter]);
         // Search ascending order
         $sortOrderBuilder = $objectManager->create('Magento\Framework\Api\SortOrderBuilder');
         $sortOrder = $sortOrderBuilder

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/GroupRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/GroupRepositoryTest.php
@@ -197,10 +197,10 @@ class GroupRepositoryTest extends \PHPUnit_Framework_TestCase
     public function testGetList($filters, $filterGroup, $expectedResult)
     {
         foreach ($filters as $filter) {
-            $this->searchCriteriaBuilder->addFilter([$filter]);
+            $this->searchCriteriaBuilder->addFilters([$filter]);
         }
         if ($filterGroup !== null) {
-            $this->searchCriteriaBuilder->addFilter($filterGroup);
+            $this->searchCriteriaBuilder->addFilters($filterGroup);
         }
 
         $searchResults = $this->groupRepository->getList($this->searchCriteriaBuilder->create());

--- a/dev/tests/integration/testsuite/Magento/Framework/Api/ExtensionAttribute/JoinProcessorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Api/ExtensionAttribute/JoinProcessorTest.php
@@ -321,6 +321,7 @@ EXPECTED_SQL;
     {
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         $groupRepository = $objectManager->create('Magento\Customer\Api\GroupRepositoryInterface');
+        /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder */
         $searchCriteriaBuilder = $objectManager->create('Magento\Framework\Api\SearchCriteriaBuilder');
         $builder = $objectManager->create('Magento\Framework\Api\FilterBuilder');
         $joinedExtensionAttribute = 'test_dummy_attribute';
@@ -328,7 +329,7 @@ EXPECTED_SQL;
         $filter = $builder->setField($joinedExtensionAttribute)
             ->setValue($joinedExtensionAttributeValue)
             ->create();
-        $searchCriteriaBuilder->addFilter([$filter]);
+        $searchCriteriaBuilder->addFilters([$filter]);
         $searchResults = $groupRepository->getList($searchCriteriaBuilder->create());
         $items = $searchResults->getItems();
         $this->assertCount(1, $items, 'Filtration by extension attribute does not work.');
@@ -346,6 +347,7 @@ EXPECTED_SQL;
     {
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         $groupRepository = $objectManager->create('Magento\Customer\Api\GroupRepositoryInterface');
+        /** @var \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder */
         $searchCriteriaBuilder = $objectManager->create('Magento\Framework\Api\SearchCriteriaBuilder');
         $builder = $objectManager->create('Magento\Framework\Api\FilterBuilder');
         $joinedExtensionAttribute = 'test_complex_dummy_attribute.frontend_label';
@@ -353,7 +355,7 @@ EXPECTED_SQL;
         $filter = $builder->setField($joinedExtensionAttribute)
             ->setValue($joinedExtensionAttributeValue)
             ->create();
-        $searchCriteriaBuilder->addFilter([$filter]);
+        $searchCriteriaBuilder->addFilters([$filter]);
         $searchResults = $groupRepository->getList($searchCriteriaBuilder->create());
         $items = $searchResults->getItems();
         $this->assertCount(1, $items, 'Filtration by extension attribute does not work.');

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Calculation/RateRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Calculation/RateRepositoryTest.php
@@ -545,10 +545,10 @@ class RateRepositoryTest extends \PHPUnit_Framework_TestCase
         $searchBuilder = Bootstrap::getObjectManager()
             ->create('Magento\Framework\Api\SearchCriteriaBuilder');
         foreach ($filters as $filter) {
-            $searchBuilder->addFilter([$filter]);
+            $searchBuilder->addFilters([$filter]);
         }
         if ($filterGroup !== null) {
-            $searchBuilder->addFilter($filterGroup);
+            $searchBuilder->addFilters($filterGroup);
         }
         $searchCriteria = $searchBuilder->create();
 

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/TaxRuleRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/TaxRuleRepositoryTest.php
@@ -300,10 +300,10 @@ class TaxRuleRepositoryTest extends \PHPUnit_Framework_TestCase
         $searchBuilder = Bootstrap::getObjectManager()
             ->create('Magento\Framework\Api\SearchCriteriaBuilder');
         foreach ($filters as $filter) {
-            $searchBuilder->addFilter([$filter]);
+            $searchBuilder->addFilters([$filter]);
         }
         if ($filterGroup !== null) {
-            $searchBuilder->addFilter($filterGroup);
+            $searchBuilder->addFilters($filterGroup);
         }
         $searchCriteria = $searchBuilder->create();
 

--- a/lib/internal/Magento/Framework/Api/AbstractServiceCollection.php
+++ b/lib/internal/Magento/Framework/Api/AbstractServiceCollection.php
@@ -134,7 +134,7 @@ abstract class AbstractServiceCollection extends \Magento\Framework\Data\Collect
                     $filterGroup[] = $this->createFilterData($field, $filter['condition'][$index]);
                 }
             }
-            $this->searchCriteriaBuilder->addFilter($filterGroup);
+            $this->searchCriteriaBuilder->addFilters($filterGroup);
         }
         foreach ($this->_orders as $field => $direction) {
             /** @var \Magento\Framework\Api\SortOrder $sortOrder */

--- a/lib/internal/Magento/Framework/Api/Search/FilterGroupBuilder.php
+++ b/lib/internal/Magento/Framework/Api/Search/FilterGroupBuilder.php
@@ -52,7 +52,7 @@ class FilterGroupBuilder extends AbstractSimpleObjectBuilder
      * @param \Magento\Framework\Api\Filter[] $filters
      * @return $this
      */
-    public function setFilters($filters)
+    public function setFilters(array $filters)
     {
         return $this->_set(FilterGroup::FILTERS, $filters);
     }

--- a/lib/internal/Magento/Framework/Api/SearchCriteriaBuilder.php
+++ b/lib/internal/Magento/Framework/Api/SearchCriteriaBuilder.php
@@ -52,7 +52,7 @@ class SearchCriteriaBuilder extends AbstractSimpleObjectBuilder
      * @param \Magento\Framework\Api\Filter[] $filter
      * @return $this
      */
-    public function addFilter(array $filter)
+    public function addFilters(array $filter)
     {
         $this->data[SearchCriteria::FILTER_GROUPS][] = $this->_filterGroupBuilder->setFilters($filter)->create();
         return $this;


### PR DESCRIPTION
Purpose
==

Make method name more descriptive and easier to understand.

Background
==

Having a method called `addFilter()` which take an array of `Filter` instances caused many doubletakes and facepalms during the m2 dev training.  
It seems as if the method name originated from the old collection `addFieldToFilter` from collections in Magento 1, where the condition type was set as a key in the passed argument array (e.g. `addFieldToFilter('name', ['eq' => $filter])`).  
In fact, some integration tests even set such expectations on the searchCriteriaBuilder, for example *app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php*.

However, this must be a bug because the array keys in the argument array are ignored, and the code only happened to work because the repositories in question default to using the 'eq' operator when applying the filter groups to the collection if no condition type is set on the filter instance.

Reasons for this PR
==

Make the method name more intuitive.  
Naming definitely could still be improved, but at least it no longer is that misleading.  
Maybe using `addFilterGroupWithFilters()` would be even more descriptive, but I chose the smaller change, since it probably is "good enough".

Remove wrong examples of method usage from tests, so they don't serve as wrong documentation.
