### PR TITLE
Make it possible to disable modal close on click

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/modal/modal.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/modal.js
@@ -52,6 +52,7 @@ define([
             innerScrollClass: '_inner-scroll',
             responsive: false,
             innerScroll: false,
+            closeOnclickOverlay: true,
             modalBlock: '[data-role="modal"]',
             modalCloseBtn: '[data-role="closeBtn"]',
             modalContent: '[data-role="content"]',
@@ -270,9 +271,11 @@ define([
             if (events) {
                 this.prevOverlayHandler = events.click[0].handler;
             }
-            this.overlay.unbind().on('click', function () {
-                that.closeModal();
-            });
+            if(this.options.closeOnclickOverlay) {
+                this.overlay.unbind().on('click', function() {
+                    that.closeModal();
+                });
+            }
         },
 
         /**


### PR DESCRIPTION
It should be possible to disable the click event on the overlay that closes the modal.
By adding an extra option to the modal in app/code/Magento/Ui/view/base/web/js/modal/modal.js, this functionality can be added.
