### PR TITLE
Propose to specify the $element parameter class name in the signature

### DIFF
--- a/app/code/Magento/Config/Block/System/Config/Form/Field.php
+++ b/app/code/Magento/Config/Block/System/Config/Form/Field.php
@@ -181,7 +181,7 @@ class Field extends \Magento\Backend\Block\Template implements \Magento\Framewor
      * @param string $html
      * @return string
      */
-    protected function _decorateRowHtml($element, $html)
+    protected function _decorateRowHtml(\Magento\Framework\Data\Form\Element\AbstractElement $element, $html)
     {
         return '<tr id="row_' . $element->getHtmlId() . '">' . $html . '</tr>';
     }


### PR DESCRIPTION
Fix for issue #2819 

Propose to specify the $element parameter class name in the signature of the \Magento\Config\Block\System\Config\Form\Field::_decorateRowHtml() method
