### PR TITLE
Make email subject translatable

### DIFF
--- a/app/code/Magento/Email/Model/Template.php
+++ b/app/code/Magento/Email/Model/Template.php
@@ -244,7 +244,7 @@ class Template extends AbstractTemplate implements \Magento\Framework\Mail\Templ
         $this->applyDesignConfig();
         $storeId = $this->getDesignConfig()->getStore();
         try {
-            $processedResult = $processor->setStoreId($storeId)->filter($this->getTemplateSubject());
+            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject()));
         } catch (\Exception $e) {
             $this->cancelDesignConfig();
             throw new \Magento\Framework\Exception\MailException(__($e->getMessage()), $e);


### PR DESCRIPTION
When the email templates are being processed the template subject is not
translatable because the translation happens within the filters via
'trans'. We must add the translated subject before the processor since
there the variables used in the subject will be replaced and thus no
longer be generic for translation.

Signed-off-by: BlackEagle ike.devolder@gmail.com
