### PR TITLE
Fix issue #2341 - Fix saving "NOT LOGGED IN" customer group

### DIFF
--- a/app/code/Magento/Customer/Model/ResourceModel/GroupRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/GroupRepository.php
@@ -109,7 +109,7 @@ class GroupRepository implements \Magento\Customer\Api\GroupRepositoryInterface
 
         /** @var \Magento\Customer\Model\Group $groupModel */
         $groupModel = null;
-        if ($group->getId()) {
+        if ($group->getId() || (string) $group->getId() === '0') {
             $this->_verifyTaxClassModel($group->getTaxClassId(), $group);
             $groupModel = $this->groupRegistry->retrieve($group->getId());
             $groupDataAttributes = $this->dataObjectProcessor->buildOutputDataArray(

--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php
@@ -594,7 +594,7 @@ abstract class AbstractDb extends AbstractResource
                     }
                 }
 
-                if ($object->getId() || $object->getId() === '0') {
+                if ($object->getId() || (string) $object->getId() === '0') {
                     $select->where($this->getIdFieldName() . '!=?', $object->getId());
                 }
 


### PR DESCRIPTION
Fixes issue #2341 

Steps to reproduce the bug:
1) Issue #2337 must be addressed (addressed in pull request #2344)
2) Browse to Stores -> Customer Groups
3) Select the "NOT LOGGED IN" group
4) Save
The result will be a "code already exists" error.

This issue occurs because the ID of this group is 0, which fails certain checks for an existing ID.  The fix is making these checks more flexible.
