### PR TITLE
bug: variable @modal-slide-header__padding-vertical is undefined

### DIFF
--- a/app/design/frontend/Magento/luma/web/css/source/_theme.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_theme.less
@@ -19,6 +19,8 @@
 @icons__font-path: '@{baseDir}fonts/Luma-Icons';
 @icons__font-name: 'luma-icons';
 
+@import 'components/_modals.less';
+
 //  Color nesting
 @panel__background-color: @color-gray-light0;
 @border-color__base: @color-gray80;


### PR DESCRIPTION
please reference to the issue
https://github.com/magento/magento2/issues/2286
this patch fix the error message "variable @modal-slide-header__padding-vertical is undefined" when use "bin/magento setup:static-content:deploy'
