### PR TITLE
No translation from "Orders and Returns" footer links

### DIFF
--- a/app/code/Magento/Sales/view/frontend/layout/default.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/default.xml
@@ -16,7 +16,7 @@
         <referenceBlock name="footer_links">
             <block class="Magento\Sales\Block\Guest\Link" name="sales-guest-form-link">
                 <arguments>
-                    <argument name="label" xsi:type="string">Orders and Returns</argument>
+                    <argument name="label" xsi:type="string" translate="true">Orders and Returns</argument>
                     <argument name="path" xsi:type="string">sales/guest/form</argument>
                 </arguments>
             </block>


### PR DESCRIPTION
Orders and Returns footer links, miss param translate="true"

/app/code/Magento/Sales/view/frontend/layout/default.xml
Line 19

``` xml
<argument name="label" xsi:type="string">Orders and Returns</argument>
```

to

``` xml
<argument name="label" xsi:type="string" translate="true">Orders and Returns</argument>
```

Cheers
