### PR TITLE
Typo in function name fixed (stove->store)

### DIFF
--- a/app/code/Magento/Theme/Model/View/Design.php
+++ b/app/code/Magento/Theme/Model/View/Design.php
@@ -169,7 +169,7 @@ class Design implements \Magento\Framework\View\DesignInterface
         $theme = null;
         $store = isset($params['store']) ? $params['store'] : null;
 
-        if ($this->_isThemePerStoveView($area)) {
+        if ($this->_isThemePerStoreView($area)) {
             if ($this->_storeManager->isSingleStoreMode()) {
                 $theme = $this->_scopeConfig->getValue(
                     self::XML_PATH_THEME_ID,
@@ -197,7 +197,7 @@ class Design implements \Magento\Framework\View\DesignInterface
      * @param string $area
      * @return bool
      */
-    private function _isThemePerStoveView($area)
+    private function _isThemePerStoreView($area)
     {
         return $area == self::DEFAULT_AREA;
     }


### PR DESCRIPTION
Even if Magento 2 is on fire, it should be called store, not stove.