### PR TITLE
Iterator cannot be used with foreach by reference

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Gallery.php
@@ -25,7 +25,7 @@ class Gallery extends \Magento\Catalog\Block\Product\View\AbstractView
         $product = $this->getProduct();
         $images = $product->getMediaGalleryImages();
         if ($images instanceof \Magento\Framework\Data\Collection) {
-            foreach ($images as &$image) {
+            foreach ($images as $image) {
                 /* @var \Magento\Framework\DataObject $image */
                 $image->setData(
                     'small_image_url',


### PR DESCRIPTION
at line 28,  I remove the reference that is used inside the `foreach`. 

First and foremost this works with PHP 5.5+ but breaks on HHVM as part of the list of inconsistencies in PHP 5

https://github.com/facebook/hhvm/blob/master/hphp/doc/inconsistencies#L37-L43

I know the for the meantime Magento2 doesn't support yet HHVM but I think removing this reference on `foreach` will make this code compatible on future releases of PHP