### PR TITLE
Add php 7 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
 env:
   - TEST_SUITE=unit
   - TEST_SUITE=integration_part_1
@@ -20,6 +21,8 @@ matrix:
       env: TEST_SUITE=static_phpcs
     - php: 5.6
       env: TEST_SUITE=static_annotation
+  allow_failures:
+    - php: 7.0
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq postfix
@@ -37,13 +40,7 @@ before_script:
   # Mock mail
   - sudo service postfix stop
   - smtp-sink -d "%d.%H.%M.%S" localhost:2500 1000 &
-  - echo -e '#!/usr/bin/env bash\nexit 0' | sudo tee /usr/sbin/sendmail
-  - >
-      echo 'sendmail_path = "/usr/sbin/sendmail -t -i "'
-      | sudo tee "/home/travis/.phpenv/versions/`php -i
-      | grep "PHP Version"
-      | head -n 1
-      | grep -o -P '\d+\.\d+\.\d+.*'`/etc/conf.d/sendmail.ini"
+  - echo 'sendmail_path = "/usr/sbin/sendmail -t -i "' > $(php --ini|grep -m 1 "ini files in:"|cut -d ":" -f 2)/sendmail.ini
   # Disable xDebug
   - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
   # Install MySQL 5.6, create DB for integration tests


### PR DESCRIPTION
I reworked the travis config to make it all work. At least most of the time the tests run through, so the config is working.

The next step would be to fix failing tests and its source code.
