### PR TITLE
Clean up class and interface dependencies on ComponentRegistrar

### DIFF
--- a/app/code/Magento/Email/Model/Template/Config/FileResolver.php
+++ b/app/code/Magento/Email/Model/Template/Config/FileResolver.php
@@ -7,7 +7,7 @@
  */
 namespace Magento\Email\Model\Template\Config;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Component\DirSearch;
 use Magento\Framework\Config\FileIteratorFactory;
 
@@ -43,7 +43,7 @@ class FileResolver implements \Magento\Framework\Config\FileResolverInterface
     public function get($filename, $scope)
     {
         $iterator = $this->iteratorFactory->create(
-            $this->dirSearch->collectFiles(ComponentRegistrar::MODULE, 'etc/' . $filename)
+            $this->dirSearch->collectFiles(ComponentRegistrarInterface::MODULE, 'etc/' . $filename)
         );
         return $iterator;
     }

--- a/app/code/Magento/Email/Test/Unit/Model/Template/Config/FileResolverTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/Config/FileResolverTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Email\Test\Unit\Model\Template\Config;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class FileResolverTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,7 +20,7 @@ class FileResolverTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($expected));
         $dirSearch->expects($this->once())
             ->method('collectFiles')
-            ->with(ComponentRegistrar::MODULE, 'etc/file');
+            ->with(ComponentRegistrarInterface::MODULE, 'etc/file');
         $model->get('file', 'scope');
     }
 }

--- a/app/code/Magento/SampleData/Model/Dependency.php
+++ b/app/code/Magento/SampleData/Model/Dependency.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\SampleData\Model;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Composer\ComposerInformation;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Config\Composer\Package;
@@ -37,7 +37,7 @@ class Dependency
     private $packageFactory;
 
     /**
-     * @var ComponentRegistrar
+     * @var ComponentRegistrarInterface
      */
     private $componentRegistrar;
 
