### PR TITLE
Support symlinking of the /pub document root

### DIFF
--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -630,7 +630,7 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel
      */
     protected function _getDocumentRoot()
     {
-        return $this->_request->getServer('DOCUMENT_ROOT');
+        return realpath($this->_request->getServer('DOCUMENT_ROOT'));
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/SetupInfo.php
+++ b/lib/internal/Magento/Framework/App/SetupInfo.php
@@ -59,7 +59,7 @@ class SetupInfo
         if (empty($server['DOCUMENT_ROOT'])) {
             throw new \InvalidArgumentException('DOCUMENT_ROOT variable is unavailable.');
         }
-        $this->docRoot = rtrim(str_replace('\\', '/', realpath($server['DOCUMENT_ROOT'])), '/');
+        $this->docRoot = rtrim(str_replace('\\', '/', $server['DOCUMENT_ROOT']), '/');
         $this->projectRoot = $projectRoot ?: $this->detectProjectRoot();
         $this->projectRoot = str_replace('\\', '/', $this->projectRoot);
     }
@@ -109,8 +109,10 @@ class SetupInfo
     public function getProjectUrl()
     {
         $isProjectInDocRoot = false !== strpos($this->projectRoot . '/', $this->docRoot . '/');
-        if (!$isProjectInDocRoot || empty($this->server['HTTP_HOST'])) {
+        if (empty($this->server['HTTP_HOST'])) {
             return '';
+        } else if (!$isProjectInDocRoot) {
+            return 'http://' . $this->server['HTTP_HOST'] . '/';
         }
         return 'http://' . $this->server['HTTP_HOST'] . substr($this->projectRoot . '/', strlen($this->docRoot));
     }

--- a/lib/internal/Magento/Framework/App/SetupInfo.php
+++ b/lib/internal/Magento/Framework/App/SetupInfo.php
@@ -59,7 +59,7 @@ class SetupInfo
         if (empty($server['DOCUMENT_ROOT'])) {
             throw new \InvalidArgumentException('DOCUMENT_ROOT variable is unavailable.');
         }
-        $this->docRoot = rtrim(str_replace('\\', '/', $server['DOCUMENT_ROOT']), '/');
+        $this->docRoot = rtrim(str_replace('\\', '/', realpath($server['DOCUMENT_ROOT'])), '/');
         $this->projectRoot = $projectRoot ?: $this->detectProjectRoot();
         $this->projectRoot = str_replace('\\', '/', $this->projectRoot);
     }

--- a/lib/internal/Magento/Framework/App/Test/Unit/SetupInfoTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/SetupInfoTest.php
@@ -92,7 +92,7 @@ class SetupInfoTest extends \PHPUnit_Framework_TestCase
         return [
             [self::$fixture, ''],
             [self::$fixture + ['HTTP_HOST' => ''], ''],
-            [['DOCUMENT_ROOT' => '/foo/bar', 'SCRIPT_FILENAME' => '/other/baz.php', 'HTTP_HOST' => 'example.com'], ''],
+            [['DOCUMENT_ROOT' => '/foo/bar', 'SCRIPT_FILENAME' => '/other/baz.php', 'HTTP_HOST' => 'example.com'], 'http://example.com/'],
             [self::$fixture + ['HTTP_HOST' => 'example.com'], 'http://example.com/dir/'],
             [
                 ['DOCUMENT_ROOT' => '/foo/bar', 'SCRIPT_FILENAME' => '/foo/bar/baz.php', 'HTTP_HOST' => 'example.com'],

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -301,7 +301,7 @@ class Processor
     {
         $documentRoot = '';
         if (!empty($_SERVER['DOCUMENT_ROOT'])) {
-            $documentRoot = rtrim($_SERVER['DOCUMENT_ROOT'], '/');
+            $documentRoot = rtrim(realpath($_SERVER['DOCUMENT_ROOT']), '/');
         }
         return dirname($documentRoot . $this->_scriptName) . '/';
     }

--- a/pub/errors/processorFactory.php
+++ b/pub/errors/processorFactory.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\Error;
 
-require_once __DIR__ . '/../../app/bootstrap.php';
+require_once realpath(__DIR__) . '/../../app/bootstrap.php';
 require_once 'processor.php';
 
 /**

--- a/pub/index.php
+++ b/pub/index.php
@@ -10,7 +10,7 @@ use Magento\Framework\App\Bootstrap;
 use Magento\Framework\App\Filesystem\DirectoryList;
 
 try {
-    require __DIR__ . '/../app/bootstrap.php';
+    require realpath(__DIR__) . '/../app/bootstrap.php';
 } catch (\Exception $e) {
     echo <<<HTML
 <div style="font:12px/1.35em arial, helvetica, sans-serif;">

--- a/pub/static.php
+++ b/pub/static.php
@@ -6,7 +6,7 @@
  * See COPYING.txt for license details.
  */
 
-require __DIR__ . '/../app/bootstrap.php';
+require realpath(__DIR__) . '/../app/bootstrap.php';
 $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
 /** @var \Magento\Framework\App\StaticResource $app */
 $app = $bootstrap->createApplication('Magento\Framework\App\StaticResource');


### PR DESCRIPTION
Magento recommends to use `/pub` as document root. Sometimes, the document root is at a fixed path. Given this installation where `/var/www` is the configured document root:

```
/data/magento2-repo-checkout
/var/www (symlinks to) => /data/magento2-repo-checkout/pub
```

It will break:

```
PHP Fatal error:  require(): Failed opening required '/var/www/../app/bootstrap.php' (include_path='.:/usr/share/php:/usr/share/pear') in /var/www/index.php on line 13
```

..because relative paths (`../`) assume `realpath()`

With this PR, top level symlinks to `pub` will work as expected. 
