### PR TITLE
Improve \Magento\Framework\Api\SortOrder

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -13,7 +13,6 @@ use Magento\Framework\Api\Data\ImageContentInterface;
 use Magento\Framework\Api\Data\ImageContentInterfaceFactory;
 use Magento\Framework\Api\ImageContentValidatorInterface;
 use Magento\Framework\Api\ImageProcessorInterface;
-use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -658,7 +657,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             $field = $sortOrder->getField();
             $collection->addOrder(
                 $field,
-                ($sortOrder->getDirection() == SearchCriteriaInterface::SORT_ASC) ? 'ASC' : 'DESC'
+                ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
             );
         }
         $collection->setCurPage($searchCriteria->getCurrentPage());

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
@@ -11,6 +11,7 @@ namespace Magento\Catalog\Test\Unit\Model;
 
 use Magento\Catalog\Model\Layer\Filter\Dynamic\AlgorithmFactory;
 use Magento\Framework\Api\Data\ImageContentInterface;
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Model\ScopeInterface;
 
@@ -602,7 +603,7 @@ class ProductRepositoryTest extends \PHPUnit_Framework_TestCase
         $searchCriteriaMock->expects($this->once())->method('getSortOrders')->willReturn([$sortOrderMock]);
         $sortOrderMock->expects($this->once())->method('getField')->willReturn('field');
         $sortOrderMock->expects($this->once())->method('getDirection')
-            ->willReturn(\Magento\Framework\Api\SearchCriteriaInterface::SORT_ASC);
+            ->willReturn(SortOrder::SORT_ASC);
         $collectionMock->expects($this->once())->method('addOrder')->with('field', 'ASC');
         $searchCriteriaMock->expects($this->once())->method('getCurrentPage')->willReturn(4);
         $collectionMock->expects($this->once())->method('setCurPage')->with(4);

--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -8,7 +8,7 @@ namespace Magento\Cms\Model;
 use Magento\Cms\Api\Data;
 use Magento\Cms\Api\BlockRepositoryInterface;
 use Magento\Framework\Api\DataObjectHelper;
-use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -146,7 +146,7 @@ class BlockRepository implements BlockRepositoryInterface
             foreach ($sortOrders as $sortOrder) {
                 $collection->addOrder(
                     $sortOrder->getField(),
-                    ($sortOrder->getDirection() == SearchCriteriaInterface::SORT_ASC) ? 'ASC' : 'DESC'
+                    ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
                 );
             }
         }

--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -8,7 +8,7 @@ namespace Magento\Cms\Model;
 use Magento\Cms\Api\Data;
 use Magento\Cms\Api\PageRepositoryInterface;
 use Magento\Framework\Api\DataObjectHelper;
-use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -143,10 +143,11 @@ class PageRepository implements PageRepositoryInterface
         $searchResults->setTotalCount($collection->getSize());
         $sortOrders = $criteria->getSortOrders();
         if ($sortOrders) {
+            /** @var SortOrder $sortOrder */
             foreach ($sortOrders as $sortOrder) {
                 $collection->addOrder(
                     $sortOrder->getField(),
-                    ($sortOrder->getDirection() == SearchCriteriaInterface::SORT_ASC) ? 'ASC' : 'DESC'
+                    ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
                 );
             }
         }

--- a/app/code/Magento/Cms/Test/Unit/Model/BlockRepositoryTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Model/BlockRepositoryTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Cms\Test\Unit\Model;
 
 use Magento\Cms\Model\BlockRepository;
-use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
 
 /**
  * Test for Magento\Cms\Model\BlockRepository
@@ -236,7 +236,7 @@ class BlockRepositoryTest extends \PHPUnit_Framework_TestCase
         $storeFilter->expects($this->any())->method('getField')->willReturn('store_id');
         $storeFilter->expects($this->once())->method('getValue')->willReturn(1);
         $sortOrder->expects($this->once())->method('getField')->willReturn($sortField);
-        $sortOrder->expects($this->once())->method('getDirection')->willReturn(SearchCriteriaInterface::SORT_DESC);
+        $sortOrder->expects($this->once())->method('getDirection')->willReturn(SortOrder::SORT_DESC);
 
         /** @var \Magento\Framework\Api\SearchCriteriaInterface $criteria */
 

--- a/app/code/Magento/Cms/Test/Unit/Model/PageRepositoryTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Model/PageRepositoryTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Cms\Test\Unit\Model;
 
 use Magento\Cms\Model\PageRepository;
-use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
 
 /**
  * Test for Magento\Cms\Model\PageRepository
@@ -236,7 +236,7 @@ class PageRepositoryTest extends \PHPUnit_Framework_TestCase
         $storeFilter->expects($this->any())->method('getField')->willReturn('store_id');
         $storeFilter->expects($this->once())->method('getValue')->willReturn(1);
         $sortOrder->expects($this->once())->method('getField')->willReturn($sortField);
-        $sortOrder->expects($this->once())->method('getDirection')->willReturn(SearchCriteriaInterface::SORT_DESC);
+        $sortOrder->expects($this->once())->method('getDirection')->willReturn(SortOrder::SORT_DESC);
 
         /** @var \Magento\Framework\Api\SearchCriteriaInterface $criteria */
 

