### PR TITLE
Add database port to Magento Setup Model Installer

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -329,6 +329,12 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             throw new \Zend_Db_Adapter_Exception('No host configured to connect');
         }
 
+        if (isset($this->_config['port'])) {
+            throw new \Zend_Db_Adapter_Exception('Port must be configured within host parameter');
+        }
+
+        unset($this->_config['port']);
+
         if (strpos($this->_config['host'], '/') !== false) {
             $this->_config['unix_socket'] = $this->_config['host'];
             unset($this->_config['host']);

--- a/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
@@ -14,6 +14,8 @@ namespace Magento\Framework\DB\Test\Unit\Adapter\Pdo;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Select;
 use Magento\Framework\DB\Select\SelectRenderer;
+use Magento\Framework\Model\ResourceModel\Type\Db\Pdo\Mysql;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 class MysqlTest extends \PHPUnit_Framework_TestCase
 {
@@ -522,5 +524,30 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
             [$longTableName, [], AdapterInterface::INDEX_TYPE_INDEX, 'IDX_'],
             ['short_table_name', ['field1', 'field2'], '', 'SHORT_TABLE_NAME_FIELD1_FIELD2'],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function connectPortThrow()
+    {
+        $arguments = [
+            'config' => ['host' => 'localhost'],
+        ];
+        $subject = (new ObjectManager($this))->getObject(Mysql::class, $arguments);
+        $this->assertInstanceOf(Mysql::class, $subject);
+
+        $arguments = [
+            'config' => ['host' => 'localhost', 'port' => '33390'],
+        ];
+
+        try {
+            (new ObjectManager($this))->getObject(Mysql::class, $arguments);
+            $this->fail('an expected exception was not thrown');
+        } catch (\InvalidArgumentException $e) {
+            $expected = 'MySQL adapter: Port must be configured within host (like \'localhost:33390\') ' .
+                        'parameter, not within port';
+            $this->assertSame($expected, $e->getMessage());
+        }
     }
 }

--- a/lib/internal/Magento/Framework/Model/ResourceModel/Type/Db/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Type/Db/Pdo/Mysql.php
@@ -114,6 +114,13 @@ class Mysql extends \Magento\Framework\Model\ResourceModel\Type\Db implements Co
             }
         }
 
+        if (isset($config['port'])) {
+            throw new \InvalidArgumentException(
+                "MySQL adapter: Port must be configured within host (like '$config[host]:$config[port]') parameter, " .
+                "not within port"
+            );
+        }
+
         $config['active'] = !(
             $config['active'] === 'false'
             || $config['active'] === false

--- a/setup/src/Magento/Setup/Test/Unit/Validator/DbValidatorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Validator/DbValidatorTest.php
@@ -38,7 +38,7 @@ class DbValidatorTest extends \PHPUnit_Framework_TestCase
     public function testCheckDatabaseConnection()
     {
         $this->connection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('fetchOne')
             ->with('SELECT version()')
             ->willReturn('5.6.0-0ubuntu0.12.04.1');
@@ -79,6 +79,7 @@ class DbValidatorTest extends \PHPUnit_Framework_TestCase
                 ]
             );
         $this->assertEquals(true, $this->dbValidator->checkDatabaseConnection('name', 'host', 'user', 'password'));
+        $this->assertEquals(true, $this->dbValidator->checkDatabaseConnection('name', 'host:3339', 'user', 'password'));
     }
 
     /**


### PR DESCRIPTION
Take optional database port setting into account when connecting to the database with the Magento Setup Model.

Previously it was not possible to use magento setup with a non-standard database port.
