### PR TITLE
Fix issue #2337 - Fix saving existing customer group

### DIFF
--- a/app/code/Magento/Customer/Controller/Adminhtml/Group/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Group/Save.php
@@ -86,7 +86,9 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Group
                 if (empty($customerGroupCode)) {
                     $customerGroupCode = null;
                 }
-                $customerGroup->setCode($customerGroupCode);
+                if (!is_null($customerGroupCode)) {
+                    $customerGroup->setCode($customerGroupCode);
+                }
                 $customerGroup->setTaxClassId($taxClass);
 
                 $this->groupRepository->save($customerGroup);


### PR DESCRIPTION
Fixes issue #2337 

Steps to reproduce bug:
1) In admin, browse to Stores -> Customer Groups.
2) Select an existing group.
3) Save
The result will be a "code is a required field" error.  The customer group is not saved.

This modification avoids explicitly setting a new customer group code on the loaded customer object if no customer group code was passed in POST data.
