### PR TITLE
Attempt to fix the grid filter

### DIFF
--- a/app/code/Magento/Ui/Component/MassAction/Filter.php
+++ b/app/code/Magento/Ui/Component/MassAction/Filter.php
@@ -80,7 +80,9 @@ class Filter
     {
         $component = $this->getComponent();
         $this->prepareComponent($component);
+        $this->applySelectionOnTargetProvider();
         $dataProvider = $component->getContext()->getDataProvider();
+        $dataProvider->setLimit(0, false);
         $ids = [];
         foreach ($dataProvider->getSearchResult()->getItems() as $document) {
             $ids[] = $document->getId();


### PR DESCRIPTION
Hi,

This is a small attempt (more some guidance) to fix #1571.

On the first line, `applySelectionOnTargetProvider` filters the collection based on what was selected on the frontend. When you select all and then unselect some rows, looks like this specific method does all the magic needed. The method already was there, just wasn't called.

The second row, `setLimit`, is an ugly workaround, but only that way the collection is filled entirely. Without it, if you use "select all" in the grid and then the first row of this PR, the resulting collection only have 20 rows (or whatever the number of items your grid was showing). Digging a little in the code, the `searchCriteriaBuilder` should copy this from the DataProvider, but I couldn't find why it wasn't.

I'm not sure if this fixes entirely, I was having the same issue in the Order Grid, identified the problem and then fixed from there. I'm also not sure if this affect some other regions of the code.

I'll be happy to provide additional information.

Thanks!
