### PR TITLE
Improve Password EAV Attribute Backend model

### DIFF
--- a/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Password.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Backend/Password.php
@@ -43,7 +43,7 @@ class Password extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBacke
      */
     public function beforeSave($object)
     {
-        $password = $object->getPassword();
+        $password = (string)$object->getPassword();
 
         $length = $this->string->strlen($password);
         if ($length > 0) {
@@ -53,7 +53,7 @@ class Password extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBacke
                 );
             }
 
-            if (trim($password) != $password) {
+            if (trim($password) !== $password) {
                 throw new LocalizedException(__('The password can not begin or end with a space.'));
             }
 
@@ -67,8 +67,8 @@ class Password extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBacke
      */
     public function validate($object)
     {
-        $password = $object->getPassword();
-        if ($password && $password == $object->getPasswordConfirm()) {
+        $password = (string)$object->getPassword();
+        if ($password && $password === (string)$object->getPasswordConfirm()) {
             return true;
         }
 


### PR DESCRIPTION
1. In method beforeSave $object->getPassword() can return not a string, so would be great to convert value to string to prevent converting value to string in all places and as result we may have not unexpected behavior behavior in future, when code will be changed. Also == operator would be great replace with === because there we will have two strings, to type converting needed.
2. In method validate $object->getPassword() and $object->getPasswordConfirm() may be not a string. As example password is string 'myPassword', password confirm is true. `'myPassword' == true 
   ` Result will be _true_.
   So those params were converted to string and and compared with ===.
3. Would be great to define which object type will be received in beforeSave and validate methods to be sure that we got \Magento\Framework\Object and this method contains getPassword and getPasswordConfirm (or __call method, which will process them correct). I didn't changed those methods because they defined in parent class wo type declaration.
