### PR TITLE
Prevent iterator from being used by reference

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -30,7 +30,7 @@ class Gallery extends \Magento\Catalog\Block\Product\View\AbstractView
         $product = $this->getProduct();
         $images = $product->getMediaGalleryImages();
         if ($images instanceof \Magento\Framework\Data\Collection) {
-            foreach ($images as &$image) {
+            foreach ($images as $image) {
                 $image->setData(
                     'small_image_url',
                     $this->_imageHelper->init($product, 'product_page_image_small')


### PR DESCRIPTION
The following fatal error was being produced when visiting the product page:
```
Fatal error: An iterator cannot be used with foreach by reference in /var/www/html/magento2/app/code/Magento/Catalog/Block/Product/View/Gallery.php on line 48
```
Looking at the mentioned line, there is no reason for $image to be a reference. Since it's an object.
