### PR TITLE
Add condition to avoid warning on calling file_exists()

### DIFF
--- a/lib/internal/Magento/Framework/Config/Dom.php
+++ b/lib/internal/Magento/Framework/Config/Dom.php
@@ -274,7 +274,8 @@ class Dom
         $schema = self::$urnResolver->getRealPath($schema);
         libxml_use_internal_errors(true);
         try {
-            if (file_exists($schema)) {
+            // 4096 is the maximum length allowed by file_exists for the filename
+            if (strlen($schema) < 4096 && file_exists($schema)) {
                 $result = $dom->schemaValidate($schema);
             } else {
                 $result = $dom->schemaValidateSource($schema);


### PR DESCRIPTION
fixes #2128

The warning was: "Warning: file_exists(): File name is longer than the maximum allowed path length on this platform (4096)…"
The cause was: if we give the schema content instead of the schema filename as the second parameter of validateDomDocument
we get this error if the schema is more longer than 4096 chars.
