### PR TITLE
Bringing menu items to one style - plural

### DIFF
--- a/app/code/Magento/CatalogRule/Block/Adminhtml/Promo/Catalog.php
+++ b/app/code/Magento/CatalogRule/Block/Adminhtml/Promo/Catalog.php
@@ -20,7 +20,7 @@ class Catalog extends \Magento\Backend\Block\Widget\Grid\Container
     {
         $this->_blockGroup = 'Magento_CatalogRule';
         $this->_controller = 'adminhtml_promo_catalog';
-        $this->_headerText = __('Catalog Price Rule');
+        $this->_headerText = __('Catalog Price Rules');
         $this->_addButtonLabel = __('Add New Rule');
         parent::_construct();
 

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Index.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/Index.php
@@ -19,7 +19,7 @@ class Index extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
         }
 
         $this->_initAction()->_addBreadcrumb(__('Catalog'), __('Catalog'));
-        $this->_view->getPage()->getConfig()->getTitle()->prepend(__('Catalog Price Rule'));
+        $this->_view->getPage()->getConfig()->getTitle()->prepend(__('Catalog Price Rules'));
         $this->_view->renderLayout();
     }
 }

--- a/app/code/Magento/CatalogRule/etc/acl.xml
+++ b/app/code/Magento/CatalogRule/etc/acl.xml
@@ -11,7 +11,7 @@
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Backend::marketing">
                     <resource id="Magento_CatalogRule::promo" title="Promotions" sortOrder="10">
-                        <resource id="Magento_CatalogRule::promo_catalog" title="Catalog Price Rule" sortOrder="10" />
+                        <resource id="Magento_CatalogRule::promo_catalog" title="Catalog Price Rules" sortOrder="10" />
                     </resource>
                 </resource>
             </resource>

--- a/app/code/Magento/CatalogRule/etc/adminhtml/menu.xml
+++ b/app/code/Magento/CatalogRule/etc/adminhtml/menu.xml
@@ -8,6 +8,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Backend/etc/menu.xsd">
     <menu>
         <add id="Magento_CatalogRule::promo" title="Promotions" module="Magento_CatalogRule" parent="Magento_Backend::marketing" sortOrder="10" resource="Magento_CatalogRule::promo"/>
-        <add id="Magento_CatalogRule::promo_catalog" title="Catalog Price Rule" sortOrder="10" module="Magento_CatalogRule" parent="Magento_CatalogRule::promo" action="catalog_rule/promo_catalog/" dependsOnModule="Magento_Catalog" resource="Magento_CatalogRule::promo_catalog"/>
+        <add id="Magento_CatalogRule::promo_catalog" title="Catalog Price Rules" sortOrder="10" module="Magento_CatalogRule" parent="Magento_CatalogRule::promo" action="catalog_rule/promo_catalog/" dependsOnModule="Magento_Catalog" resource="Magento_CatalogRule::promo_catalog"/>
     </menu>
 </config>

--- a/app/code/Magento/Newsletter/etc/acl.xml
+++ b/app/code/Magento/Newsletter/etc/acl.xml
@@ -11,7 +11,7 @@
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Backend::marketing">
                     <resource id="Magento_Backend::marketing_communications">
-                        <resource id="Magento_Newsletter::template" title="Newsletter Template" sortOrder="20" />
+                        <resource id="Magento_Newsletter::template" title="Newsletter Templates" sortOrder="20" />
                         <resource id="Magento_Newsletter::queue" title="Newsletter Queue" sortOrder="30"/>
                         <resource id="Magento_Newsletter::subscriber" title="Newsletter Subscribers" sortOrder="40"/>
                     </resource>

--- a/app/code/Magento/Newsletter/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Newsletter/etc/adminhtml/menu.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Backend/etc/menu.xsd">
     <menu>
