### PR TITLE
Added  parameter for Magento Logger class

### DIFF
--- a/lib/internal/Magento/Framework/Logger/Handler/Base.php
+++ b/lib/internal/Magento/Framework/Logger/Handler/Base.php
@@ -34,11 +34,15 @@ class Base extends StreamHandler
      */
     public function __construct(
         DriverInterface $filesystem,
-        $filePath = null
+        $filePath = null,
+        $fileName = null
     ) {
         $this->filesystem = $filesystem;
+        if(null === $fileName){
+            $fileName = $this->fileName;
+        }
         parent::__construct(
-            $filePath ? $filePath . $this->fileName : BP . $this->fileName,
+            $filePath ? $filePath . $fileName : BP . $fileName,
             $this->loggerType
         );
         $this->setFormatter(new LineFormatter(null, null, true));


### PR DESCRIPTION
I have added a new optional parameter so it is possible to define virtual types for the Base logger handler.
With this change now it is possible to do something like this:

``` xml
<virtualType name="MyCustomLog" type="Magento\Framework\Logger\Handler\Base">
    <arguments>
        <argument name="fileName" xsi:type="string">/var/log/custom.log</argument>
    </arguments>
</virtualType>
```

I have also tried to modify the System and Debug handler implementation so it can be added in the di.xml. However, there is some information that is logged before di is resolved.

Without this change, adding a custom log implies creating a new handler class just to define the file.

Let me know if something needs further clarification
