### PR TITLE
Problem when callback is object

### DIFF
--- a/lib/web/mage/requirejs/mixins.js
+++ b/lib/web/mage/requirejs/mixins.js
@@ -241,12 +241,10 @@ require([
 
         if (!Array.isArray(deps)) {
             callback = deps;
-            deps = null;
+            deps = [];
         }
 
-        if (!deps && typeof callback === 'function') {
-            deps = [];
-
+        if (!deps.length && typeof callback === 'function') {
             if (callback.length) {
                 callback
                     .toString()


### PR DESCRIPTION
The current version of `mixins.js` causes problems when `define` is called without dependencies and the callback is an object and not a function.

For example `define("example", someObject)` will work with RequireJS, but the callback object will be destroyed when `mixins.js` is used.

This is because `mixin.js` initially sets `deps` to `null` if no dependencies are defined, but then changes it to an empty array if `callback` is a function. If `callback` is an object, `originalDefine` gets called with `deps` set to `null`, which is not a valid argument. (If `deps` is not an array RequireJS will change the value of `callback` to the value of `deps`, which is `null` in this case.)

This problem can be avoided by setting `deps` to an empty array instead of `null` whenever the provided argument is not an array.
