### PR TITLE
always save original $data to $_source

### DIFF
--- a/lib/internal/Magento/Framework/App/Config/Data.php
+++ b/lib/internal/Magento/Framework/App/Config/Data.php
@@ -29,8 +29,11 @@ class Data implements DataInterface
      */
     public function __construct(MetadataProcessor $processor, array $data)
     {
+        foreach ($data as $k => $v) {
+            $this->_source[$k] = $v;
+        }
         $this->_data = $processor->process($data);
-        $this->_source = $data;
+//        $this->_source = $data;
     }
 
     /**


### PR DESCRIPTION
Environment:
OS: Ubuntu 14.04
Web server: Nginx 1.9.7
PHP version: 7.0.2 (as FPM)

Issue:
Braintree payment method cannot be used during checkout.

More details:

When using "Braintree" as payment method, the javascript object "window.checkoutConfig.payment.braintree" has no value for "clientToken" which will result the payment method not visible on checkout page plus a javascript error.

After further investigation, the reason has been located at:
File:
lib/internal/Magento/Framework/App/Config/Data.php

In "__construct", passed parameter "$data" has been manipulated after being passed to "process" method of "$processor" object especially values which should be kept as "encrypted" for the "$_source" property.

These values include but not limited to:
"$data['payment']['braintree']['public_key']"

Making calls to "var_dump($data['payment']['braintree']['public_key']);" before and after "$processor->process($data);" will see different values.

The result is that the value of "payment/braintree/public_key" being passed from data table "core_config_data" to "frontend" usage has been decrypted TWICE (due to values are passed through base -> website -> store as "scope"). So the curl request sent to Braintree will result a "401" error (unauthorised) due to wrong keys have been passed.

The code change I composed could not be the best solution but has been local tested and it works. Please advise if a better solution should be applied.

Thanks Magento team!
