### PR TITLE
Make Module Registrar instances immutable

### DIFF
--- a/lib/internal/Magento/Framework/Module/Registrar.php
+++ b/lib/internal/Magento/Framework/Module/Registrar.php
@@ -19,6 +19,18 @@ class Registrar implements ModuleRegistryInterface
      * @var string[]
      */
     private static $modulePaths = [];
+    
+    /**
+     * Paths to modules, immutable
+     *
+     * @var string[]
+     */
+    private $immutableModulePaths;
+    
+    public function __construct()
+    {
+        $this->immutableModulePaths = self::$modulePaths;
+    }
 
     /**
      * Sets the location of a module. Necessary for modules which do not reside in modules directory
@@ -37,7 +49,7 @@ class Registrar implements ModuleRegistryInterface
      */
     public function getModulePaths()
     {
-        return self::$modulePaths;
+        return $this->immutableModulePaths;
     }
 
     /**
@@ -45,6 +57,6 @@ class Registrar implements ModuleRegistryInterface
      */
     public function getModulePath($moduleName)
     {
-        return isset(self::$modulePaths[$moduleName]) ? self::$modulePaths[$moduleName] : null;
+        return isset($this->immutableModulePaths[$moduleName]) ? $this->immutableModulePaths[$moduleName] : null;
     }
 }


### PR DESCRIPTION
At present, registering modules via the module registrar can change the configuration of the application after it has already been bootstrapped. Allowing this will likely cause unexpected behaviour in the application. This change introduces immutability to instances of the module registrar; instances will now only return modules which were registered prior to their instantiation.