### PR TITLE
Update AbstractAction

### DIFF
--- a/lib/internal/Magento/Framework/App/Action/AbstractAction.php
+++ b/lib/internal/Magento/Framework/App/Action/AbstractAction.php
@@ -33,7 +33,7 @@ abstract class AbstractAction implements \Magento\Framework\App\ActionInterface
      * @param \Magento\Framework\App\Action\Context $context
      */
     public function __construct(
-        \Magento\Framework\App\Action\Context $context
+        Context $context
     ) {
         $this->_request = $context->getRequest();
         $this->_response = $context->getResponse();


### PR DESCRIPTION
Updating constructor that Context could have passed as 'Context' rather than fully-qualified name for the future reference. It may cause miss understanding to new comrades in magento 2 who want to dig in magento 2 library. It would be simpler.

Issue: Namespace and DI in Magento/Framework/App/Action (lib) discussed.

Cheers!
