### PR TITLE
MAGETWO-42678: DbValidator has support for wildcards

### DIFF
--- a/setup/src/Magento/Setup/Test/Unit/Validator/DbValidatorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Validator/DbValidatorTest.php
@@ -53,6 +53,70 @@ class DbValidatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @see MAGETWO-42678
+     * @throws \Magento\Setup\Exception
+     */
+    public function testCheckDatabaseConnectionWithWildcardsInBeginningOfDatabaseName()
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('fetchOne')
+            ->with('SELECT version()')
+            ->willReturn('5.6.0-0ubuntu0.12.04.1');
+        $pdo = $this->getMockForAbstractClass('Zend_Db_Statement_Interface', [], '', false);
+        $this->connection
+            ->expects($this->once())
+            ->method('query')
+            ->with('SHOW GRANTS FOR current_user()')
+            ->willReturn($pdo);
+        $pdo->expects($this->once())->method('fetchAll')->willReturn([['GRANT ALL PRIVILEGES ON `%me`.* TO']]);
+        $this->assertEquals(true, $this->dbValidator->checkDatabaseConnection('name', 'host', 'user', 'password'));
+    }
+
+    /**
+     * @see MAGETWO-42678
+     * @throws \Magento\Setup\Exception
+     */
+    public function testCheckDatabaseConnectionWithWildcardsOnBothSidesOfDatabaseName()
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('fetchOne')
+            ->with('SELECT version()')
+            ->willReturn('5.6.0-0ubuntu0.12.04.1');
+        $pdo = $this->getMockForAbstractClass('Zend_Db_Statement_Interface', [], '', false);
+        $this->connection
+            ->expects($this->once())
+            ->method('query')
+            ->with('SHOW GRANTS FOR current_user()')
+            ->willReturn($pdo);
+        $pdo->expects($this->once())->method('fetchAll')->willReturn([['GRANT ALL PRIVILEGES ON `%am%`.* TO']]);
+        $this->assertEquals(true, $this->dbValidator->checkDatabaseConnection('name', 'host', 'user', 'password'));
+    }
+
+    /**
+     * @see MAGETWO-42678
+     * @throws \Magento\Setup\Exception
+     */
+    public function testCheckDatabaseConnectionWithWildcardsInEndOfDatabaseName()
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('fetchOne')
+            ->with('SELECT version()')
+            ->willReturn('5.6.0-0ubuntu0.12.04.1');
+        $pdo = $this->getMockForAbstractClass('Zend_Db_Statement_Interface', [], '', false);
+        $this->connection
+            ->expects($this->once())
+            ->method('query')
+            ->with('SHOW GRANTS FOR current_user()')
+            ->willReturn($pdo);
+        $pdo->expects($this->once())->method('fetchAll')->willReturn([['GRANT ALL PRIVILEGES ON `na%`.* TO']]);
+        $this->assertEquals(true, $this->dbValidator->checkDatabaseConnection('name', 'host', 'user', 'password'));
+    }
+
+
+    /**
      * @expectedException \Magento\Setup\Exception
      * @expectedExceptionMessage Database user does not have enough privileges.
      */


### PR DESCRIPTION
DbValidator has support for privileges on a database defined with wildcards

Fixes #1813 (MAGETWO-42678)
