### PR TITLE
fixed cutting off long oauth callback urls for oauth clients like google apps script (Google Drive)

### DIFF
--- a/app/code/Magento/Integration/Setup/InstallSchema.php
+++ b/app/code/Magento/Integration/Setup/InstallSchema.php
@@ -68,13 +68,13 @@ class InstallSchema implements InstallSchemaInterface
         )->addColumn(
             'callback_url',
             \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-            255,
+            512,
             [],
             'Callback URL'
         )->addColumn(
             'rejected_callback_url',
             \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-            255,
+            512,
             ['nullable' => false],
             'Rejected callback URL'
         )->addIndex(
@@ -163,7 +163,7 @@ class InstallSchema implements InstallSchemaInterface
         )->addColumn(
             'callback_url',
             \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-            255,
+            512,
             ['nullable' => false],
             'Token Callback URL'
         )->addColumn(


### PR DESCRIPTION
fixed cutting off long oauth callback urls for oauth clients like Google Drive Apps Script by increasing size of callback_url, rejected_callback_url columns from 255 to 512 chars

Google Drives Apps Script have very long oauth URLs. 
Example: 
https://script.google.com/macros/d/MR7xx5QeHK_nwZLsUd8pxVZXvWRuAoVU2/usercallback?state=ADEpC8zf967naK-fzUxtnUVDyckTiet7SC7ci3sj-qztyiv0X8C91iTemZedlAAQ3sAm6jxCq00KNPwPJts8cOABWaddof_xskq6rUu25EAD1d5C4BwWOEOK4Ud9qGl3b7ofAe-Rs-46M_EJjTifs5i3b--ZDz-FMpz1Kk4m6jxCq00KNPwPJts&oauth_token=0896ce575a666a8113d382bb849bd0f0&oauth_verifier=1f3719ba1d2d5ae4a739be1bf79644f4

Magento saves it in callback_url column and cuts 16 chars (from example above).
That is why it's not possible to write Addons for Goolgle Sheets/Documents.

Please increase the size of callback_url and rejected_callback_url columns.

Links:
- https://developers.google.com/apps-script/add-ons/
- https://developers.google.com/apps-script/reference/script/state-token-builder
