### PR TITLE
Fix issue with ModuleDirReader not finding files in vendor modules

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Module/Dir/ReaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Module/Dir/ReaderTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Module\Dir;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Config\FileIteratorFactory;
+use Magento\Framework\Module\ModuleListInterface;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\Read as DirectoryRead;
+
+class ReaderTest extends \PHPUnit_Framework_TestCase
+{
+    private $vendorModuleName = 'Vendor_Example';
+    
+    /**
+     * @var Reader
+     */
+    private $moduleDirReader;
+
+    /**
+     * @var DirectoryRead|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $directoryReadMock;
+
+    /**
+     * @var FileIteratorFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $filesIteratorFactoryMock;
+
+    /**
+     * @return DirectoryRead|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createDirectoryReadMock()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $factory = $objectManager->get(\Magento\Framework\Filesystem\File\ReadFactory::class);
+        $driver = $objectManager->get(\Magento\Framework\Filesystem\Driver\File::class);
+        $directoryReadMock = $this->getMock(
+            DirectoryRead::class,
+            ['isExist'],
+            [$factory, $driver, BP . '/app/code']
+        );
+        return $directoryReadMock;
+    }
+    
+    /**
+     * @param string[] $existingFiles
+     */
+    private function mockFilesExist(array $existingFiles)
+    {
+        $this->directoryReadMock->expects($this->any())->method('isExist')
+            ->willReturnCallback(function ($file) use ($existingFiles) {
+                return in_array($file, $existingFiles, true);
+            });
+    }
+
+    protected function setUp()
+    {
+        $appCodeModuleName = 'Magento_Example';
+        \Magento\Framework\Module\Registrar::registerModule($this->vendorModuleName, BP . '/vendor/example/example');
+        \Magento\TestFramework\Helper\Bootstrap::getInstance()->reinitialize();
+
+        /** @var ModuleListInterface|\PHPUnit_Framework_MockObject_MockObject $moduleListMock */
+        $moduleListMock = $this->getMock(ModuleListInterface::class);
+        $moduleListMock->expects($this->any())->method('getNames')->willReturn(
+            [$appCodeModuleName, $this->vendorModuleName]
+        );
+
+        $this->directoryReadMock = $this->createDirectoryReadMock();
+        /** @var Filesystem|\PHPUnit_Framework_MockObject_MockObject $filesystemMock */
+        $filesystemMock = $this->getMock(Filesystem::class, [], [], '', false);
+        $filesystemMock->expects($this->any())->method('getDirectoryRead')
+            ->with(DirectoryList::MODULES)
+            ->willReturn($this->directoryReadMock);
+
+        $this->filesIteratorFactoryMock = $this->getMock(FileIteratorFactory::class, [], [], '', false);
+
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->moduleDirReader = new Reader(
+            $objectManager->get(\Magento\Framework\Module\Dir::class),
+            $moduleListMock,
+            $filesystemMock,
+            $this->filesIteratorFactoryMock
+        );
+    }
+
+    protected function tearDown()
+    {
+        \Magento\Framework\Module\Registrar::unregisterModule($this->vendorModuleName);
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     */
+    public function testItIncludesConfigurationFilesFromModulesInVendor()
+    {
+        $existingFiles = ['Magento/Example/etc/di.xml', '../../vendor/example/example/etc/di.xml'];
+        $this->mockFilesExist($existingFiles);
+
+        $this->filesIteratorFactoryMock->expects($this->once())->method('create')
+            ->with($this->directoryReadMock, $existingFiles);
+
+        $this->moduleDirReader->getConfigurationFiles('di.xml');
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     */
+    public function testItIncludesComposerFilesFromModulesInVendor()
+    {
+        $existingFiles = ['Magento/Example/composer.json', '../../vendor/example/example/composer.json'];
+        $this->mockFilesExist($existingFiles);
+
+        $this->filesIteratorFactoryMock->expects($this->once())->method('create')
+            ->with($this->directoryReadMock, $existingFiles);
+        
+        $this->moduleDirReader->getComposerJsonFiles();
+    }
+}

--- a/lib/internal/Magento/Framework/Filesystem/Test/Unit/Driver/FileTest.php
+++ b/lib/internal/Magento/Framework/Filesystem/Test/Unit/Driver/FileTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Filesystem\Test\Unit\Driver;
+
+use Magento\Framework\Filesystem\Driver\File as FileDriver;
+
+class FileTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider relativePathDataProvider
+     */
+    public function testGetRelativePath($basePath, $path, $expected)
+    {
+        $this->assertSame($expected, (new FileDriver())->getRelativePath($basePath, $path));
+    }
+
+    public function relativePathDataProvider()
+    {
+        return [
+            'path within bp' => ['/base/path', '/base/path/file', '/file'],
+            'path within bp, bp with /' => ['/base/path/', '/base/path/file', 'file'],
+            'path within bp, path with /' => ['/base/path/', '/base/path/file/', 'file/'],
+            
+            'path eq bp, with /' => ['/base/path/', '/base/path/', ''],
+            'path eq bp, no /' => ['/base/path', '/base/path', ''],
+            'path eq bp, path no /' => ['/base/path/', '/base/path', ''],
+            'path eq bp, path with /' => ['/base/path', '/base/path/', '/'],
+            
+            'path relative, path no /' => ['/base/path', 'relative/path', 'relative/path'],
+            'path relative, path no /, bp with /' => ['/base/path/', 'relative/file', 'relative/file'],
+            'path relative, path with /' => ['/base/path', 'relative/file/', 'relative/file/'],
+            'path relative, path with /, bp with /' => ['/base/path/', 'relative/file/', 'relative/file/'],
+            
+            'bp is root' => ['/', '/path/to/file', 'path/to/file'],
+            'path is root' => ['/base/path/dir', '/', '../../../'],
+
+            'path is parent of bp' => ['/base/path', '/base', '..'],
+            'path is parent of bp, path with /' => ['/base/path', '/base/', '../'],
+            'path is grandparent of bp' => ['/base/path/dir', '/base', '../..'],
+            'path is grandparent of bp, path with /' => ['/base/path/dir', '/base/', '../../'],
+            
+            'path one up one down' => ['/base/path/dir', '/base/path/another-dir', '../another-dir'],
+            'path one up one down, path has /' => ['/base/path/dir', '/base/path/another-dir/', '../another-dir/'],
+            
+            'no shared parent' => ['/one/dir/path', '/another/dir/path', '../../../another/dir/path'],
+        ];
+    }
+}

--- a/lib/internal/Magento/Framework/Module/Registrar.php
+++ b/lib/internal/Magento/Framework/Module/Registrar.php
@@ -32,6 +32,11 @@ class Registrar implements ModuleRegistryInterface
         self::$modulePaths[$moduleName] = $path;
     }
 
+    public static function unregisterModule($moduleName)
+    {
+        unset(self::$modulePaths[$moduleName]);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
This PR contains:

* Complete implementation of  
  `\Magento\Framework\Filesystem\Driver\File::getRelativePath()`
* Unit test to check complete behavior of  
  `\Magento\Framework\Filesystem\Driver\File::getRelativePath()`
* Integration test to check if the `\Magento\Framework\Module\Dir\Reader` finds files in modules installed into `vendor/`.

The integration test does not cover the check for `Controller` directories and gathering action classes, because the ModuleDirReader directly operates on the file system, which is a lot more effort to test.

For more information please refer to issue #1481 