### PR TITLE
Fix direct file deletion by MarketplaceManager

### DIFF
--- a/setup/src/Magento/Setup/Model/MarketplaceManager.php
+++ b/setup/src/Magento/Setup/Model/MarketplaceManager.php
@@ -269,17 +269,14 @@ class MarketplaceManager
         if ($directory->isExist($this->pathToAuthFile) && $directory->isReadable($this->pathToAuthFile)) {
             try {
                 $authJsonData = $this->getAuthJson();
-                if (!empty($authJsonData) && isset($authJsonData['http-basic'][$serviceUrl])) {
+                if (isset($authJsonData['http-basic'][$serviceUrl])) {
                     unset($authJsonData['http-basic'][$serviceUrl]);
-                    if (empty($authJsonData['http-basic'])) {
-                        return unlink(getenv('COMPOSER_HOME') . DIRECTORY_SEPARATOR . $this->pathToAuthFile);
+                    $path = DirectoryList::COMPOSER_HOME . DIRECTORY_SEPARATOR . $this->pathToAuthFile;
+                    if ($authJsonData === ['http-basic' => []]) {
+                        return $this->getDirectory()->delete($path);
                     } else {
                         $data = json_encode($authJsonData, JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT);
-                        $this->getDirectory()->writeFile(
-                            DirectoryList::COMPOSER_HOME . DIRECTORY_SEPARATOR . $this->pathToAuthFile,
-                            $data
-                        );
-                        return true;
+                        return $data !== false && $this->getDirectory()->writeFile($path, $data);
                     }
                 }
             } catch (\Exception $e) {

--- a/setup/src/Magento/Setup/Test/Unit/Model/MarketplaceManagerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/MarketplaceManagerTest.php
@@ -486,9 +486,12 @@ class MarketplaceManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getCredentialBaseUrl')
             ->will($this->returnValue($this->checkingCredentialsUrl));
         $marketplaceManager
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('getDirectory')
             ->will($this->returnValue($directory));
+        $directory
+            ->expects($this->once())
+            ->method('delete');
         $directory
             ->expects($this->never())
             ->method('writeFile');


### PR DESCRIPTION
The MarketplaceManager does no longer directly unlink() the composer
authentication file (auth.json) by environment variable. The changes in
detail:
- Switch to delete() via the directory-write-adapter like the rest of the
  method and class.
- Use of the correct file-path instead of pathname injection via the
  COMPOSER_HOME environment variable.
- Add return value error check for json_encode() operation.
- Fix of the misconception that an empty 'http-basic' entry would
  equal an empty auth.json.
- Remove superfluous empty() condition.

The former code contained multiple risky operations:
- The risk to unintentionally unlink() auth.json from the system-wide
  global COMPOSER_HOME directory.
- The risk to loose data from auth.json in other authentication keys.
- The risk to truncate the whole auth.json file on error in json_encode().
- The risk to remove the auth.json file despite more options are possible.

References:
- https://getcomposer.org/doc/06-config.md#http-basic
- https://getcomposer.org/doc/articles/http-basic-authentication.md
