### PR TITLE
Fix for images in system.xml with config_path

### DIFF
--- a/app/code/Magento/Config/Model/Config/Backend/File.php
+++ b/app/code/Magento/Config/Model/Config/Backend/File.php
@@ -88,7 +88,7 @@ class File extends \Magento\Framework\App\Config\Value
             $file['name'] = $this->_requestData->getName($this->getPath());
         } elseif (!empty($value['tmp_name'])) {
             $file['tmp_name'] = $value['tmp_name'];
-            $file['name'] = $value['value'];
+            $file['name'] = $value['name'];
         }
         if (!empty($file)) {
             $uploadDir = $this->_getUploadDir();


### PR DESCRIPTION
In the system.xml if you put a field of type="image" and specify a config_path like this:
                    <field id="popup_image" translate="label" type="image" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                        <label>Popup Image</label>
                        <backend_model>Magento\Config\Model\Config\Backend\Image</backend_model>
                        <upload_dir config="system/filesystem/media" scope_info="1">sales/payment/ebizmarts</upload_dir>
                        <base_url type="media" scope_info="1">sales/payment/ebizmarts</base_url>
                        <config_path>payment/ebizmarts/popup_image</config_path>
                    </field>

that not works.
This patch fix this
