### PR TITLE
Implement missing getMediaBaseDirectory function

### DIFF
--- a/app/code/Magento/MediaStorage/Model/File/Storage/Database.php
+++ b/app/code/Magento/MediaStorage/Model/File/Storage/Database.php
@@ -42,6 +42,13 @@ class Database extends \Magento\MediaStorage\Model\File\Storage\Database\Abstrac
     protected $_mediaHelper;
 
     /**
+     * Store media base directory path
+     *
+     * @var string
+     */
+    protected $_mediaBaseDirectory = null;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\MediaStorage\Helper\File\Storage\Database $coreFileStorageDb
@@ -351,5 +358,18 @@ class Database extends \Magento\MediaStorage\Model\File\Storage\Database\Abstrac
         $this->_getResource()->deleteFile($filename, $directory);
 
         return $this;
+    }
+
+    /**
+     * Retrieve media base directory path
+     *
+     * @return string
+     */
+    public function getMediaBaseDirectory()
+    {
+        if (is_null($this->_mediaBaseDirectory)) {
+            $this->_mediaBaseDirectory = $this->_coreFileStorageDb->getMediaBaseDir();
+        }
+        return $this->_mediaBaseDirectory;
     }
 }


### PR DESCRIPTION
The database storage model class was [calling a function](https://github.com/magento/magento2/blob/2.0.1/app/code/Magento/MediaStorage/Model/File/Storage/Database.php#L253) that didn't exist. I copied over [a similar function from the file storage model class](https://github.com/magento/magento2/blob/2.0.1/app/code/Magento/MediaStorage/Model/File/Storage/File.php#L316) with some minor changes to make it work.
