### PR TITLE
Massactions.js does NOT support callbacks at the moment

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
@@ -124,7 +124,9 @@ define([
             var callback = action.callback,
                 args     = [action, selections];
 
-            if (utils.isObject(callback)) {
+            if (typeof callback === 'string') {
+                callback = registry.get(callback);
+            } else if (utils.isObject(callback)) {
                 args.unshift(callback.target);
 
                 callback = registry.async(callback.provider);


### PR DESCRIPTION
The app\code\Magento\Ui\view\base\web\js\grid\massactions.js class implements a function called "_getCallback". However, it is impossible to pass a callback into it from your massaction defined in the UI XML such as sales_order_grid.xml. Let me explain why:

1) You define your massaction in sales_order_grid.xml for example:
```xml
<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../Ui/etc/ui_configuration.xsd">
    <container name="listing_top">
        <massaction name="listing_massaction">
            <argument name="data" xsi:type="array">
                <item name="config" xsi:type="array">
                    <item name="actions" xsi:type="array">
                        <item name="cancel" xsi:type="array">
                            <item name="type" xsi:type="string">cancel</item>
                            <item name="label" xsi:type="string" translate="true">Cancel</item>
                            <item name="url" xsi:type="string">sales/order/massCancel</item>
                            <item name="callback" xsi:type="string">myCustomCallback</item>
                        </item>
                    </item>
                </item>
            </argument>
        </massaction>
    </container>
</listing>
```

2) The function Magento\Ui\TemplateEngine\Xhtml::appendLayoutConfiguration() then retrieves the generated XML configuration for all javascript areas, json_encodes it, and another function outputs it to the browser: 

```PHP
$layoutConfiguration = $this->wrapContent(json_encode($this->structure->generate($this->component)));
```

And here is the problem. The PHP function json_encode turns the previously in sales_order_grid.xml defined callback into a string, always, no way around it, you cannot use {"whatever":true} to retain an object, json_encode puts it as a string. Now if you look at massactions.js:
```Javascript
            var callback = action.callback,
                args     = [action, selections];

            if (utils.isObject(callback)) {
                args.unshift(callback.target);

                callback = registry.async(callback.provider);
            } else if (typeof callback != 'function') {
                callback = this.defaultCallback.bind(this);
            }
```

Nothing in the above code will match. The callback is not an object (but rather a string, after "json.parse") and not a function, and thus the defaultCallback is used. This means, right now it is impossible to use a custom callback.

The proposed pull request tries to implement support for callbacks implemented as strings. Simply register it in a class using registry.set like this, and massactions.js then retrieves the callback from the registry:

```Javascript
define([
    'uiRegistry',
    'mageUtils'
], function (registry, utils) {
    'use strict';

    registry.set('myCustomCallback', function (action, data) {
            // Do whatever you want...
        }
    );
});
```

Please let me know your thoughts.