### PR TITLE
Fixed a typo in method name: ImportExport/Model/AbstractModel::getFormattedLogTrace()

### DIFF
--- a/app/code/Magento/ImportExport/Model/AbstractModel.php
+++ b/app/code/Magento/ImportExport/Model/AbstractModel.php
@@ -87,7 +87,7 @@ abstract class AbstractModel extends \Magento\Framework\DataObject
      *
      * @return string
      */
-    public function getFormatedLogTrace()
+    public function getFormattedLogTrace()
     {
         $trace = '';
         $lineNumber = 1;


### PR DESCRIPTION
Just a typo in the method name in ImportExport/Model/AbstractModel class.
This method is called "as-is" in Magento_ScheduledImportExport EE module.
