### PR TITLE
add product to product save event

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
@@ -104,7 +104,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product
 
                 $this->_eventManager->dispatch(
                     'controller_action_catalog_product_save_entity_after',
-                    ['controller' => $this]
+                    ['controller' => $this, 'product' => $product]
                 );
 
                 if ($redirectBack === 'duplicate') {


### PR DESCRIPTION
Seems useful to pass the product object when dispatching a product save event.
