### PR TITLE
Fix Interception code generator in case constructor has no parameter

### DIFF
--- a/lib/internal/Magento/Framework/Interception/Code/Generator/Interceptor.php
+++ b/lib/internal/Magento/Framework/Interception/Code/Generator/Interceptor.php
@@ -58,7 +58,7 @@ class Interceptor extends \Magento\Framework\Code\Generator\EntityAbstract
                 $parameters
             ) ? "parent::__construct({$this->_getParameterList(
                 $parameters
-            )});" : '')
+            )});" : 'parent::__construct();')
         ];
     }
 


### PR DESCRIPTION
#### Problem

If constructor of class being intercepted has no parameter, the call to parent::__construct() is being missed in generated constructor. This causes all the logic in original constructor being ignored.

For example, this is generated constructor in case the original one has a parameter:

``` php
    public function __construct(\SmartOSC\SecondModule\Model\Bar $bar)
    {
        $this->___init();
        parent::__construct($bar);
    }
```

and this is the case original constructor has none:

``` php
    public function __construct()
    {
        $this->___init();
    }
```
#### The Fix

In case parameters is empty, return 'parent::__construct();' instead of empty string.
