### PR TITLE
Allow .xsd files to be located in modules with number(s) in their namespace / packagename

### DIFF
--- a/lib/internal/Magento/Framework/Config/Dom/UrnResolver.php
+++ b/lib/internal/Magento/Framework/Config/Dom/UrnResolver.php
@@ -31,7 +31,7 @@ class UrnResolver
 
         $componentRegistrar = new ComponentRegistrar();
         $matches = [];
-        $modulePattern = '/urn:(?<vendor>([a-zA-Z]*)):module:(?<module>([A-Za-z\_]*)):(?<path>(.+))/';
+        $modulePattern = '/urn:(?<vendor>([a-zA-Z]*)):module:(?<module>([A-Za-z0-9\_]*)):(?<path>(.+))/';
         $frameworkPattern = '/urn:(?<vendor>([a-zA-Z]*)):(?<framework>(framework[A-Za-z\-]*)):(?<path>(.+))/';
         if (preg_match($modulePattern, $schema, $matches)) {
             //urn:magento:module:Magento_Catalog:etc/catalog_attributes.xsd


### PR DESCRIPTION
If a "noNamespaceSchemaLocation" is specified in a configuration file and contains numbers magento throws an error.
There is no documentation stating that numbers are not allowed in namespaces / packagenames and in fact, core comes with magento2-base.

To replicate the error: 
1. create a .xml within a module, 
2. specify a noNamespaceSchemaLocation containing a number
3. run php bin/magento dev:urn-catalog:generate .idea/misc.xml --verbose
