### PR TITLE
Allow user zoom

### DIFF
--- a/app/code/Magento/Theme/view/frontend/layout/default_head_blocks.xml
+++ b/app/code/Magento/Theme/view/frontend/layout/default_head_blocks.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd">
     <head>
         <meta name="x_ua_compatible" content="IE=edge,chrome=1"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <css src="mage/calendar.css"/>
         <script src="requirejs/require.js"/>
     </head>


### PR DESCRIPTION
**Purpose:** Update meta viewport attributes to improve accessibility by allowing user zoom. If developers need to limit zoom, they should be able to do so at the theme level.

In order to comply with WAI WCAG 2.0 AA accessibility requirements you should never disable pinch zoom:

* W3C:
http://www.w3.org/TR/mobile-accessibility-mapping/#zoom-magnification
* The Accessibility Project:
http://a11yproject.com/posts/never-use-maximum-scale/
* Google:
https://developers.google.com/web/fundamentals/layouts/rwd-fundamentals/set-the-viewport?hl=en