@@ -45,13 +45,13 @@ class Dependency
      * @param ComposerInformation $composerInformation
      * @param Filesystem $filesystem
      * @param PackageFactory $packageFactory
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      */
     public function __construct(
         ComposerInformation $composerInformation,
         Filesystem $filesystem,
         PackageFactory $packageFactory,
-        ComponentRegistrar $componentRegistrar
+        ComponentRegistrarInterface $componentRegistrar
     ) {
         $this->composerInformation = $composerInformation;
         $this->filesystem = $filesystem;
@@ -85,7 +85,7 @@ class Dependency
     protected function getSuggestsFromModules()
     {
         $suggests = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $moduleDir) {
             $file = $moduleDir . '/composer.json';
 
             /** @var Package $package */

--- a/app/code/Magento/Theme/Model/Theme/ThemePackageInfo.php
+++ b/app/code/Magento/Theme/Model/Theme/ThemePackageInfo.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Theme\Model\Theme;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem\Directory\ReadFactory;
 
 /**
@@ -14,7 +14,7 @@ use Magento\Framework\Filesystem\Directory\ReadFactory;
 class ThemePackageInfo
 {
     /**
-     * @var ComponentRegistrar
+     * @var ComponentRegistrarInterface
      */
     private $componentRegistrar;
 
@@ -31,11 +31,11 @@ class ThemePackageInfo
     /**
      * Constructor
      *
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      * @param ReadFactory $readDirFactory
      */
     public function __construct(
-        ComponentRegistrar $componentRegistrar,
+        ComponentRegistrarInterface $componentRegistrar,
         ReadFactory $readDirFactory
     ) {
         $this->componentRegistrar = $componentRegistrar;
@@ -51,7 +51,7 @@ class ThemePackageInfo
      */
     public function getPackageName($themePath)
     {
-        $themePath = $this->componentRegistrar->getPath(ComponentRegistrar::THEME, $themePath);
+        $themePath = $this->componentRegistrar->getPath(ComponentRegistrarInterface::THEME, $themePath);
         $themeDir = $this->readDirFactory->create($themePath);
         if ($themeDir->isExist('composer.json')) {
             $rawData = [];
@@ -87,7 +87,7 @@ class ThemePackageInfo
      */
     private function initializeMap()
     {
-        $themePaths = $this->componentRegistrar->getPaths(ComponentRegistrar::THEME);
+        $themePaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::THEME);
         /** @var \Magento\Theme\Model\Theme $theme */
         foreach ($themePaths as $fullThemePath => $themeDir) {
             $themeDirRead = $this->readDirFactory->create($themeDir);

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/ThemePackageInfoTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/ThemePackageInfoTest.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Theme\Test\Unit\Model\Theme;
 
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Theme\Model\Theme\ThemePackageInfo;
 
 class ThemePackageInfoTest extends \PHPUnit_Framework_TestCase
@@ -20,7 +21,7 @@ class ThemePackageInfoTest extends \PHPUnit_Framework_TestCase
     private $themePackageInfo;
 
     /**
-     * @var \Magento\Framework\Component\ComponentRegistrar|\PHPUnit_Framework_MockObject_MockObject
+     * @var ComponentRegistrarInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $componentRegistrar;
 
@@ -31,7 +32,7 @@ class ThemePackageInfoTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->componentRegistrar = $this->getMock('Magento\Framework\Component\ComponentRegistrar', [], [], '', false);
+        $this->componentRegistrar = $this->getMock(ComponentRegistrarInterface::class, [], [], '', false);
         $this->dirRead = $this->getMock('Magento\Framework\Filesystem\Directory\Read', [], [], '', false);
         $this->dirReadFactory = $this->getMock('Magento\Framework\Filesystem\Directory\ReadFactory', [], [], '', false);
         $this->dirReadFactory->expects($this->any())->method('create')->willReturn($this->dirRead);

--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -51,7 +51,7 @@ class DataProvider implements DataProviderInterface
      * @param Config $config
      * @param \Magento\Framework\Filesystem\File\ReadFactory $fileReadFactory
      * @param \Magento\Framework\Phrase\Renderer\Translate $translate
-     * @param \Magento\Framework\Component\ComponentRegistrar $componentRegistrar
+     * @param \Magento\Framework\Component\ComponentRegistrarInterface $componentRegistrar
      * @param \Magento\Framework\Component\DirSearch $dirSearch
      * @param \Magento\Framework\View\Design\Theme\ThemePackageList $themePackageList
      * @param \Magento\Framework\App\Utility\Files|null $filesUtility
@@ -61,7 +61,7 @@ class DataProvider implements DataProviderInterface
         Config $config,
         \Magento\Framework\Filesystem\File\ReadFactory $fileReadFactory,
         \Magento\Framework\Phrase\Renderer\Translate $translate,
-        \Magento\Framework\Component\ComponentRegistrar $componentRegistrar,
+        \Magento\Framework\Component\ComponentRegistrarInterface $componentRegistrar,
         \Magento\Framework\Component\DirSearch $dirSearch,
         \Magento\Framework\View\Design\Theme\ThemePackageList $themePackageList,
         \Magento\Framework\App\Utility\Files $filesUtility = null

--- a/app/code/Magento/Widget/Model/Config/FileResolver.php
+++ b/app/code/Magento/Widget/Model/Config/FileResolver.php
@@ -7,8 +7,8 @@
  */
 namespace Magento\Widget\Model\Config;
 
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Component\DirSearch;
-use Magento\Framework\Component\ComponentRegistrar;
 
 class FileResolver implements \Magento\Framework\Config\FileResolverInterface
 {
@@ -54,7 +54,10 @@ class FileResolver implements \Magento\Framework\Config\FileResolverInterface
                 $iterator = $this->_moduleReader->getConfigurationFiles($filename);
                 break;
             case 'design':
-                $themePaths = $this->componentDirSearch->collectFiles(ComponentRegistrar::THEME, 'etc/' . $filename);
+                $themePaths = $this->componentDirSearch->collectFiles(
+                    ComponentRegistrarInterface::THEME,
+                    'etc/' . $filename
+                );
                 $iterator = $this->iteratorFactory->create($themePaths);
                 break;
             default:

--- a/app/code/Magento/Widget/Test/Unit/Model/Config/FileResolverTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/Config/FileResolverTest.php
@@ -6,7 +6,7 @@
 
 namespace Magento\Widget\Test\Unit\Model\Config;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use \Magento\Widget\Model\Config\FileResolver;
 
 class FileResolverTest extends \PHPUnit_Framework_TestCase
@@ -55,7 +55,7 @@ class FileResolverTest extends \PHPUnit_Framework_TestCase
         $expected = new \StdClass();
         $this->componentDirSearch->expects($this->once())
             ->method('collectFiles')
-            ->with(ComponentRegistrar::THEME, 'etc/file')
+            ->with(ComponentRegistrarInterface::THEME, 'etc/file')
             ->will($this->returnValue(['test']));
         $this->factory->expects($this->once())->method('create')->with(['test'])->willReturn($expected);
         $this->assertSame($expected, $this->object->get('file', 'design'));

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Design/Fallback/RulePoolTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Design/Fallback/RulePoolTest.php
@@ -7,7 +7,7 @@
 namespace Magento\Framework\View\Design\Fallback;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem;
 use Magento\TestFramework\Helper\Bootstrap;
 
@@ -145,7 +145,7 @@ class RulePoolTest extends \PHPUnit_Framework_TestCase
         $componentRegistrar = $objectManager->get(
             '\Magento\Framework\Component\ComponentRegistrarInterface'
         );
-        $coreModulePath = $componentRegistrar->getPath(ComponentRegistrar::MODULE, 'Magento_Theme');
+        $coreModulePath = $componentRegistrar->getPath(ComponentRegistrarInterface::MODULE, 'Magento_Theme');
         /** @var \Magento\Framework\Filesystem $filesystem */
         $filesystem = $objectManager->get('\Magento\Framework\Filesystem');
         $libPath = rtrim($filesystem->getDirectoryRead(DirectoryList::LIB_WEB)->getAbsolutePath(), '/');

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/EavAttributesConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/EavAttributesConfigFilesTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Test\Integrity\Modular;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class EavAttributesConfigFilesTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,7 +21,7 @@ class EavAttributesConfigFilesTest extends \PHPUnit_Framework_TestCase
         $moduleDirSearch = $objectManager->get('Magento\Framework\Component\DirSearch');
         $fileIteratorFactory = $objectManager->get('Magento\Framework\Config\FileIteratorFactory');
         $xmlFiles = $fileIteratorFactory->create(
-            $moduleDirSearch->collectFiles(ComponentRegistrar::MODULE, 'etc/{*/eav_attributes.xml,eav_attributes.xml}')
+            $moduleDirSearch->collectFiles(ComponentRegistrarInterface::MODULE, 'etc/{*/eav_attributes.xml,eav_attributes.xml}')
         );
 
         $validationStateMock = $this->getMock('Magento\Framework\Config\ValidationStateInterface');

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ExportConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ExportConfigFilesTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Test\Integrity\Modular;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class ExportConfigFilesTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,7 +21,7 @@ class ExportConfigFilesTest extends \PHPUnit_Framework_TestCase
         $moduleDirSearch = $objectManager->get('Magento\Framework\Component\DirSearch');
         $fileIteratorFactory = $objectManager->get('Magento\Framework\Config\FileIteratorFactory');
         $xmlFiles = $fileIteratorFactory->create(
-            $moduleDirSearch->collectFiles(ComponentRegistrar::MODULE, 'etc/{*/export.xml,export.xml}')
+            $moduleDirSearch->collectFiles(ComponentRegistrarInterface::MODULE, 'etc/{*/export.xml,export.xml}')
         );
 
         $validationStateMock = $this->getMock('Magento\Framework\Config\ValidationStateInterface');

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/FieldsetConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/FieldsetConfigFilesTest.php
@@ -7,7 +7,7 @@
  */
 namespace Magento\Test\Integrity\Modular;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class FieldsetConfigFilesTest extends \Magento\TestFramework\TestCase\AbstractConfigFiles
 {
@@ -38,7 +38,7 @@ class FieldsetConfigFilesTest extends \Magento\TestFramework\TestCase\AbstractCo
      */
     protected function _getXsdPath()
     {
-        return $this->componentRegistrar->getPath(ComponentRegistrar::LIBRARY, 'magento/framework')
+        return $this->componentRegistrar->getPath(ComponentRegistrarInterface::LIBRARY, 'magento/framework')
         . '/DataObject/etc/fieldset_file.xsd';
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ImportConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ImportConfigFilesTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Test\Integrity\Modular;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class ImportConfigFilesTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,7 +21,7 @@ class ImportConfigFilesTest extends \PHPUnit_Framework_TestCase
         $moduleDirSearch = $objectManager->get('Magento\Framework\Component\DirSearch');
         $fileIteratorFactory = $objectManager->get('Magento\Framework\Config\FileIteratorFactory');
         $xmlFiles = $fileIteratorFactory->create(
-            $moduleDirSearch->collectFiles(ComponentRegistrar::MODULE, 'etc/{*/import.xml,import.xml}')
+            $moduleDirSearch->collectFiles(ComponentRegistrarInterface::MODULE, 'etc/{*/import.xml,import.xml}')
         );
 
         $validationStateMock = $this->getMock('Magento\Framework\Config\ValidationStateInterface');

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/PaymentConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/PaymentConfigFilesTest.php
@@ -7,7 +7,7 @@
  */
 namespace Magento\Test\Integrity\Modular;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class PaymentConfigFilesTest extends \Magento\TestFramework\TestCase\AbstractConfigFiles
 {
@@ -38,7 +38,7 @@ class PaymentConfigFilesTest extends \Magento\TestFramework\TestCase\AbstractCon
      */
     protected function _getXsdPath()
     {
-        return $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, 'Magento_Payment')
+        return $this->componentRegistrar->getPath(ComponentRegistrarInterface::MODULE, 'Magento_Payment')
             . '/etc/payment_file.xsd';
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ProductOptionsConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ProductOptionsConfigFilesTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Test\Integrity\Modular;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class ProductOptionsConfigFilesTest extends \PHPUnit_Framework_TestCase
 {
@@ -23,7 +23,7 @@ class ProductOptionsConfigFilesTest extends \PHPUnit_Framework_TestCase
         $fileIteratorFactory = $objectManager->get('Magento\Framework\Config\FileIteratorFactory');
         $xmlFiles = $fileIteratorFactory->create(
             $moduleDirSearch->collectFiles(
-                ComponentRegistrar::MODULE,
+                ComponentRegistrarInterface::MODULE,
                 'etc/{*/product_options.xml,product_options.xml}'
             )
         );

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ProductTypesConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ProductTypesConfigFilesTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Test\Integrity\Modular;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class ProductTypesConfigFilesTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,7 +21,10 @@ class ProductTypesConfigFilesTest extends \PHPUnit_Framework_TestCase
         $moduleDirSearch = $objectManager->get('Magento\Framework\Component\DirSearch');
         $fileIteratorFactory = $objectManager->get('Magento\Framework\Config\FileIteratorFactory');
         $xmlFiles = $fileIteratorFactory->create(
-            $moduleDirSearch->collectFiles(ComponentRegistrar::MODULE, 'etc/{*/product_types.xml,product_types.xml}')
+            $moduleDirSearch->collectFiles(
+                ComponentRegistrarInterface::MODULE,
+                'etc/{*/product_types.xml,product_types.xml}'
+            )
         );
 
         $fileResolverMock = $this->getMock('Magento\Framework\Config\FileResolverInterface');

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ResourcesConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ResourcesConfigFilesTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Test\Integrity\Modular;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class ResourcesConfigFilesTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,7 +21,10 @@ class ResourcesConfigFilesTest extends \PHPUnit_Framework_TestCase
         $moduleDirSearch = $objectManager->get('Magento\Framework\Component\DirSearch');
         $fileIteratorFactory = $objectManager->get('Magento\Framework\Config\FileIteratorFactory');
         $xmlFiles = $fileIteratorFactory->create(
-            $moduleDirSearch->collectFiles(ComponentRegistrar::MODULE, 'etc/{*/resources.xml,resources.xml}')
+            $moduleDirSearch->collectFiles(
+                ComponentRegistrarInterface::MODULE,
+                'etc/{*/resources.xml,resources.xml}'
+            )
         );
 
         $fileResolverMock = $this->getMock('Magento\Framework\Config\FileResolverInterface');

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/SystemConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/SystemConfigFilesTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Test\Integrity\Modular;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class SystemConfigFilesTest extends \PHPUnit_Framework_TestCase
 {
@@ -24,7 +24,7 @@ class SystemConfigFilesTest extends \PHPUnit_Framework_TestCase
         $modulesDir = $filesystem->getDirectoryRead(DirectoryList::ROOT);
         /** @var $moduleDirSearch \Magento\Framework\Component\DirSearch */
         $moduleDirSearch = $objectManager->get('Magento\Framework\Component\DirSearch');
-        $fileList = $moduleDirSearch->collectFiles(ComponentRegistrar::MODULE, 'etc/adminhtml/system.xml');
+        $fileList = $moduleDirSearch->collectFiles(ComponentRegistrarInterface::MODULE, 'etc/adminhtml/system.xml');
         $configMock = $this->getMock(
             'Magento\Framework\Module\Dir\Reader',
             ['getConfigurationFiles', 'getModuleDir'],

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ThemeConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ThemeConfigFilesTest.php
@@ -7,7 +7,7 @@
  */
 namespace Magento\Test\Integrity\Modular;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class ThemeConfigFilesTest extends \Magento\TestFramework\TestCase\AbstractConfigFiles
 {
@@ -38,7 +38,7 @@ class ThemeConfigFilesTest extends \Magento\TestFramework\TestCase\AbstractConfi
      */
     protected function _getXsdPath()
     {
-        return $this->componentRegistrar->getPath(ComponentRegistrar::LIBRARY, 'magento/framework')
+        return $this->componentRegistrar->getPath(ComponentRegistrarInterface::LIBRARY, 'magento/framework')
             . '/View/PageLayout/etc/layouts.xsd';
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/WidgetConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/WidgetConfigFilesTest.php
@@ -7,7 +7,7 @@
  */
 namespace Magento\Test\Integrity\Modular;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class WidgetConfigFilesTest extends \Magento\TestFramework\TestCase\AbstractConfigFiles
 {
@@ -38,7 +38,7 @@ class WidgetConfigFilesTest extends \Magento\TestFramework\TestCase\AbstractConf
      */
     protected function _getXsdPath()
     {
-        return $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, 'Magento_Widget')
+        return $this->componentRegistrar->getPath(ComponentRegistrarInterface::MODULE, 'Magento_Widget')
             . '/etc/widget_file.xsd';
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/ViewFileReferenceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/ViewFileReferenceTest.php
@@ -118,10 +118,7 @@ class ViewFileReferenceTest extends \PHPUnit_Framework_TestCase
         $localePlaceholder = '<locale_placeholder>';
         $params = ['area' => $theme->getArea(), 'theme' => $theme, 'locale' => $localePlaceholder];
         $patternDirs = self::$_fallbackRule->getPatternDirs($params);
-        $themePath =  self::$_componentRegistrar->getPath(
-            \Magento\Framework\Component\ComponentRegistrar::THEME,
-            $theme->getFullPath()
-        );
+        $themePath =  self::$_componentRegistrar->getPath(ComponentRegistrar::THEME, $theme->getFullPath());
         foreach ($patternDirs as $patternDir) {
             $patternPath = $patternDir . '/';
             if ((strpos($patternPath, $themePath) !== false) // It is theme's directory
@@ -229,7 +226,7 @@ class ViewFileReferenceTest extends \PHPUnit_Framework_TestCase
     protected static function _getFilesToProcess()
     {
         $result = [];
-        $componentRegistrar = new \Magento\Framework\Component\ComponentRegistrar();
+        $componentRegistrar = new ComponentRegistrar();
         $dirs = array_merge(
             $componentRegistrar->getPaths(ComponentRegistrar::MODULE),
             $componentRegistrar->getPaths(ComponentRegistrar::THEME)

--- a/lib/internal/Magento/Framework/App/Language/Dictionary.php
+++ b/lib/internal/Magento/Framework/App/Language/Dictionary.php
@@ -6,7 +6,7 @@
 
 namespace Magento\Framework\App\Language;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem\Directory\ReadFactory;
 
 /**
@@ -31,7 +31,7 @@ class Dictionary
     /**
      * Component Registrar
      *
-     * @var ReadFactory
+     * @var ComponentRegistrarInterface
      */
     private $componentRegistrar;
 
@@ -47,12 +47,12 @@ class Dictionary
 
     /**
      * @param ReadFactory $directoryReadFactory
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      * @param ConfigFactory $configFactory
      */
     public function __construct(
         ReadFactory $directoryReadFactory,
-        ComponentRegistrar $componentRegistrar,
+        ComponentRegistrarInterface $componentRegistrar,
         ConfigFactory $configFactory
     ) {
         $this->directoryReadFactory = $directoryReadFactory;
@@ -72,7 +72,7 @@ class Dictionary
     public function getDictionary($languageCode)
     {
         $languages = [];
-        $this->paths = $this->componentRegistrar->getPaths(ComponentRegistrar::LANGUAGE);
+        $this->paths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::LANGUAGE);
         foreach ($this->paths as $path) {
             $directoryRead = $this->directoryReadFactory->create($path);
             if ($directoryRead->isExist('language.xml')) {
@@ -172,7 +172,10 @@ class Dictionary
      */
     private function readPackCsv($vendor, $package)
     {
-        $path = $this->componentRegistrar->getPath(ComponentRegistrar::LANGUAGE, strtolower($vendor . '_' . $package));
+        $path = $this->componentRegistrar->getPath(
+            ComponentRegistrarInterface::LANGUAGE,
+            strtolower($vendor . '_' . $package)
+        );
         $result = [];
         if (isset($path)) {
             $directoryRead = $this->directoryReadFactory->create($path);

--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -6,7 +6,7 @@
 
 namespace Magento\Framework\App\Utility;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Component\DirSearch;
 use Magento\Framework\View\Design\Theme\ThemePackageList;
 
@@ -39,7 +39,7 @@ class Files
     /**
      * Component registrar
      *
-     * @var ComponentRegistrar
+     * @var ComponentRegistrarInterface
      */
     protected $componentRegistrar;
 
@@ -114,12 +114,12 @@ class Files
     /**
      * Set path to source code
      *
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      * @param DirSearch $dirSearch
      * @param ThemePackageList $themePackageList
      */
     public function __construct(
-        ComponentRegistrar $componentRegistrar,
+        ComponentRegistrarInterface $componentRegistrar,
         DirSearch $dirSearch,
         ThemePackageList $themePackageList
     ) {
@@ -136,7 +136,7 @@ class Files
     private function getModuleTestDirsRegex()
     {
         $moduleTestDirs = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $moduleDir) {
             $moduleTestDirs[] = str_replace('\\', '/', '#' . $moduleDir . '/Test#');
         }
         return $moduleTestDirs;
@@ -210,7 +210,7 @@ class Files
     {
         if ($flags & self::INCLUDE_LIBS) {
             $libraryExcludeDirs = [];
-            foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::LIBRARY) as $libraryDir) {
+            foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::LIBRARY) as $libraryDir) {
                 $libraryExcludeDirs[] = str_replace('\\', '/', '#' . $libraryDir . '/Test#');
                 $libraryExcludeDirs[] = str_replace('\\', '/', '#' . $libraryDir) . '/[\\w]+/Test#';
                 if (!($flags & self::INCLUDE_NON_CLASSES)) {
@@ -218,7 +218,7 @@ class Files
                 }
             }
             return $this->getFilesSubset(
-                $this->componentRegistrar->getPaths(ComponentRegistrar::LIBRARY),
+                $this->componentRegistrar->getPaths(ComponentRegistrarInterface::LIBRARY),
                 '*.php',
                 $libraryExcludeDirs
             );
@@ -267,11 +267,11 @@ class Files
     {
         if ($flags & self::INCLUDE_APP_CODE) {
             $excludePaths = [];
-            $paths = $this->componentRegistrar->getPaths(ComponentRegistrar::MODULE);
+            $paths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
             if ($flags & self::INCLUDE_NON_CLASSES) {
                 $paths[] = BP . '/app';
             } else {
-                foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
+                foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $moduleDir) {
                     $excludePaths[] = str_replace('\\', '/', '#' . $moduleDir . '/registration.php#');
                     $excludePaths[] = str_replace('\\', '/', '#' . $moduleDir . '/cli_commands.php#');
                 }
@@ -299,11 +299,11 @@ class Files
                 BP . '/setup/src/Magento/Setup/Test',
             ];
             $moduleTestDir = [];
-            foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
+            foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $moduleDir) {
                 $moduleTestDir[] = $moduleDir . '/Test';
             }
             $libraryTestDirs = [];
-            foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::LIBRARY) as $libraryDir) {
+            foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::LIBRARY) as $libraryDir) {
                 $libraryTestDirs[] = $libraryDir . '/Test';
                 $libraryTestDirs[] = $libraryDir . '/*/Test';
             }
@@ -342,7 +342,7 @@ class Files
         $cacheKey = __METHOD__ . '|' . BP . '|' . serialize(func_get_args());
         if (!isset(self::$_cache[$cacheKey])) {
             $configXmlPaths = [];
-            foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
+            foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $moduleDir) {
                 $configXmlPaths[] = $moduleDir . '/etc/config.xml';
                 // Module DB-specific configs, e.g. config.mysql4.xml
                 $configXmlPaths[] = $moduleDir . '/etc/config.*.xml';
@@ -377,7 +377,7 @@ class Files
     ) {
         $cacheKey = __METHOD__ . '|' . BP . '|' . serialize(func_get_args());
         if (!isset(self::$_cache[$cacheKey])) {
-            $files = $this->dirSearch->collectFiles(ComponentRegistrar::MODULE, "/etc/{$fileNamePattern}");
+            $files = $this->dirSearch->collectFiles(ComponentRegistrarInterface::MODULE, "/etc/{$fileNamePattern}");
             $files = array_filter(
                 $files,
                 function ($file) use ($excludedFileNames) {
@@ -409,19 +409,19 @@ class Files
         $cacheKey = __METHOD__ . '|' . BP . '|' . serialize(func_get_args());
         if (!isset(self::$_cache[$cacheKey])) {
             $files = $this->getFilesSubset(
-                $this->componentRegistrar->getPaths(ComponentRegistrar::MODULE),
+                $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE),
                 $fileNamePattern,
                 []
             );
             $libraryExcludeDirs = [];
-            foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::LIBRARY) as $libraryDir) {
+            foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::LIBRARY) as $libraryDir) {
                 $libraryExcludeDirs[] = str_replace('\\', '/', '#' . $libraryDir . '/Test#');
                 $libraryExcludeDirs[] = str_replace('\\', '/', '#' . $libraryDir) . '/[\\w]+/Test#';
             }
             $files = array_merge(
                 $files,
                 $this->getFilesSubset(
-                    $this->componentRegistrar->getPaths(ComponentRegistrar::LIBRARY),
+                    $this->componentRegistrar->getPaths(ComponentRegistrarInterface::LIBRARY),
                     $fileNamePattern,
                     $libraryExcludeDirs
                 )
@@ -429,7 +429,7 @@ class Files
             $files = array_merge(
                 $files,
                 $this->getFilesSubset(
-                    $this->componentRegistrar->getPaths(ComponentRegistrar::THEME),
+                    $this->componentRegistrar->getPaths(ComponentRegistrarInterface::THEME),
                     $fileNamePattern,
                     []
                 )
@@ -460,7 +460,7 @@ class Files
         $cacheKey = __METHOD__ . '|' . BP . '|' . serialize(func_get_args());
         if (!isset(self::$_cache[$cacheKey])) {
             self::$_cache[$cacheKey] = $this->dirSearch->collectFiles(
-                ComponentRegistrar::THEME,
+                ComponentRegistrarInterface::THEME,
                 "/etc/{$fileNamePattern}"
             );
         }
@@ -570,7 +570,8 @@ class Files
         $files = [];
         $area = $params['area'];
         $requiredModuleName = $params['namespace'] . '_' . $params['module'];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
+        $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
+        foreach ($modulePaths as $moduleName => $moduleDir) {
             if ($requiredModuleName == '*_*' || $moduleName == $requiredModuleName) {
                 $moduleFiles = [];
                 $this->_accumulateFilesByPatterns(
@@ -715,7 +716,8 @@ class Files
     private function getEtcAreaPaths($namespace, $module, $area)
     {
         $etcAreaPaths = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
+        $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
+        foreach ($modulePaths as $moduleName => $moduleDir) {
             $keyInfo = explode('_', $moduleName);
             if ($keyInfo[0] == $namespace || $namespace == '*') {
                 if ($keyInfo[1] == $module || $module == '*') {
@@ -742,7 +744,8 @@ class Files
             return self::$_cache[$key];
         }
         $moduleWebPaths = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
+        $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
+        foreach ($modulePaths as $moduleName => $moduleDir) {
             $keyInfo = explode('_', $moduleName);
             if ($keyInfo[0] == $namespace || $namespace == '*') {
                 if ($keyInfo[1] == $module || $module == '*') {
@@ -800,7 +803,8 @@ class Files
             return self::$_cache[$key];
         }
         $moduleTemplatePaths = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
+        $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
+        foreach ($modulePaths as $moduleName => $moduleDir) {
             $keyInfo = explode('_', $moduleName);
             if ($keyInfo[0] == $namespace || $namespace == '*') {
                 if ($keyInfo[1] == $module || $module == '*') {
@@ -838,7 +842,7 @@ class Files
         $result = [];
         $moduleWebPath = [];
         $moduleLocalePath = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $moduleDir) {
             $moduleWebPath[] = $moduleDir . "/view/{$area}/web";
             $moduleLocalePath[] = $moduleDir . "/view/{$area}/web/i18n/{$locale}";
         }
@@ -948,7 +952,8 @@ class Files
      */
     protected function _parseModuleStatic($file)
     {
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $modulePath) {
+        $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
+        foreach ($modulePaths as $moduleName => $modulePath) {
             if (preg_match(
                 '/^' . preg_quote("{$modulePath}/", '/') . 'view\/([a-z]+)\/web\/(.+)$/i',
                 $file,
@@ -970,7 +975,8 @@ class Files
      */
     protected function _parseModuleLocaleStatic($file)
     {
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $modulePath) {
+        $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
+        foreach ($modulePaths as $moduleName => $modulePath) {
             $appCode = preg_quote("{$modulePath}/", '/');
             if (preg_match('/^' . $appCode . 'view\/([a-z]+)\/web\/i18n\/([a-z_]+)\/(.+)$/i', $file, $matches) === 1) {
                 list(, $area, $locale, $filePath) = $matches;
@@ -993,7 +999,7 @@ class Files
             return self::$_cache[$key];
         }
         $viewAreaPaths = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $moduleDir) {
             $viewAreaPaths[] = $moduleDir . "/view/{$area}";
         }
         $themePaths = [];
@@ -1093,7 +1099,8 @@ class Files
      */
     private function accumulateModuleTemplateFiles($withMetaInfo, array &$result)
     {
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
+        $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
+        foreach ($modulePaths as $moduleName => $moduleDir) {
             $files = [];
             $this->_accumulateFilesByPatterns(
                 [$moduleDir . "/view/*/templates"],
@@ -1134,7 +1141,7 @@ class Files
             return self::$_cache[$key];
         }
         $moduleEmailPaths = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $moduleDir) {
             $moduleEmailPaths[] = $moduleDir . "/view/email";
         }
         $files = self::getFiles($moduleEmailPaths, '*.html');
@@ -1158,8 +1165,8 @@ class Files
 
         $paths = array_merge(
             [BP . '/app', BP . '/dev', BP . '/lib', BP . '/pub'],
-            $this->componentRegistrar->getPaths(ComponentRegistrar::LANGUAGE),
-            $this->componentRegistrar->getPaths(ComponentRegistrar::THEME),
+            $this->componentRegistrar->getPaths(ComponentRegistrarInterface::LANGUAGE),
+            $this->componentRegistrar->getPaths(ComponentRegistrarInterface::THEME),
             $this->getPaths()
         );
         $subFiles = self::getFiles($paths, '*');
@@ -1214,7 +1221,7 @@ class Files
     {
         $primaryConfigs = glob(BP . '/app/etc/{di.xml,*/di.xml}', GLOB_BRACE);
         $moduleConfigs = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $moduleDir) {
             $moduleConfigs = array_merge($moduleConfigs, glob($moduleDir . '/etc/{di,*/di}.xml', GLOB_BRACE));
         }
         $configs = array_merge($primaryConfigs, $moduleConfigs);
@@ -1238,10 +1245,10 @@ class Files
     private function getPaths()
     {
         $directories = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $fullModuleDir) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $fullModuleDir) {
             $directories[] = $fullModuleDir;
         }
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::LIBRARY) as $libraryDir) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::LIBRARY) as $libraryDir) {
             $directories[] = $libraryDir;
         }
         return $directories;
@@ -1349,7 +1356,7 @@ class Files
         }
 
         $result = [];
-        foreach (array_keys($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE)) as $moduleName) {
+        foreach (array_keys($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE)) as $moduleName) {
             $namespace = explode('_', $moduleName)[0];
             if (!in_array($namespace, $result) && $namespace !== 'Zend') {
                 $result[] = $namespace;
@@ -1367,7 +1374,7 @@ class Files
      */
     public function getModuleFile($namespace, $module, $file)
     {
-        return $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $namespace . '_' . $module) .
+        return $this->componentRegistrar->getPath(ComponentRegistrarInterface::MODULE, $namespace . '_' . $module) .
         '/' . $file;
     }
 
@@ -1383,7 +1390,7 @@ class Files
         $key = __METHOD__ . "/{$module}";
         if (!isset(self::$_cache[$key])) {
             $files = self::getFiles(
-                [$this->componentRegistrar->getPath(ComponentRegistrar::MODULE, 'Magento_'. $module)],
+                [$this->componentRegistrar->getPath(ComponentRegistrarInterface::MODULE, 'Magento_'. $module)],
                 '*.php'
             );
             self::$_cache[$key] = $files;
@@ -1407,7 +1414,7 @@ class Files
     {
         $key = __METHOD__ . '|' . BP . '|' . serialize(func_get_args());
         if (!isset(self::$_cache[$key])) {
-            $excludes = $componentType == ComponentRegistrar::MODULE ? $this->getModuleTestDirsRegex() : [];
+            $excludes = $componentType == ComponentRegistrarInterface::MODULE ? $this->getModuleTestDirsRegex() : [];
             $files = $this->getFilesSubset(
                 $this->componentRegistrar->getPaths($componentType),
                 'composer.json',
@@ -1487,10 +1494,10 @@ class Files
         $files = [];
         if ($componentType == '*') {
             $componentTypes = [
-                ComponentRegistrar::MODULE,
-                ComponentRegistrar::LIBRARY,
-                ComponentRegistrar::THEME,
-                ComponentRegistrar::LANGUAGE,
+                ComponentRegistrarInterface::MODULE,
+                ComponentRegistrarInterface::LIBRARY,
+                ComponentRegistrarInterface::THEME,
+                ComponentRegistrarInterface::LANGUAGE,
             ];
         } else {
             $componentTypes = [$componentType];
@@ -1519,7 +1526,7 @@ class Files
         $key = __METHOD__ . "/{$moduleName}";
         if (!isset(self::$_cache[$key])) {
             self::$_cache[$key] = file_exists(
-                $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $moduleName)
+                $this->componentRegistrar->getPath(ComponentRegistrarInterface::MODULE, $moduleName)
             );
         }
 

--- a/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
+++ b/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
@@ -12,15 +12,6 @@ namespace Magento\Framework\Component;
  */
 class ComponentRegistrar implements ComponentRegistrarInterface
 {
-    /**#@+
-     * Different types of components
-     */
-    const MODULE = 'module';
-    const LIBRARY = 'library';
-    const THEME = 'theme';
-    const LANGUAGE = 'language';
-    /**#@- */
-
     /**
      * All paths
      *

--- a/lib/internal/Magento/Framework/Component/ComponentRegistrarInterface.php
+++ b/lib/internal/Magento/Framework/Component/ComponentRegistrarInterface.php
@@ -10,6 +10,15 @@ namespace Magento\Framework\Component;
  */
 interface ComponentRegistrarInterface
 {
+    /**#@+
+     * Different types of components
+     */
+    const MODULE = 'module';
+    const LIBRARY = 'library';
+    const THEME = 'theme';
+    const LANGUAGE = 'language';
+    /**#@- */
+    
     /**
      * Get list of registered Magento components
      *

--- a/lib/internal/Magento/Framework/Css/PreProcessor/File/Collector/Library.php
+++ b/lib/internal/Magento/Framework/Css/PreProcessor/File/Collector/Library.php
@@ -6,7 +6,6 @@
 namespace Magento\Framework\Css\PreProcessor\File\Collector;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\ReadInterface;
@@ -84,7 +83,7 @@ class Library implements CollectorInterface
         foreach ($theme->getInheritedThemes() as $currentTheme) {
             $themeFullPath = $currentTheme->getFullPath();
             $path = $this->componentRegistrar->getPath(
-                ComponentRegistrar::THEME,
+                ComponentRegistrarInterface::THEME,
                 $themeFullPath
             );
             if (empty($path)) {

--- a/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/File/Collector/LibraryTest.php
+++ b/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/File/Collector/LibraryTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\Css\Test\Unit\PreProcessor\File\Collector;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use \Magento\Framework\Css\PreProcessor\File\Collector\Library;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem;
@@ -148,7 +148,7 @@ class LibraryTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($readerMock));
         $this->componentRegistrarMock->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $themePath)
+            ->with(ComponentRegistrarInterface::THEME, $themePath)
             ->will($this->returnValue(['/path/to/theme']));
         $readerMock->expects($this->once())
             ->method('search')

--- a/lib/internal/Magento/Framework/Module/Dir.php
+++ b/lib/internal/Magento/Framework/Module/Dir.php
@@ -47,7 +47,7 @@ class Dir
      */
     public function getDir($moduleName, $type = '')
     {
-        $path = $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $moduleName);
+        $path = $this->componentRegistrar->getPath(ComponentRegistrarInterface::MODULE, $moduleName);
 
         if ($type) {
             if (!in_array($type, [

--- a/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
@@ -9,7 +9,6 @@ namespace Magento\Framework\Module\ModuleList;
 use Magento\Framework\Module\Declaration\Converter\Dom;
 use Magento\Framework\Xml\Parser;
 use Magento\Framework\Component\ComponentRegistrarInterface;
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Filesystem\DriverInterface;
 
 /**
@@ -114,7 +113,7 @@ class Loader
      */
     private function getModuleConfigs()
     {
-        $modulePaths = $this->moduleRegistry->getPaths(ComponentRegistrar::MODULE);
+        $modulePaths = $this->moduleRegistry->getPaths(ComponentRegistrarInterface::MODULE);
         foreach ($modulePaths as $modulePath) {
             $filePath = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, "$modulePath/etc/module.xml");
             yield [$filePath, $this->filesystemDriver->fileGetContents($filePath)];

--- a/lib/internal/Magento/Framework/Module/PackageInfo.php
+++ b/lib/internal/Magento/Framework/Module/PackageInfo.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\Module;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 /**
  * Provide information of dependencies and conflicts in composer.json files, mapping of package name to module name,
@@ -49,7 +49,7 @@ class PackageInfo
     private $reader;
 
     /**
-     * @var ComponentRegistrar
+     * @var ComponentRegistrarInterface
      */
     private $componentRegistrar;
 
@@ -62,9 +62,9 @@ class PackageInfo
      * Constructor
      *
      * @param Dir\Reader $reader
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      */
-    public function __construct(Dir\Reader $reader, ComponentRegistrar $componentRegistrar)
+    public function __construct(Dir\Reader $reader, ComponentRegistrarInterface $componentRegistrar)
     {
         $this->reader = $reader;
         $this->componentRegistrar = $componentRegistrar;
@@ -79,7 +79,8 @@ class PackageInfo
     {
         if ($this->packageModuleMap === null) {
             $jsonData = $this->reader->getComposerJsonFiles()->toArray();
-            foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
+            $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
+            foreach ($modulePaths as $moduleName => $moduleDir) {
                 $key = $moduleDir . '/composer.json';
                 if (isset($jsonData[$key]) && $jsonData[$key]) {
                     $packageData = \Zend_Json::decode($jsonData[$key]);

--- a/lib/internal/Magento/Framework/Module/Test/Unit/DirTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/DirTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\Module\Test\Unit;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class DirTest extends \PHPUnit_Framework_TestCase
 {
@@ -37,7 +37,7 @@ class DirTest extends \PHPUnit_Framework_TestCase
     {
         $this->moduleRegistryMock->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::MODULE, 'Test_Module')
+            ->with(ComponentRegistrarInterface::MODULE, 'Test_Module')
             ->will($this->returnValue('/Test/Module'));
 
         $this->assertEquals('/Test/Module', $this->_model->getDir('Test_Module'));
@@ -47,7 +47,7 @@ class DirTest extends \PHPUnit_Framework_TestCase
     {
         $this->moduleRegistryMock->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::MODULE, 'Test_Module')
+            ->with(ComponentRegistrarInterface::MODULE, 'Test_Module')
             ->will($this->returnValue('/Test/Module'));
 
         $this->assertEquals('/Test/Module/etc', $this->_model->getDir('Test_Module', 'etc'));
@@ -61,7 +61,7 @@ class DirTest extends \PHPUnit_Framework_TestCase
     {
         $this->moduleRegistryMock->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::MODULE, 'Test_Module')
+            ->with(ComponentRegistrarInterface::MODULE, 'Test_Module')
             ->will($this->returnValue('/Test/Module'));
 
         $this->_model->getDir('Test_Module', 'unknown');

--- a/lib/internal/Magento/Framework/Module/Test/Unit/PackageInfoTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/PackageInfoTest.php
@@ -5,12 +5,13 @@
  */
 namespace Magento\Framework\Module\Test\Unit;
 
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use \Magento\Framework\Module\PackageInfo;
 
 class PackageInfoTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Magento\Framework\Component\ComponentRegistrar|\PHPUnit_Framework_MockObject_MockObject
+     * @var ComponentRegistrarInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $componentRegistrar;
 
@@ -26,7 +27,7 @@ class PackageInfoTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->componentRegistrar = $this->getMock('Magento\Framework\Component\ComponentRegistrar', [], [], '', false);
+        $this->componentRegistrar = $this->getMock(ComponentRegistrarInterface::class, [], [], '', false);
         $this->reader = $this->getMock('Magento\Framework\Module\Dir\Reader', [], [], '', false);
         $this->componentRegistrar->expects($this->once())
             ->method('getPaths')

--- a/lib/internal/Magento/Framework/Setup/SampleData/FixtureManager.php
+++ b/lib/internal/Magento/Framework/Setup/SampleData/FixtureManager.php
@@ -5,14 +5,14 @@
  */
 namespace Magento\Framework\Setup\SampleData;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\ReadInterface;
 
 class FixtureManager
 {
     /**
-     * @var ComponentRegistrar
+     * @var ComponentRegistrarInterface
      */
     private $componentRegistrar;
 
@@ -29,11 +29,13 @@ class FixtureManager
     protected $_string;
 
     /**
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      * @param \Magento\Framework\Stdlib\StringUtils $string
      */
-    public function __construct(ComponentRegistrar $componentRegistrar, \Magento\Framework\Stdlib\StringUtils $string)
-    {
+    public function __construct(
+        ComponentRegistrarInterface $componentRegistrar,
+        \Magento\Framework\Stdlib\StringUtils $string
+    ) {
         $this->componentRegistrar = $componentRegistrar;
         $this->_string = $string;
     }
@@ -48,7 +50,7 @@ class FixtureManager
         list($moduleName, $filePath) = \Magento\Framework\View\Asset\Repository::extractModule(
             $this->normalizePath($fileId)
         );
-        return $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $moduleName) . '/' . $filePath;
+        return $this->componentRegistrar->getPath(ComponentRegistrarInterface::MODULE, $moduleName) . '/' . $filePath;
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Design/Fallback/Rule/Module.php
+++ b/lib/internal/Magento/Framework/View/Design/Fallback/Rule/Module.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\View\Design\Fallback\Rule;
 
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 
 /**
@@ -56,7 +55,7 @@ class Module implements RuleInterface
             );
         }
         $params['module_dir'] = $this->componentRegistrar->getPath(
-            ComponentRegistrar::MODULE,
+            ComponentRegistrarInterface::MODULE,
             $params['module_name']
         );
         if (empty($params['module_dir'])) {

--- a/lib/internal/Magento/Framework/View/Design/Fallback/Rule/Theme.php
+++ b/lib/internal/Magento/Framework/View/Design/Fallback/Rule/Theme.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\View\Design\Fallback\Rule;
 
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\View\Design\ThemeInterface;
 
@@ -63,7 +62,7 @@ class Theme implements RuleInterface
         while ($theme) {
             if ($theme->getFullPath()) {
                 $params['theme_dir'] = $this->componentRegistrar->getPath(
-                    ComponentRegistrar::THEME,
+                    ComponentRegistrarInterface::THEME,
                     $theme->getFullPath()
                 );
                 $result = array_merge($result, $this->rule->getPatternDirs($params));

--- a/lib/internal/Magento/Framework/View/Design/Theme/Customization/Path.php
+++ b/lib/internal/Magento/Framework/View/Design/Theme/Customization/Path.php
@@ -6,7 +6,6 @@
 namespace Magento\Framework\View\Design\Theme\Customization;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 
 /**
@@ -90,7 +89,7 @@ class Path
     {
         $path = null;
         if ($theme->getFullPath()) {
-            $path = $this->componentRegistrar->getPath(ComponentRegistrar::THEME, $theme->getFullPath());
+            $path = $this->componentRegistrar->getPath(ComponentRegistrarInterface::THEME, $theme->getFullPath());
         }
         return $path;
     }

--- a/lib/internal/Magento/Framework/View/Design/Theme/ThemePackageList.php
+++ b/lib/internal/Magento/Framework/View/Design/Theme/ThemePackageList.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\View\Design\Theme;
 
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 
 /**
@@ -48,7 +47,7 @@ class ThemePackageList
      */
     public function getTheme($key)
     {
-        $themePath = $this->componentRegistrar->getPath(ComponentRegistrar::THEME, $key);
+        $themePath = $this->componentRegistrar->getPath(ComponentRegistrarInterface::THEME, $key);
         if (empty($themePath)) {
             throw new \UnexpectedValueException("No theme registered with name '$key'");
         }
@@ -63,7 +62,7 @@ class ThemePackageList
     public function getThemes()
     {
         $themes = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::THEME) as $key => $path) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::THEME) as $key => $path) {
             $themes[$key] = $this->factory->create($key, $path);
         }
         return $themes;

--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -6,7 +6,7 @@
 namespace Magento\Framework\View\Element\Template\File;
 
 use \Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 /**
  * Class Validator
@@ -73,19 +73,19 @@ class Validator
      *
      * @param \Magento\Framework\Filesystem $filesystem
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfigInterface
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      * @param string|null $scope
      */
     public function __construct(
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfigInterface,
-        ComponentRegistrar $componentRegistrar,
+        ComponentRegistrarInterface $componentRegistrar,
         $scope = null
     ) {
         $this->_filesystem = $filesystem;
         $this->_isAllowSymlinks = $scopeConfigInterface->getValue(self::XML_PATH_TEMPLATE_ALLOW_SYMLINK, $scope);
-        $this->_themesDir = $componentRegistrar->getPaths(ComponentRegistrar::THEME);
-        $this->moduleDirs = $componentRegistrar->getPaths(ComponentRegistrar::MODULE);
+        $this->_themesDir = $componentRegistrar->getPaths(ComponentRegistrarInterface::THEME);
+        $this->moduleDirs = $componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
         $this->_compiledDir = $this->_filesystem->getDirectoryRead(DirectoryList::TEMPLATE_MINIFICATION_DIR)
             ->getAbsolutePath();
     }

--- a/lib/internal/Magento/Framework/View/File/Collector/Base.php
+++ b/lib/internal/Magento/Framework/View/File/Collector/Base.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\File\Collector;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Component\DirSearch;
 use Magento\Framework\View\Design\ThemeInterface;
 use Magento\Framework\View\File\CollectorInterface;
@@ -59,7 +59,7 @@ class Base implements CollectorInterface
     {
         $result = [];
         $sharedFiles = $this->componentDirSearch->collectFilesWithContext(
-            ComponentRegistrar::MODULE,
+            ComponentRegistrarInterface::MODULE,
             "view/base/{$this->subDir}{$filePath}"
         );
         foreach ($sharedFiles as $file) {
@@ -67,7 +67,7 @@ class Base implements CollectorInterface
         }
         $area = $theme->getData('area');
         $themeFiles = $this->componentDirSearch->collectFilesWithContext(
-            ComponentRegistrar::MODULE,
+            ComponentRegistrarInterface::MODULE,
             "view/{$area}/{$this->subDir}{$filePath}"
         );
         foreach ($themeFiles as $file) {

--- a/lib/internal/Magento/Framework/View/File/Collector/Override/Base.php
+++ b/lib/internal/Magento/Framework/View/File/Collector/Override/Base.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\View\File\Collector\Override;
 
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\ReadFactory;
@@ -91,7 +90,7 @@ class Base implements CollectorInterface
         if (empty($themePath)) {
             return [];
         }
-        $themeAbsolutePath = $this->componentRegistrar->getPath(ComponentRegistrar::THEME, $themePath);
+        $themeAbsolutePath = $this->componentRegistrar->getPath(ComponentRegistrarInterface::THEME, $themePath);
         if (!$themeAbsolutePath) {
             return [];
         }

--- a/lib/internal/Magento/Framework/View/File/Collector/Override/ThemeModular.php
+++ b/lib/internal/Magento/Framework/View/File/Collector/Override/ThemeModular.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\View\File\Collector\Override;
 
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem\Directory\ReadFactory;
 use Magento\Framework\View\Design\ThemeInterface;
@@ -92,7 +91,7 @@ class ThemeModular implements CollectorInterface
         if (empty($themePath)) {
             return [];
         }
-        $themeAbsolutePath = $this->componentRegistrar->getPath(ComponentRegistrar::THEME, $themePath);
+        $themeAbsolutePath = $this->componentRegistrar->getPath(ComponentRegistrarInterface::THEME, $themePath);
         if (!$themeAbsolutePath) {
             return [];
         }

--- a/lib/internal/Magento/Framework/View/File/Collector/Theme.php
+++ b/lib/internal/Magento/Framework/View/File/Collector/Theme.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\View\File\Collector;
 
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\ReadFactory;
@@ -52,7 +51,7 @@ class Theme implements CollectorInterface
         if (empty($themePath)) {
             return [];
         }
-        $themeAbsolutePath = $this->componentRegistrar->getPath(ComponentRegistrar::THEME, $themePath);
+        $themeAbsolutePath = $this->componentRegistrar->getPath(ComponentRegistrarInterface::THEME, $themePath);
         if (!$themeAbsolutePath) {
             return [];
         }

--- a/lib/internal/Magento/Framework/View/File/Collector/ThemeModular.php
+++ b/lib/internal/Magento/Framework/View/File/Collector/ThemeModular.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\View\File\Collector;
 
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem\Directory\ReadFactory;
 use Magento\Framework\View\Design\ThemeInterface;
@@ -80,7 +79,7 @@ class ThemeModular implements CollectorInterface
         if (empty($themePath)) {
             return [];
         }
-        $themeAbsolutePath = $this->componentRegistrar->getPath(ComponentRegistrar::THEME, $themePath);
+        $themeAbsolutePath = $this->componentRegistrar->getPath(ComponentRegistrarInterface::THEME, $themePath);
         if (!$themeAbsolutePath) {
             return [];
         }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Design/Fallback/Rule/ModuleTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Design/Fallback/Rule/ModuleTest.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\View\Test\Unit\Design\Fallback\Rule;
 
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use \Magento\Framework\View\Design\Fallback\Rule\Module;
 use Magento\Framework\View\Design\Fallback\Rule\RuleInterface;
@@ -52,7 +51,7 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
         $modulePath = '/module/path';
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::MODULE, $module)
+            ->with(ComponentRegistrarInterface::MODULE, $module)
             ->will($this->returnValue($modulePath));
         $this->rule->expects($this->once())
             ->method('getPatternDirs')

--- a/lib/internal/Magento/Framework/View/Test/Unit/Design/Fallback/Rule/ThemeTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Design/Fallback/Rule/ThemeTest.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Framework\View\Test\Unit\Design\Fallback\Rule;
 
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\View\Design\Fallback\Rule\RuleInterface;
 use \Magento\Framework\View\Design\Fallback\Rule\Theme;
@@ -56,8 +55,8 @@ class ThemeTest extends \PHPUnit_Framework_TestCase
         $this->componentRegistrar->expects($this->any())
             ->method('getPath')
             ->will($this->returnValueMap([
-                [ComponentRegistrar::THEME, 'package/parent_theme', '/path/to/parent/theme'],
-                [ComponentRegistrar::THEME, 'package/current_theme', '/path/to/current/theme'],
+                [ComponentRegistrarInterface::THEME, 'package/parent_theme', '/path/to/parent/theme'],
+                [ComponentRegistrarInterface::THEME, 'package/current_theme', '/path/to/current/theme'],
             ]));
 
         $ruleDirsMap = [

--- a/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/Customization/PathTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/Customization/PathTest.php
@@ -9,7 +9,7 @@
  */
 namespace Magento\Framework\View\Test\Unit\Design\Theme\Customization;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class PathTest extends \PHPUnit_Framework_TestCase
 {
@@ -93,7 +93,7 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $expectedPath = '/fill/theme/path';
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, 'frontend/Magento/theme')
+            ->with(ComponentRegistrarInterface::THEME, 'frontend/Magento/theme')
             ->will($this->returnValue($expectedPath));
         $this->assertEquals($expectedPath, $this->_model->getThemeFilesPath($this->_theme));
     }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/ThemePackageListTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/ThemePackageListTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\Test\Unit\Design\Theme;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\View\Design\Theme\ThemePackageList;
 
 class ThemePackageListTest extends \PHPUnit_Framework_TestCase
@@ -41,7 +41,7 @@ class ThemePackageListTest extends \PHPUnit_Framework_TestCase
         $themeKey = 'theme';
         $this->registrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $themeKey)
+            ->with(ComponentRegistrarInterface::THEME, $themeKey)
             ->willReturn(null);
         $this->factory->expects($this->never())
             ->method('create');
@@ -54,7 +54,7 @@ class ThemePackageListTest extends \PHPUnit_Framework_TestCase
         $themePath = 'path';
         $this->registrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $themeKey)
+            ->with(ComponentRegistrarInterface::THEME, $themeKey)
             ->willReturn($themePath);
         $themePackage = $this->getMock('\Magento\Framework\View\Design\Theme\ThemePackage', [], [], '', false);
         $this->factory->expects($this->once())
@@ -68,7 +68,7 @@ class ThemePackageListTest extends \PHPUnit_Framework_TestCase
     {
         $this->registrar->expects($this->once())
             ->method('getPaths')
-            ->with(ComponentRegistrar::THEME)
+            ->with(ComponentRegistrarInterface::THEME)
             ->willReturn(['theme1' => 'path1', 'theme2' => 'path2']);
         $themePackage = $this->getMock('\Magento\Framework\View\Design\Theme\ThemePackage', [], [], '', false);
         $this->factory->expects($this->exactly(2))

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/Template/File/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/Template/File/ValidatorTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Framework\View\Test\Unit\Element\Template\File;
 
 use \Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use \Magento\Framework\Filesystem\DriverPool;
 
 /**
@@ -51,7 +51,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     private $compiledDirectoryMock;
 
     /**
-     * @var ComponentRegistrar|\PHPUnit_Framework_MockObject_MockObject
+     * @var ComponentRegistrarInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $componentRegistrar;
 
@@ -80,14 +80,14 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('getAbsolutePath')
             ->will($this->returnValue('/magento/var/compiled'));
 
-        $this->componentRegistrar = $this->getMock('Magento\Framework\Component\ComponentRegistrar', [], [], '', false);
+        $this->componentRegistrar = $this->getMock(ComponentRegistrarInterface::class, [], [], '', false);
         $this->componentRegistrar->expects($this->any())
             ->method('getPaths')
             ->will(
                 $this->returnValueMap(
                     [
-                        [ComponentRegistrar::MODULE, ['/magento/app/code/Some/Module']],
-                        [ComponentRegistrar::THEME, ['/magento/themes/default']]
+                        [ComponentRegistrarInterface::MODULE, ['/magento/app/code/Some/Module']],
+                        [ComponentRegistrarInterface::THEME, ['/magento/themes/default']]
                     ]
                 )
             );

--- a/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/BaseTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/BaseTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\Test\Unit\File\Collector;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\View\File;
 
 class BaseTest extends \PHPUnit_Framework_TestCase
@@ -68,8 +68,8 @@ class BaseTest extends \PHPUnit_Framework_TestCase
             ->method('collectFilesWithContext')
             ->willReturnMap(
                 [
-                    [ComponentRegistrar::MODULE, 'view/base/layout/*.xml', $files['shared']],
-                    [ComponentRegistrar::MODULE, 'view/frontend/layout/*.xml', $files['theme']]
+                    [ComponentRegistrarInterface::MODULE, 'view/base/layout/*.xml', $files['shared']],
+                    [ComponentRegistrarInterface::MODULE, 'view/frontend/layout/*.xml', $files['theme']]
                 ]
             );
         $this->fileFactoryMock->expects($this->atLeastOnce())

--- a/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/Override/BaseTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/Override/BaseTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\Test\Unit\File\Collector\Override;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\View\File\Collector\Override\Base;
 use Magento\Framework\Filesystem\Directory\Read;
 use Magento\Framework\View\File\Factory;
@@ -104,7 +104,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
 
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $themePath)
+            ->with(ComponentRegistrarInterface::THEME, $themePath)
             ->will($this->returnValue('/full/theme/path'));
         $this->pathPatternHelperMock->expects($this->any())
             ->method('translatePatternFromGlob')

--- a/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/Override/ThemeModularTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/Override/ThemeModularTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\Test\Unit\File\Collector\Override;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 class ThemeModularTest extends \PHPUnit_Framework_TestCase
 {
@@ -117,7 +117,7 @@ class ThemeModularTest extends \PHPUnit_Framework_TestCase
             );
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $themePath)
+            ->with(ComponentRegistrarInterface::THEME, $themePath)
             ->will($this->returnValue('/full/theme/path'));
 
         $this->assertSame([$fileOne, $fileTwo], $this->model->getFiles($theme, $inputPath));
@@ -156,7 +156,7 @@ class ThemeModularTest extends \PHPUnit_Framework_TestCase
             ->willReturn('preset/3.xml');
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $themePath)
+            ->with(ComponentRegistrarInterface::THEME, $themePath)
             ->will($this->returnValue('/full/theme/path'));
 
         $this->assertSame([$fileOne], $this->model->getFiles($theme, $inputPath));
@@ -186,7 +186,7 @@ class ThemeModularTest extends \PHPUnit_Framework_TestCase
             ->willReturn('[^/]*\\.xml');
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $themePath)
+            ->with(ComponentRegistrarInterface::THEME, $themePath)
             ->will($this->returnValue('/full/theme/path'));
 
         $this->model->getFiles($theme, $inputPath);

--- a/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/ThemeModularTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/ThemeModularTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\Test\Unit\File\Collector;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\View\File\Collector\ThemeModular;
 use Magento\Framework\Filesystem\Directory\Read;
 use Magento\Framework\View\File\Factory;
@@ -104,7 +104,7 @@ class ThemeModularTest extends \PHPUnit_Framework_TestCase
 
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $themePath)
+            ->with(ComponentRegistrarInterface::THEME, $themePath)
             ->will($this->returnValue('/full/theme/path'));
         $this->pathPatternHelperMock->expects($this->any())
             ->method('translatePatternFromGlob')

--- a/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/ThemeTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/ThemeTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\View\Test\Unit\File\Collector;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\View\File\Collector\Theme;
 use Magento\Framework\View\File\Factory;
 
@@ -92,7 +92,7 @@ class ThemeTest extends \PHPUnit_Framework_TestCase
     {
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $this->themePath)
+            ->with(ComponentRegistrarInterface::THEME, $this->themePath)
             ->will($this->returnValue(self::FULL_THEME_PATH));
         $this->themeDirectoryMock->expects($this->any())
             ->method('search')
@@ -110,7 +110,7 @@ class ThemeTest extends \PHPUnit_Framework_TestCase
 
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $this->themePath)
+            ->with(ComponentRegistrarInterface::THEME, $this->themePath)
             ->will($this->returnValue(self::FULL_THEME_PATH));
         $fileMock = $this->getMockBuilder('Magento\Framework\View\File')
             ->disableOriginalConstructor()
@@ -140,7 +140,7 @@ class ThemeTest extends \PHPUnit_Framework_TestCase
 
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
-            ->with(ComponentRegistrar::THEME, $this->themePath)
+            ->with(ComponentRegistrarInterface::THEME, $this->themePath)
             ->will($this->returnValue(self::FULL_THEME_PATH));
         $fileMock = $this->getMockBuilder('Magento\Framework\View\File')
             ->disableOriginalConstructor()

--- a/setup/src/Magento/Setup/Console/Command/DependenciesShowFrameworkCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DependenciesShowFrameworkCommand.php
@@ -5,9 +5,7 @@
  */
 namespace Magento\Setup\Console\Command;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\Utility\Files;
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Setup\Model\ObjectManagerProvider;
 use Magento\Setup\Module\Dependency\ServiceLocator;
@@ -62,7 +60,7 @@ class DependenciesShowFrameworkCommand extends AbstractDependenciesCommand
      */
     protected function buildReport($outputPath)
     {
-        $filePaths = $this->registrar->getPaths(ComponentRegistrar::MODULE);
+        $filePaths = $this->registrar->getPaths(ComponentRegistrarInterface::MODULE);
 
         $filesForParse = Files::init()->getFiles($filePaths, '*');
         $configFiles = Files::init()->getConfigFiles('module.xml', [], false);

--- a/setup/src/Magento/Setup/Console/Command/DependenciesShowModulesCircularCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DependenciesShowModulesCircularCommand.php
@@ -6,7 +6,7 @@
 namespace Magento\Setup\Console\Command;
 
 use Magento\Framework\App\Utility\Files;
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Setup\Module\Dependency\ServiceLocator;
 
 /**
@@ -42,7 +42,7 @@ class DependenciesShowModulesCircularCommand extends AbstractDependenciesCommand
      */
     protected function buildReport($outputPath)
     {
-        $filesForParse = Files::init()->getComposerFiles(ComponentRegistrar::MODULE, false);
+        $filesForParse = Files::init()->getComposerFiles(ComponentRegistrarInterface::MODULE, false);
 
         asort($filesForParse);
         ServiceLocator::getCircularDependenciesReportBuilder()->build(

--- a/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
@@ -6,12 +6,12 @@
 
 namespace Magento\Setup\Console\Command;
 
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\App\DeploymentConfig;
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Setup\Model\ObjectManagerProvider;
 use Magento\Setup\Module\Di\App\Task\Manager;
 use Magento\Setup\Module\Di\App\Task\OperationFactory;
@@ -53,7 +53,7 @@ class DiCompileCommand extends Command
     private $fileDriver;
 
     /**
-     * @var ComponentRegistrar
+     * @var ComponentRegistrarInterface
      */
     private $componentRegistrar;
 
@@ -66,7 +66,7 @@ class DiCompileCommand extends Command
      * @param ObjectManagerProvider $objectManagerProvider
      * @param Filesystem $filesystem
      * @param DriverInterface $fileDriver
-     * @param \Magento\Framework\Component\ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      */
     public function __construct(
         DeploymentConfig $deploymentConfig,
@@ -75,7 +75,7 @@ class DiCompileCommand extends Command
         ObjectManagerProvider $objectManagerProvider,
         Filesystem $filesystem,
         DriverInterface $fileDriver,
-        ComponentRegistrar $componentRegistrar
+        ComponentRegistrarInterface $componentRegistrar
     ) {
         $this->deploymentConfig = $deploymentConfig;
         $this->directoryList    = $directoryList;
@@ -139,8 +139,8 @@ class DiCompileCommand extends Command
             return;
         }
 
-        $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrar::MODULE);
-        $libraryPaths = $this->componentRegistrar->getPaths(ComponentRegistrar::LIBRARY);
+        $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE);
+        $libraryPaths = $this->componentRegistrar->getPaths(ComponentRegistrarInterface::LIBRARY);
         $generationPath = $this->directoryList->getPath(DirectoryList::GENERATION);
 
         $this->objectManager->get('Magento\Framework\App\Cache')->clean();

--- a/setup/src/Magento/Setup/Console/Command/DiCompileMultiTenantCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileMultiTenantCommand.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Setup\Console\Command;
 
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Setup\Model\ObjectManagerProvider;
 use Magento\Framework\App\ObjectManager;
@@ -14,7 +15,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Magento\Framework\Api\Code\Generator\Mapper;
 use Magento\Framework\Api\Code\Generator\SearchResults;
 use Magento\Framework\Autoload\AutoloaderRegistry;
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Interception\Code\Generator\Interceptor;
 use Magento\Framework\ObjectManager\Code\Generator\Converter;
 use Magento\Framework\ObjectManager\Code\Generator\Factory;
@@ -98,7 +98,7 @@ class DiCompileMultiTenantCommand extends AbstractSetupCommand
     private $log;
 
     /**
-     * @var ComponentRegistrar
+     * @var ComponentRegistrarInterface
      */
     private $componentRegistrar;
 
@@ -107,12 +107,12 @@ class DiCompileMultiTenantCommand extends AbstractSetupCommand
      *
      * @param ObjectManagerProvider $objectManagerProvider
      * @param DirectoryList $directoryList
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      */
     public function __construct(
         ObjectManagerProvider $objectManagerProvider,
         DirectoryList $directoryList,
-        ComponentRegistrar $componentRegistrar
+        ComponentRegistrarInterface $componentRegistrar
     ) {
         $this->objectManager = $objectManagerProvider->get();
         $this->directoryList = $directoryList;
@@ -175,7 +175,7 @@ class DiCompileMultiTenantCommand extends AbstractSetupCommand
     private function getModuleExcludePatterns()
     {
         $modulesExcludePatterns = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $modulePath) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $modulePath) {
             $modulesExcludePatterns[] = "#^" . $modulePath . "/Test#";
         }
         return $modulesExcludePatterns;
@@ -189,7 +189,7 @@ class DiCompileMultiTenantCommand extends AbstractSetupCommand
     private function getLibraryExcludePatterns()
     {
         $libraryExcludePatterns = [];
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::LIBRARY) as $libraryPath) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::LIBRARY) as $libraryPath) {
             $libraryExcludePatterns[] = "#^" . $libraryPath . "/([\\w]+/)?Test#";
         }
         return $libraryExcludePatterns;
@@ -254,7 +254,7 @@ class DiCompileMultiTenantCommand extends AbstractSetupCommand
         // 1.1 Code scan
         $filePatterns = ['php' => '/.*\.php$/', 'di' => '/\/etc\/([a-zA-Z_]*\/di|di)\.xml$/'];
         $directoryScanner = new Scanner\DirectoryScanner();
-        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $codeScanDir) {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE) as $codeScanDir) {
             $this->files = array_merge_recursive(
                 $this->files,
                 $directoryScanner->scan($codeScanDir, $filePatterns, $fileExcludePatterns)
@@ -352,8 +352,8 @@ class DiCompileMultiTenantCommand extends AbstractSetupCommand
         ];
         $compilationDirs = array_merge(
             $compilationDirs,
-            $this->componentRegistrar->getPaths(ComponentRegistrar::MODULE),
-            $this->componentRegistrar->getPaths(ComponentRegistrar::LIBRARY)
+            $this->componentRegistrar->getPaths(ComponentRegistrarInterface::MODULE),
+            $this->componentRegistrar->getPaths(ComponentRegistrarInterface::LIBRARY)
         );
         $serializer = $input->getOption(self::INPUT_KEY_SERIALIZER) == Igbinary::NAME ? new Igbinary() : new Standard();
         // 2.1 Code scan

--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -11,7 +11,7 @@ use Magento\Framework\App\DeploymentConfig\Reader;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\MaintenanceMode;
 use Magento\Framework\App\ResourceConnection\Config;
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Exception\FileSystemException;
@@ -214,7 +214,7 @@ class Installer
     /**
      * Component Registrar
      *
-     * @var ComponentRegistrar
+     * @var ComponentRegistrarInterface
      */
     private $componentRegistrar;
 
@@ -240,7 +240,7 @@ class Installer
      * @param SetupFactory $setupFactory
      * @param DataSetupFactory $dataSetupFactory
      * @param \Magento\Framework\Setup\SampleData\State $sampleDataState
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -264,7 +264,7 @@ class Installer
         SetupFactory $setupFactory,
         DataSetupFactory $dataSetupFactory,
         \Magento\Framework\Setup\SampleData\State $sampleDataState,
-        ComponentRegistrar $componentRegistrar
+        ComponentRegistrarInterface $componentRegistrar
     ) {
         $this->filePermissions = $filePermissions;
         $this->deploymentConfigWriter = $deploymentConfigWriter;

--- a/setup/src/Magento/Setup/Module/I18n/Context.php
+++ b/setup/src/Magento/Setup/Module/I18n/Context.php
@@ -5,8 +5,7 @@
  */
 namespace Magento\Setup\Module\I18n;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem;
 
 /**
@@ -31,16 +30,16 @@ class Context
     /**#@-*/
 
     /**
-     * @var ComponentRegistrar
+     * @var ComponentRegistrarInterface
      */
     private $componentRegistrar;
 
     /**
      * Constructor
      *
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      */
-    public function __construct(ComponentRegistrar $componentRegistrar)
+    public function __construct(ComponentRegistrarInterface $componentRegistrar)
     {
         $this->componentRegistrar = $componentRegistrar;
     }
@@ -57,9 +56,9 @@ class Context
      */
     public function getContextByPath($path)
     {
-        if ($value = $this->getComponentName(ComponentRegistrar::MODULE, $path)) {
+        if ($value = $this->getComponentName(ComponentRegistrarInterface::MODULE, $path)) {
             $type = self::CONTEXT_TYPE_MODULE;
-        } elseif ($value = $this->getComponentName(ComponentRegistrar::THEME, $path)) {
+        } elseif ($value = $this->getComponentName(ComponentRegistrarInterface::THEME, $path)) {
             $type = self::CONTEXT_TYPE_THEME;
         } elseif ($value = strstr($path, '/lib/web/')) {
             $type = self::CONTEXT_TYPE_LIB;
@@ -100,11 +99,11 @@ class Context
     {
         switch ($type) {
             case self::CONTEXT_TYPE_MODULE:
-                $absolutePath = $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $value);
+                $absolutePath = $this->componentRegistrar->getPath(ComponentRegistrarInterface::MODULE, $value);
                 $path = str_replace(BP . '/', '', $absolutePath);
                 break;
             case self::CONTEXT_TYPE_THEME:
-                $absolutePath = $this->componentRegistrar->getPath(ComponentRegistrar::THEME, $value);
+                $absolutePath = $this->componentRegistrar->getPath(ComponentRegistrarInterface::THEME, $value);
                 $path = str_replace(BP . '/', '', $absolutePath);
                 break;
             case self::CONTEXT_TYPE_LIB:

--- a/setup/src/Magento/Setup/Module/I18n/Dictionary/Options/Resolver.php
+++ b/setup/src/Magento/Setup/Module/I18n/Dictionary/Options/Resolver.php
@@ -5,8 +5,7 @@
  */
 namespace Magento\Setup\Module\I18n\Dictionary\Options;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 /**
  * Dictionary generator options resolver
@@ -29,19 +28,19 @@ class Resolver implements ResolverInterface
     protected $withContext;
 
     /**
-     * @var ComponentRegistrar
+     * @var ComponentRegistrarInterface
      */
     protected $componentRegistrar;
 
     /**
      * Resolver construct
      *
-     * @param ComponentRegistrar $componentRegistrar
+     * @param ComponentRegistrarInterface $componentRegistrar
      * @param string $directory
      * @param bool $withContext
      */
     public function __construct(
-        ComponentRegistrar $componentRegistrar,
+        ComponentRegistrarInterface $componentRegistrar,
         $directory,
         $withContext
     ) {
@@ -59,8 +58,8 @@ class Resolver implements ResolverInterface
             if ($this->withContext) {
                 $directory = rtrim($this->directory, '\\/');
                 $this->directory = ($directory == '.' || $directory == '..') ? BP : realpath($directory);
-                $moduleDirs = $this->getComponentDirectories(ComponentRegistrar::MODULE);
-                $themeDirs = $this->getComponentDirectories(ComponentRegistrar::THEME);
+                $moduleDirs = $this->getComponentDirectories(ComponentRegistrarInterface::MODULE);
+                $themeDirs = $this->getComponentDirectories(ComponentRegistrarInterface::THEME);
 
                 $this->options = [
                     [

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/DiCompileCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/DiCompileCommandTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Setup\Test\Unit\Console\Command;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Setup\Console\Command\DiCompileCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -35,7 +35,7 @@ class DiCompileCommandTest extends \PHPUnit_Framework_TestCase
     /** @var  \Magento\Framework\App\Filesystem\DirectoryList | \PHPUnit_Framework_MockObject_MockObject*/
     private $directoryList;
 
-    /** @var  \Magento\Framework\Component\ComponentRegistrar|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var  \Magento\Framework\Component\ComponentRegistrarInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $componentRegistrar;
 
     public function setUp()
@@ -70,16 +70,10 @@ class DiCompileCommandTest extends \PHPUnit_Framework_TestCase
         $this->fileDriver = $this->getMockBuilder('Magento\Framework\Filesystem\Driver\File')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->componentRegistrar = $this->getMock(
-            '\Magento\Framework\Component\ComponentRegistrar',
-            [],
-            [],
-            '',
-            false
-        );
+        $this->componentRegistrar = $this->getMock(ComponentRegistrarInterface::class, [], [], '', false);
         $this->componentRegistrar->expects($this->any())->method('getPaths')->willReturnMap([
-            [ComponentRegistrar::MODULE, ['/path/to/module/one', '/path/to/module/two']],
-            [ComponentRegistrar::LIBRARY, ['/path/to/library/one', '/path/to/library/two']],
+            [ComponentRegistrarInterface::MODULE, ['/path/to/module/one', '/path/to/module/two']],
+            [ComponentRegistrarInterface::LIBRARY, ['/path/to/library/one', '/path/to/library/two']],
         ]);
 
         $this->command = new DiCompileCommand(

--- a/setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php
@@ -3,10 +3,10 @@
  * Copyright © 2015 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Setup\Test\Unit\Model;
 
 use Magento\Backend\Setup\ConfigOptionsList;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use \Magento\Setup\Model\Installer;
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -127,7 +127,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase
     private $sampleDataState;
 
     /**
-     * @var \Magento\Framework\Component\ComponentRegistrar|\PHPUnit_Framework_MockObject_MockObject
+     * @var ComponentRegistrarInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $componentRegistrar;
 
@@ -178,7 +178,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase
         $this->setupFactory = $this->getMock('Magento\Setup\Module\SetupFactory', [], [], '', false);
         $this->dataSetupFactory = $this->getMock('Magento\Setup\Module\DataSetupFactory', [], [], '', false);
         $this->sampleDataState = $this->getMock('Magento\Framework\Setup\SampleData\State', [], [], '', false);
-        $this->componentRegistrar = $this->getMock('Magento\Framework\Component\ComponentRegistrar', [], [], '', false);
+        $this->componentRegistrar = $this->getMock(ComponentRegistrarInterface::class, [], [], '', false);
         $this->object = $this->createObject();
     }
 

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/ContextTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/ContextTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Setup\Test\Unit\Module\I18n;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 use \Magento\Setup\Module\I18n\Context;
 
 class ContextTest extends \PHPUnit_Framework_TestCase
@@ -16,13 +16,13 @@ class ContextTest extends \PHPUnit_Framework_TestCase
     protected $context;
 
     /**
-     * @var \Magento\Framework\Component\ComponentRegistrar|\PHPUnit_Framework_MockObject_MockObject
+     * @var ComponentRegistrarInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $componentRegistrar;
 
     protected function setUp()
     {
-        $this->componentRegistrar = $this->getMock('Magento\Framework\Component\ComponentRegistrar', [], [], '', false);
+        $this->componentRegistrar = $this->getMock(ComponentRegistrarInterface::class, [], [], '', false);
     }
 
     /**
@@ -82,8 +82,8 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         $this->componentRegistrar->expects($this->any())
             ->method('getPaths')
             ->willReturnMap([
-                [ComponentRegistrar::MODULE, ['/path/to/module']],
-                [ComponentRegistrar::THEME, ['/path/to/theme']]
+                [ComponentRegistrarInterface::MODULE, ['/path/to/module']],
+                [ComponentRegistrarInterface::THEME, ['/path/to/theme']]
             ]);
         $this->context = new Context($this->componentRegistrar);
         $this->context->getContextByPath('invalid_path');
@@ -103,7 +103,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         }
         $this->componentRegistrar->expects($this->any())
             ->method('getPaths')
-            ->with(ComponentRegistrar::MODULE)
+            ->with(ComponentRegistrarInterface::MODULE)
             ->willReturn($paths);
         $this->componentRegistrar->expects($this->any())->method('getPath')->will($this->returnValueMap($registrar));
         $this->context = new Context($this->componentRegistrar);
@@ -119,7 +119,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
             [
                 'app/code/Magento/Module/i18n/',
                 [Context::CONTEXT_TYPE_MODULE, 'Magento_Module'],
-                [[ComponentRegistrar::MODULE, 'Magento_Module', BP . '/app/code/Magento/Module']]
+                [[ComponentRegistrarInterface::MODULE, 'Magento_Module', BP . '/app/code/Magento/Module']]
             ],
             ['/i18n/', [Context::CONTEXT_TYPE_THEME, 'theme/test.phtml'], []],
             ['lib/web/i18n/', [Context::CONTEXT_TYPE_LIB, 'lib/web/module/test.phtml'], []],
@@ -134,7 +134,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
     {
         $this->componentRegistrar->expects($this->any())
             ->method('getPaths')
-            ->with(ComponentRegistrar::MODULE)
+            ->with(ComponentRegistrarInterface::MODULE)
             ->willReturn(['module' => '/path/to/module']);
         $this->context = new Context($this->componentRegistrar);
         $this->context->buildPathToLocaleDirectoryByContext('invalid_type', 'Magento_Module');

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Options/ResolverTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Options/ResolverTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Setup\Test\Unit\Module\I18n\Dictionary\Options;
 
-use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrarInterface;
 
 /**
  * Class ResolverTest
@@ -21,14 +21,14 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
     public function testGetOptions($directory, $withContext, $result)
     {
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
-        $componentRegistrar = $this->getMock('Magento\Framework\Component\ComponentRegistrar', [], [], '', false);
+        $componentRegistrar = $this->getMock(ComponentRegistrarInterface::class, [], [], '', false);
         $root = __DIR__ . '/_files/source';
         $componentRegistrar->expects($this->any())
             ->method('getPaths')
             ->will(
                 $this->returnValueMap([
-                    [ComponentRegistrar::MODULE, [$root . '/app/code/module1', $root . '/app/code/module2']],
-                    [ComponentRegistrar::THEME, [$root . '/app/design']],
+                    [ComponentRegistrarInterface::MODULE, [$root . '/app/code/module1', $root . '/app/code/module2']],
+                    [ComponentRegistrarInterface::THEME, [$root . '/app/design']],
                 ])
             );
         $directoryList = $this->getMock('Magento\Framework\App\Filesystem\DirectoryList', [], [], '', false);
@@ -119,7 +119,7 @@ class ResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOptionsWrongDir($directory, $withContext, $message)
     {
-        $componentRegistrar = $this->getMock('Magento\Framework\Component\ComponentRegistrar', [], [], '', false);
+        $componentRegistrar = $this->getMock(ComponentRegistrarInterface::class, [], [], '', false);
         $root = __DIR__ . '/_files/source';
         $componentRegistrar->expects($this->any())
             ->method('getPaths')


### PR DESCRIPTION
Summary:
- Move the `ComponentRegistrar` type constants to `ComponentRegistrarInterface`
- Have clients of `ComponentRegistrar` depend on the interface only (where possible)
- This PR introduces **no** breaking changes, it contains just some cleanup refactoring.

Since the methods declared in the interface require the type code as part of the argument list, it makes more sense in my view to have the type code constants be part of the interface declaration,
rather then the concrete implementation.
Because PHP allows using interface constants on classes implementing that interface this is not a breaking change.
For example, any reference to `ComponentRegistrar::MODULE` will continue to resolve cleanly, even though now the constant is declared as `ComponentRegistrarInterface::MODULE`.

With this change in place, many files dependent on both `\Magento\Framework\Component\ComponentRegistrar` and `\Magento\Framework\Component\ComponentRegistrarInterface` can now only depend on the interface.

Because of this the second part of the PR is simply cleaning up the dependencies where possible.
Any class instantiating the `ComponentRegistrar` directly remains unchanged, but any class requiring
it as a dependency can now only depend on `ComponentRegistrarInterface`.
