### PR TITLE
Add type declaration to setter methods of generated ExtensionAttribute classes

### DIFF
--- a/app/code/Magento/Vault/Plugin/PaymentVaultAttributesLoad.php
+++ b/app/code/Magento/Vault/Plugin/PaymentVaultAttributesLoad.php
@@ -59,7 +59,9 @@ class PaymentVaultAttributesLoad
         $paymentToken = $paymentExtension->getVaultPaymentToken();
         if ($paymentToken === null) {
             $paymentToken = $this->paymentTokenManagement->getByPaymentId($payment->getEntityId());
-            $paymentExtension->setVaultPaymentToken($paymentToken);
+            if ($paymentToken instanceof \Magento\Vault\Api\Data\PaymentTokenInterface) {
+                $paymentExtension->setVaultPaymentToken($paymentToken);
+            }
             $payment->setExtensionAttributes($paymentExtension);
         }
 

--- a/lib/internal/Magento/Framework/Api/Code/Generator/ExtensionAttributesInterfaceGenerator.php
+++ b/lib/internal/Magento/Framework/Api/Code/Generator/ExtensionAttributesInterfaceGenerator.php
@@ -21,6 +21,7 @@ class ExtensionAttributesInterfaceGenerator extends \Magento\Framework\Api\Code\
      * Initialize dependencies.
      *
      * @param \Magento\Framework\Api\ExtensionAttribute\Config $config
+     * @param \Magento\Framework\Reflection\TypeProcessor $typeProcessor
      * @param string|null $sourceClassName
      * @param string|null $resultClassName
      * @param Io $ioObject
