### PR TITLE
Correct the error message when creating wrong object for block

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
@@ -261,7 +261,7 @@ class Block implements Layout\GeneratorInterface
         }
         if (!$block instanceof \Magento\Framework\View\Element\AbstractBlock) {
             throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('Invalid block type: %1', [$block]),
+                new \Magento\Framework\Phrase('Invalid block type: %1', [is_object($block) ? get_class($block) : (string) $block]),
                 $e
             );
         }


### PR DESCRIPTION
In case the $block is neither string nor AbstractBlock (e.g in case use wrong class for block), the error message will become:

```
Invalid block type: %1
```

Should add the check for object and use get_class in that case.
