### PR TITLE
allows specific button translation. removed unused method getTtlValue()

### DIFF
--- a/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
+++ b/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
@@ -30,7 +30,7 @@ class Export extends \Magento\Config\Block\System\Config\Form\Field
         $url = $this->getUrl("*/PageCache/exportVarnishConfig", $params);
         $data = [
             'id' => 'system_full_page_cache_varnish_export_button_version' . $this->getVarnishVersion(),
-            'label' => __('Export VCL for Varnish ') . $this->getVarnishVersion(),
+            'label' => __('Export VCL for Varnish %1', $this->getVarnishVersion()),
             'onclick' => "setLocation('" . $url . "')",
         ];
 
@@ -46,16 +46,5 @@ class Export extends \Magento\Config\Block\System\Config\Form\Field
     public function getVarnishVersion()
     {
         return 0;
-    }
-
-    /**
-     * Return PageCache TTL value from config
-     * to avoid saving empty field
-     *
-     * @return string
-     */
-    public function getTtlValue()
-    {
-        return $this->_scopeConfig->getValue(\Magento\PageCache\Model\Config::XML_PAGECACHE_TTL);
     }
 }


### PR DESCRIPTION
Button label is concatenated with a numeric version number. This does not allow specific button translations/changes for "Varnish 3" or "Varnish 4". Also it is a cleaner approach to have the version number to be part of the translated string.

The getTtlValue() is used nowhere and can be safely removed.