### PR TITLE
Allow setting of the target variable for grid action links

### DIFF
--- a/lib/web/mage/adminhtml/grid.js
+++ b/lib/web/mage/adminhtml/grid.js
@@ -787,6 +787,9 @@ window.varienGridAction = {
             var win = window.open(config.href, 'action_window', 'width=500,height=600,resizable=1,scrollbars=1');
             win.focus();
             select.options[0].selected = true;
+        } else if(config.target) {
+            var win = window.open(config.href, config.target);
+            win.focus();
         } else {
             setLocation(config.href);
         }


### PR DESCRIPTION
This allows developers to set the target attribute in an admin Grid class. If the target is set to `_blank`, the link will be opened in a new window or tab.

```php
protected function _prepareColumns()
{
    $this->addColumn('action',
        array(
            'header'    =>  $this->__('Actions'),
            'type'      => 'action',
            'getter'    => 'getId',
            'actions'   => array(
                array(
                    'caption'   => $this->__('Some Action'),
                    'target'    => '_blank',
                    'url'       => array('base'=> '*/some/link'),
                    'field'     => 'id'
                )
            )
    ));
}
```