### PR TITLE
use return value instead of reference parameter

### DIFF
--- a/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Price.php
+++ b/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Price.php
@@ -45,9 +45,9 @@ class Price extends \Magento\Ui\Component\Listing\Columns\Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             $store = $this->storeManager->getStore(
@@ -64,5 +64,7 @@ class Price extends \Magento\Ui\Component\Listing\Columns\Column
                 }
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Catalog/Ui/Component/Listing/Columns/ProductActions.php
+++ b/app/code/Magento/Catalog/Ui/Component/Listing/Columns/ProductActions.php
@@ -42,9 +42,9 @@ class ProductActions extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array &$dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             $storeId = $this->context->getFilterParam('store_id');
@@ -60,5 +60,7 @@ class ProductActions extends Column
                 ];
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Thumbnail.php
+++ b/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Thumbnail.php
@@ -39,9 +39,9 @@ class Thumbnail extends \Magento\Ui\Component\Listing\Columns\Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             $fieldName = $this->getData('name');
@@ -58,6 +58,8 @@ class Thumbnail extends \Magento\Ui\Component\Listing\Columns\Column
                 $item[$fieldName . '_orig_src'] = $origImageHelper->getUrl();
             }
         }
+
+        return $dataSource;
     }
 
     /**

--- a/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Websites.php
+++ b/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Websites.php
@@ -44,7 +44,7 @@ class Websites extends \Magento\Ui\Component\Listing\Columns\Column
     /**
      * {@inheritdoc}
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         $websiteNames = [];
         foreach ($this->getData('options') as $website) {
@@ -60,6 +60,8 @@ class Websites extends \Magento\Ui\Component\Listing\Columns\Column
                 $item[$fieldName] = implode(', ', $websites);
             }
         }
+
+        return $dataSource;
     }
 
     /**

--- a/app/code/Magento/Cms/Test/Unit/Ui/Component/Listing/Column/PageActionsTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Ui/Component/Listing/Column/PageActionsTest.php
@@ -81,7 +81,7 @@ class PageActionsTest extends \PHPUnit_Framework_TestCase
             );
 
         $model->setName($name);
-        $model->prepareDataSource($items);
+        $items = $model->prepareDataSource($items);
         // Run test
         $this->assertEquals($expectedItems, $items['data']['items']);
     }

--- a/app/code/Magento/Cms/Ui/Component/Listing/Column/BlockActions.php
+++ b/app/code/Magento/Cms/Ui/Component/Listing/Column/BlockActions.php
@@ -55,9 +55,9 @@ class BlockActions extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -98,5 +98,7 @@ class BlockActions extends Column
                 }
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Cms/Ui/Component/Listing/Column/PageActions.php
+++ b/app/code/Magento/Cms/Ui/Component/Listing/Column/PageActions.php
@@ -59,9 +59,9 @@ class PageActions extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -92,5 +92,7 @@ class PageActions extends Column
                 }
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/ActionsTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/ActionsTest.php
@@ -90,7 +90,7 @@ class ActionsTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn('http://magento.com/customer/index/edit');
 
-        $this->component->prepareDataSource($dataSource);
+        $dataSource = $this->component->prepareDataSource($dataSource);
 
         $this->assertEquals($expectedDataSource, $dataSource);
     }

--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/AttributeColumnTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/AttributeColumnTest.php
@@ -125,7 +125,7 @@ class AttributeColumnTest extends \PHPUnit_Framework_TestCase
                 'is_searchable_in_grid' => true,
             ]);
 
-        $this->component->prepareDataSource($dataSource);
+        $dataSource = $this->component->prepareDataSource($dataSource);
 
         $this->assertEquals($expectedSource, $dataSource);
     }

--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/AttributeColumnTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/AttributeColumnTest.php
@@ -62,19 +62,6 @@ class AttributeColumnTest extends \PHPUnit_Framework_TestCase
         $this->component->setData('name', 'gender');
     }
 
-    public function testPrepareDataSourceWithoutItems()
-    {
-        $dataSource = [
-            'data' => [
-
-            ]
-        ];
-        $this->attributeRepository->expects($this->never())
-            ->method('getMetadataByCode');
-
-        $this->assertNull($this->component->prepareDataSource($dataSource));
-    }
-
     public function testPrepareDataSource()
     {
         $genderOptionId = 1;

--- a/app/code/Magento/Customer/Ui/Component/Listing/Column/Actions.php
+++ b/app/code/Magento/Customer/Ui/Component/Listing/Column/Actions.php
@@ -42,9 +42,9 @@ class Actions extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array &$dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             $storeId = $this->context->getFilterParam('store_id');
@@ -60,5 +60,7 @@ class Actions extends Column
                 ];
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Customer/Ui/Component/Listing/Column/AttributeColumn.php
+++ b/app/code/Magento/Customer/Ui/Component/Listing/Column/AttributeColumn.php
@@ -42,10 +42,6 @@ class AttributeColumn extends Column
      */
     public function prepareDataSource(array $dataSource)
     {
-        if (!isset($dataSource['data']['items'])) {
-            return null;
-        }
-
         $metaData = $this->attributeRepository->getMetadataByCode($this->getName());
         if ($metaData && count($metaData[AttributeMetadata::OPTIONS])) {
             foreach ($dataSource['data']['items'] as &$item) {

--- a/app/code/Magento/Customer/Ui/Component/Listing/Column/AttributeColumn.php
+++ b/app/code/Magento/Customer/Ui/Component/Listing/Column/AttributeColumn.php
@@ -38,9 +38,9 @@ class AttributeColumn extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array &$dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (!isset($dataSource['data']['items'])) {
             return null;
@@ -60,5 +60,7 @@ class AttributeColumn extends Column
                 }
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Customer/Ui/Component/Listing/Column/Online/Type.php
+++ b/app/code/Magento/Customer/Ui/Component/Listing/Column/Online/Type.php
@@ -19,7 +19,7 @@ class Type extends Column
      * @param array $dataSource
      * @return void
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -28,5 +28,7 @@ class Type extends Column
                     : __('Customer');
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/AddressTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/AddressTest.php
@@ -39,7 +39,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->model->setData('name', $itemName);
-        $this->model->prepareDataSource($dataSource);
+        $dataSource = $this->model->prepareDataSource($dataSource);
         $this->assertEquals($newItemValue, $dataSource['data']['items'][0][$itemName]);
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/CustomerGroupTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/CustomerGroupTest.php
@@ -57,7 +57,7 @@ class CustomerGroupTest extends \PHPUnit_Framework_TestCase
             ->willReturn($group);
 
         $this->model->setData('name', $itemName);
-        $this->model->prepareDataSource($dataSource);
+        $dataSource = $this->model->prepareDataSource($dataSource);
         $this->assertEquals($newItemValue, $dataSource['data']['items'][0][$itemName]);
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/OrderActionsTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/OrderActionsTest.php
@@ -63,7 +63,7 @@ class OrderActionsTest extends \PHPUnit_Framework_TestCase
             ->willReturn($url);
 
         $this->model->setData('name', $itemName);
-        $this->model->prepareDataSource($dataSource);
+        $dataSource = $this->model->prepareDataSource($dataSource);
         $this->assertEquals($newItemValue, $dataSource['data']['items'][0][$itemName]);
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/PaymentMethodTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/PaymentMethodTest.php
@@ -57,7 +57,7 @@ class PaymentMethodTest extends \PHPUnit_Framework_TestCase
             ->willReturn($payment);
 
         $this->model->setData('name', $itemName);
-        $this->model->prepareDataSource($dataSource);
+        $dataSource = $this->model->prepareDataSource($dataSource);
         $this->assertEquals($newItemValue, $dataSource['data']['items'][0][$itemName]);
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/PriceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/PriceTest.php
@@ -53,7 +53,7 @@ class PriceTest extends \PHPUnit_Framework_TestCase
             ->willReturn($newItemValue);
 
         $this->model->setData('name', $itemName);
-        $this->model->prepareDataSource($dataSource);
+        $dataSource = $this->model->prepareDataSource($dataSource);
         $this->assertEquals($newItemValue, $dataSource['data']['items'][0][$itemName]);
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/StatusTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/StatusTest.php
@@ -48,7 +48,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
             ['collectionFactory' => $collectionFactoryMock]
         );
         $model->setData('name', $itemName);
-        $model->prepareDataSource($dataSource);
+        $dataSource = $model->prepareDataSource($dataSource);
         $this->assertEquals($newItemValue, $dataSource['data']['items'][0][$itemName]);
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/Address.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/Address.php
@@ -19,14 +19,16 @@ class Address extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
                 $item[$this->getData('name')] = str_replace("\n", '<br/>', $item[$this->getData('name')]);
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/Creditmemo/State.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/Creditmemo/State.php
@@ -44,9 +44,9 @@ class State extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -55,5 +55,7 @@ class State extends Column
                     : $item[$this->getData('name')];
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/CustomerGroup.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/CustomerGroup.php
@@ -46,9 +46,9 @@ class CustomerGroup extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -62,5 +62,7 @@ class CustomerGroup extends Column
                 }
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/Invoice/State.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/Invoice/State.php
@@ -44,9 +44,9 @@ class State extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -55,5 +55,7 @@ class State extends Column
                     : $item[$this->getData('name')];
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/OrderActions.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/OrderActions.php
@@ -49,9 +49,9 @@ class OrderActions extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -70,5 +70,7 @@ class OrderActions extends Column
                 }
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/OrderCreditmemoActions.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/OrderCreditmemoActions.php
@@ -49,9 +49,9 @@ class OrderCreditmemoActions extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -70,5 +70,7 @@ class OrderCreditmemoActions extends Column
                 }
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/OrderInvoiceActions.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/OrderInvoiceActions.php
@@ -49,9 +49,9 @@ class OrderInvoiceActions extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -70,5 +70,7 @@ class OrderInvoiceActions extends Column
                 }
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/OrderShipmentActions.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/OrderShipmentActions.php
@@ -49,9 +49,9 @@ class OrderShipmentActions extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -70,5 +70,7 @@ class OrderShipmentActions extends Column
                 }
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/PaymentMethod.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/PaymentMethod.php
@@ -44,9 +44,9 @@ class PaymentMethod extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -59,5 +59,7 @@ class PaymentMethod extends Column
                 }
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/Price.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/Price.php
@@ -44,14 +44,16 @@ class Price extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
                 $item[$this->getData('name')] = $this->priceFormatter->format($item[$this->getData('name')], false);
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/Status.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/Status.php
@@ -46,7 +46,7 @@ class Status extends Column
      * @param array $dataSource
      * @return void
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
@@ -55,5 +55,7 @@ class Status extends Column
                     : $item[$this->getData('name')];
             }
         }
