### PR TITLE
Typo in addAction function: _.findIdnex should be .findIndex

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
@@ -98,7 +98,7 @@ define([
          */
         addAction: function (action) {
             var actions = this.actions(),
-                index = _.findIdnex(actions, {
+                index = _.findIndex(actions, {
                     type: action.type
                 });
 


### PR DESCRIPTION
Typo in "app\code\Magento\Ui\view\base\web\js\grid\massactions.js" addAction function: _.findIdnex should be .findIndex

This fixes the addAction function.