### PR TITLE
Update nginx.conf.sample to remove PHP configuration settings

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -149,8 +149,6 @@ location ~ (index|get|static|report|404|503)\.php$ {
     try_files $uri =404;
     fastcgi_pass   fastcgi_backend;
 
-    fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-    fastcgi_param  PHP_VALUE "memory_limit=768M \n max_execution_time=600";
     fastcgi_read_timeout 600s;
     fastcgi_connect_timeout 600s;
     fastcgi_param  MAGE_MODE $MAGE_MODE;

--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -150,7 +150,7 @@ location ~ (index|get|static|report|404|503)\.php$ {
     fastcgi_pass   fastcgi_backend;
 
     fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-    fastcgi_param  PHP_VALUE "memory_limit=256M \n max_execution_time=600";
+    fastcgi_param  PHP_VALUE "memory_limit=768M \n max_execution_time=600";
     fastcgi_read_timeout 600s;
     fastcgi_connect_timeout 600s;
     fastcgi_param  MAGE_MODE $MAGE_MODE;


### PR DESCRIPTION
Increase PHP memory_limit in nginx.conf.sample to match official documentation.

Update: See conversation below, PR updated to remove PHP configurations entirely
