### PR TITLE
Adding prompts to admin:user:create cli command

### DIFF
--- a/bin/magento
+++ b/bin/magento
@@ -20,7 +20,7 @@ try {
     $handler = new \Magento\Framework\App\ErrorHandler();
     set_error_handler([$handler, 'handler']);
     $application = new Magento\Framework\Console\Cli('Magento CLI');
-    $application->run();
+    $application->run(new Magento\Framework\Console\Input);
 } catch (\Exception $e) {
     while ($e) {
         echo $e->getMessage();

--- a/lib/internal/Magento/Framework/Console/Input.php
+++ b/lib/internal/Magento/Framework/Console/Input.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Console;
+
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Input extends ArgvInput
+{
+    /**
+     * Prompt for option value and set as default
+     *
+     * @param  DialogHelper    $dialog
+     * @param  OutputInterface $output
+     * @param  string          $name
+     * @param  boolean         $isHidden
+     * @return void
+     */
+    public function promptForOption(DialogHelper $dialog, OutputInterface $output, $name, $isHidden = false)
+    {
+        $method = $isHidden ? 'askHiddenResponse' : 'ask';
+        $this->definition->getOption($name)->setDefault($dialog->$method(
+            $output,
+            '<info>' . ucwords(str_replace('-', ' ', $name)) . '</info>: '
+        ));
+    }
+}

--- a/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php
@@ -45,7 +45,7 @@ class AdminUserCreateCommand extends AbstractSetupCommand
     protected function configure()
     {
         $this->setName('admin:user:create')
-            ->setDescription('Creates an administrator')
+            ->setDescription('Creates an administrator. Values for required options will be prompted, if not specified')
             ->setDefinition($this->getOptionsList());
         parent::configure();
     }
@@ -55,6 +55,7 @@ class AdminUserCreateCommand extends AbstractSetupCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->setMissingValues($input, $output);
         $errors = $this->validate($input);
         if ($errors) {
             $output->writeln('<error>' . implode('</error>' . PHP_EOL .  '<error>', $errors) . '</error>');
@@ -122,5 +123,29 @@ class AdminUserCreateCommand extends AbstractSetupCommand
         }
 
         return $errors;
+    }
+
+    /**
+     * Get admin user data
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return void
+     */
+    protected function setMissingValues(InputInterface &$input, OutputInterface $output)
+    {
+        $dialog = $this->getHelper('dialog');
+        $keys = [
+            AdminAccount::KEY_FIRST_NAME,
+            AdminAccount::KEY_LAST_NAME,
+            AdminAccount::KEY_USER,
+            AdminAccount::KEY_EMAIL,
+            AdminAccount::KEY_PASSWORD,
+        ];
+        foreach ($keys as $key) {
+            if (!$input->getOption($key)) {
+                $input->promptForOption($dialog, $output, $key, $key === AdminAccount::KEY_PASSWORD);
+            }
+        }
     }
 }

--- a/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php
@@ -134,6 +134,9 @@ class AdminUserCreateCommand extends AbstractSetupCommand
      */
     protected function setMissingValues(InputInterface &$input, OutputInterface $output)
     {
+        if (!method_exists($input, 'promptForOption')) {
+            return;
+        }
         $dialog = $this->getHelper('dialog');
         $keys = [
             AdminAccount::KEY_FIRST_NAME,

--- a/setup/src/Magento/Setup/Console/Input/PromptableInputOption.php
+++ b/setup/src/Magento/Setup/Console/Input/PromptableInputOption.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Setup\Console\Input;
+
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class PromptableInputOption extends InputOption
+{
+
+    /**
+     * Ignore the default param since we will prompt for it instead
+     *
+     * @param string
+     * @param string|array
+     * @param int
+     * @param string
+     * @param mixed
+     */
+    public function __construct($name, $shortcut = null, $mode = null, $description = '', $default = null)
+    {
+        parent::__construct($name, $shortcut, $mode, $description, null);
+    }
+
+    /**
+     * Prompt for the value to be used if none given, instead of using a default
+     *
+     * @return mixed
+     */
+    public function getDefault()
+    {
+        $default = parent::getDefault();
+        if ($default !== null) {
+            return $default;
+        }
+        $dialog = new DialogHelper;
+        $this->setDefault($dialog->ask(
+            new ConsoleOutput,
+            '<info>' . ucwords(str_replace('-', ' ', $this->getName())) . '</info>: '
+        ));
+        return parent::getDefault();
+    }
+}


### PR DESCRIPTION
This will prompt for the admin info if not given in the options:

```
$ ./bin/magento admin:user:create
Admin Firstname: Foo
Admin Lastname: Bar
Admin User: foobar
Admin Email: foobar@example.com
Admin Password: 
Created Magento administrator user named foobar
```
