### PR TITLE
Remove product description from meta description field mask

### DIFF
--- a/app/code/Magento/Catalog/etc/adminhtml/system.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/system.xml
@@ -31,7 +31,7 @@
                 </field>
                 <field id="meta_description" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Mask for Meta Description</label>
-                    <comment>Use {{name}} and {{description}} as Product Name and Product Description placeholders</comment>
+                    <comment>Use {{name}} as Product Name placeholder</comment>
                 </field>
             </group>
             <group id="frontend" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/app/code/Magento/Catalog/etc/config.xml
+++ b/app/code/Magento/Catalog/etc/config.xml
@@ -15,7 +15,7 @@
                 <sku>{{name}}</sku>
                 <meta_title>{{name}}</meta_title>
                 <meta_keyword>{{name}}</meta_keyword>
-                <meta_description>{{name}} {{description}}</meta_description>
+                <meta_description>{{name}}</meta_description>
             </fields_masks>
             <frontend>
                 <list_mode>grid-list</list_mode>


### PR DESCRIPTION
When adding a new simple product in the Magento 2 admin, I fill out the Description field from the _Product Details_ tab like below:

<img width="405" alt="screen shot 2015-07-15 at 11 07 34 pm" src="https://cloud.githubusercontent.com/assets/852768/8715826/f446f382-2b55-11e5-8425-3556e59b6d9d.png">

Next, I go to the _Search Engine Optimization_ tab, and I can see that certain values are pre-populated from the _Product Details_ tab (field mask?), like below:

<img width="672" alt="screen shot 2015-07-15 at 11 04 13 pm" src="https://cloud.githubusercontent.com/assets/852768/8715846/5f4f5f0c-2b56-11e5-8b33-17e389caed9b.png">

The problem is, the description is pulled into the meta description field as HTML, which is not ideal obviously.  I propose just removing the description from the meta description field mask altogether.
