### PR TITLE
Set getRemoteAddress to detect comma seperated RFC 7239 lists

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/PhpEnvironment/RemoteAddress.php
+++ b/lib/internal/Magento/Framework/HTTP/PhpEnvironment/RemoteAddress.php
@@ -58,6 +58,12 @@ class RemoteAddress
             if (!$this->remoteAddress) {
                 $this->remoteAddress = $this->request->getServer('REMOTE_ADDR');
             }
+
+            if ((filter_var($this->remoteAddress, FILTER_VALIDATE_IP) !== true) && (strpos($this->remoteAddress, ',') !== true)) {
+                $ipList = explode(',', $this->remoteAddress);
+                $this->remoteAddress = reset($ipList);
+            }
+
         }
 
         if (!$this->remoteAddress) {


### PR DESCRIPTION
 RFC 7239 allows comma separated X-Forwarded-For headers. This modification ensures in the event the getRemoteAddress gets one via the alternativeHeaders variable, the correct client IP can be returned. This is done by getting the first IP in the list after detecting for a comma separated IP list.
