### PR TITLE
Magento\Sitemap\Model\Sitemap

### DIFF
--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -62,7 +62,7 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel
     protected $_sitemapIncrement = 0;
 
     /**
-     * Sitemap start and end tags
+     * Sitemap start and end tagsbeforeSave
      *
      * @var array
      */
@@ -275,6 +275,31 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel
     }
 
     /**
+     * Return all sitemap items
+     * @return $this
+     */
+    public function getSitemapItems()
+    {
+        return $this->_sitemapItems;
+    }
+
+    /**
+     * Add new sitemap item
+     * 
+     * @param \Magento\Framework\DataObject $sitemapItem
+     * @return $this
+     */
+    public function addSitemapItems(\Magento\Framework\DataObject $sitemapItem, $ontoEnd = true)
+    {
+        if ($ontoEnd) {
+            array_push($this->_sitemapItems, $sitemapItem);
+        } else {
+            array_unshift($this->_sitemapItems, $sitemapItem);
+        }
+        return $this;
+    }
+
+    /**
      * Check sitemap file location and permissions
      *
      * @return \Magento\Framework\Model\AbstractModel
@@ -337,7 +362,7 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel
     {
         $this->_initSitemapItems();
         /** @var $sitemapItem \Magento\Framework\DataObject */
-        foreach ($this->_sitemapItems as $sitemapItem) {
+        foreach ($this->getSitemapItems() as $sitemapItem) {
             $changefreq = $sitemapItem->getChangefreq();
             $priority = $sitemapItem->getPriority();
             foreach ($sitemapItem->getCollection() as $item) {


### PR DESCRIPTION
Add 2 public methods to Sitemap.php to be able rewrite sitemapItems over di.xml
For example:
I writing blog extension and want to blog posts can be added to sitemap.

So I can create SitemapPlagin with method for exaple:

```
    public function beforeGetSitemapItems(Sitemap $subject)
    {
        if ($this->_sitemapItemsAdded) {
            return;
        }

        $helper = $this->_sitemapData;
        $storeId = $subject->getStoreId();

        $sitemapItem =  new \Magento\Framework\Object(
            [
                'changefreq' => 'weekly',
                'priority' => '0.25',
                'collection' => $this->_postFactory->create()->getCollection($storeId),
            ]
        );

        $subject->addSitemapItems($sitemapItem);

        $this->_sitemapItemsAdded = true;
    }
```
