### PR TITLE
Add countries to exclude from the required state in config (bis)

### DIFF
--- a/app/code/Magento/Directory/Setup/InstallData.php
+++ b/app/code/Magento/Directory/Setup/InstallData.php
@@ -844,11 +844,19 @@ class InstallData implements InstallDataInterface
         );
 
         /**
+         * @var $countriesToExclude array
+         */
+        $countriesToExclude = ['FR', 'DE'];
+
+        /**
          * @var $countries array
          */
         $countries = [];
         foreach ($this->directoryData->getCountryCollection() as $country) {
-            if ($country->getRegionCollection()->getSize() > 0) {
+            if (
+                $country->getRegionCollection()->getSize() > 0
+                && !in_array($country->getId(), $countriesToExclude)
+            ) {
                 $countries[] = $country->getId();
             }
         }


### PR DESCRIPTION
Hi,

I reopen this because it was closed (#1524) for the bad reason and it's not reopened since month ago.

I updated the file according to the comment of @daim2k5.

My last message was:

ping @vancoz @daim2k5

> Hello @jacquesbh and @daim2k5 we are going to close this PR as we have this functionality in store config.

As I said, the problem which is solved by this PR is this:
<img width="811" alt="config_problem" src="https://cloud.githubusercontent.com/assets/858611/10715051/ab5b8852-7b07-11e5-9998-6726ec69708a.png">

We don't want this country codes in this list because the state isn't required for our countries.

So this PR fix this by using a list with excluded countries.

Thanks guys.
