### PR TITLE
Add ability to use tree-massactions ("sub-menus") for mass actions on…

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
@@ -398,6 +398,7 @@
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="selectProvider" xsi:type="string">sales_order_grid.sales_order_grid.sales_order_columns.ids</item>
+                    <item name="component" xsi:type="string">Magento_Ui/js/grid/tree-massactions</item>
                     <item name="displayArea" xsi:type="string">bottom</item>
                     <item name="indexField" xsi:type="string">entity_id</item>
                 </item>


### PR DESCRIPTION
… grids

Just like in the Magento_Catalog ui components for the "Products" grid, the sales grids should also be able to use the tree-massactions component to realize "sub menus" for bulk actions. See: https://github.com/magento/magento2/blob/develop/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml#L194

![image](https://cloud.githubusercontent.com/assets/5671344/10431124/943c3c10-7103-11e5-8494-70b21bff5e83.png)
