### PR TITLE
Don't omit the "callable" argument type hint when generating methods

### DIFF
--- a/lib/internal/Magento/Framework/Code/Generator/EntityAbstract.php
+++ b/lib/internal/Magento/Framework/Code/Generator/EntityAbstract.php
@@ -328,6 +328,8 @@ abstract class EntityAbstract
             $parameterInfo['type'] = 'array';
         } elseif ($parameter->getClass()) {
             $parameterInfo['type'] = $this->_getFullyQualifiedClassName($parameter->getClass()->getName());
+        } elseif ($parameter->isCallable()) {
+            $parameterInfo['type'] = 'callable';
         }
 
         if ($parameter->isOptional() && $parameter->isDefaultValueAvailable()) {


### PR DESCRIPTION
When I enabled the profiler, I got an exception:

```
Strict Notice: Declaration of Magento\Widget\Model\Template\Filter\Logger::setTemplateProcessor() should be compatible with Magento\Framework\Filter\Template::setTemplateProcessor(callable $callback) in /vagrant/var/generation/Magento/Widget/Model/Template/Filter/Logger.php on line 398
#0 /vagrant/lib/internal/Magento/Framework/Code/Generator.php(121): Magento\Framework\App\ErrorHandler->handler(2048, 'Declaration of ...', '/vagrant/var/ge...', 398, Array)
#1 /vagrant/lib/internal/Magento/Framework/Code/Generator.php(121): Magento\Framework\Code\Generator::includeFile()
#2 /vagrant/lib/internal/Magento/Framework/Code/Generator.php(110): Magento\Framework\Code\Generator->includeFile('/vagrant/var/ge...')
#3 /vagrant/lib/internal/Magento/Framework/Code/Generator/Autoloader.php(35): Magento\Framework\Code\Generator->generateClass('Magento\\Widget\\...')
#4 [internal function]: Magento\Framework\Code\Generator\Autoloader->load('Magento\\Widget\\...')
#5 /vagrant/lib/internal/Magento/Framework/ObjectManager/Profiler/FactoryDecorator.php(55): spl_autoload_call('Magento\\Widget\\...')
#6 /vagrant/lib/internal/Magento/Framework/ObjectManager/ObjectManager.php(71): Magento\Framework\ObjectManager\Profiler\FactoryDecorator->create('Magento\\Widget\\...')
#7 /vagrant/app/code/Magento/Cms/Model/Template/FilterProvider.php(58): Magento\Framework\ObjectManager\ObjectManager->get('Magento\\Widget\\...')
#8 /vagrant/app/code/Magento/Cms/Model/Template/FilterProvider.php(82): Magento\Cms\Model\Template\FilterProvider->_getFilterInstance('Magento\\Widget\\...')
#9 [internal function]: Magento\Cms\Model\Template\FilterProvider->getPageFilter()
#10 /vagrant/var/generation/Magento/Cms/Model/Template/FilterProvider/Logger.php(39): call_user_func_array(Array, Array)
#11 /vagrant/var/generation/Magento/Cms/Model/Template/FilterProvider/Logger.php(81): Magento\Cms\Model\Template\FilterProvider\Logger->_invoke('getPageFilter', Array)
...
```

Then I realised that the generated code completely omits the `callable` type hint of an argument, so - say -  Proxies wrapping such a method would trigger an exception. Also, as you can see, profile Logger generation fails, too.
