### PR TITLE
Pagecache export button

### DIFF
--- a/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
+++ b/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
@@ -29,7 +29,7 @@ class Export extends \Magento\Config\Block\System\Config\Form\Field
 
         $data = [
             'id' => 'system_full_page_cache_varnish_export_button_version' . $this->getVarnishVersion(),
-            'label' => $this->getLabel(),
+            'label' => $this->_getLabel(),
             'onclick' => "setLocation('" . $this->_getUrl($params) . "')",
         ];
 

--- a/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
+++ b/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
@@ -30,7 +30,7 @@ class Export extends \Magento\Config\Block\System\Config\Form\Field
         $url = $this->getUrl("*/PageCache/exportVarnishConfig", $params);
         $data = [
             'id' => 'system_full_page_cache_varnish_export_button_version' . $this->getVarnishVersion(),
-            'label' => __('Export VCL for Varnish ') . $this->getVarnishVersion(),
+            'label' => __('Export VCL for Varnish %1', $this->getVarnishVersion()),
             'onclick' => "setLocation('" . $url . "')",
         ];
 
@@ -46,16 +46,5 @@ class Export extends \Magento\Config\Block\System\Config\Form\Field
     public function getVarnishVersion()
     {
         return 0;
-    }
-
-    /**
-     * Return PageCache TTL value from config
-     * to avoid saving empty field
-     *
-     * @return string
-     */
-    public function getTtlValue()
-    {
-        return $this->_scopeConfig->getValue(\Magento\PageCache\Model\Config::XML_PAGECACHE_TTL);
     }
 }

--- a/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
+++ b/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
@@ -47,14 +47,22 @@ class Export extends \Magento\Config\Block\System\Config\Form\Field
         return 0;
     }
 
+    /**
+     * @return string
+     */
     protected function _getLabel()
     {
         return __('Export VCL for Varnish ') . $this->getVarnishVersion();
     }
 
-    protected function _getUrl($params)
+    /**
+     * @param array $params
+     *
+     * @return string
+     */
+    protected function _getUrl($params = [])
     {
-        return $this->getUrl("*/PageCache/exportVarnishConfig", $params);
+        return $this->getUrl('*/PageCache/exportVarnishConfig', $params);
     }
 
 }

--- a/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
+++ b/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
@@ -30,7 +30,7 @@ class Export extends \Magento\Config\Block\System\Config\Form\Field
         $url = $this->getUrl("*/PageCache/exportVarnishConfig", $params);
         $data = [
             'id' => 'system_full_page_cache_varnish_export_button_version' . $this->getVarnishVersion(),
-            'label' => __('Export VCL for Varnish %1', $this->getVarnishVersion()),
+            'label' => __('Export VCL for Varnish ') . $this->getVarnishVersion(),
             'onclick' => "setLocation('" . $url . "')",
         ];
 
@@ -46,5 +46,16 @@ class Export extends \Magento\Config\Block\System\Config\Form\Field
     public function getVarnishVersion()
     {
         return 0;
+    }
+
+    /**
+     * Return PageCache TTL value from config
+     * to avoid saving empty field
+     *
+     * @return string
+     */
+    public function getTtlValue()
+    {
+        return $this->_scopeConfig->getValue(\Magento\PageCache\Model\Config::XML_PAGECACHE_TTL);
     }
 }

--- a/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
+++ b/app/code/Magento/PageCache/Block/System/Config/Form/Field/Export.php
@@ -27,11 +27,10 @@ class Export extends \Magento\Config\Block\System\Config\Form\Field
             'varnish' => $this->getVarnishVersion()
         ];
 
-        $url = $this->getUrl("*/PageCache/exportVarnishConfig", $params);
         $data = [
             'id' => 'system_full_page_cache_varnish_export_button_version' . $this->getVarnishVersion(),
-            'label' => __('Export VCL for Varnish ') . $this->getVarnishVersion(),
-            'onclick' => "setLocation('" . $url . "')",
+            'label' => $this->getLabel(),
+            'onclick' => "setLocation('" . $this->_getUrl($params) . "')",
         ];
 
         $html = $buttonBlock->setData($data)->toHtml();
@@ -48,14 +47,14 @@ class Export extends \Magento\Config\Block\System\Config\Form\Field
         return 0;
     }
 
-    /**
-     * Return PageCache TTL value from config
-     * to avoid saving empty field
-     *
-     * @return string
-     */
-    public function getTtlValue()
+    protected function _getLabel()
     {
-        return $this->_scopeConfig->getValue(\Magento\PageCache\Model\Config::XML_PAGECACHE_TTL);
+        return __('Export VCL for Varnish ') . $this->getVarnishVersion();
     }
+
+    protected function _getUrl($params)
+    {
+        return $this->getUrl("*/PageCache/exportVarnishConfig", $params);
+    }
+
 }


### PR DESCRIPTION
Allows better reusability of the button class by separating button label and URL generation.
Also removes unused method getTtlValue().
