### PR TITLE
Add reason for not logging exception; correct invalid user error message

### DIFF
--- a/app/code/Magento/Customer/Controller/Account/LoginPost.php
+++ b/app/code/Magento/Customer/Controller/Account/LoginPost.php
@@ -97,7 +97,9 @@ class LoginPost extends Action implements AccountInterface
                     $this->session->setUsername($login['username']);
                 } catch (\Exception $e) {
                     // PA DSS violation: throwing or logging an exception here can disclose customer password
-                    $this->messageManager->addError(__('Unspecified error occured. Please contact us for assistence!'));
+                    $this->messageManager->addError(
+                        __('An unspecified error occurred. Please contact us for assistance.')
+                    );
                 }
             } else {
                 $this->messageManager->addError(__('A login and a password are required.'));

--- a/app/code/Magento/Customer/Controller/Account/LoginPost.php
+++ b/app/code/Magento/Customer/Controller/Account/LoginPost.php
@@ -86,8 +86,7 @@ class LoginPost extends Action implements AccountInterface
                 } catch (EmailNotConfirmedException $e) {
                     $value = $this->customerUrl->getEmailConfirmationUrl($login['username']);
                     $message = __(
-                        'This account is not confirmed.' .
-                        ' <a href="%1">Click here</a> to resend confirmation email.',
+                        'This account is not confirmed. <a href="%1">Click here</a> to resend confirmation email.',
                         $value
                     );
                     $this->messageManager->addError($message);
@@ -97,7 +96,8 @@ class LoginPost extends Action implements AccountInterface
                     $this->messageManager->addError($message);
                     $this->session->setUsername($login['username']);
                 } catch (\Exception $e) {
-                    $this->messageManager->addError(__('Invalid login or password.'));
+                    // PA DSS violation: throwing or logging an exception here can disclose customer password
+                    $this->messageManager->addError(__('Unspecified error occured. Please contact us for assistence!'));
                 }
             } else {
                 $this->messageManager->addError(__('A login and a password are required.'));

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/LoginPostTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/LoginPostTest.php
@@ -423,7 +423,7 @@ class LoginPostTest extends \PHPUnit_Framework_TestCase
             case '\Exception':
                 $this->messageManager->expects($this->once())
                     ->method('addError')
-                    ->with(__('Invalid login or password.'))
+                    ->with(__('An unspecified error occurred. Please contact us for assistance.'))
                     ->willReturnSelf();
                 break;
         }


### PR DESCRIPTION
This comment warning of a PA-DSS violation was found in the M1 core. This closes #2066; further details on related issue page.
