### PR TITLE
Fix fwrite() truncation on resource

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Driver/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/File.php
@@ -701,16 +701,34 @@ class File implements DriverInterface
      */
     public function fileWrite($resource, $data)
     {
-        $result = @fwrite($resource, $data);
-        if (false === $result) {
-            throw new FileSystemException(
-                new \Magento\Framework\Phrase(
-                    'Error occurred during execution of fileWrite %1',
-                    [$this->getWarningMessage()]
-                )
-            );
+        $lenData = strlen($data);
+        for ($result = 0; $result < $lenData; $result += $fwrite) {
+            $fwrite = @fwrite($resource, substr($data, $result));
+            if (0 === $fwrite) {
+                $this->fileSystemException('Unable to write');
+            }
+            if (false === $fwrite) {
+                $this->fileSystemException('Error occurred during execution of fileWrite %1', [$this->getWarningMessage()]);
+            }
         }
+
         return $result;
+    }
+
+    /**
+     * throw a FileSystemException with a Phrase of message and optional arguments
+     *
+     * @param string $message
+     * @param array $arguments
+     * @throws FileSystemException
+     */
+    private function fileSystemException($message, $arguments = [])
+    {
+        throw new FileSystemException(
+            new \Magento\Framework\Phrase(
+                $message, $arguments
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
When using fwrite() operation on a resource, it is not a given to expect
that all data has been written in the operation.

This fix still checks for the error return value, but also if all bytes
have been written and if not all bytes have yet been written, the write
operation will continue until all bytes have been written _or_ an error
occurs.

This is particularly important for operation on network streams.
