### PR TITLE
add missing method to EngineInterface

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Resource/EngineInterface.php
+++ b/app/code/Magento/CatalogSearch/Model/Resource/EngineInterface.php
@@ -48,4 +48,12 @@ interface EngineInterface
      * @return string
      */
     public function prepareEntityIndex($index, $separator = ' ');
+
+    /**
+     * Checks if the search engine is available.
+     *
+     * @return bool
+     */
+    public function isAvailable();
+
 }


### PR DESCRIPTION
Magento\CatalogSearch\Model\Resource\EngineProvider calls $engine->isAvailable()
but EngineInterface doesn't contain this method.