### PR TITLE
MAGETWO-47959: Prevent getSwatchAttributesData() function from triggering a PHP notice

### DIFF
--- a/app/code/Magento/Swatches/Block/Product/Renderer/Listing/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Listing/Configurable.php
@@ -39,6 +39,7 @@ class Configurable extends \Magento\Swatches\Block\Product\Renderer\Configurable
      */
     protected function getSwatchAttributesData()
     {
+        $result = [];
         $swatchAttributeData = parent::getSwatchAttributesData();
         foreach ($swatchAttributeData as $attributeId => $item) {
             if (!empty($item['used_in_product_listing'])) {


### PR DESCRIPTION
Fix for issue #2879.
getSwatchAttributesData() returns an undefined variable and triggers a PHP notice if _used_in_product_listing_ option is used.