--- a/app/code/Magento/Customer/Model/Resource/AddressRepository.php
+++ b/app/code/Magento/Customer/Model/Resource/AddressRepository.php
@@ -165,7 +165,7 @@ class AddressRepository implements \Magento\Customer\Api\AddressRepositoryInterf
             $field = $sortOrder->getField();
             $collection->addOrder(
                 $field,
-                ($sortOrder->getDirection() == SearchCriteriaInterface::SORT_ASC) ? 'ASC' : 'DESC'
+                ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
             );
         }
         $collection->setCurPage($searchCriteria->getCurrentPage());

--- a/app/code/Magento/Customer/Model/Resource/CustomerRepository.php
+++ b/app/code/Magento/Customer/Model/Resource/CustomerRepository.php
@@ -11,6 +11,7 @@ use Magento\Customer\Model\Data\CustomerSecure;
 use Magento\Framework\Api\DataObjectHelper;
 use Magento\Framework\Api\ImageProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\NoSuchEntityException;
 
@@ -270,10 +271,11 @@ class CustomerRepository implements \Magento\Customer\Api\CustomerRepositoryInte
         $searchResults->setTotalCount($collection->getSize());
         $sortOrders = $searchCriteria->getSortOrders();
         if ($sortOrders) {
+            /** @var SortOrder $sortOrder */
             foreach ($searchCriteria->getSortOrders() as $sortOrder) {
                 $collection->addOrder(
                     $sortOrder->getField(),
-                    ($sortOrder->getDirection() == SearchCriteriaInterface::SORT_ASC) ? 'ASC' : 'DESC'
+                    ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
                 );
             }
         }

--- a/app/code/Magento/Customer/Model/Resource/GroupRepository.php
+++ b/app/code/Magento/Customer/Model/Resource/GroupRepository.php
@@ -10,6 +10,7 @@ use Magento\Customer\Api\Data\GroupInterface;
 use Magento\Customer\Model\Resource\Group\Collection;
 use Magento\Framework\Api\Search\FilterGroup;
 use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\State\InvalidTransitionException;
 use Magento\Tax\Api\Data\TaxClassInterface;
@@ -184,13 +185,13 @@ class GroupRepository implements \Magento\Customer\Api\GroupRepositoryInterface
             $this->addFilterGroupToCollection($group, $collection);
         }
         $sortOrders = $searchCriteria->getSortOrders();
