### PR TITLE
fix for 'Call to a member function getTargetPath()' in AfterImportDataObserver

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
@@ -359,7 +359,11 @@ class AfterImportDataObserver implements ObserverInterface
                 $urlRewrite = $this->generateForCustom($currentUrlRewrite, $category);
             }
             if ($urlRewrite) {
-                $urlRewrites[] = $urlRewrite;
+                if (is_array($urlRewrite)) {
+                    $urlRewrites = array_merge($urlRewrites, $urlRewrite);
+                } else {
+                    $urlRewrites[] = $urlRewrite;
+                }
             }
         }
 


### PR DESCRIPTION
Quick fix for fatal error 'Call to a member function getTargetPath()' in AfterImportDataObserver.
See issue https://github.com/magento/magento2/issues/2926

P.S. Reopened a pull request correctly.
