### PR TITLE
Fix Newsletter's TransportBuilderTest

### DIFF
--- a/app/code/Magento/Newsletter/Test/Unit/Model/Queue/TransportBuilderTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/Queue/TransportBuilderTest.php
@@ -24,13 +24,15 @@ class TransportBuilderTest extends \Magento\Framework\Mail\Test\Unit\Template\Tr
      * @param int $templateType
      * @param string $messageType
      * @param string $bodyText
+     * @param string $templateNamespace
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function testGetTransport(
         $templateType = TemplateTypesInterface::TYPE_HTML,
         $messageType = MessageInterface::TYPE_HTML,
-        $bodyText = '<h1>Html message</h1>'
+        $bodyText = '<h1>Html message</h1>',
+        $templateNamespace
     ) {
         $filter = $this->getMock('Magento\Email\Model\Template\Filter', [], [], '', false);
         $data = [


### PR DESCRIPTION
Method declaration `\Magento\Newsletter\Test\Unit\Model\Queue\TransportBuilderTest::testGetTransport()` is now compatible with its parent `\Magento\Framework\Mail\Test\Unit\Template\TransportBuilderTest::testGetTransport()`.
