### PR TITLE
Add strtolower on IDE format lookup against input to make it friendlier

### DIFF
--- a/app/code/Magento/Developer/Console/Command/XmlCatalogGenerateCommand.php
+++ b/app/code/Magento/Developer/Console/Command/XmlCatalogGenerateCommand.php
@@ -160,6 +160,7 @@ class XmlCatalogGenerateCommand extends Command
      */
     private function getFormatters($format)
     {
+        $format = strtolower($format);
         if (!isset($this->formats[$format])) {
             return false;
         }


### PR DESCRIPTION
Currently user needs to input exact format param, properly cased, for the dev:urn-catalog:generate command to work.
This small tweak uses strtolower in order to format the user input so strings like "PhpStorm", "PHPStorm", "PHPSTORM" are now all valid.
The reason for this proposed update is that PhpStorm by default always suggests PHPSTORM as the key for the IDE on different uses (a common example is xdebug).
This change is transparent to the end user, and to the rest of the codebase.
