### PR TITLE
Fix text overlap in sales PDFs

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
@@ -395,6 +395,8 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
 
         if ($putOrderId) {
             $page->drawText(__('Order # ') . $order->getRealOrderId(), 35, $top -= 30, 'UTF-8');
+        } else {
+            $top -= 15;
         }
         $page->drawText(
             __('Order Date: ') .


### PR DESCRIPTION
In Magento\Sales\Model\Order\Pdf\AbstractPdf::insertOrder, the current vertical coordinate ($top) is advanced 30 units for the order ID, which leaves space above it for the document ID (shipment, invoice, etc) to be printed above it.  For the next text to be printed, order date, the vertical coordinate is advanced another 15 units to put it under order ID.  However, printing of order ID can be disabled in Store Configuration, and if this setting is off, order date is printed on its own, with only the 15 units change in the vertical coordinate.  This results in the order date text overlapping the eventual placement of the document ID.

To fix this, the vertical coordinate is being advanced appropriately if the order ID is not being printed, before printing the order date.
