### PR TITLE
add nginx rewrite so signed urls work with nginx

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -83,6 +83,12 @@ location /static/ {
     if ($MAGE_MODE = "production") {
         expires max;
     }
+    
+    # Remove signature of the static files that is used to overcome the browser cache
+    location ~ ^/static/version {
+        rewrite ^/static/(version\d*/)?(.*)$ /static/$2 last;
+    }
+    
     location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2)$ {
         add_header Cache-Control "public";
         add_header X-Frame-Options "SAMEORIGIN";


### PR DESCRIPTION
When turning on signed urls all assets were returning 404s with the nginx sample file. This was because static.php returns 404 when in production mode so we can't fall back to that, and there is nothing set up in the default nginx config to reroute these urls. 

This rewrite redirects all urls like /static/versionxxxx/ to the /static directory. I believe that this is what the /static/.htaccess file already does for apache.