@@ -29,6 +30,7 @@ class ExtensionAttributesInterfaceGenerator extends \Magento\Framework\Api\Code\
      */
     public function __construct(
         \Magento\Framework\Api\ExtensionAttribute\Config $config,
+        \Magento\Framework\Reflection\TypeProcessor $typeProcessor,
         $sourceClassName = null,
         $resultClassName = null,
         Io $ioObject = null,
@@ -40,6 +42,7 @@ class ExtensionAttributesInterfaceGenerator extends \Magento\Framework\Api\Code\
         }
         parent::__construct(
             $config,
+            $typeProcessor,
             $sourceClassName,
             $resultClassName,
             $ioObject,

--- a/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/ExtensionAttributesGeneratorTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/ExtensionAttributesGeneratorTest.php
@@ -16,6 +16,11 @@ class ExtensionAttributesGeneratorTest extends \PHPUnit_Framework_TestCase
     protected $configMock;
 
     /**
+     * @var \Magento\Framework\Reflection\TypeProcessor|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $typeProcessorMock;
+
+    /**
      * @var \Magento\Framework\Api\Code\Generator\ExtensionAttributesGenerator|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $model;
@@ -26,11 +31,17 @@ class ExtensionAttributesGeneratorTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->typeProcessorMock = $this->getMockBuilder('Magento\Framework\Reflection\TypeProcessor')
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->model = $objectManager->getObject(
             'Magento\Framework\Api\Code\Generator\ExtensionAttributesGenerator',
             [
                 'config' => $this->configMock,
+                'typeProcessor' => $this->typeProcessorMock,
                 'sourceClassName' => '\Magento\Catalog\Api\Data\Product',
                 'resultClassName' => '\Magento\Catalog\Api\Data\ProductExtension',
                 'classGenerator' => null
@@ -53,6 +64,11 @@ class ExtensionAttributesGeneratorTest extends \PHPUnit_Framework_TestCase
                         ],
                         'complex_object_attribute' => [
                             Converter::DATA_TYPE => '\Magento\Bundle\Api\Data\OptionInterface[]',
+                            Converter::RESOURCE_PERMISSIONS => [],
+                        ],
+                        // Ensure type declaration is added to argument of setter
+                        'complex_object_attribute_with_type_declaration' => [
+                            Converter::DATA_TYPE => '\Magento\Bundle\Api\Data\BundleOptionInterface',
                             Converter::RESOURCE_PERMISSIONS => [],
                         ],
                     ],

--- a/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/ExtensionAttributesInterfaceGeneratorTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/ExtensionAttributesInterfaceGeneratorTest.php
@@ -29,6 +29,11 @@ class ExtensionAttributesInterfaceGeneratorTest extends \PHPUnit_Framework_TestC
                             Converter::DATA_TYPE => '\Magento\Bundle\Api\Data\OptionInterface[]',
                             Converter::RESOURCE_PERMISSIONS => [],
                         ],
+                        // Ensure type declaration is added to argument of setter
+                        'complex_object_attribute_with_type_declaration' => [
+                            Converter::DATA_TYPE => '\Magento\Bundle\Api\Data\BundleOptionInterface',
+                            Converter::RESOURCE_PERMISSIONS => [],
+                        ],
                     ],
                     'Magento\Catalog\Api\Data\Product' => [
                         'should_not_include' => [
@@ -38,12 +43,17 @@ class ExtensionAttributesInterfaceGeneratorTest extends \PHPUnit_Framework_TestC
                     ],
                 ]
             );
+        $typeProcessorMock = $this->getMockBuilder('Magento\Framework\Reflection\TypeProcessor')
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
 
         /** @var \Magento\Framework\Api\Code\Generator\ExtensionAttributesInterfaceGenerator $model */
         $model = $objectManager->getObject(
             'Magento\Framework\Api\Code\Generator\ExtensionAttributesInterfaceGenerator',
             [
                 'config' => $configMock,
+                'typeProcessor' => $typeProcessorMock,
                 'sourceClassName' => '\Magento\Catalog\Api\Data\Product',
                 'resultClassName' => '\Magento\Catalog\Api\Data\ProductExtensionInterface',
                 'classGenerator' => null

--- a/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/_files/SampleExtension.txt
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/_files/SampleExtension.txt
@@ -40,4 +40,23 @@ class ProductExtension extends \Magento\Framework\Api\AbstractSimpleObject imple
         $this->setData('complex_object_attribute', $complexObjectAttribute);
         return $this;
     }
+
+    /**
+     * @return \Magento\Bundle\Api\Data\BundleOptionInterface|null
+     */
+    public function getComplexObjectAttributeWithTypeDeclaration()
+    {
+        return $this->_get('complex_object_attribute_with_type_declaration');
+    }
+
+    /**
+     * @param \Magento\Bundle\Api\Data\BundleOptionInterface
+     * $complexObjectAttributeWithTypeDeclaration
+     * @return $this
+     */
+    public function setComplexObjectAttributeWithTypeDeclaration(\Magento\Bundle\Api\Data\BundleOptionInterface $complexObjectAttributeWithTypeDeclaration)
+    {
+        $this->setData('complex_object_attribute_with_type_declaration', $complexObjectAttributeWithTypeDeclaration);
+        return $this;
+    }
 }

--- a/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/_files/SampleExtensionInterface.txt
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/_files/SampleExtensionInterface.txt
@@ -26,4 +26,16 @@ interface ProductExtensionInterface extends \Magento\Framework\Api\ExtensionAttr
      * @return $this
      */
     public function setComplexObjectAttribute($complexObjectAttribute);
+
+    /**
+     * @return \Magento\Bundle\Api\Data\BundleOptionInterface|null
+     */
+    public function getComplexObjectAttributeWithTypeDeclaration();
+
+    /**
+     * @param \Magento\Bundle\Api\Data\BundleOptionInterface
+     * $complexObjectAttributeWithTypeDeclaration
+     * @return $this
+     */
+    public function setComplexObjectAttributeWithTypeDeclaration(\Magento\Bundle\Api\Data\BundleOptionInterface $complexObjectAttributeWithTypeDeclaration);
 }

--- a/lib/internal/Magento/Framework/Reflection/Test/Unit/TypeProcessorTest.php
+++ b/lib/internal/Magento/Framework/Reflection/Test/Unit/TypeProcessorTest.php
@@ -115,6 +115,26 @@ class TypeProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->_typeProcessor->isArrayType('string[]'));
     }
 
