### PR TITLE
add router.php for php Built-in webserver

### DIFF
--- a/phpserver/.htaccess
+++ b/phpserver/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all

--- a/phpserver/README.md
+++ b/phpserver/README.md
@@ -1,0 +1,35 @@
+PHP Built-in webserver
+======================
+
+php has a Built-in webserver since version 5.4
+https://secure.php.net/manual/en/features.commandline.webserver.php
+
+As many applications and frameworks rely on rewrites on webserver side,
+the same as magento does, it offers an argument for a router script.
+Either the script returns false which means, it should try to deliver the file
+as usual via file system lookup, or it executes the specific php scripts via include.
+
+Example:
+requests to `/static/frontend/Magento/blank/en_US/mage/calendar.css` should deliver the file if it exists, or execute `/static.php` if not.
+
+Without a router script, that is not possible via the php built-in server.
+
+### How to use it
+
+example usage: ```php -S 127.0.0.41:8082 -t ./pub/ ./phpserver/router.php```
+
+### What exactly does the script
+
+first we have an low level `$debug` closure, for the case you need to debug execution.
+
+If the requestpath starts with index.php, get.php, static.php, we return to normal request flow.  
+If we notice a favicon.ico request, the same.
+
+Then rewrite paths for `pub/errors/default/` by removing the `pub/` part. (was at least needed for older versions)
+
+Request starting with `media/`, `opt/`, `static/` test if the file exists.
+If Yes, then handle it, if not "forward" `static` to `static.php` and `media` to `get.php`
+
+If non of the rules matched, return 404.
+You may instead include the index.php, if 404 should be handled by magento or you want
+urls without `index.php/`.

--- a/phpserver/router.php
+++ b/phpserver/router.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * this is a router file for the php Built-in web server
+ * https://secure.php.net/manual/en/features.commandline.webserver.php
+ *
+ * It provides the same "rewrites" as the .htaccess for apache,
+ * or the nginx.conf.sample for nginx.
+ *
+ * example usage: php -S 127.0.0.41:8082 -t ./pub/ ./router.php
+ */
+
+$debug = function($val){
+    return;
+    if(is_array($val)){
+      $val = json_encode($val);
+    }
+    echo 'debug: '.$val.PHP_EOL.'<br/>'.PHP_EOL;
+};
+
+/**
+ * Caution, this is very experimental stuff
+ * no garant for working result
+ * has tons of potencial big security holes
+ */
+
+if (php_sapi_name() === 'cli-server') {
+
+    $debug($_SERVER["REQUEST_URI"]);
+    if (preg_match('/^\/(index|get|static)\.php(\/)?/', $_SERVER["REQUEST_URI"])) {
+        return false;    // serve the requested resource as-is.
+    }
+
+    $path = pathinfo($_SERVER["SCRIPT_FILENAME"]);
+    $url   = pathinfo(substr($_SERVER["REQUEST_URI"], 1));
+    $route = parse_url(substr($_SERVER["REQUEST_URI"], 1))["path"];
+
+    $debug($path);
+    $debug($route);
+
+    if( $path["basename"] == 'favicon.ico' ){
+        return false;
+    }
+
+    $debug($route);
+    $debug(strpos($route, 'errors/default/css/'));
+
+    if(strpos($route, 'pub/errors/default/') === 0){
+        $route = preg_replace('#pub/errors/default/#', 'errors/default/', $route, 1);
+    }
+
+    $debug($route);
+
+
+    if(
+        strpos($route, 'media/') === 0 ||
+        strpos($route, 'opt/') === 0 ||
+        strpos($route, 'static/') === 0 ||
+        strpos($route, 'errors/default/css/') === 0 ||
+        strpos($route, 'errors/default/images/') === 0
+    ){
+        $magentoPackagePubDir = __DIR__."/../pub";
+
+        $file = $magentoPackagePubDir.'/'.$route;
+        $debug($file);
+        if(file_exists($file)){
+          $debug('file exists');
+          return false;
+        }else{
+          $debug('file exists not');
+            if(strpos($route, 'static/') === 0){
+                $route = preg_replace('#static/#', '', $route, 1);
+                $_GET['resource'] = $route;
+                include($magentoPackagePubDir.'/static.php');
+                exit;
+            }elseif(strpos($route, 'media/') === 0){
+                include($magentoPackagePubDir.'/get.php');
+                exit;
+            }
+        }
+    }
+
+header('HTTP/1.0 404 Not Found');
+
+}


### PR DESCRIPTION
php has a Built-in webserver since version 5.4 https://secure.php.net/manual/en/features.commandline.webserver.php

As many applications and frameworks rely on rewrite on webserver side, the same as magento does, it offers an argument for a router script. Either the script returns ```false``` which means, it should try to deliver the file via the file system, or it executes the  specific php scripts via include.

Example:
requests to ```/static/frontend/Magento/blank/en_US/mage/calendar.css``` should deliver the file if it exists, or execute ```/static.php``` if not.


Without a router script, that is not possible via the php built-in server.

advantage: one step less for developers, as no working webserver is needed anymore.


Hint: the script works for me, but is maybe not perfect.
I would like to also have some comments from the community, if it matches their needs