### PR TITLE
Cart Empty container tag

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_index.xml
@@ -180,8 +180,9 @@
                     </block>
                 </container>
                 <container name="checkout.cart.noitems" as="no-items">
-                    <block class="Magento\Checkout\Block\Cart" name="checkout.cart.empty" before="-" template="cart/noItems.phtml"/>
-                    <container name="checkout.cart.empty.widget" as="checkout_cart_empty_widget" label="Empty Shopping Cart Content Before"/>
+                    <block class="Magento\Checkout\Block\Cart" name="checkout.cart.empty" before="-" template="cart/noItems.phtml">
+                        <container name="checkout.cart.empty.widget" as="checkout_cart_empty_widget" label="Empty Shopping Cart Content Before"/>
+                    </block>
                 </container>
             </block>
         </referenceContainer>


### PR DESCRIPTION
The container checkout.cart.empty.widget is not a child of checkout.cart.empty, however it called directly from the template file in the first lines :
<?php echo $block->getChildHtml('checkout_cart_empty_widget'); ?>

in noItems.phtml :

``` php
<?php
/**
 * Copyright © 2015 Magento. All rights reserved.
 * See COPYING.txt for license details.
 */

/**  @var $block \Magento\Checkout\Block\Cart */
?>
<div class="cart-empty">
    <?php echo $block->getChildHtml('checkout_cart_empty_widget'); ?>
```

But you have this in your layout, checkout_cart_index.xml :

``` xml
                    <block class="Magento\Checkout\Block\Cart" name="checkout.cart.empty" before="-" template="cart/noItems.phtml"/>
                    <container name="checkout.cart.empty.widget" as="checkout_cart_empty_widget" label="Empty Shopping Cart Content Before"/>
```

instead of 

``` xml
                    <block class="Magento\Checkout\Block\Cart" name="checkout.cart.empty" before="-" template="cart/noItems.phtml">
                        <container name="checkout.cart.empty.widget" as="checkout_cart_empty_widget" label="Empty Shopping Cart Content Before"/>
                    </block>
```