+    public function testIsValidTypeDeclaration()
+    {
+        $this->assertTrue($this->_typeProcessor->isValidTypeDeclaration('Traversable')); // Interface
+        $this->assertTrue($this->_typeProcessor->isValidTypeDeclaration('stdObj')); // Class
+        $this->assertTrue($this->_typeProcessor->isValidTypeDeclaration('array'));
+        $this->assertTrue($this->_typeProcessor->isValidTypeDeclaration('callable'));
+        $this->assertTrue($this->_typeProcessor->isValidTypeDeclaration('self'));
+        $this->assertTrue($this->_typeProcessor->isValidTypeDeclaration('self'));
+        $this->assertFalse($this->_typeProcessor->isValidTypeDeclaration('string'));
+        $this->assertFalse($this->_typeProcessor->isValidTypeDeclaration('string[]'));
+        $this->assertFalse($this->_typeProcessor->isValidTypeDeclaration('int'));
+        $this->assertFalse($this->_typeProcessor->isValidTypeDeclaration('float'));
+        $this->assertFalse($this->_typeProcessor->isValidTypeDeclaration('double'));
+        $this->assertFalse($this->_typeProcessor->isValidTypeDeclaration('boolean'));
+        $this->assertFalse($this->_typeProcessor->isValidTypeDeclaration('[]'));
+        $this->assertFalse($this->_typeProcessor->isValidTypeDeclaration('mixed[]'));
+        $this->assertFalse($this->_typeProcessor->isValidTypeDeclaration('stdObj[]'));
+        $this->assertFalse($this->_typeProcessor->isValidTypeDeclaration('Traversable[]'));
+    }
+
     public function getArrayItemType()
     {
         $this->assertEquals('string', $this->_typeProcessor->getArrayItemType('str[]'));

--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -420,6 +420,18 @@ class TypeProcessor
     }
 
     /**
+     * Check if given type is valid to use as an argument type declaration
+     *
+     * @see http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration
+     * @param $type
+     * @return bool
+     */
+    public function isValidTypeDeclaration($type)
+    {
+        return !($this->isTypeSimple($type) || $this->isTypeAny($type) || $this->isArrayType($type));
+    }
+
+    /**
      * Get item type of the array.
      *
      * @param string $arrayType

--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -14,6 +14,7 @@ use Zend\Code\Reflection\ParameterReflection;
  * Type processor of config reader properties
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 class TypeProcessor
 {
@@ -423,7 +424,7 @@ class TypeProcessor
      * Check if given type is valid to use as an argument type declaration
      *
      * @see http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration
-     * @param $type
+     * @param string $type
      * @return bool
      */
     public function isValidTypeDeclaration($type)


### PR DESCRIPTION
The code that generates the classes that implement the `\Magento\Framework\Api\ExtensionAttributesInterface` interface were doing so in a way that did not add type declarations to the setter methods. This pull request adds functionality to add type declarations, but _only_ for types that are valid type declarations. It is important to have type declarations added to the setter methods of ExtensionAttribute classes as it ensures that the getter methods will always return objects of the proper interface/class.

Summary of changes:
- Modified `\Magento\Framework\Api\Code\Generator\ExtensionAttributesGenerator::_getClassMethods` method to add type declaration to method, as long as type is a valid (e.g. not a primitive type or an array of classes/interfaces).
- Added isValidTypeDeclaration method to \Magento\Framework\Reflection\TypeProcessor to centralize the logic for determining whether a string is valid as a type declaration. When and if Magento 2 supports PHP 7, the logic of this method should be changed to support primitive types. I referenced the [PHP Type Declaration](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) section when writing the `\Magento\Framework\Reflection\Test\Unit\TypeProcessorTest::testIsValidTypeDeclaration` test. I wrote what I believe to be a very comprehensive set of true and false assertions.

Here is an example of how this auto-generated file changes: `var/generation/Magento/Catalog/Api/Data/ProductAttributeMediaGalleryEntryExtension.php`. 
## Before pull request

``` php
<?php
namespace Magento\Catalog\Api\Data;

/**
 * Extension class for @see
 * \Magento\Catalog\Api\Data\ProductAttributeMediaGalleryEntryInterface
 */
class ProductAttributeMediaGalleryEntryExtension extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\Catalog\Api\Data\ProductAttributeMediaGalleryEntryExtensionInterface
{
    /**
     * @return \Magento\Framework\Api\Data\VideoContentInterface|null
     */
    public function getVideoContent()
    {
        return $this->_get('video_content');
    }

    /**
     * @param \Magento\Framework\Api\Data\VideoContentInterface $videoContent
     * @return $this
     */
    public function setVideoContent($videoContent)
    {
        $this->setData('video_content', $videoContent);
        return $this;
    }
}
```
## After pull request

You'll notice that the `setVideoContent` method has a `\Magento\Framework\Api\Data\VideoContentInterface` type declaration.

``` php
<?php
namespace Magento\Catalog\Api\Data;

/**
 * Extension class for @see
 * \Magento\Catalog\Api\Data\ProductAttributeMediaGalleryEntryInterface
 */
class ProductAttributeMediaGalleryEntryExtension extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\Catalog\Api\Data\ProductAttributeMediaGalleryEntryExtensionInterface
{
    /**
     * @return \Magento\Framework\Api\Data\VideoContentInterface|null
     */
    public function getVideoContent()
    {
        return $this->_get('video_content');
    }

    /**
     * @param \Magento\Framework\Api\Data\VideoContentInterface $videoContent
     * @return $this
     */
    public function setVideoContent(\Magento\Framework\Api\Data\VideoContentInterface $videoContent)
    {
        $this->setData('video_content', $videoContent);
        return $this;
    }
}
```
