### PR TITLE
Use the correct access modifier for the abstract method "execute"

### DIFF
--- a/lib/internal/Magento/Framework/App/Action/Action.php
+++ b/lib/internal/Magento/Framework/App/Action/Action.php
@@ -123,7 +123,7 @@ abstract class Action extends AbstractAction
     /**
      * @return ResultInterface
      */
-    abstract protected function execute();
+    abstract public function execute();
 
     /**
      * Throw control to different action (control and module if was specified).


### PR DESCRIPTION
All action classes use the access modifier "public" for the method "execute". Use the same acces modifier for the abstract method "execute".