### PR TITLE
Update AbstractAddress.php

### DIFF
--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -248,25 +248,11 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
      */
     public function setStreet($street)
     {
+        if (is_array($street)) {
+            $street = $this->_implodeArrayValues($street);
+        }
         $this->setData('street', $street);
         return $this;
-    }
-
-    /**
-     * Enforce format of the street field
-     *
-     * @param array|string $key
-     * @param null $value
-     * @return \Magento\Framework\DataObject
-     */
-    public function setData($key, $value = null)
-    {
-        if (is_array($key)) {
-            $key = $this->_implodeArrayField($key);
-        } elseif (is_array($value)) {
-            $value = $this->_implodeArrayValues($value);
-        }
-        return parent::setData($key, $value);
     }
 
     /**


### PR DESCRIPTION
Problem:
You redeclare setData to set imploded streets, but this method is used by Your discount model, for example 
$address->setCartFixedRules($cartRules);
in result array of cart rules set like string and discount to whole cart don't work properly.

How To Reproduce:
You can reproduce this issue by giving discount to whole cart with more than 1 item in cart.
Discount applied 1 time and after that you set array of cartRules to address, but in result you set string instead array and cartFixed rule was broken.
screen shot - http://joxi.ru/vAWRbgGFMwzv2W?d=1 , http://joxi.ru/4Ak05d1hw3DVrq?d=1

Why this fix:
You redeclare magic setter of Street and by logic I think that all works with Streets should be made therein.