+
+        return $dataSource;
     }
 }

--- a/app/code/Magento/Store/Ui/Component/Listing/Column/Store.php
+++ b/app/code/Magento/Store/Ui/Component/Listing/Column/Store.php
@@ -57,15 +57,17 @@ class Store extends Column
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
                 $item[$this->getData('name')] = $this->prepareItem($item);
             }
         }
+
+        return $dataSource;
     }
 
     /**

--- a/app/code/Magento/Ui/Component/AbstractComponent.php
+++ b/app/code/Magento/Ui/Component/AbstractComponent.php
@@ -225,12 +225,12 @@ abstract class AbstractComponent extends DataObject implements UiComponentInterf
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function prepareDataSource(array & $dataSource)
+    public function prepareDataSource(array $dataSource)
     {
-        //
+        return $dataSource;
     }
 
     /**

--- a/app/code/Magento/Ui/Component/AbstractComponent.php
+++ b/app/code/Magento/Ui/Component/AbstractComponent.php
@@ -226,7 +226,6 @@ abstract class AbstractComponent extends DataObject implements UiComponentInterf
      *
      * @param array $dataSource
      * @return array
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function prepareDataSource(array $dataSource)
     {

--- a/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
@@ -360,6 +360,6 @@ class Context implements ContextInterface
                 $this->prepareDataSource($data, $child);
             }
         }
-        $component->prepareDataSource($data);
+        $data = $component->prepareDataSource($data);
     }
 }

--- a/lib/internal/Magento/Framework/View/Element/UiComponentInterface.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponentInterface.php
@@ -113,9 +113,9 @@ interface UiComponentInterface extends BlockInterface
      * Prepare Data Source
      *
      * @param array $dataSource
-     * @return void
+     * @return array
      */
-    public function prepareDataSource(array & $dataSource);
+    public function prepareDataSource(array $dataSource);
 
     /**
      * Get Data Source data


### PR DESCRIPTION
Plugins can not listen on methods with reference parameters. The reason for this is the usage of the php function "call_user_func_array". I found this call in the method "___callPlugins" of the trait "Magento\Framework\Interception\Interceptor".

Note on php.net for "call_user_func_array":

Before PHP 5.4, referenced variables in param_arr are passed to the function by reference, regardless of whether the function expects the respective parameter to be passed by reference. This form of call-time pass by reference does not emit a deprecation notice, but it is nonetheless deprecated, and has been removed in PHP 5.4. Furthermore, this does not apply to internal functions, for which the function signature is honored. Passing by value when the function expects a parameter by reference results in a warning and having call_user_func() return FALSE (there is, however, an exception for passed values with reference count = 1, such as in literals, as these can be turned into references without ill effects — but also without writes to that value having any effect —; do not rely in this behavior, though, as the reference count is an implementation detail and the soundness of this behavior is questionable).