### PR TITLE
Fix Web API error masking in production mode

### DIFF
--- a/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php
@@ -189,14 +189,10 @@ class ErrorProcessor
      */
     protected function _critical(\Exception $exception)
     {
-        $exceptionClass = get_class($exception);
         $reportId = uniqid("webapi-");
-        $exceptionForLog = new $exceptionClass(
-            /** Trace is added separately by critical. */
-            "Report ID: {$reportId}; Message: {$exception->getMessage()}",
-            $exception->getCode()
-        );
-        $this->_logger->critical($exceptionForLog);
+
+        $this->_logger->critical(new WebapiException\WebapiExceptionReport($reportId, $exception));
+
         return $reportId;
     }
 

--- a/lib/internal/Magento/Framework/Webapi/Exception/WebapiExceptionReport.php
+++ b/lib/internal/Magento/Framework/Webapi/Exception/WebapiExceptionReport.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Magento\Framework\Webapi\Exception;
+
+class WebapiExceptionReport extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $reportId;
+
+    /**
+     * @param string     $reportId
+     * @param \Exception $exception
+     */
+    public function __construct($reportId, \Exception $exception)
+    {
+        $this->reportId = $reportId;
+
+        parent::__construct(
+            "Report ID: {$reportId}; Message: {$exception->getMessage()}",
+            $exception->getCode(),
+            $exception
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getReportId()
+    {
+        return $this->reportId;
+    }
+}

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/ErrorProcessorTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/ErrorProcessorTest.php
@@ -226,6 +226,22 @@ class ErrorProcessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test logged exception is the same as the thrown one in production mode
+     */
+    public function testCriticalExceptionStackTrace()
+    {
+        $thrownException = new \Exception('', 0);
+
+        $this->_loggerMock->expects($this->once())
+            ->method('critical')
+            ->will($this->returnCallback(function(\Exception $loggedException) use($thrownException) {
+                $this->assertSame($thrownException, $loggedException->getPrevious());
+            }));
+
+        $this->_errorProcessor->maskException($thrownException);
+    }
+
+    /**
      * @return array
      */
     public function dataProviderForSendResponseExceptions()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

In this PR I have changed exception masking for Web API. Current implementation hide Stack trace and may cause fatal errors for custom exception types because it tries to reinstantiate exception with different messages. In my proposed implementation I'm wrapping original exception into `WebapiExceptionReport` which carry `reportId` in the property and original exception as `previous` exception.
### Ways to reproduce:
#### A. Losing stack trace
1. Make sure developer mode disabled
2. Make an API query where a critical exception occurs. You may want to change API implementation in order to force an exception.

**Expected result**
I can see WebAPI report ID in the API response and exception stack trace in the log file.

**Actual result**
I can see WebAPI report ID in the API response but exception stack trace always refer to `crtitical` method call:

```
[2015-11-14 00:14:31] main.CRITICAL: exception 'ReflectionException' with message 'Report ID: webapi-56467ce7f2048; Message: Class string does not exist' in /var/www/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php:194
Stack trace:
#0 /var/www/lib/internal/Magento/Framework/Webapi/ErrorProcessor.php(139): Magento\Framework\Webapi\ErrorProcessor->_critical(Object(ReflectionException))
#1 /var/www/app/code/Magento/Webapi/Controller/Rest.php(163): Magento\Framework\Webapi\ErrorProcessor->maskException(Object(ReflectionException))
#2 /var/www/var/generation/Magento/Webapi/Controller/Rest/Interceptor.php(24): Magento\Webapi\Controller\Rest->dispatch(Object(Magento\Framework\App\Request\Http))
#3 /var/www/lib/internal/Magento/Framework/App/Http.php(115): Magento\Webapi\Controller\Rest\Interceptor->dispatch(Object(Magento\Framework\App\Request\Http))
#4 /var/www/lib/internal/Magento/Framework/App/Bootstrap.php(258): Magento\Framework\App\Http->launch()
#5 /var/www/index.php(45): Magento\Framework\App\Bootstrap->run(Object(Magento\Framework\App\Http))
#6 {main} [] []
```
#### B. Fatal error during exception creation
1. Make sure developer mode is disabled
2. Define a new exception type which has custom constructor, for example:

``` php
class UnexpectedPropertyTypeException extends Exception
{
    public function __construct(array $expectedTypes, $actualType)
    {
        parent::__construct(sprintf("Unexpected property type %s, expected types: %s", $actualType, implode(', ', $expectedTypes)));
    }
}
```
1. Throw this exception somewhere in your API implementation

**Expected result**
We should see exception message in the log

**Actual result**
`Fatal error: Argument 1 passed to ...::__construct() must be of the type array, string given`
