### PR TITLE
Moved libs & extensions to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,13 +49,7 @@
         "symfony/event-dispatcher": "~2.1",
         "phpseclib/phpseclib": "~0.3",
         "tedivm/jshrink": "~1.0.1",
-        "magento/composer": "~1.0.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "4.1.0",
-        "squizlabs/php_codesniffer": "1.5.3",
-        "phpmd/phpmd": "@stable",
-        "pdepend/pdepend": "2.0.6",
+        "magento/composer": "~1.0.0",
         "lib-libxml": "*",
         "ext-ctype": "*",
         "ext-gd": "*",
@@ -69,9 +63,15 @@
         "ext-intl": "*",
         "ext-xsl": "*",
         "ext-mbstring": "*",
-        "sjparkinson/static-review": "~4.1",
-        "fabpot/php-cs-fixer": "~1.2",
         "lusitanian/oauth": "~0.3 <=0.7.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "4.1.0",
+        "squizlabs/php_codesniffer": "1.5.3",
+        "phpmd/phpmd": "@stable",
+        "pdepend/pdepend": "2.0.6",
+        "sjparkinson/static-review": "~4.1",
+        "fabpot/php-cs-fixer": "~1.2"
     },
     "replace": {
         "magento/module-marketplace": "self.version",


### PR DESCRIPTION
Looks like some libs & extension requirements were in require-dev. This breaks installing if --no-dev flag added to install. This seems to fix, although I need to run it through a vagrant build to be 100% sure