### PR TITLE
Error In CategoryEdit

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Tree.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Tree.php
@@ -43,7 +43,7 @@ class Tree extends \Magento\Catalog\Controller\Adminhtml\Category
     {
         $storeId = (int)$this->getRequest()->getParam('store');
         $categoryId = (int)$this->getRequest()->getParam('id');
-
+        $resultRedirect = $this->resultRedirectFactory->create();
         if ($storeId) {
             if (!$categoryId) {
                 $store = $this->_objectManager
@@ -57,7 +57,7 @@ class Tree extends \Magento\Catalog\Controller\Adminhtml\Category
         $category = $this->_initCategory(true);
         if (!$category) {
             /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
-            $resultRedirect = $this->resultRedirectFactory->create();
+            
             return $resultRedirect->setPath('catalog/*/', ['_current' => true, 'id' => null]);
         }
 
@@ -65,7 +65,7 @@ class Tree extends \Magento\Catalog\Controller\Adminhtml\Category
         $root = $block->getRoot();
         /** @var \Magento\Framework\Controller\Result\Json $resultJson */
         $resultJson = $this->resultJsonFactory->create();
-        return $resultJson->setData([
+        $resultJson->setData([
             'data' => $block->getTree(),
             'parameters' => [
                 'text' => $block->buildNodeName($root),
@@ -78,5 +78,6 @@ class Tree extends \Magento\Catalog\Controller\Adminhtml\Category
                 'root_visible' => (int)$root->getIsVisible(),
             ],
         ]);
+        return $resultRedirect->setPath('catalog/category/edit', ['_current' => true, 'id' => $categoryId]);
     }
 }


### PR DESCRIPTION
When I click on any category in backend, it return this string in white page:
```
{"data":[{"text":"Apple (1)","id":"4","store":1,"path":"1\/2\/4","cls":"folder active-category","allowDrop":true,"allowDrag":true,"expanded":true}],"parameters":{"text":"Default Category (0)","draggable":false,"allowDrop":true,"id":2,"expanded":0,"store_id":1,"category_id":4,"root_visible":1}}
```
The issue is coming from the file ``Magento\Catalog\Controller\Adminhtml\Category\Tree.php``. It return the json result. The solution is that copy the code from line no 60 in execute function ``$resultRedirect = $this->resultRedirectFactory->create();`` and paste it at the start of the function and end of the execute function remove return from the line
``return $resultJson->setData(...);``
and add a line below this code
``return $resultRedirect->setPath('catalog/category/edit', ['_current' => true, 'id' => $categoryId]);``
