### PR TITLE
Added missing @method annotation for setWebsiteIds

### DIFF
--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -28,6 +28,7 @@ use Magento\Framework\Api\Data\ImageContentInterface;
  * @method string getUrlKey()
  * @method Product setUrlKey(string $urlKey)
  * @method Product setRequestPath(string $requestPath)
+ * @method Product setWebsiteIds(array $ids)
  *
  * @SuppressWarnings(PHPMD.LongVariable)
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)


### PR DESCRIPTION
setWebsiteIds is used inside the class (getWebsiteIds method). It's useful to have setWebsiteIds in code completion.