-        <add id="Magento_Newsletter::newsletter_template" title="Newsletter Template" module="Magento_Newsletter" parent="Magento_Backend::marketing_communications" sortOrder="30" action="newsletter/template/" resource="Magento_Newsletter::template"/>
+        <add id="Magento_Newsletter::newsletter_template" title="Newsletter Templates" module="Magento_Newsletter" parent="Magento_Backend::marketing_communications" sortOrder="30" action="newsletter/template/" resource="Magento_Newsletter::template"/>
         <add id="Magento_Newsletter::newsletter_queue" title="Newsletter Queue" module="Magento_Newsletter" sortOrder="40" parent="Magento_Backend::marketing_communications" action="newsletter/queue/" resource="Magento_Newsletter::queue"/>
         <add id="Magento_Newsletter::newsletter_subscriber" title="Newsletter Subscribers" module="Magento_Newsletter" sortOrder="50" parent="Magento_Backend::marketing_communications" action="newsletter/subscriber/" resource="Magento_Newsletter::subscriber"/>
         <add id="Magento_Newsletter::newsletter_problem" title="Newsletter Problem Reports" module="Magento_Newsletter" sortOrder="50" parent="Magento_Reports::report_marketing" action="newsletter/problem/" resource="Magento_Newsletter::problem"/>

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Index.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status/Index.php
@@ -41,7 +41,7 @@ class Index extends \Magento\Sales\Controller\Adminhtml\Order\Status
         /** @var \Magento\Backend\Model\View\Result\Page $resultPage */
         $resultPage = $this->resultPageFactory->create();
         $resultPage->setActiveMenu('Magento_Sales::system_order_statuses');
-        $resultPage->getConfig()->getTitle()->prepend(__('Order Status'));
+        $resultPage->getConfig()->getTitle()->prepend(__('Order Statuses'));
 
         return $resultPage;
     }

--- a/app/code/Magento/Sales/etc/acl.xml
+++ b/app/code/Magento/Sales/etc/acl.xml
@@ -40,7 +40,7 @@
                 </resource>
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
-                        <resource id="Magento_Sales::order_statuses"  title="Order Status" sortOrder="40" />
+                        <resource id="Magento_Sales::order_statuses"  title="Order Statuses" sortOrder="40" />
                         <resource id="Magento_Config::config">
                             <resource id="Magento_Sales::config_sales" title="Sales Section" sortOrder="60" />
                             <resource id="Magento_Sales::sales_email" title="Sales Emails Section" sortOrder="65" />

--- a/app/code/Magento/Sales/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/menu.xml
@@ -14,6 +14,6 @@
         <add id="Magento_Sales::sales_shipment" title="Shipments" module="Magento_Sales" sortOrder="30" parent="Magento_Sales::sales_operation" action="sales/shipment" resource="Magento_Sales::shipment"/>
         <add id="Magento_Sales::sales_creditmemo" title="Credit Memos" module="Magento_Sales" sortOrder="40" parent="Magento_Sales::sales_operation" action="sales/creditmemo" resource="Magento_Sales::sales_creditmemo"/>
         <add id="Magento_Sales::sales_transactions" title="Transactions" module="Magento_Sales" sortOrder="70" parent="Magento_Sales::sales_operation" action="sales/transactions" resource="Magento_Sales::transactions"/>
-        <add id="Magento_Sales::system_order_statuses" title="Order Status" module="Magento_Sales" sortOrder="40" parent="Magento_Backend::stores_settings" action="sales/order_status" resource="Magento_Sales::order_statuses"/>
+        <add id="Magento_Sales::system_order_statuses" title="Order Statuses" module="Magento_Sales" sortOrder="40" parent="Magento_Backend::stores_settings" action="sales/order_status" resource="Magento_Sales::order_statuses"/>
     </menu>
 </config>


### PR DESCRIPTION
While translating have noticed that menu items styles differs.
Example for Marketing -> Promotions:
current
- Catalog Price Rule
- Cart Price Rules

new
- Catalog Price Rules
- Cart Price Rules

Same for acl titles and main grid.
