### PR TITLE
Add countries to exclude from the required state in config

### DIFF
--- a/app/code/Magento/Directory/Setup/InstallData.php
+++ b/app/code/Magento/Directory/Setup/InstallData.php
@@ -844,11 +844,19 @@ class InstallData implements InstallDataInterface
         );
 
         /**
+         * @var $countriesToExclude array
+         */
+        $countriesToExclude = ['FR'];
+
+        /**
          * @var $countries array
          */
         $countries = [];
         foreach ($this->directoryData->getCountryCollection() as $country) {
-            if ($country->getRegionCollection()->getSize() > 0) {
+            if (
+                $country->getRegionCollection()->getSize() > 0
+                && !in_array($country->getId(), $countriesToExclude)
+            ) {
                 $countries[] = $country->getId();
             }
         }


### PR DESCRIPTION
Hi!

I'm French and one of the first things we do each time when configuring a Magento is to remove France of the Countries with required state in configuration.
Because in France the state isn't required! The states are only administrative and not used by mail services.

I just added an array containing countries to exclude before creating the configuration.

It would be great to avoid this config change each time we install a new Magento :).

Thanks !