### PR TITLE
Correct typo in admin panel advanced inventory settings

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/tab/inventory.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/tab/inventory.phtml
@@ -154,7 +154,7 @@ toggleValueElements($('inventory_use_config_max_sale_qty'), $('inventory_use_con
         <?php if (!$block->isVirtual()) : ?>
         <div class="field">
             <label class="label" for="inventory_is_decimal_divided">
-                <span><?php /* @escapeNotVerified */ echo __('Allow Multiple Boxes for Shipping.') ?></span>
+                <span><?php /* @escapeNotVerified */ echo __('Allow Multiple Boxes for Shipping') ?></span>
             </label>
             <div class="control">
                 <select id="inventory_is_decimal_divided" name="<?php /* @escapeNotVerified */ echo $block->getFieldSuffix() ?>[stock_data][is_decimal_divided]" <?php /* @escapeNotVerified */ echo $_readonly;?>>

--- a/app/code/Magento/Ui/view/base/web/templates/grid/editing/header-buttons.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/editing/header-buttons.html
@@ -7,7 +7,7 @@
 <div class="data-grid-info-panel" visible="isMultiEditing || (hasActive() && (hasMessages() || hasErrors() ))">
     <div class="messages" visible="hasMessages() || hasErrors()">
         <div class="message message-warning" visible="hasErrors()">
-            <strong>There are <text args="countErrors()"/> meesages requires your attention.</strong>
+            <strong>There are <text args="countErrors()"/> messages requiring your attention.</strong>
             Please make corrections to the errors in the table below and re-submit.
         </div>
         <div class="message" outereach="messages" text="message"

--- a/dev/tests/integration/testsuite/Magento/Setup/Fixtures/_files/small.xml
+++ b/dev/tests/integration/testsuite/Magento/Setup/Fixtures/_files/small.xml
@@ -22,7 +22,7 @@
         <categories_nesting_level>3</categories_nesting_level>
         <!-- Nesting level for categories -->
         <catalog_price_rules>10</catalog_price_rules>
-        <!-- Number os catalog price rules -->
+        <!-- Number of catalog price rules -->
         <cart_price_rules>10</cart_price_rules>
         <!-- Number of cart price rules -->
         <cart_price_rules_floor>2</cart_price_rules_floor>

--- a/setup/performance-toolkit/profiles/ce/extra_large.xml
+++ b/setup/performance-toolkit/profiles/ce/extra_large.xml
@@ -14,7 +14,7 @@
         <configurable_products>50000</configurable_products> <!--Configurable products count (each configurable has 3 simple products as options, that are not displayed individually in catalog) -->
         <categories>3000</categories> <!-- Number of categories to generate -->
         <categories_nesting_level>6</categories_nesting_level> <!-- Nesting level for categories -->
-        <catalog_price_rules>100</catalog_price_rules> <!-- Number os catalog price rules -->
+        <catalog_price_rules>100</catalog_price_rules> <!-- Number of catalog price rules -->
         <cart_price_rules>100</cart_price_rules> <!-- Number of cart price rules -->
         <cart_price_rules_floor>5</cart_price_rules_floor> <!-- The price rule condition: minimum products amount in shopping cart for price rule to be applied -->
         <customers>5000</customers> <!-- Number of customers to generate -->

--- a/setup/performance-toolkit/profiles/ce/large.xml
+++ b/setup/performance-toolkit/profiles/ce/large.xml
@@ -14,7 +14,7 @@
         <configurable_products>25000</configurable_products> <!--Configurable products count (each configurable has 3 simple products as options, that are not displayed individually in catalog) -->
         <categories>1000</categories> <!-- Number of categories to generate -->
         <categories_nesting_level>3</categories_nesting_level> <!-- Nesting level for categories -->
-        <catalog_price_rules>50</catalog_price_rules> <!-- Number os catalog price rules -->
+        <catalog_price_rules>50</catalog_price_rules> <!-- Number of catalog price rules -->
         <cart_price_rules>50</cart_price_rules> <!-- Number of cart price rules -->
         <cart_price_rules_floor>2</cart_price_rules_floor> <!-- The price rule condition: minimum products amount in shopping cart for price rule to be applied -->
         <customers>2000</customers> <!-- Number of customers to generate -->

--- a/setup/performance-toolkit/profiles/ce/medium.xml
+++ b/setup/performance-toolkit/profiles/ce/medium.xml
@@ -14,7 +14,7 @@
         <configurable_products>1000</configurable_products> <!--Configurable products count (each configurable has 3 simple products as options, that are not displayed individually in catalog) -->
         <categories>300</categories> <!-- Number of categories to generate -->
         <categories_nesting_level>3</categories_nesting_level> <!-- Nesting level for categories -->
-        <catalog_price_rules>20</catalog_price_rules> <!-- Number os catalog price rules -->
+        <catalog_price_rules>20</catalog_price_rules> <!-- Number of catalog price rules -->
         <cart_price_rules>20</cart_price_rules> <!-- Number of cart price rules -->
         <cart_price_rules_floor>2</cart_price_rules_floor> <!-- The price rule condition: minimum products amount in shopping cart for price rule to be applied -->
         <customers>200</customers> <!-- Number of customers to generate -->

--- a/setup/performance-toolkit/profiles/ce/small.xml
+++ b/setup/performance-toolkit/profiles/ce/small.xml
@@ -14,7 +14,7 @@
         <configurable_products>50</configurable_products> <!--Configurable products count (each configurable has 3 simple products as options, that are not displayed individually in catalog) -->
         <categories>30</categories> <!-- Number of categories to generate -->
         <categories_nesting_level>3</categories_nesting_level> <!-- Nesting level for categories -->
-        <catalog_price_rules>10</catalog_price_rules> <!-- Number os catalog price rules -->
+        <catalog_price_rules>10</catalog_price_rules> <!-- Number of catalog price rules -->
         <cart_price_rules>10</cart_price_rules> <!-- Number of cart price rules -->
         <cart_price_rules_floor>2</cart_price_rules_floor> <!-- The price rule condition: minimum products amount in shopping cart for price rule to be applied -->
         <customers>20</customers> <!-- Number of customers to generate -->


### PR DESCRIPTION
Advanced inventory settings in admin panel each have a label. Only one of the labels has a period at the end, which is inconsistent with the other titles: "Allow Multiple Boxes for Shipping."

This PR removes the period to make the title consistent with the others.
<img width="847" alt="screen shot 2015-12-14 at 8 22 22 am" src="https://cloud.githubusercontent.com/assets/10635536/11783531/67c31c1a-a23d-11e5-9cc3-25ddf7966de7.png">
