### PR TITLE
Updated links to point to http://devdocs.magento.com/guides/v2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The Magento 2 development team will review all issues and contributions submitte
 
 ## Contribution requirements
 
-1. Contributions must adhere to [Magento coding standards](http://devdocs.magento.com/guides/v1.0/coding-standards/bk-coding-standards.html).
+1. Contributions must adhere to [Magento coding standards](http://devdocs.magento.com/guides/v2.0/coding-standards/bk-coding-standards.html).
 2. Pull requests (PRs) must be accompanied by a meaningful description of their purpose. Comprehensive descriptions increase the chances of a pull request to be merged quickly and without additional clarification requests.
 3. Commits must be accompanied by meaningful commit messages.
 4. PRs which include bug fixing, must be accompanied with step-by-step description of how to reproduce the bug.
@@ -27,5 +27,5 @@ If you are a new GitHub user, we recommend that you create your own [free github
 1. Search current [listed issues](https://github.com/magento/magento2/issues) (open or closed) for similar proposals of intended contribution before starting work on a new contribution.
 2. Review the [Contributor License Agreement](https://github.com/magento/magento2/blob/master/CONTRIBUTOR_LICENSE_AGREEMENT.html) if this is your first time contributing.
 3. Create and test your work.
-4. Fork the Magento 2 repository according to [Fork a repository instructions](http://devdocs.magento.com/guides/v1.0/contributor-guide/CONTRIBUTING.html#fork) and when you are ready to send us a pull request – follow [Create a pull request instructions](http://devdocs.magento.com/guides/v1.0/contributor-guide/CONTRIBUTING.html#pull_request).
+4. Fork the Magento 2 repository according to [Fork a repository instructions](http://devdocs.magento.com/guides/v2.0/contributor-guide/contributing.html#fork) and when you are ready to send us a pull request – follow [Create a pull request instructions](http://devdocs.magento.com/guides/v2.0/contributor-guide/contributing.html#pull_request).
 5. Once your contribution is received, Magento 2 development team will review the contribution and collaborate with you as needed to improve the quality of the contribution.


### PR DESCRIPTION
Updated links to point to http://devdocs.magento.com/guides/v2.0 instead of http://devdocs.magento.com/guides/v1.0

Some links were just properly redirected to the new version (coding standards), but most of them would just not work and point to 404 github page (see pull-request and fork pages)
