### PR TITLE
Deny all php except whitelisted files

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -83,6 +83,12 @@ location /static/ {
     if ($MAGE_MODE = "production") {
         expires max;
     }
+    
+    # Remove signature of the static files that is used to overcome the browser cache
+    location ~ ^/static/version {
+        rewrite ^/static/(version\d*/)?(.*)$ /static/$2 last;
+    }
+
     location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2)$ {
         add_header Cache-Control "public";
         add_header X-Frame-Options "SAMEORIGIN";

--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -141,10 +141,6 @@ location /media/import/ {
     deny all;
 }
 
-location ~ cron\.php {
-    deny all;
-}
-
 location ~ (index|get|static|report|404|503)\.php$ {
     try_files $uri =404;
     fastcgi_pass   fastcgi_backend;
@@ -158,4 +154,8 @@ location ~ (index|get|static|report|404|503)\.php$ {
     fastcgi_index  index.php;
     fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
     include        fastcgi_params;
+}
+
+location ~ \.php$ {
+    deny all;
 }


### PR DESCRIPTION
resolves issue with php files being downloaded as plain text. https://github.com/magento/magento2/issues/2317
