### PR TITLE
Add "Not Specified" as a gender option when customer does not specify gender

### DIFF
--- a/app/code/Magento/Customer/Setup/CustomerSetup.php
+++ b/app/code/Magento/Customer/Setup/CustomerSetup.php
@@ -324,7 +324,7 @@ class CustomerSetup extends EavSetup
                         'validate_rules' => 'a:0:{}',
                         'position' => 110,
                         'admin_checkout' => 1,
-                        'option' => ['values' => ['Not Specified', 'Male', 'Female']],
+                        'option' => ['values' => ['Male', 'Female', 'Not Specified']],
                     ],
                     'disable_auto_group_change' => [
                         'type' => 'static',

--- a/app/code/Magento/Customer/Setup/CustomerSetup.php
+++ b/app/code/Magento/Customer/Setup/CustomerSetup.php
@@ -324,7 +324,7 @@ class CustomerSetup extends EavSetup
                         'validate_rules' => 'a:0:{}',
                         'position' => 110,
                         'admin_checkout' => 1,
-                        'option' => ['values' => ['Male', 'Female']],
+                        'option' => ['values' => ['Not Specified', 'Male', 'Female']],
                     ],
                     'disable_auto_group_change' => [
                         'type' => 'static',

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/GenderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/GenderTest.php
@@ -169,7 +169,11 @@ class GenderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetGenderOptions()
     {
-        $options = [['label' => __('Not Specified'), 'value' => 'NA'], ['label' => __('Male'), 'value' => 'M'], ['label' => __('Female'), 'value' => 'F']];
+        $options = [
+            ['label' => __('Male'), 'value' => 'M'],
+            ['label' => __('Female'), 'value' => 'F'],
+            ['label' => __('Not Specified'), 'value' => 'NA']
+        ];
 
         $this->attribute->expects($this->once())->method('getOptions')->will($this->returnValue($options));
         $this->assertSame($options, $this->block->getGenderOptions());

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/GenderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/GenderTest.php
@@ -169,7 +169,7 @@ class GenderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetGenderOptions()
     {
-        $options = [['label' => __('Male'), 'value' => 'M'], ['label' => __('Female'), 'value' => 'F']];
+        $options = [['label' => __('Not Specified'), 'value' => 'NA'], ['label' => __('Male'), 'value' => 'M'], ['label' => __('Female'), 'value' => 'F']];
 
         $this->attribute->expects($this->once())->method('getOptions')->will($this->returnValue($options));
         $this->assertSame($options, $this->block->getGenderOptions());

--- a/dev/tests/api-functional/testsuite/Magento/Customer/Api/CustomerMetadataTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Customer/Api/CustomerMetadataTest.php
@@ -98,9 +98,9 @@ class CustomerMetadataTest extends WebapiAbstract
                     AttributeMetadata::DATA_MODEL       => '',
                     AttributeMetadata::OPTIONS          => [
                         ['label' => '', 'value' => ''],
-                        ['label' => 'Not Specified', 'value' => '1'],
-                        ['label' => 'Male', 'value' => '2'],
-                        ['label' => 'Female', 'value' => '3']
+                        ['label' => 'Male', 'value' => '1'],
+                        ['label' => 'Female', 'value' => '2'],
+                        ['label' => 'Not Specified', 'value' => '3']
                     ],
                     AttributeMetadata::FRONTEND_CLASS   => '',
                     AttributeMetadata::FRONTEND_LABEL   => 'Gender',

--- a/dev/tests/api-functional/testsuite/Magento/Customer/Api/CustomerMetadataTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Customer/Api/CustomerMetadataTest.php
@@ -98,8 +98,9 @@ class CustomerMetadataTest extends WebapiAbstract
                     AttributeMetadata::DATA_MODEL       => '',
                     AttributeMetadata::OPTIONS          => [
                         ['label' => '', 'value' => ''],
-                        ['label' => 'Male', 'value' => '1'],
-                        ['label' => 'Female', 'value' => '2'],
+                        ['label' => 'Not Specified', 'value' => '1'],
+                        ['label' => 'Male', 'value' => '2'],
+                        ['label' => 'Female', 'value' => '3']
                     ],
                     AttributeMetadata::FRONTEND_CLASS   => '',
                     AttributeMetadata::FRONTEND_LABEL   => 'Gender',

--- a/dev/tests/functional/tests/app/Magento/Customer/Test/Handler/Customer/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Customer/Test/Handler/Customer/Curl.php
@@ -35,9 +35,9 @@ class Curl extends AbstractCurl implements CustomerInterface
             'United Kingdom' => 'GB'
         ],
         'gender' => [
-            'Not Specified' => 1,
-            'Male' => 2,
-            'Female' => 3
+            'Male' => 1,
+            'Female' => 2,
+            'Not Specified' => 3
         ],
         'region_id' => [
             'California' => 12,

--- a/dev/tests/functional/tests/app/Magento/Customer/Test/Handler/Customer/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Customer/Test/Handler/Customer/Curl.php
@@ -35,8 +35,9 @@ class Curl extends AbstractCurl implements CustomerInterface
             'United Kingdom' => 'GB'
         ],
         'gender' => [
-            'Male' => 1,
-            'Female' => 2,
+            'Not Specified' => 1,
+            'Male' => 2,
+            'Female' => 3
         ],
         'region_id' => [
             'California' => 12,

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/GenderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/GenderTest.php
@@ -47,8 +47,8 @@ class GenderTest extends \PHPUnit_Framework_TestCase
     {
         $html = $this->_block->toHtml();
         $this->assertContains('<span>Gender</span>', $html);
-        $this->assertContains('<option value="1">Not Specified</option>', $html);
-        $this->assertContains('<option value="2">Male</option>', $html);
-        $this->assertContains('<option value="3">Female</option>', $html);
+        $this->assertContains('<option value="1">Male</option>', $html);
+        $this->assertContains('<option value="2">Female</option>', $html);
+        $this->assertContains('<option value="3">Not Specified</option>', $html);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/GenderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/GenderTest.php
@@ -47,7 +47,8 @@ class GenderTest extends \PHPUnit_Framework_TestCase
     {
         $html = $this->_block->toHtml();
         $this->assertContains('<span>Gender</span>', $html);
-        $this->assertContains('<option value="1">Male</option>', $html);
-        $this->assertContains('<option value="2">Female</option>', $html);
+        $this->assertContains('<option value="1">Not Specified</option>', $html);
+        $this->assertContains('<option value="2">Male</option>', $html);
+        $this->assertContains('<option value="3">Female</option>', $html);
     }
 }


### PR DESCRIPTION
When creating a new customer in the Magento 2 admin, the gender field has only two options: Male or Female.  This is not ideal as many times a customer won't specify their gender and there won't be any way to infer it.  I propose adding a new option of 'Not Specified' for these cases.