-        /** @var \Magento\Framework\Api\SortOrder $sortOrder */
+        /** @var SortOrder $sortOrder */
         if ($sortOrders) {
             foreach ($searchCriteria->getSortOrders() as $sortOrder) {
                 $field = $this->translateField($sortOrder->getField());
                 $collection->addOrder(
                     $field,
-                    ($sortOrder->getDirection() == SearchCriteriaInterface::SORT_ASC) ? 'ASC' : 'DESC'
+                    ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
                 );
             }
         } else {

--- a/app/code/Magento/Customer/Test/Unit/Model/Resource/AddressRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Resource/AddressRepositoryTest.php
@@ -326,7 +326,7 @@ class AddressRepositoryTest extends \PHPUnit_Framework_TestCase
             ->willReturn('Field');
         $sortOrder->expects($this->once())
             ->method('getDirection')
-            ->willReturn(1);
+            ->willReturn(\Magento\Framework\Api\SortOrder::SORT_ASC);
         $collection->expects($this->once())
             ->method('addOrder')
             ->with('Field', 'ASC');

--- a/app/code/Magento/Customer/Test/Unit/Model/Resource/CustomerRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Resource/CustomerRepositoryTest.php
@@ -737,7 +737,7 @@ class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
             ->willReturn('Field');
         $sortOrder->expects($this->once())
             ->method('getDirection')
-            ->willReturn(1);
+            ->willReturn(\Magento\Framework\Api\SortOrder::SORT_ASC);
         $searchCriteria->expects($this->once())
             ->method('getCurrentPage')
             ->willReturn(1);

--- a/app/code/Magento/Customer/Test/Unit/Model/Resource/Group/Grid/ServiceCollectionTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Resource/Group/Grid/ServiceCollectionTest.php
@@ -8,6 +8,7 @@ namespace Magento\Customer\Test\Unit\Model\Resource\Group\Grid;
 
 use Magento\Framework\Api\SearchCriteria;
 use Magento\Customer\Model\Resource\Group\Grid\ServiceCollection;
+use Magento\Framework\Api\SortOrder;
 
 /**
  * Unit test for \Magento\Customer\Model\Resource\Group\Grid\ServiceCollection
@@ -81,7 +82,7 @@ class ServiceCollectionTest extends \PHPUnit_Framework_TestCase
     {
         $sortOrder = $this->sortOrderBuilder
             ->setField('name')
-            ->setDirection(SearchCriteria::SORT_ASC)
+            ->setDirection(SortOrder::SORT_ASC)
             ->create();
         /** @var SearchCriteria $expectedSearchCriteria */
         $expectedSearchCriteria = $this->searchCriteriaBuilder
@@ -111,7 +112,7 @@ class ServiceCollectionTest extends \PHPUnit_Framework_TestCase
         $value = '35';
         $sortOrder = $this->sortOrderBuilder
             ->setField('name')
-            ->setDirection(SearchCriteria::SORT_ASC)
+            ->setDirection(SortOrder::SORT_ASC)
             ->create();
         /** @var SearchCriteria $expectedSearchCriteria */
         $filter = $this->filterBuilder->setField($field)->setConditionType($conditionType)->setValue($value)->create();
@@ -143,7 +144,7 @@ class ServiceCollectionTest extends \PHPUnit_Framework_TestCase
 
         $sortOrder = $this->sortOrderBuilder
             ->setField('name')
-            ->setDirection(SearchCriteria::SORT_ASC)
+            ->setDirection(SortOrder::SORT_ASC)
             ->create();
         /** @var SearchCriteria $expectedSearchCriteria */
         $expectedSearchCriteria = $this->searchCriteriaBuilder
@@ -179,7 +180,7 @@ class ServiceCollectionTest extends \PHPUnit_Framework_TestCase
 
         $sortOrder = $this->sortOrderBuilder
             ->setField('name')
-            ->setDirection(SearchCriteria::SORT_ASC)
+            ->setDirection(SortOrder::SORT_ASC)
             ->create();
         /** @var SearchCriteria $expectedSearchCriteria */
         $expectedSearchCriteria = $this->searchCriteriaBuilder

--- a/app/code/Magento/Customer/Test/Unit/Model/Resource/GroupRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Resource/GroupRepositoryTest.php
@@ -409,7 +409,7 @@ class GroupRepositoryTest extends \PHPUnit_Framework_TestCase
             ->with('Field', 'ASC');
         $sortOrder->expects($this->once())
             ->method('getDirection')
-            ->willReturn(1);
+            ->willReturn(\Magento\Framework\Api\SortOrder::SORT_ASC);
         $searchCriteria->expects($this->once())
             ->method('getCurrentPage')
             ->willReturn(1);

--- a/app/code/Magento/Eav/Model/AttributeRepository.php
+++ b/app/code/Magento/Eav/Model/AttributeRepository.php
@@ -7,7 +7,7 @@
 namespace Magento\Eav\Model;
 
 use Magento\Eav\Model\Resource\Entity\Attribute\Collection;
-use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\StateException;
@@ -118,11 +118,11 @@ class AttributeRepository implements \Magento\Eav\Api\AttributeRepositoryInterfa
         foreach ($searchCriteria->getFilterGroups() as $group) {
             $this->addFilterGroupToCollection($group, $attributeCollection);
         }
-        /** @var \Magento\Framework\Api\SortOrder $sortOrder */
+        /** @var SortOrder $sortOrder */
         foreach ((array)$searchCriteria->getSortOrders() as $sortOrder) {
             $attributeCollection->addOrder(
                 $sortOrder->getField(),
-                ($sortOrder->getDirection() == SearchCriteriaInterface::SORT_ASC) ? 'ASC' : 'DESC'
+                ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
             );
         }
 

--- a/app/code/Magento/Quote/Model/QuoteRepository.php
+++ b/app/code/Magento/Quote/Model/QuoteRepository.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\Quote\Model;
 
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Quote;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Framework\Api\SearchCriteria;
 use Magento\Framework\Api\Search\FilterGroup;
 use Magento\Quote\Model\Resource\Quote\Collection as QuoteCollection;
 use Magento\Framework\Exception\InputException;
@@ -220,10 +220,11 @@ class QuoteRepository implements \Magento\Quote\Api\CartRepositoryInterface
         $searchData->setTotalCount($this->quoteCollection->getSize());
         $sortOrders = $searchCriteria->getSortOrders();
         if ($sortOrders) {
+            /** @var SortOrder $sortOrder */
             foreach ($sortOrders as $sortOrder) {
                 $this->quoteCollection->addOrder(
                     $sortOrder->getField(),
-                    $sortOrder->getDirection() == SearchCriteria::SORT_ASC ? 'ASC' : 'DESC'
+                    $sortOrder->getDirection() == SortOrder::SORT_ASC ? 'ASC' : 'DESC'
                 );
             }
         }

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteRepositoryTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteRepositoryTest.php
@@ -9,7 +9,7 @@ namespace Magento\Quote\Test\Unit\Model;
 
 use \Magento\Quote\Model\QuoteRepository;
 
-use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
 
 class QuoteRepositoryTest extends \PHPUnit_Framework_TestCase
@@ -404,8 +404,8 @@ class QuoteRepositoryTest extends \PHPUnit_Framework_TestCase
     public function getListSuccessDataProvider()
     {
         return [
-            'asc' => [SearchCriteria::SORT_ASC, 'ASC'],
-            'desc' => [SearchCriteria::SORT_DESC, 'DESC']
+            'asc' => [SortOrder::SORT_ASC, 'ASC'],
+            'desc' => [SortOrder::SORT_DESC, 'DESC']
         ];
     }
 }

--- a/app/code/Magento/Tax/Model/Calculation/RateRepository.php
+++ b/app/code/Magento/Tax/Model/Calculation/RateRepository.php
@@ -10,11 +10,9 @@ namespace Magento\Tax\Model\Calculation;
 use Magento\Directory\Model\CountryFactory;
 use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\Api\Search\FilterGroup;
