### PR TITLE
Fix typo in SalesRule crontab.xml

### DIFF
--- a/app/code/Magento/SalesRule/etc/crontab.xml
+++ b/app/code/Magento/SalesRule/etc/crontab.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="default">
-        <job name="aggregate_sales_report_coupons_data" instance="Magento\SalesRule\Crone\AggregateSalesReportCouponsData" method="execute">
+        <job name="aggregate_sales_report_coupons_data" instance="Magento\SalesRule\Cron\AggregateSalesReportCouponsData" method="execute">
             <schedule>0 0 * * *</schedule>
         </job>
     </group>


### PR DESCRIPTION
 from Crone to Cron because folder Crone does not exists.

Someone should have tested it ;-)
