### PR TITLE
Added 'target' attribute to the allowed attributes array for link block

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/Html/Link.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link.php
@@ -22,6 +22,7 @@ class Link extends \Magento\Framework\View\Element\Template
         'title',
         'charset',
         'name',
+        'target',
         'hreflang',
         'rel',
         'rev',


### PR DESCRIPTION
Added the 'target' property to the $allowedAttributes array, so it can be changed from the layout, like the following example:

``` xml
 <block class="Magento\Framework\View\Element\Html\Link" name="a-blank-page-link">
    <arguments>
        <argument name="path" xsi:type="string">a-blank-page.html</argument>
        <argument name="target" xsi:type="string">_blank</argument>
        <argument name="label" xsi:type="string" translate="true">A blank page</argument>
    </arguments>
</block>
```
