### PR TITLE
FQCN do not start with a backslash

### DIFF
--- a/lib/internal/Magento/Framework/Api/Code/Generator/ExtensionAttributesGenerator.php
+++ b/lib/internal/Magento/Framework/Api/Code/Generator/ExtensionAttributesGenerator.php
@@ -156,9 +156,8 @@ class ExtensionAttributesGenerator extends \Magento\Framework\Code\Generator\Ent
                 $attributeType = $attributeMetadata[Converter::DATA_TYPE];
                 if (strpos($attributeType, '\\') !== false) {
                     /** Add preceding slash to class names, while leaving primitive types as is */
-                    $attributeType = $this->_getFullyQualifiedClassName($attributeType);
-                    $this->allCustomAttributes[$dataInterface][$attributeName][Converter::DATA_TYPE] =
-                        $this->_getFullyQualifiedClassName($attributeType);
+                    $attributeType = "\\" . $this->_getFullyQualifiedClassName($attributeType);
+                    $this->allCustomAttributes[$dataInterface][$attributeName][Converter::DATA_TYPE] = $attributeType;
                 }
             }
             return $this->allCustomAttributes[$dataInterface];

--- a/lib/internal/Magento/Framework/Code/Generator/DefinedClasses.php
+++ b/lib/internal/Magento/Framework/Code/Generator/DefinedClasses.php
@@ -21,6 +21,7 @@ class DefinedClasses
      */
     public function isClassLoadable($className)
     {
+        $className = ltrim($className, "\\");
         return $this->isClassLoadableFromMemory($className) || $this->isClassLoadableFromDisc($className);
     }
 

--- a/lib/internal/Magento/Framework/Code/Generator/EntityAbstract.php
+++ b/lib/internal/Magento/Framework/Code/Generator/EntityAbstract.php
@@ -78,9 +78,9 @@ abstract class EntityAbstract
             $this->definedClasses = new DefinedClasses();
         }
 
-        $this->_sourceClassName = $this->_getFullyQualifiedClassName($sourceClassName);
+        $this->_sourceClassName = "\\" . $this->_getFullyQualifiedClassName($sourceClassName);
         if ($resultClassName) {
-            $this->_resultClassName = $this->_getFullyQualifiedClassName($resultClassName);
+            $this->_resultClassName = "\\" . $this->_getFullyQualifiedClassName($resultClassName);
         } elseif ($this->_sourceClassName) {
             $this->_resultClassName = $this->_getDefaultResultClassName($this->_sourceClassName);
         }
@@ -149,8 +149,7 @@ abstract class EntityAbstract
      */
     protected function _getFullyQualifiedClassName($className)
     {
-        $className = ltrim($className, '\\');
-        return $className ? '\\' . $className : '';
+        return ltrim($className, '\\');
     }
 
     /**
@@ -324,7 +323,7 @@ abstract class EntityAbstract
         if ($parameter->isArray()) {
             $parameterInfo['type'] = 'array';
         } elseif ($parameter->getClass()) {
-            $parameterInfo['type'] = $this->_getFullyQualifiedClassName($parameter->getClass()->getName());
+            $parameterInfo['type'] = "\\" . $this->_getFullyQualifiedClassName($parameter->getClass()->getName());
         }
 
         if ($parameter->isOptional() && $parameter->isDefaultValueAvailable()) {


### PR DESCRIPTION
there must have been a misconception by the developer who wrote that
::_getFullyQualifiedClassName() method to use it in code generation.

the method has been corrected, usages have been corrected and the auto-
load related ClassLoaderWrapper is giving error and throws a
RuntimeException if a classname (as it must be FQCN in PHP autoloading)
is invalid.

This is especially important as there has been a bug back in very early re-
visions of PHP 5.3 where PHP itself prefixed with backslash (seems to be
a somewhat common mistake).

As much as the mistake might be common in certain circles, the more it is
important to clearly communicate at all points that passing a class-name
that is a FQCN must not start with a backslash to educate users to fully
grasp the concept of the FQCN.

Additional:
- Superfluous double-the-same-function-call removed.
- The Wrapper is a Decorator, Docblock speaks common language now.
- Only if the file was not found previously, the entry in the classmap
  will be NULLed. Otherwise an existing correct entry might be over-
  written.
