### PR TITLE
Add PHP 7 to Travis config and fix PHP 7 test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
 env:
   - TEST_SUITE=unit
   - TEST_SUITE=integration_part_1
@@ -20,6 +21,8 @@ matrix:
       env: TEST_SUITE=static_phpcs
     - php: 5.6
       env: TEST_SUITE=static_annotation
+  allow_failures:
+    - php: 7.0
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq postfix
@@ -37,13 +40,7 @@ before_script:
   # Mock mail
   - sudo service postfix stop
   - smtp-sink -d "%d.%H.%M.%S" localhost:2500 1000 &
-  - echo -e '#!/usr/bin/env bash\nexit 0' | sudo tee /usr/sbin/sendmail
-  - >
-      echo 'sendmail_path = "/usr/sbin/sendmail -t -i "'
-      | sudo tee "/home/travis/.phpenv/versions/`php -i
-      | grep "PHP Version"
-      | head -n 1
-      | grep -o -P '\d+\.\d+\.\d+.*'`/etc/conf.d/sendmail.ini"
+  - echo 'sendmail_path = "/usr/sbin/sendmail -t -i "' > $(php --ini|grep -m 1 "ini files in:"|cut -d ":" -f 2)/sendmail.ini
   # Disable xDebug
   - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
   # Install MySQL 5.6, create DB for integration tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ matrix:
       env: TEST_SUITE=static_phpcs
     - php: 5.6
       env: TEST_SUITE=static_annotation
-  allow_failures:
-    - php: 7.0
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq postfix

--- a/setup/src/Magento/Setup/Test/Unit/Model/PhpReadinessCheckTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/PhpReadinessCheckTest.php
@@ -209,13 +209,15 @@ class PhpReadinessCheckTest extends \PHPUnit_Framework_TestCase
                     'message' => $xdebugMessage,
                     'error' => false,
                 ],
-                'always_populate_raw_post_data' => [
-                    'message' => $rawPostMessage,
-                    'helpUrl' => 'http://php.net/manual/en/ini.core.php#ini.always-populate-settings-data',
-                    'error' => false
-                ]
             ]
         ];
+        if (!$this->isPhp7OrHackLang()) {
+            $expected['data']['always_populate_raw_post_data'] = [
+                'message' => $rawPostMessage,
+                'helpUrl' => 'http://php.net/manual/en/ini.core.php#ini.always-populate-settings-data',
+                'error' => false
+            ];
+        }
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpSettings());
     }
 
@@ -246,14 +248,16 @@ class PhpReadinessCheckTest extends \PHPUnit_Framework_TestCase
                 'xdebug_max_nesting_level' => [
                     'message' => $xdebugMessage,
                     'error' => true,
-                ],
-                'always_populate_raw_post_data' => [
-                    'message' => $rawPostMessage,
-                    'helpUrl' => 'http://php.net/manual/en/ini.core.php#ini.always-populate-settings-data',
-                    'error' => false
                 ]
             ]
         ];
+        if (!$this->isPhp7OrHackLang()) {
+            $expected['data']['always_populate_raw_post_data'] = [
+                'message' => $rawPostMessage,
+                'helpUrl' => 'http://php.net/manual/en/ini.core.php#ini.always-populate-settings-data',
+                'error' => false
+            ];
+        }
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpSettings());
     }
 
@@ -272,14 +276,17 @@ class PhpReadinessCheckTest extends \PHPUnit_Framework_TestCase
         );
         $expected = [
             'responseType' => ResponseTypeInterface::RESPONSE_TYPE_SUCCESS,
-            'data' => [
+            'data' => []
+        ];
+        if (!$this->isPhp7OrHackLang()) {
+            $expected['data'] = [
                 'always_populate_raw_post_data' => [
                     'message' => $rawPostMessage,
                     'helpUrl' => 'http://php.net/manual/en/ini.core.php#ini.always-populate-settings-data',
                     'error' => false
                 ]
-            ]
-        ];
+            ];
+        }
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpSettings());
     }
 
@@ -332,6 +339,14 @@ class PhpReadinessCheckTest extends \PHPUnit_Framework_TestCase
             ]
         ];
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpExtensions());
+    }
+    
+    /**
+     * @return bool
+     */
+    protected function isPhp7OrHackLang()
+    {
+        return version_compare(PHP_VERSION, '7.0.0-beta') >= 0 || defined('HHVM_VERSION');
     }
 }
 

--- a/setup/src/Magento/Setup/Test/Unit/Model/PhpReadinessCheckTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/PhpReadinessCheckTest.php
@@ -193,7 +193,6 @@ class PhpReadinessCheckTest extends \PHPUnit_Framework_TestCase
             50
         );
 
-        $this->setUpNoPrettyVersionParser();
         $rawPostMessage = sprintf(
             'Your PHP Version is %s, but always_populate_raw_post_data = -1.
  	        $HTTP_RAW_POST_DATA is deprecated from PHP 5.6 onwards and will be removed in PHP 7.0.
@@ -212,6 +211,7 @@ class PhpReadinessCheckTest extends \PHPUnit_Framework_TestCase
             ]
         ];
         if (!$this->isPhp7OrHackLang()) {
+            $this->setUpNoPrettyVersionParser();
             $expected['data']['always_populate_raw_post_data'] = [
                 'message' => $rawPostMessage,
                 'helpUrl' => 'http://php.net/manual/en/ini.core.php#ini.always-populate-settings-data',
@@ -233,7 +233,6 @@ class PhpReadinessCheckTest extends \PHPUnit_Framework_TestCase
             200
         );
 
-        $this->setUpNoPrettyVersionParser();
         $rawPostMessage = sprintf(
             'Your PHP Version is %s, but always_populate_raw_post_data = -1.
  	        $HTTP_RAW_POST_DATA is deprecated from PHP 5.6 onwards and will be removed in PHP 7.0.
@@ -252,6 +251,7 @@ class PhpReadinessCheckTest extends \PHPUnit_Framework_TestCase
             ]
         ];
         if (!$this->isPhp7OrHackLang()) {
+            $this->setUpNoPrettyVersionParser();
             $expected['data']['always_populate_raw_post_data'] = [
                 'message' => $rawPostMessage,
                 'helpUrl' => 'http://php.net/manual/en/ini.core.php#ini.always-populate-settings-data',
@@ -265,7 +265,6 @@ class PhpReadinessCheckTest extends \PHPUnit_Framework_TestCase
     {
         $this->phpInfo->expects($this->once())->method('getCurrent')->willReturn([]);
 
-        $this->setUpNoPrettyVersionParser();
         $rawPostMessage = sprintf(
             'Your PHP Version is %s, but always_populate_raw_post_data = -1.
  	        $HTTP_RAW_POST_DATA is deprecated from PHP 5.6 onwards and will be removed in PHP 7.0.
@@ -279,6 +278,7 @@ class PhpReadinessCheckTest extends \PHPUnit_Framework_TestCase
             'data' => []
         ];
         if (!$this->isPhp7OrHackLang()) {
+            $this->setUpNoPrettyVersionParser();
             $expected['data'] = [
                 'always_populate_raw_post_data' => [
                     'message' => $rawPostMessage,


### PR DESCRIPTION
Thanks to @dimitri-koenig for the initial Travis config changes and to @adragus-inviqa for suggesting the solution to the test failures (see #1858)