-use Magento\Framework\Api\SearchCriteria;
 use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Tax\Model\Calculation\Rate;
 use Magento\Tax\Model\Calculation\Rate\Converter;
 use Magento\Tax\Model\Resource\Calculation\Rate\Collection;
@@ -168,7 +166,7 @@ class RateRepository implements \Magento\Tax\Api\TaxRateRepositoryInterface
             foreach ($sortOrders as $sortOrder) {
                 $collection->addOrder(
                     $this->translateField($sortOrder->getField()),
-                    ($sortOrder->getDirection() == SearchCriteria::SORT_ASC) ? 'ASC' : 'DESC'
+                    ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
                 );
             }
         }

--- a/app/code/Magento/Tax/Model/TaxClass/Repository.php
+++ b/app/code/Magento/Tax/Model/TaxClass/Repository.php
@@ -9,7 +9,6 @@ namespace Magento\Tax\Model\TaxClass;
 
 use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\Api\Search\FilterGroup;
-use Magento\Framework\Api\SearchCriteria;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\CouldNotDeleteException;
@@ -214,7 +213,7 @@ class Repository implements \Magento\Tax\Api\TaxClassRepositoryInterface
             foreach ($searchCriteria->getSortOrders() as $sortOrder) {
                 $collection->addOrder(
                     $sortOrder->getField(),
-                    ($sortOrder->getDirection() == SearchCriteria::SORT_ASC) ? 'ASC' : 'DESC'
+                    ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
                 );
             }
         }

--- a/app/code/Magento/Tax/Model/TaxRuleRepository.php
+++ b/app/code/Magento/Tax/Model/TaxRuleRepository.php
@@ -7,7 +7,6 @@
 namespace Magento\Tax\Model;
 
 use Magento\Framework\Api\Search\FilterGroup;
-use Magento\Framework\Api\SearchCriteria;
 use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\CouldNotSaveException;
@@ -163,7 +162,7 @@ class TaxRuleRepository implements TaxRuleRepositoryInterface
             foreach ($sortOrders as $sortOrder) {
                 $collection->addOrder(
                     $this->translateField($sortOrder->getField()),
-                    ($sortOrder->getDirection() == SearchCriteria::SORT_ASC) ? 'ASC' : 'DESC'
+                    ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
                 );
             }
         }

--- a/app/code/Magento/Tax/Test/Unit/Model/Calculation/RateRepositoryTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/Calculation/RateRepositoryTest.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Tax\Test\Unit\Model\Calculation;
 
+use Magento\Framework\Api\SortOrder;
 use \Magento\Tax\Model\Calculation\RateRepository;
 
-use Magento\Framework\Api\SearchCriteria;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\AlreadyExistsException;
@@ -391,7 +391,7 @@ class RateRepositoryTest extends \PHPUnit_Framework_TestCase
             ->method('getSortOrders')
             ->will($this->returnValue([$sortOrderMock]));
         $sortOrderMock->expects($this->once())->method('getField')->willReturn('field_name');
-        $sortOrderMock->expects($this->once())->method('getDirection')->willReturn(SearchCriteria::SORT_ASC);
+        $sortOrderMock->expects($this->once())->method('getDirection')->willReturn(SortOrder::SORT_ASC);
         $collectionMock->expects($this->once())->method('addOrder')->with('main_table.field_name', 'ASC');
         $currentPage = 1;
         $pageSize = 100;

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxClass/RepositoryTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxClass/RepositoryTest.php
@@ -6,11 +6,11 @@
 
 namespace Magento\Tax\Test\Unit\Model\TaxClass;
 
+use Magento\Framework\Api\SortOrder;
 use \Magento\Tax\Model\TaxClass\Repository;
 
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Api\SearchCriteria;
 
 class RepositoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -215,7 +215,7 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
 
         $searchCriteria->expects($this->exactly(2))->method('getSortOrders')->willReturn([$sortOrder]);
         $sortOrder->expects($this->once())->method('getField')->willReturn('field');
-        $sortOrder->expects($this->once())->method('getDirection')->willReturn(SearchCriteria::SORT_ASC);
+        $sortOrder->expects($this->once())->method('getDirection')->willReturn(SortOrder::SORT_ASC);
         $collection->expects($this->once())->method('addOrder')->with('field', 'ASC');
         $searchCriteria->expects($this->once())->method('getPageSize')->willReturn(20);
         $searchCriteria->expects($this->once())->method('getCurrentPage')->willReturn(0);

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxRuleRepositoryTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxRuleRepositoryTest.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Tax\Test\Unit\Model;
 
+use Magento\Framework\Api\SortOrder;
 use \Magento\Tax\Model\TaxRuleRepository;
 
-use Magento\Framework\Api\SearchCriteria as SearchCriteria;
 
 class TaxRuleRepositoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -215,7 +215,7 @@ class TaxRuleRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->searchResultsMock->expects($this->once())->method('setTotalCount')->with($collectionSize);
         $searchCriteriaMock->expects($this->once())->method('getSortOrders')->willReturn([$sortOrderMock]);
         $sortOrderMock->expects($this->once())->method('getField')->willReturn('sort_order');
