### PR TITLE
Workaround PHP7 session_regenerate_id error

### DIFF
--- a/lib/internal/Magento/Framework/Session/SaveHandler/Native.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler/Native.php
@@ -10,4 +10,15 @@ namespace Magento\Framework\Session\SaveHandler;
  */
 class Native extends \SessionHandler
 {
+    /**
+     * Workaround for php7 session_regenerate_id error
+     * @see https://bugs.php.net/bug.php?id=71187
+     *
+     * @param string $sessionId
+     * @return string
+     */
+    public function read($sessionId)
+    {
+        return (string)parent::read($sessionId);
+    }
 }


### PR DESCRIPTION
Issue:
When using php7 with memcached all goes well until you goto checkout.
Then the following issue occurs:

Recoverable Error: session_regenerate_id(): Failed to create(read)
session ID: user (path: 127.0.0.1:11211) in
/var/www/website/lib/internal/Magento/Framework/Session/SessionManager.php
on line 473

It is a currently known issue in PHP7:
https://bugs.php.net/bug.php?id=71187

Hereby the workaround to allow people to run magento2 on php7
installations.

Signed-off-by: BlackEagle ike.devolder@gmail.com
