### PR TITLE
fix problem with setCartFixedRules

### DIFF
--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -253,6 +253,17 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
     }
 
     /**
+     * Non-magic setter for a cart fixed rules field
+     *
+     * @param array $cartRules
+     * @return \Magento\Framework\DataObject
+     */
+    public function setCartFixedRules($cartRules)
+    {
+        return parent::setData('cart_fixed_rules', $cartRules);
+    }
+
+    /**
      * Enforce format of the street field
      *
      * @param array|string $key


### PR DESCRIPTION
Problem:
You redeclare setData to set imploded streets, but this method is used by Your discount model, for example
$address->setCartFixedRules($cartRules);
in result array of cart rules set like string and discount to whole cart don't work properly.

How To Reproduce:
You can reproduce this issue by giving discount to whole cart with more than 1 item in cart.
Discount applied 1 time and after that you set array of cartRules to address, but in result you set string instead array and cartFixed rule was broken.
screen shot - http://joxi.ru/vAWRbgGFMwzv2W?d=1 , http://joxi.ru/4Ak05d1hw3DVrq?d=1

Why this fix:
Just redeclare setter of CartFixedRules and call parent setData to prevent imploding strings