### PR TITLE
Add gzip option to nginx

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -126,7 +126,6 @@ gzip_disable "msie6";
 
 gzip_comp_level 6;
 gzip_min_length 1100;
-gzip_buffers 16 8k;
 gzip_proxied any;
 gzip_types
     text/plain

--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -120,3 +120,23 @@ location ~ (index|get|static|report|404|503)\.php$ {
     fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
     include        fastcgi_params;
 }
+
+gzip on;
+gzip_disable "msie6";
+
+gzip_comp_level 6;
+gzip_min_length 1100;
+gzip_buffers 16 8k;
+gzip_proxied any;
+gzip_types
+    text/plain
+    text/css
+    text/js
+    text/xml
+    text/javascript
+    application/javascript
+    application/x-javascript
+    application/json
+    application/xml
+    application/xml+rss;
+


### PR DESCRIPTION
Gzip compresion is missing from the nginx config. Or, is there a different / better way to compress the assets (eg: with a command?).