-        $sortOrderMock->expects($this->once())->method('getDirection')->willReturn(SearchCriteria::SORT_ASC);
+        $sortOrderMock->expects($this->once())->method('getDirection')->willReturn(SortOrder::SORT_ASC);
         $collectionMock->expects($this->once())->method('addOrder')->with('position', 'ASC');
         $searchCriteriaMock->expects($this->once())->method('getCurrentPage')->willReturn($currentPage);
         $collectionMock->expects($this->once())->method('setCurPage')->with($currentPage);

--- a/app/code/Magento/Ui/Model/Resource/BookmarkRepository.php
+++ b/app/code/Magento/Ui/Model/Resource/BookmarkRepository.php
@@ -6,6 +6,7 @@
 namespace Magento\Ui\Model\Resource;
 
 use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
 use Magento\Ui\Api\BookmarkRepositoryInterface;
 use Magento\Framework\Api\Search\FilterGroup;
 use Magento\Ui\Api\Data\BookmarkInterface;
@@ -107,11 +108,12 @@ class BookmarkRepository implements BookmarkRepositoryInterface
         $searchResults->setTotalCount($collection->getSize());
         $sortOrders = $searchCriteria->getSortOrders();
         if ($sortOrders) {
+            /** @var SortOrder $sortOrder */
             foreach ($sortOrders as $sortOrder) {
                 $field = $sortOrder->getField();
                 $collection->addOrder(
                     $field,
-                    ($sortOrder->getDirection() == SearchCriteriaInterface::SORT_ASC) ? 'ASC' : 'DESC'
+                    ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
                 );
             }
         }

--- a/dev/tests/api-functional/testsuite/Magento/Customer/Api/CustomerRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Customer/Api/CustomerRepositoryTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Customer\Api;
 
 use Magento\Customer\Api\Data\CustomerInterface as Customer;
-use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\InputException;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\Helper\Customer as CustomerHelper;
@@ -458,8 +458,8 @@ class CustomerRepositoryTest extends WebapiAbstract
         $sortOrderBuilder = Bootstrap::getObjectManager()->create(
             'Magento\Framework\Api\SortOrderBuilder'
         );
-        /** @var \Magento\Framework\Api\SortOrder $sortOrder */
-        $sortOrder = $sortOrderBuilder->setField(Customer::EMAIL)->setDirection(SearchCriteria::SORT_ASC)->create();
+        /** @var SortOrder $sortOrder */
+        $sortOrder = $sortOrderBuilder->setField(Customer::EMAIL)->setDirection(SortOrder::SORT_ASC)->create();
         $this->searchCriteriaBuilder->setSortOrders([$sortOrder]);
 
         $searchCriteria = $this->searchCriteriaBuilder->create();
@@ -502,7 +502,7 @@ class CustomerRepositoryTest extends WebapiAbstract
             ->create();
         $this->searchCriteriaBuilder->addFilters([$filter1, $filter2]);
         $this->searchCriteriaBuilder->addFilters([$filter3]);
-        $this->searchCriteriaBuilder->setSortOrders([Customer::EMAIL => SearchCriteria::SORT_ASC]);
+        $this->searchCriteriaBuilder->setSortOrders([Customer::EMAIL => SortOrder::SORT_ASC]);
         $searchCriteria = $this->searchCriteriaBuilder->create();
         $searchData = $searchCriteria->__toArray();
         $requestData = ['searchCriteria' => $searchData];

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartRepositoryTest.php
@@ -6,7 +6,6 @@
 namespace Magento\Quote\Api;
 
 use Magento\Framework\Api\FilterBuilder;
-use Magento\Framework\Api\SearchCriteria;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SortOrderBuilder;
 use Magento\Framework\Api\SortOrder;
@@ -178,10 +177,9 @@ class CartRepositoryTest extends WebapiAbstract
         $this->searchCriteriaBuilder->addFilters([$minCreatedAtFilter]);
         $this->searchCriteriaBuilder->addFilters([$maxCreatedAtFilter]);
         /** @var SortOrder $sortOrder */
-        $sortOrder = $this->sortOrderBuilder->setField('subtotal')->setDirection(SearchCriteria::SORT_ASC)->create();
+        $sortOrder = $this->sortOrderBuilder->setField('subtotal')->setDirection(SortOrder::SORT_ASC)->create();
         $this->searchCriteriaBuilder->setSortOrders([$sortOrder]);
         $searchCriteria = $this->searchCriteriaBuilder->create()->__toArray();
