### PR TITLE
Remove dependency of date renderer on global state locale

### DIFF
--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Grid/Column/Renderer/Date.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Grid/Column/Renderer/Date.php
@@ -78,7 +78,7 @@ class Date extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Date
             } else {
                 $date = $this->_localeDate->date(new \DateTime($data), null, false);
             }
-            return \IntlDateFormatter::formatObject($date, $format);
+            return \IntlDateFormatter::formatObject($date, $format, $this->_localeResolver->getLocale());
         }
         return $this->getColumn()->getDefault();
     }

--- a/app/code/Magento/Reports/Test/Unit/Block/Adminhtml/Sales/Grid/Column/Renderer/DateTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Block/Adminhtml/Sales/Grid/Column/Renderer/DateTest.php
@@ -31,6 +31,44 @@ class DateTest extends \PHPUnit_Framework_TestCase
     protected $localeDate;
 
     /**
+     * @var string
+     */
+    private $globalStateLocaleBackup;
+
+    /**
+     * @param string $locale
+     */
+    private function mockGridDateRendererBehaviorWithLocale($locale)
+    {
+        $this->resolverMock->expects($this->any())->method('getLocale')->willReturn($locale);
+        $this->localeDate->expects($this->any())->method('getDateFormat')->willReturnCallback(
+            function ($value) use ($locale) {
+                return (new \IntlDateFormatter(
+                    $locale,
+                    $value,
+                    \IntlDateFormatter::NONE
+                ))->getPattern();
+            }
+        );
+    }
+
+    /**
+     * @param string $objectDataIndex
+     * @param string $periodType
+     */
+    private function mockGridDateColumnConfig($objectDataIndex, $periodType)
+    {
+        $columnMock = $this->getMockBuilder('Magento\Backend\Block\Widget\Grid\Column')
+            ->disableOriginalConstructor()
+            ->setMethods(['getIndex', 'getPeriodType'])
+            ->getMock();
+        $columnMock->expects($this->once())->method('getIndex')->willReturn($objectDataIndex);
+        $columnMock->expects($this->atLeastOnce())->method('getPeriodType')->willReturn($periodType);
+
+        $this->date->setColumn($columnMock);
+    }
+
+    /**
      * {@inheritDoc}
      */
     protected function setUp()
@@ -41,7 +79,7 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->localeDate
             ->expects($this->once())
             ->method('date')
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $this->contextMock = $this->getMockBuilder('Magento\Backend\Block\Context')
             ->disableOriginalConstructor()
@@ -49,7 +87,7 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->contextMock
             ->expects($this->once())
             ->method('getLocaleDate')
-            ->will($this->returnValue($this->localeDate));
+            ->willReturn($this->localeDate);
 
         $this->resolverMock = $this->getMockBuilder('Magento\Framework\Locale\ResolverInterface')
             ->getMock();
@@ -58,43 +96,41 @@ class DateTest extends \PHPUnit_Framework_TestCase
             $this->contextMock,
             $this->resolverMock
         );
+        
+        $this->globalStateLocaleBackup = \Locale::getDefault();
+    }
+
+    protected function tearDown()
+    {
+        $this->restoreTheDefaultLocaleGlobalState();
+    }
+
+    private function restoreTheDefaultLocaleGlobalState()
+    {
+        if (\Locale::getDefault() !== $this->globalStateLocaleBackup) {
+            \Locale::setDefault($this->globalStateLocaleBackup);
+        }
     }
 
     /**
      * @param string $data
-     * @param string $index
      * @param string $locale
+     * @param string $index
      * @param string $period
      * @param string $result
      * @dataProvider datesDataProvider
      * @return void
      */
-    public function testRender($data, $index, $locale, $period, $result)
+    public function testRender($data, $locale, $index, $period, $result)
     {
-        $this->resolverMock->expects($this->any())->method('getLocale')->will($this->returnValue($locale));
-        $this->localeDate->expects($this->any())->method('getDateFormat')->willReturnCallback(
-            function ($value) use ($locale) {
-                return (new \IntlDateFormatter(
-                    $locale,
-                    $value,
-                    \IntlDateFormatter::NONE
-                ))->getPattern();
-            }
-        );
+        $this->mockGridDateRendererBehaviorWithLocale($locale);
+        $this->mockGridDateColumnConfig($index, $period);
 
         $objectMock = $this->getMockBuilder('Magento\Framework\Object')
             ->setMethods(['getData'])
             ->getMock();
-        $objectMock->expects($this->once())->method('getData')->will($this->returnValue($data));
+        $objectMock->expects($this->once())->method('getData')->willReturn($data);
 
-        $columnMock = $this->getMockBuilder('Magento\Backend\Block\Widget\Grid\Column')
-            ->disableOriginalConstructor()
-            ->setMethods(['getIndex', 'getPeriodType'])
-            ->getMock();
-        $columnMock->expects($this->once())->method('getIndex')->will($this->returnValue($index));
-        $columnMock->expects($this->atLeastOnce())->method('getPeriodType')->will($this->returnValue($period));
-
-        $this->date->setColumn($columnMock);
 
         $this->assertEquals($result, $this->date->render($objectMock));
     }
@@ -107,39 +143,53 @@ class DateTest extends \PHPUnit_Framework_TestCase
         return [
             [
                 'data' => '2000',
-                'index' => 'period',
                 'locale' => 'en_US',
+                'index' => 'period',
                 'period' => 'year',
                 'result' => '2000'
             ],
             [
                 'data' => '2030',
-                'index' => 'period',
                 'locale' => 'en_US',
+                'index' => 'period',
                 'period' => 'year',
                 'result' => '2030'
             ],
             [
                 'data' => '2000-01',
-                'index' => 'period',
                 'locale' => 'en_US',
+                'index' => 'period',
                 'period' => 'month',
                 'result' => '1/2000'
             ],
             [
                 'data' => '2030-12',
-                'index' => 'period',
                 'locale' => 'en_US',
+                'index' => 'period',
                 'period' => 'month',
                 'result' => '12/2030'
             ],
             [
                 'data' => '2014-06-25',
-                'index' => 'period',
                 'locale' => 'en_US',
+                'index' => 'period',
                 'period' => 'day',
                 'result' => 'Jun 25, 2014'
             ]
         ];
+    }
+
+    public function testDateIsRenderedIndependentOfSystemDefaultLocale()
+    {
+        \Locale::setDefault('de_DE');
+        $this->mockGridDateRendererBehaviorWithLocale('en_US');
+        $this->mockGridDateColumnConfig('period', 'day');
+
+        $objectMock = $this->getMockBuilder('Magento\Framework\Object')
+            ->setMethods(['getData'])
+            ->getMock();
+        $objectMock->expects($this->any())->method('getData')->willReturn('2014-06-25');
+        
+        $this->assertEquals('Jun 25, 2014', $this->date->render($objectMock));
     }
 }


### PR DESCRIPTION
This does two things

**1) Introduce new test to reproduce bug from Issue #1468**
The new test is called
```
\Magento\Reports\Test\Unit\Block\Adminhtml\Sales\Grid\Column\Renderer\DateTest::testDateIsRenderedIndependentOfSystemDefaultLocale()
```
The existing test `testRender` was refactored a little to avoid code duplication with the new test.

**2) Introduce fix for Issue #1468**
The fix is to simply pass the locale that was used to create the date format string as a third argument to `\IntlDateFormatter::formatObject()`, so it will be used to fetch the matching datetime constants also.

```php
\IntlDateFormatter::formatObject($date, $format, $this->_localeResolver->getLocale());
```
