### PR TITLE
Fix #1722 Ensure class keyword is not resolving a class name

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/PhpScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/PhpScanner.php
@@ -239,6 +239,9 @@ class PhpScanner implements ScannerInterface
             if (($tokens[$tokenIterator][0] == T_CLASS || $tokens[$tokenIterator][0] == T_INTERFACE)
                 && $tokens[$tokenIterator - 1][0] != T_DOUBLE_COLON
             ) {
+                if ($tokens[$tokenIterator - 1][0] == T_PAAMAYIM_NEKUDOTAYIM) {
+                    continue;
+                }
                 $classes = array_merge($classes, $this->_fetchClasses($namespace, $tokenIterator, $count, $tokens));
             }
         }


### PR DESCRIPTION
See #1722.

If the `class` keyword is being used for obtaining a fully qualified class name, e.g. `Foo::class`, the previous token will be a double colon. In this situation the scanner should not attempt to derive a class name. 