### PR TITLE
Cast composite Ids as string when running price indexer

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Price/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Price/AbstractAction.php
@@ -390,7 +390,7 @@ abstract class AbstractAction
             $pairs = $this->_connection->fetchPairs($select);
             foreach ($pairs as $productId => $productType) {
                 if (!in_array($productId, $changedIds)) {
-                    $changedIds[] = $productId;
+                    $changedIds[] = (string) $productId;
                     $byType[$productType][$productId] = $productId;
                     $compositeIds[$productId] = $productId;
                 }


### PR DESCRIPTION
I discovered this bug while investigating price index performance problems in EE 1.13. The same problem exists in Magento 2 (The following SQL examples are from M2 with sample data).

I found that the handling of composite ids produces flawed SQL. Specifically the mixing of ids as strings and integers. This produces SQL such as this: 

`[snip] AND (index_price.entity_id IN('2044', '2045', 2047));` 
Note the id 2047 is not a quoted string. 

The mysql documentation states that this can lead to inconsistent results. (http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_in)

This mixing of data types can also lead to poor performance. This IN statement causes the mysql optimizer to not use the primary key e.g.

```
explain select * FROM `catalog_product_index_price` AS `index_price`  LEFT JOIN `catalog_product_index_price_tmp` AS `ip_tmp` ON index_price.entity_id = ip_tmp.entity_id AND index_price.website_id = ip_tmp.website_id WHERE (ip_tmp.entity_id IS NULL) AND (index_price.entity_id IN('2044', '2045', 2047));
+----+-------------+-------------+--------+----------------------------------------------------+------+---------+------+------+---------------------+
| id | select_type | table       | type   | possible_keys                                      | key  | key_len | ref  | rows | Extra               |
+----+-------------+-------------+--------+----------------------------------------------------+------+---------+------+------+---------------------+
|  1 | SIMPLE      | ip_tmp      | system | PRIMARY,CATALOG_PRODUCT_INDEX_PRICE_TMP_WEBSITE_ID | NULL | NULL    | NULL |    0 | const row not found |
|  1 | SIMPLE      | index_price | ALL    | PRIMARY                                            | NULL | NULL    | NULL | 8176 | Using where         |
+----+-------------+-------------+--------+----------------------------------------------------+------+---------+------+------+---------------------+
```

**vs**

```
explain select * FROM `catalog_product_index_price` AS `index_price`  LEFT JOIN `catalog_product_index_price_tmp` AS `ip_tmp` ON index_price.entity_id = ip_tmp.entity_id AND index_price.website_id = ip_tmp.website_id WHERE (ip_tmp.entity_id IS NULL) AND (index_price.entity_id IN('2044', '2045', '2047'));
+----+-------------+-------------+--------+----------------------------------------------------+---------+---------+------+------+---------------------+
| id | select_type | table       | type   | possible_keys                                      | key     | key_len | ref  | rows | Extra               |
+----+-------------+-------------+--------+----------------------------------------------------+---------+---------+------+------+---------------------+
|  1 | SIMPLE      | ip_tmp      | system | PRIMARY,CATALOG_PRODUCT_INDEX_PRICE_TMP_WEBSITE_ID | NULL    | NULL    | NULL |    0 | const row not found |
|  1 | SIMPLE      | index_price | range  | PRIMARY                                            | PRIMARY | 4       | NULL |   12 | Using where         |
+----+-------------+-------------+--------+----------------------------------------------------+---------+---------+------+------+---------------------+
```

Note the use of the PRIMARY key and rows examined on the index_price table.

Casting the composite ids as a string produces consistent SQL. On my production instance of EE 1.13 this fix reduces the indexing execution time by 15 seconds for each batch (over 30 minutes faster with my product data).
