### PR TITLE
Remove call to load() in getChildrenCategories method

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Category.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category.php
@@ -731,7 +731,7 @@ class Category extends AbstractResource
         )->setOrder(
             'position',
             \Magento\Framework\DB\Select::SQL_ASC
-        )->joinUrlRewrite()->load();
+        )->joinUrlRewrite();
 
         return $collection;
     }


### PR DESCRIPTION
This is important because it allows custom category view blocks to use this method to get children categories, but still add attributes to what is loaded. At the moment we are working on a build where we are having to duplicate the code of this method now because we need the description along with some custom media attributes.
