### PR TITLE
Start phpunit from vendor bin-dir and use correct PHP env

### DIFF
--- a/app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php
+++ b/app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php
@@ -86,7 +86,7 @@ class DevTestsRunCommand extends Command
             list($dir, $options) = $this->commands[$key];
             $dirName = realpath(BP . '/dev/tests/' . $dir);
             chdir($dirName);
-            $command = 'php '. BP . '/' . $vendorDir . '/phpunit/phpunit/phpunit ' . $options;
+            $command = BP . '/' . $vendorDir . '/bin/phpunit ' . $options;
             $message = $dirName . '> ' . $command;
             $output->writeln(['', str_pad("---- {$message} ", 70, '-'), '']);
             passthru($command, $returnVal);


### PR DESCRIPTION
It's not necessary to start php with a hard coded "php" bin. PHPUnit contains a SheeBang in the first line which correclty use the /usr/bin/env command to find the configured PHP bin of the operating system.