-
         $requestData = ['searchCriteria' => $searchCriteria];
         $serviceInfo = [
             'rest' => [

--- a/dev/tests/api-functional/testsuite/Magento/Tax/Api/TaxRateRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Tax/Api/TaxRateRepositoryTest.php
@@ -7,8 +7,8 @@
 namespace Magento\Tax\Api;
 
 use Magento\Framework\Api\FilterBuilder;
-use Magento\Framework\Api\SearchCriteria;
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Api\SortOrderBuilder;
 use Magento\Tax\Model\Calculation\Rate;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -485,7 +485,7 @@ class TaxRateRepositoryTest extends WebapiAbstract
             ->create();
         $sortOrder = $this->sortOrderBuilder
             ->setField(Rate::KEY_POSTCODE)
-            ->setDirection(SearchCriteria::SORT_DESC)
+            ->setDirection(SortOrder::SORT_DESC)
             ->create();
         // Order them by descending postcode (not the default order)
         $this->searchCriteriaBuilder->addFilters([$filter])

--- a/dev/tests/api-functional/testsuite/Magento/Webapi/JoinDirectivesTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Webapi/JoinDirectivesTest.php
@@ -49,7 +49,7 @@ class JoinDirectivesTest extends \Magento\TestFramework\TestCase\WebapiAbstract
     public function testGetList()
     {
         /** @var SortOrder $sortOrder */
-        $sortOrder = $this->sortOrderBuilder->setField('store_id')->setDirection(SearchCriteria::SORT_ASC)->create();
+        $sortOrder = $this->sortOrderBuilder->setField('store_id')->setDirection(SortOrder::SORT_ASC)->create();
         $this->searchBuilder->setSortOrders([$sortOrder]);
         $searchCriteria = $this->searchBuilder->create()->__toArray();
         $requestData = ['searchCriteria' => $searchCriteria];
@@ -87,7 +87,7 @@ class JoinDirectivesTest extends \Magento\TestFramework\TestCase\WebapiAbstract
     {
         $this->getExpectedExtensionAttributes();
         /** @var SortOrder $sortOrder */
-        $sortOrder = $this->sortOrderBuilder->setField('store_id')->setDirection(SearchCriteria::SORT_ASC)->create();
+        $sortOrder = $this->sortOrderBuilder->setField('store_id')->setDirection(SortOrder::SORT_ASC)->create();
         $this->searchBuilder->setSortOrders([$sortOrder]);
         $this->searchBuilder->addFilters([$this->filterBuilder->setField('state')->setValue(2)->create()]);
         $searchCriteria = $this->searchBuilder->create()->__toArray();

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/AddressRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/AddressRepositoryTest.php
@@ -7,7 +7,7 @@
 namespace Magento\Customer\Model\Resource;
 
 use Magento\Customer\Api\AddressRepositoryInterface;
-use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\NoSuchEntityException;
 
@@ -375,8 +375,8 @@ class AddressRepositoryTest extends \PHPUnit_Framework_TestCase
                 [$filterBuilder->setField('firstname')->setValue('John')->create()],
                 null,
                 [
-                    $orderBuilder->setField('firstname')->setDirection(SearchCriteriaInterface::SORT_DESC)->create(),
-                    $orderBuilder->setField('city')->setDirection(SearchCriteriaInterface::SORT_ASC)->create(),
+                    $orderBuilder->setField('firstname')->setDirection(SortOrder::SORT_DESC)->create(),
+                    $orderBuilder->setField('city')->setDirection(SortOrder::SORT_ASC)->create(),
                 ],
                 [
                     ['id' => 1, 'city' => 'CityM', 'postcode' => 75477, 'firstname' => 'John'],
@@ -390,7 +390,7 @@ class AddressRepositoryTest extends \PHPUnit_Framework_TestCase
                     $filterBuilder->setField('postcode')->setValue('47676')->create(),
                 ],
                 [
-                    $orderBuilder->setField('city')->setDirection(SearchCriteriaInterface::SORT_DESC)->create(),
+                    $orderBuilder->setField('city')->setDirection(SortOrder::SORT_DESC)->create(),
                 ],
                 [
                     ['id' => 2, 'city' => 'CityX', 'postcode' => 47676, 'firstname' => 'John'],
@@ -401,8 +401,8 @@ class AddressRepositoryTest extends \PHPUnit_Framework_TestCase
                 [$filterBuilder->setField('postcode')->setValue('0')->setConditionType('gt')->create()],
                 null,
                 [
-                    $orderBuilder->setField('firstname')->setDirection(SearchCriteriaInterface::SORT_ASC)->create(),
-                    $orderBuilder->setField('postcode')->setDirection(SearchCriteriaInterface::SORT_ASC)->create(),
+                    $orderBuilder->setField('firstname')->setDirection(SortOrder::SORT_ASC)->create(),
+                    $orderBuilder->setField('postcode')->setDirection(SortOrder::SORT_ASC)->create(),
                 ],
                 [
                     ['id' => 2, 'city' => 'CityX', 'postcode' => 47676, 'firstname' => 'John'],

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/CustomerRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/CustomerRepositoryTest.php
@@ -8,7 +8,7 @@ namespace Magento\Customer\Model\Resource;
 
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
-use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
 use Magento\TestFramework\Helper\Bootstrap;
 
 /**
@@ -343,7 +343,7 @@ class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
         $sortOrderBuilder = $objectManager->create('Magento\Framework\Api\SortOrderBuilder');
         $sortOrder = $sortOrderBuilder
             ->setField('lastname')
-            ->setDirection(SearchCriteriaInterface::SORT_ASC)
+            ->setDirection(SortOrder::SORT_ASC)
             ->create();
         $searchBuilder->addSortOrder($sortOrder);
         $searchResults = $this->customerRepository->getList($searchBuilder->create());
@@ -355,7 +355,7 @@ class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
         // Search descending order
         $sortOrder = $sortOrderBuilder
             ->setField('lastname')
-            ->setDirection(SearchCriteriaInterface::SORT_DESC)
+            ->setDirection(SortOrder::SORT_DESC)
             ->create();
         $searchBuilder->addSortOrder($sortOrder);
         $searchResults = $this->customerRepository->getList($searchBuilder->create());

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/GroupRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/Resource/GroupRepositoryTest.php
@@ -7,7 +7,7 @@
 namespace Magento\Customer\Model\Resource;
 
 use Magento\Customer\Api\Data\GroupInterface;
-use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SortOrder;
 
 /**
  * Integration test for \Magento\Customer\Model\Resource\GroupRepository
@@ -23,7 +23,7 @@ class GroupRepositoryTest extends \PHPUnit_Framework_TestCase
     /** @var \Magento\Framework\ObjectManagerInterface */
     private $objectManager;
 
-    /** @var \Magento\Customer\Model\Data\GroupInterfaceFactory */
+    /** @var \Magento\Customer\Api\Data\GroupInterfaceFactory */
     private $groupFactory;
 
     /** @var  \Magento\Framework\Api\SearchCriteriaBuilder */
@@ -281,9 +281,9 @@ class GroupRepositoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetListSortOrder($field, $direction, $methodName, $expectedResult)
     {
-        /** @var \Magento\Framework\Api\SortOrder $sortOrder */
+        /** @var SortOrder $sortOrder */
         /** @var string $direction */
-        $direction = ($direction == 'ASC') ? SearchCriteria::SORT_ASC : SearchCriteria::SORT_DESC;
+        $direction = ($direction == 'ASC') ? SortOrder::SORT_ASC : SortOrder::SORT_DESC;
         $sortOrder = $this->sortOrderBuilder->setField($field)->setDirection($direction)->create();
         $this->searchCriteriaBuilder->addSortOrder($sortOrder);
 

--- a/lib/internal/Magento/Framework/Api/AbstractServiceCollection.php
+++ b/lib/internal/Magento/Framework/Api/AbstractServiceCollection.php
@@ -137,9 +137,9 @@ abstract class AbstractServiceCollection extends \Magento\Framework\Data\Collect
             $this->searchCriteriaBuilder->addFilters($filterGroup);
         }
         foreach ($this->_orders as $field => $direction) {
-            /** @var \Magento\Framework\Api\SortOrder $sortOrder */
+            /** @var SortOrder $sortOrder */
             /** @var string $direction */
-            $direction = ($direction == 'ASC') ? SearchCriteria::SORT_ASC : SearchCriteria::SORT_DESC;
+            $direction = ($direction == 'ASC') ? SortOrder::SORT_ASC : SortOrder::SORT_DESC;
             $sortOrder = $this->sortOrderBuilder->setField($field)->setDirection($direction)->create();
             $this->searchCriteriaBuilder->addSortOrder($sortOrder);
         }

--- a/lib/internal/Magento/Framework/Api/SearchCriteriaInterface.php
+++ b/lib/internal/Magento/Framework/Api/SearchCriteriaInterface.php
@@ -13,9 +13,6 @@ namespace Magento\Framework\Api;
  */
 interface SearchCriteriaInterface
 {
-    const SORT_ASC = 1;
-    const SORT_DESC = -1;
-
     /**
      * Get a list of filter groups.
      *

--- a/lib/internal/Magento/Framework/Api/SortOrder.php
+++ b/lib/internal/Magento/Framework/Api/SortOrder.php
@@ -6,14 +6,27 @@
 
 namespace Magento\Framework\Api;
 
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Phrase;
+
 /**
  * Data object for sort order.
- * @codeCoverageIgnore
  */
 class SortOrder extends AbstractSimpleObject
 {
     const FIELD = 'field';
     const DIRECTION = 'direction';
+    const SORT_ASC = 'ASC';
+    const SORT_DESC = 'DESC';
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+        if (null !== $this->getDirection()) {
+            $this->validateDirection($this->getDirection());
+        }
+    }
+
 
     /**
      * Get sorting field.
@@ -54,6 +67,58 @@ class SortOrder extends AbstractSimpleObject
      */
     public function setDirection($direction)
     {
-        return $this->setData(SortOrder::DIRECTION, $direction);
+        $this->validateDirection($direction);
+        return $this->setData(SortOrder::DIRECTION, $this->normalizeDirectionInput($direction));
+    }
+
+    /**
+     * Validate direction argument ASC or DESC
+     * 
+     * @param mixed $direction
+     * @return string
+     * @throws InputException
+     */
+    private function validateDirection($direction)
+    {
+        $this->validateDirectionIsString($direction);
+        $this->validateDirectionIsAscOrDesc($direction);
+    }
+
+    /**
+     * @param string $direction
+     * @throws InputException
+     */
+    private function validateDirectionIsString($direction)
+    {
+        if (!is_string($direction)) {
+            throw new InputException(new Phrase(
+                'The sort order has to be specified as a string, got %1.',
+                [gettype($direction)]
+            ));
+        }
+    }
+
+    /**
+     * @param string $direction
+     * @throws InputException
+     */
+    private function validateDirectionIsAscOrDesc($direction)
+    {
+        $normalizedDirection = $this->normalizeDirectionInput($direction);
+        if (!in_array($normalizedDirection, [SortOrder::SORT_ASC, SortOrder::SORT_DESC], true)) {
+            throw new InputException(new Phrase(
+                'The sort order has to be specified as %1 for ascending order or %2 for descending order.',
+                [SortOrder::SORT_ASC, SortOrder::SORT_DESC]
+            ));
+        }
+    }
+
+    /**
+     * @param string $direction
+     * @return string
+     */
+    private function normalizeDirectionInput($direction)
+    {
+        return strtoupper($direction);
     }
 }

--- a/lib/internal/Magento/Framework/Api/SortOrderBuilder.php
+++ b/lib/internal/Magento/Framework/Api/SortOrderBuilder.php
@@ -36,4 +36,22 @@ class SortOrderBuilder extends AbstractSimpleObjectBuilder
         $this->_set(SortOrder::DIRECTION, $direction);
         return $this;
     }
+
+    /**
+     * @return $this
+     */
+    public function setAscendingDirection()
+    {
+        $this->setDirection(SortOrder::SORT_ASC);
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setDescendingDirection()
+    {
+        $this->setDirection(SortOrder::SORT_DESC);
+        return $this;
+    }
 }

--- a/lib/internal/Magento/Framework/Api/Test/Unit/SortOrderTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/SortOrderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+
+namespace Magento\Framework\Api\Test\Unit;
+
+use Magento\Framework\Api\SortOrder;
+
+/**
+ * @covers \Magento\Framework\Api\SortOrder
+ */
+class SortOrderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SortOrder
+     */
+    private $sortOrder;
+
+    protected function setUp()
+    {
+        $this->sortOrder = new SortOrder();
+    }
+    
+    public function testItReturnsNullIfNoOrderIsSet()
+    {
+        $this->assertNull($this->sortOrder->getDirection());
+    }
+
+    /**
+     * @dataProvider sortOrderDirectionProvider
+     */
+    public function testItReturnsTheCorrectValuesIfSortOrderIsSet($sortOrder)
+    {
+        $this->sortOrder->setDirection($sortOrder);
+        $this->assertSame($sortOrder, $this->sortOrder->getDirection());
+    }
+
+    public function sortOrderDirectionProvider()
+    {
+        return [[SortOrder::SORT_ASC], [SortOrder::SORT_DESC]];
+    }
+    
+    /**
+     * @param mixed $invalidDirection
+     * @dataProvider invalidSortDirectionProvider
+     * @expectedException \Magento\Framework\Exception\InputException
+     */
+    public function testItThrowsAnExceptionIfAnInvalidSortOrderIsSet($invalidDirection)
+    {
+        $this->sortOrder->setDirection($invalidDirection);
+    }
+
+    public function invalidSortDirectionProvider()
+    {
+        return [
+            [-1],
+            [1],
+            [0],
+            [true],
+            [false],
+            [[]],
+        ];
+    }
+
+    public function testTheSortDirectionCanBeSpecifiedCaseInsensitive()
+    {
+        $this->sortOrder->setDirection(strtolower(SortOrder::SORT_ASC));
+        $this->assertSame(SortOrder::SORT_ASC, $this->sortOrder->getDirection());
+        $this->sortOrder->setDirection(strtoupper(SortOrder::SORT_ASC));
+        $this->assertSame(SortOrder::SORT_ASC, $this->sortOrder->getDirection());
+        
+        $this->sortOrder->setDirection(strtolower(SortOrder::SORT_DESC));
+        $this->assertSame(SortOrder::SORT_DESC, $this->sortOrder->getDirection());
+        $this->sortOrder->setDirection(strtoupper(SortOrder::SORT_DESC));
+        $this->assertSame(SortOrder::SORT_DESC, $this->sortOrder->getDirection());
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\InputException
+     */
+    public function testItValidatesADirectionAssignedDuringInstantiation()
+    {
+        $this->sortOrder = new SortOrder([
+            SortOrder::DIRECTION => 'not-asc-or-desc'
+        ]);
+    }
+}


### PR DESCRIPTION
Purpose
==

Make the specification of sort directions on sort criteria easier for developers.

Background
==

This PR addresses several issues:

**PHPDoc type hint mismatch**
All parameter type hints expecting a sort direction specify `@param string $direction`, but the constants `SearchCriteriaInterface::SORT_ASC` and `SearchCriteriaInterface::SORT_DESC` are integers.
As a developer, when I see a method `setDirection()` that takes a string, I expect the argument to be either `ASC` or `DESC`. Neither work, but there is no error helpful error message.

**Unintuitive placement of constants**
Also the location of the constants is not intuitive. When working with the code in question, a developer is focused on the classes `SortOrder` and `SortOrderBuilder`. So the expectation would be to find the class constants on either of those classes.  
The addition of the methods `setAscendingDirection()` and `setDescendingDirection()` to the `SortOrderBuilder` removes the need for developers to know the location of constants at all.

**Missing validation**
The sort direction can be specified as a scalar argument, but there is no validation.
This PR adds validation and throws an explanatory exception on validation failure.

Reasons for this PR
==

I simply hope to make it easier and more intuitive for developers to specify a sort order.