### PR TITLE
Adding example RewriteBase to static/.htaccess for Apache users

### DIFF
--- a/pub/static/.htaccess
+++ b/pub/static/.htaccess
@@ -11,6 +11,7 @@ Options -MultiViews
 
 <IfModule mod_rewrite.c>
     RewriteEngine On
+    #RewriteBase /magento/static/
 
     # Remove signature of the static files that is used to overcome the browser cache
     RewriteRule ^version.+?/(.+)$ $1 [L]


### PR DESCRIPTION
Similar to the example configuration in [`pub/.htaccess`](https://github.com/magento/magento2/blob/5dcc61839134091f6c02e113b5cc0cc20e69ce52/pub/.htaccess#L114), I'd like to add one here.  My local install wouldn't work without it.  This hint would have helped me track down the issue sooner.
