### PR TITLE
bin/magento must return non zero on exceptions

### DIFF
--- a/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
+++ b/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
@@ -80,7 +80,7 @@ class ImagesResizeCommand extends Command
         if (!count($productIds)) {
             $output->writeln("<info>No product images to resize</info>");
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
         try {
@@ -101,7 +101,7 @@ class ImagesResizeCommand extends Command
         } catch (\Exception $e) {
             $output->writeln("<error>{$e->getMessage()}</error>");
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
         $output->write("\n");

--- a/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
+++ b/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
@@ -106,5 +106,6 @@ class ImagesResizeCommand extends Command
 
         $output->write("\n");
         $output->writeln("<info>Product images resized successfully</info>");
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
     }
 }

--- a/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
+++ b/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
@@ -79,7 +79,8 @@ class ImagesResizeCommand extends Command
         $productIds = $productCollection->getAllIds();
         if (!count($productIds)) {
             $output->writeln("<info>No product images to resize</info>");
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
 
         try {
@@ -99,7 +100,8 @@ class ImagesResizeCommand extends Command
             }
         } catch (\Exception $e) {
             $output->writeln("<error>{$e->getMessage()}</error>");
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
 
         $output->write("\n");

--- a/app/code/Magento/Deploy/Console/Command/DeployStaticContentCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/DeployStaticContentCommand.php
@@ -118,6 +118,6 @@ class DeployStaticContentCommand extends Command
             'Magento\Deploy\Model\Deployer',
             ['filesUtil' => $filesUtil, 'output' => $output, 'isDryRun' => $options[self::DRY_RUN_OPTION]]
         );
-        $deployer->deploy($this->objectManagerFactory, $languages);
+        return $deployer->deploy($this->objectManagerFactory, $languages);
     }
 }

--- a/app/code/Magento/Deploy/Console/Command/SetModeCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/SetModeCommand.php
@@ -109,7 +109,8 @@ class SetModeCommand extends Command
             if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
                 $output->writeln($e->getTraceAsString());
             }
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
     }
 }

--- a/app/code/Magento/Deploy/Console/Command/SetModeCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/SetModeCommand.php
@@ -110,7 +110,7 @@ class SetModeCommand extends Command
                 $output->writeln($e->getTraceAsString());
             }
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
     }
 }

--- a/app/code/Magento/Deploy/Model/Deployer.php
+++ b/app/code/Magento/Deploy/Model/Deployer.php
@@ -215,10 +215,10 @@ class Deployer
         }
         if ($this->errorCount > 0) {
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
-        return 0;
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
     }
 
     /**

--- a/app/code/Magento/Deploy/Model/Deployer.php
+++ b/app/code/Magento/Deploy/Model/Deployer.php
@@ -112,7 +112,7 @@ class Deployer
      *
      * @param ObjectManagerFactory $omFactory
      * @param array $locales
-     * @return void
+     * @return int
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
@@ -213,6 +213,12 @@ class Deployer
         if (!$this->isDryRun) {
             $this->versionStorage->save($version);
         }
+        if ($this->errorCount > 0) {
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
+        }
+
+        return 0;
     }
 
     /**

--- a/app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php
+++ b/app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php
@@ -102,11 +102,11 @@ class DevTestsRunCommand extends Command
                 $output->writeln(' - ' . $message);
             }
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         } else {
             $output->writeln('PASSED (' . count($runCommands) . ')');
         }
-        return 0;
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
     }
 
     /**

--- a/app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php
+++ b/app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php
@@ -101,6 +101,8 @@ class DevTestsRunCommand extends Command
             foreach ($failures as $message) {
                 $output->writeln(' - ' . $message);
             }
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         } else {
             $output->writeln('PASSED (' . count($runCommands) . ')');
         }

--- a/app/code/Magento/Developer/Console/Command/XmlConverterCommand.php
+++ b/app/code/Magento/Developer/Console/Command/XmlConverterCommand.php
@@ -129,12 +129,12 @@ class XmlConverterCommand extends Command
                 $output->write($result);
             }
 
-            return;
+            return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
         } catch (\Exception $exception) {
             $errorMessage = $exception->getMessage();
             $output->writeln("<error>$errorMessage</error>");
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
     }
 }

--- a/app/code/Magento/Developer/Console/Command/XmlConverterCommand.php
+++ b/app/code/Magento/Developer/Console/Command/XmlConverterCommand.php
@@ -133,7 +133,8 @@ class XmlConverterCommand extends Command
         } catch (\Exception $exception) {
             $errorMessage = $exception->getMessage();
             $output->writeln("<error>$errorMessage</error>");
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
     }
 }

--- a/app/code/Magento/Indexer/Console/Command/IndexerReindexCommand.php
+++ b/app/code/Magento/Indexer/Console/Command/IndexerReindexCommand.php
@@ -44,6 +44,7 @@ class IndexerReindexCommand extends AbstractIndexerManageCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $indexers = $this->getIndexers($input);
+        $returnValue = 0;
         foreach ($indexers as $indexer) {
             try {
                 $this->validateIndexerStatus($indexer);
@@ -64,11 +65,16 @@ class IndexerReindexCommand extends AbstractIndexerManageCommand
                 );
             } catch (LocalizedException $e) {
                 $output->writeln($e->getMessage());
+                // we must have an exit code higher than zero to indicate something was wrong
+                $returnValue = 255;
             } catch (\Exception $e) {
                 $output->writeln($indexer->getTitle() . ' indexer process unknown error:');
                 $output->writeln($e->getMessage());
+                // we must have an exit code higher than zero to indicate something was wrong
+                $returnValue = 255;
             }
         }
+        return $returnValue;
     }
 
     /**

--- a/app/code/Magento/Indexer/Console/Command/IndexerReindexCommand.php
+++ b/app/code/Magento/Indexer/Console/Command/IndexerReindexCommand.php
@@ -44,7 +44,7 @@ class IndexerReindexCommand extends AbstractIndexerManageCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $indexers = $this->getIndexers($input);
-        $returnValue = 0;
+        $returnValue = \Magento\Framework\Console\Cli::RETURN_SUCCESS;
         foreach ($indexers as $indexer) {
             try {
                 $this->validateIndexerStatus($indexer);
@@ -66,12 +66,12 @@ class IndexerReindexCommand extends AbstractIndexerManageCommand
             } catch (LocalizedException $e) {
                 $output->writeln($e->getMessage());
                 // we must have an exit code higher than zero to indicate something was wrong
-                $returnValue = 255;
+                $returnValue = \Magento\Framework\Console\Cli::RETURN_FAILURE;
             } catch (\Exception $e) {
                 $output->writeln($indexer->getTitle() . ' indexer process unknown error:');
                 $output->writeln($e->getMessage());
                 // we must have an exit code higher than zero to indicate something was wrong
-                $returnValue = 255;
+                $returnValue = \Magento\Framework\Console\Cli::RETURN_FAILURE;
             }
         }
         return $returnValue;

--- a/app/code/Magento/Indexer/Console/Command/IndexerSetModeCommand.php
+++ b/app/code/Magento/Indexer/Console/Command/IndexerSetModeCommand.php
@@ -48,7 +48,7 @@ class IndexerSetModeCommand extends AbstractIndexerManageCommand
 
         $indexers = $this->getIndexers($input);
 
-        $returnValue = 0;
+        $returnValue = \Magento\Framework\Console\Cli::RETURN_SUCCESS;
         foreach ($indexers as $indexer) {
             try {
                 $previousStatus = $indexer->isScheduled() ? 'Update by Schedule' : 'Update on Save';
@@ -65,12 +65,12 @@ class IndexerSetModeCommand extends AbstractIndexerManageCommand
             } catch (LocalizedException $e) {
                 $output->writeln($e->getMessage() . PHP_EOL);
                 // we must have an exit code higher than zero to indicate something was wrong
-                $returnValue = 255;
+                $returnValue =  \Magento\Framework\Console\Cli::RETURN_FAILURE;
             } catch (\Exception $e) {
                 $output->writeln($indexer->getTitle() . " indexer process unknown error:" . PHP_EOL);
                 $output->writeln($e->getMessage() . PHP_EOL);
                 // we must have an exit code higher than zero to indicate something was wrong
-                $returnValue = 255;
+                $returnValue =  \Magento\Framework\Console\Cli::RETURN_FAILURE;
             }
         }
 

--- a/app/code/Magento/Indexer/Console/Command/IndexerSetModeCommand.php
+++ b/app/code/Magento/Indexer/Console/Command/IndexerSetModeCommand.php
@@ -48,6 +48,7 @@ class IndexerSetModeCommand extends AbstractIndexerManageCommand
 
         $indexers = $this->getIndexers($input);
 
+        $returnValue = 0;
         foreach ($indexers as $indexer) {
             try {
                 $previousStatus = $indexer->isScheduled() ? 'Update by Schedule' : 'Update on Save';
@@ -63,13 +64,17 @@ class IndexerSetModeCommand extends AbstractIndexerManageCommand
                 }
             } catch (LocalizedException $e) {
                 $output->writeln($e->getMessage() . PHP_EOL);
+                // we must have an exit code higher than zero to indicate something was wrong
+                $returnValue = 255;
             } catch (\Exception $e) {
                 $output->writeln($indexer->getTitle() . " indexer process unknown error:" . PHP_EOL);
                 $output->writeln($e->getMessage() . PHP_EOL);
+                // we must have an exit code higher than zero to indicate something was wrong
+                $returnValue = 255;
             }
         }
 
-        return $this;
+        return $returnValue;
     }
 
     /**

--- a/app/code/Magento/Theme/Console/Command/ThemeUninstallCommand.php
+++ b/app/code/Magento/Theme/Console/Command/ThemeUninstallCommand.php
@@ -196,7 +196,8 @@ class ThemeUninstallCommand extends Command
         $messages = array_merge($messages, $this->validate($themePaths));
         if (!empty($messages)) {
             $output->writeln($messages);
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
         $messages = array_merge(
             $messages,
@@ -209,7 +210,8 @@ class ThemeUninstallCommand extends Command
                 '<error>Unable to uninstall. Please resolve the following issues:</error>'
                 . PHP_EOL . implode(PHP_EOL, $messages)
             );
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
 
         try {
@@ -230,6 +232,8 @@ class ThemeUninstallCommand extends Command
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             $output->writeln('<error>Please disable maintenance mode after you resolved above issues</error>');
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
     }
 

--- a/app/code/Magento/Theme/Console/Command/ThemeUninstallCommand.php
+++ b/app/code/Magento/Theme/Console/Command/ThemeUninstallCommand.php
@@ -197,7 +197,7 @@ class ThemeUninstallCommand extends Command
         if (!empty($messages)) {
             $output->writeln($messages);
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
         $messages = array_merge(
             $messages,
@@ -211,7 +211,7 @@ class ThemeUninstallCommand extends Command
                 . PHP_EOL . implode(PHP_EOL, $messages)
             );
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
         try {
@@ -233,7 +233,7 @@ class ThemeUninstallCommand extends Command
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             $output->writeln('<error>Please disable maintenance mode after you resolved above issues</error>');
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
     }
 

--- a/bin/magento
+++ b/bin/magento
@@ -7,6 +7,7 @@
 use \Magento\Framework\App\ProductMetadata;
 use \Magento\Framework\Composer\ComposerJsonFinder;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Console\Cli;
 
 if (PHP_SAPI !== 'cli') {
     echo 'bin/magento must be run as a CLI application';
@@ -23,7 +24,7 @@ try {
     $handler = new \Magento\Framework\App\ErrorHandler();
     set_error_handler([$handler, 'handler']);
     $productMetadata = new ProductMetadata(new ComposerJsonFinder(new DirectoryList(BP)));
-    $application = new Magento\Framework\Console\Cli('Magento CLI', $productMetadata->getVersion());
+    $application = new Cli('Magento CLI', $productMetadata->getVersion());
     $application->run();
 } catch (\Exception $e) {
     while ($e) {
@@ -32,5 +33,5 @@ try {
         echo "\n\n";
         $e = $e->getPrevious();
     }
-    exit(1);
+    exit(Cli::RETURN_FAILURE);
 }

--- a/bin/magento
+++ b/bin/magento
@@ -32,4 +32,5 @@ try {
         echo "\n\n";
         $e = $e->getPrevious();
     }
+    exit(1);
 }

--- a/lib/internal/Magento/Framework/Console/Cli.php
+++ b/lib/internal/Magento/Framework/Console/Cli.php
@@ -29,8 +29,12 @@ class Cli extends SymfonyApplication
     const INPUT_KEY_BOOTSTRAP = 'bootstrap';
 
     /**
-     * @var \Zend\ServiceManager\ServiceManager
+     * Cli exit codes
      */
+    const RETURN_SUCCESS = 0;
+    const RETURN_FAILURE = 1;
+
+    /** @var \Zend\ServiceManager\ServiceManager */
     private $serviceManager;
 
     /**

--- a/setup/src/Magento/Setup/Console/Command/AbstractDependenciesCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/AbstractDependenciesCommand.php
@@ -104,6 +104,8 @@ abstract class AbstractDependenciesCommand extends Command
                 '<error>Please check the path you provided. Dependencies report generator failed with error: ' .
                 $e->getMessage() . '</error>'
             );
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
     }
 }

--- a/setup/src/Magento/Setup/Console/Command/AbstractDependenciesCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/AbstractDependenciesCommand.php
@@ -105,7 +105,7 @@ abstract class AbstractDependenciesCommand extends Command
                 $e->getMessage() . '</error>'
             );
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
     }
 }

--- a/setup/src/Magento/Setup/Console/Command/AbstractMaintenanceCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/AbstractMaintenanceCommand.php
@@ -83,7 +83,8 @@ abstract class AbstractMaintenanceCommand extends AbstractSetupCommand
         $messages = $this->validate($addresses);
         if (!empty($messages)) {
             $output->writeln('<error>' . implode('</error>' . PHP_EOL . '<error>', $messages));
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
 
         $this->maintenanceMode->set($this->isEnable());

--- a/setup/src/Magento/Setup/Console/Command/AbstractMaintenanceCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/AbstractMaintenanceCommand.php
@@ -84,7 +84,7 @@ abstract class AbstractMaintenanceCommand extends AbstractSetupCommand
         if (!empty($messages)) {
             $output->writeln('<error>' . implode('</error>' . PHP_EOL . '<error>', $messages));
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
         $this->maintenanceMode->set($this->isEnable());

--- a/setup/src/Magento/Setup/Console/Command/AbstractModuleManageCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/AbstractModuleManageCommand.php
@@ -76,13 +76,15 @@ abstract class AbstractModuleManageCommand extends AbstractModuleCommand
         $messages = $this->validate($modules);
         if (!empty($messages)) {
             $output->writeln(implode(PHP_EOL, $messages));
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
         try {
             $modulesToChange = $this->getStatus()->getModulesToChange($isEnable, $modules);
         } catch (\LogicException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
         if (!empty($modulesToChange)) {
             $force = $input->getOption(self::INPUT_KEY_FORCE);
@@ -93,7 +95,8 @@ abstract class AbstractModuleManageCommand extends AbstractModuleCommand
                         "<error>Unable to change status of modules because of the following constraints:</error>"
                     );
                     $output->writeln('<error>' . implode("</error>\n<error>", $constraints) . '</error>');
-                    return;
+                    // we must have an exit code higher than zero to indicate something was wrong
+                    return 255;
                 }
             }
             $this->setIsEnabled($isEnable, $modulesToChange, $output);

--- a/setup/src/Magento/Setup/Console/Command/AbstractModuleManageCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/AbstractModuleManageCommand.php
@@ -77,14 +77,14 @@ abstract class AbstractModuleManageCommand extends AbstractModuleCommand
         if (!empty($messages)) {
             $output->writeln(implode(PHP_EOL, $messages));
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
         try {
             $modulesToChange = $this->getStatus()->getModulesToChange($isEnable, $modules);
         } catch (\LogicException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
         if (!empty($modulesToChange)) {
             $force = $input->getOption(self::INPUT_KEY_FORCE);
@@ -96,7 +96,7 @@ abstract class AbstractModuleManageCommand extends AbstractModuleCommand
                     );
                     $output->writeln('<error>' . implode("</error>\n<error>", $constraints) . '</error>');
                     // we must have an exit code higher than zero to indicate something was wrong
-                    return 255;
+                    return \Magento\Framework\Console\Cli::RETURN_FAILURE;
                 }
             }
             $this->setIsEnabled($isEnable, $modulesToChange, $output);

--- a/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php
@@ -58,7 +58,8 @@ class AdminUserCreateCommand extends AbstractSetupCommand
         $errors = $this->validate($input);
         if ($errors) {
             $output->writeln('<error>' . implode('</error>' . PHP_EOL .  '<error>', $errors) . '</error>');
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
         $installer = $this->installerFactory->create(new ConsoleLogger($output));
         $installer->installAdminUser($input->getOptions());

--- a/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php
@@ -25,7 +25,7 @@ class AdminUserCreateCommand extends AbstractSetupCommand
      * @var UserValidationRules
      */
     private $validationRules;
-    
+
     /**
      * @param InstallerFactory $installerFactory
      * @param UserValidationRules $validationRules
@@ -59,7 +59,7 @@ class AdminUserCreateCommand extends AbstractSetupCommand
         if ($errors) {
             $output->writeln('<error>' . implode('</error>' . PHP_EOL .  '<error>', $errors) . '</error>');
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
         $installer = $this->installerFactory->create(new ConsoleLogger($output));
         $installer->installAdminUser($input->getOptions());

--- a/setup/src/Magento/Setup/Console/Command/BackupCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/BackupCommand.php
@@ -115,8 +115,10 @@ class BackupCommand extends AbstractSetupCommand
         if (!$this->deploymentConfig->isAvailable()
             && ($input->getOption(self::INPUT_KEY_MEDIA) || $input->getOption(self::INPUT_KEY_DB))) {
             $output->writeln("<info>No information is available: the Magento application is not installed.</info>");
-            return;
+            // We need exit code higher than 0 here as an indication
+            return 255;
         }
+        $returnValue = 0;
         try {
             $inputOptionProvided = false;
             $output->writeln('<info>Enabling maintenance mode</info>');
@@ -143,10 +145,12 @@ class BackupCommand extends AbstractSetupCommand
             }
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            $returnValue = 255;
         } finally {
             $output->writeln('<info>Disabling maintenance mode</info>');
             $this->maintenanceMode->set(false);
         }
+        return $returnValue;
     }
 
     /**

--- a/setup/src/Magento/Setup/Console/Command/BackupCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/BackupCommand.php
@@ -116,9 +116,9 @@ class BackupCommand extends AbstractSetupCommand
             && ($input->getOption(self::INPUT_KEY_MEDIA) || $input->getOption(self::INPUT_KEY_DB))) {
             $output->writeln("<info>No information is available: the Magento application is not installed.</info>");
             // We need exit code higher than 0 here as an indication
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
-        $returnValue = 0;
+        $returnValue = \Magento\Framework\Console\Cli::RETURN_SUCCESS;
         try {
             $inputOptionProvided = false;
             $output->writeln('<info>Enabling maintenance mode</info>');
@@ -145,7 +145,7 @@ class BackupCommand extends AbstractSetupCommand
             }
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
-            $returnValue = 255;
+            $returnValue =  \Magento\Framework\Console\Cli::RETURN_FAILURE;
         } finally {
             $output->writeln('<info>Disabling maintenance mode</info>');
             $this->maintenanceMode->set(false);

--- a/setup/src/Magento/Setup/Console/Command/CronRunCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/CronRunCommand.php
@@ -75,13 +75,15 @@ class CronRunCommand extends AbstractSetupCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (!$this->checkRun()) {
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
         try {
             $this->status->toggleUpdateInProgress();
         } catch (\RuntimeException $e) {
             $this->status->add($e->getMessage());
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
 
         try {
@@ -106,6 +108,13 @@ class CronRunCommand extends AbstractSetupCommand
         } finally {
             $this->status->toggleUpdateInProgress(false);
         }
+
+        if ($this->status->isUpdateError()) {
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
+        }
+
+        return 0;
     }
 
     /**

--- a/setup/src/Magento/Setup/Console/Command/CronRunCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/CronRunCommand.php
@@ -76,14 +76,14 @@ class CronRunCommand extends AbstractSetupCommand
     {
         if (!$this->checkRun()) {
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
         try {
             $this->status->toggleUpdateInProgress();
         } catch (\RuntimeException $e) {
             $this->status->add($e->getMessage());
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
         try {
@@ -111,10 +111,10 @@ class CronRunCommand extends AbstractSetupCommand
 
         if ($this->status->isUpdateError()) {
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
-        return 0;
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
     }
 
     /**

--- a/setup/src/Magento/Setup/Console/Command/DbDataUpgradeCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DbDataUpgradeCommand.php
@@ -63,7 +63,7 @@ class DbDataUpgradeCommand extends AbstractSetupCommand
         if (!$this->deploymentConfig->isAvailable()) {
             $output->writeln("<info>No information is available: the Magento application is not installed.</info>");
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
         $installer = $this->installFactory->create(new ConsoleLogger($output));
         $installer->installDataFixtures();

--- a/setup/src/Magento/Setup/Console/Command/DbDataUpgradeCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DbDataUpgradeCommand.php
@@ -62,7 +62,8 @@ class DbDataUpgradeCommand extends AbstractSetupCommand
     {
         if (!$this->deploymentConfig->isAvailable()) {
             $output->writeln("<info>No information is available: the Magento application is not installed.</info>");
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
         $installer = $this->installFactory->create(new ConsoleLogger($output));
         $installer->installDataFixtures();

--- a/setup/src/Magento/Setup/Console/Command/DbSchemaUpgradeCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DbSchemaUpgradeCommand.php
@@ -63,7 +63,7 @@ class DbSchemaUpgradeCommand extends AbstractSetupCommand
         if (!$this->deploymentConfig->isAvailable()) {
             $output->writeln("<info>No information is available: the Magento application is not installed.</info>");
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
         $installer = $this->installFactory->create(new ConsoleLogger($output));
         $installer->installSchema();

--- a/setup/src/Magento/Setup/Console/Command/DbSchemaUpgradeCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DbSchemaUpgradeCommand.php
@@ -62,7 +62,8 @@ class DbSchemaUpgradeCommand extends AbstractSetupCommand
     {
         if (!$this->deploymentConfig->isAvailable()) {
             $output->writeln("<info>No information is available: the Magento application is not installed.</info>");
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
         $installer = $this->installFactory->create(new ConsoleLogger($output));
         $installer->installSchema();

--- a/setup/src/Magento/Setup/Console/Command/DbStatusCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DbStatusCommand.php
@@ -93,6 +93,8 @@ class DbStatusCommand extends AbstractSetupCommand
                     '<info>Some modules use code versions newer or older than the database. ' .
                     "First update the module code, then run 'setup:upgrade'.</info>"
                 );
+                // we must have an exit code higher than zero to indicate something was wrong
+                return 255;
             } else {
                 $output->writeln("<info>Run 'setup:upgrade' to update your DB schema and data.</info>");
             }

--- a/setup/src/Magento/Setup/Console/Command/DbStatusCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DbStatusCommand.php
@@ -94,7 +94,7 @@ class DbStatusCommand extends AbstractSetupCommand
                     "First update the module code, then run 'setup:upgrade'.</info>"
                 );
                 // we must have an exit code higher than zero to indicate something was wrong
-                return 255;
+                return \Magento\Framework\Console\Cli::RETURN_FAILURE;
             } else {
                 $output->writeln("<info>Run 'setup:upgrade' to update your DB schema and data.</info>");
             }

--- a/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
@@ -126,7 +126,8 @@ class DiCompileCommand extends Command
             foreach ($errors as $line) {
                 $output->writeln($line);
             }
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
 
         $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrar::MODULE);
@@ -199,6 +200,8 @@ class DiCompileCommand extends Command
             $output->writeln('<info>Generated code and dependency injection configuration successfully.</info>');
         } catch (OperationException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
     }
 

--- a/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
@@ -127,7 +127,7 @@ class DiCompileCommand extends Command
                 $output->writeln($line);
             }
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
         $modulePaths = $this->componentRegistrar->getPaths(ComponentRegistrar::MODULE);
@@ -201,7 +201,7 @@ class DiCompileCommand extends Command
         } catch (OperationException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
     }
 

--- a/setup/src/Magento/Setup/Console/Command/GenerateFixturesCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/GenerateFixturesCommand.php
@@ -111,7 +111,7 @@ class GenerateFixturesCommand extends Command
             if (!$input->getOption(self::SKIP_REINDEX_OPTION)) {
                 $fixtureModel->reindex($output);
             }
-            
+
             $totalEndTime = microtime(true);
             $totalResultTime = $totalEndTime - $totalStartTime;
 
@@ -119,7 +119,7 @@ class GenerateFixturesCommand extends Command
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
     }
 }

--- a/setup/src/Magento/Setup/Console/Command/GenerateFixturesCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/GenerateFixturesCommand.php
@@ -117,7 +117,9 @@ class GenerateFixturesCommand extends Command
 
             $output->writeln('<info>Total execution time: ' . gmdate('H:i:s', $totalResultTime) . '</info>');
         } catch (\Exception $e) {
-             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
     }
 }

--- a/setup/src/Magento/Setup/Console/Command/InstallStoreConfigurationCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/InstallStoreConfigurationCommand.php
@@ -84,12 +84,14 @@ class InstallStoreConfigurationCommand extends AbstractSetupCommand
             $output->writeln(
                 "<info>Store settings can't be saved because the Magento application is not installed.</info>"
             );
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
         $errors = $this->validate($input);
         if ($errors) {
             $output->writeln($errors);
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
         $installer = $this->installerFactory->create(new ConsoleLogger($output));
         $installer->installUserConfig($input->getOptions());

--- a/setup/src/Magento/Setup/Console/Command/InstallStoreConfigurationCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/InstallStoreConfigurationCommand.php
@@ -85,13 +85,13 @@ class InstallStoreConfigurationCommand extends AbstractSetupCommand
                 "<info>Store settings can't be saved because the Magento application is not installed.</info>"
             );
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
         $errors = $this->validate($input);
         if ($errors) {
             $output->writeln($errors);
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
         $installer = $this->installerFactory->create(new ConsoleLogger($output));
         $installer->installUserConfig($input->getOptions());

--- a/setup/src/Magento/Setup/Console/Command/MaintenanceAllowIpsCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/MaintenanceAllowIpsCommand.php
@@ -86,7 +86,8 @@ class MaintenanceAllowIpsCommand extends AbstractSetupCommand
             $messages = $this->validate($addresses);
             if (!empty($messages)) {
                 $output->writeln('<error>' . implode('</error>' . PHP_EOL . '<error>', $messages));
-                return;
+                // we must have an exit code higher than zero to indicate something was wrong
+                return 255;
             }
 
             if (!empty($addresses)) {

--- a/setup/src/Magento/Setup/Console/Command/MaintenanceAllowIpsCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/MaintenanceAllowIpsCommand.php
@@ -87,7 +87,7 @@ class MaintenanceAllowIpsCommand extends AbstractSetupCommand
             if (!empty($messages)) {
                 $output->writeln('<error>' . implode('</error>' . PHP_EOL . '<error>', $messages));
                 // we must have an exit code higher than zero to indicate something was wrong
-                return 255;
+                return \Magento\Framework\Console\Cli::RETURN_FAILURE;
             }
 
             if (!empty($addresses)) {

--- a/setup/src/Magento/Setup/Console/Command/ModuleUninstallCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ModuleUninstallCommand.php
@@ -199,7 +199,7 @@ class ModuleUninstallCommand extends AbstractModuleCommand
                 '<error>You cannot run this command because the Magento application is not installed.</error>'
             );
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
         $modules = $input->getArgument(self::INPUT_KEY_MODULES);
@@ -208,7 +208,7 @@ class ModuleUninstallCommand extends AbstractModuleCommand
         if (!empty($messages)) {
             $output->writeln($messages);
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
         // check dependencies
@@ -216,7 +216,7 @@ class ModuleUninstallCommand extends AbstractModuleCommand
         if (!empty($dependencyMessages)) {
             $output->writeln($dependencyMessages);
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
         $helper = $this->getHelper('question');
@@ -225,7 +225,7 @@ class ModuleUninstallCommand extends AbstractModuleCommand
             false
         );
         if (!$helper->ask($input, $output, $question) && $input->isInteractive()) {
-            return;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
         try {
             $output->writeln('<info>Enabling maintenance mode</info>');
@@ -260,8 +260,7 @@ class ModuleUninstallCommand extends AbstractModuleCommand
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             $output->writeln('<error>Please disable maintenance mode after you resolved above issues</error>');
-            // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
     }
 

--- a/setup/src/Magento/Setup/Console/Command/ModuleUninstallCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ModuleUninstallCommand.php
@@ -307,8 +307,6 @@ class ModuleUninstallCommand extends AbstractModuleCommand
         $this->moduleUninstaller->uninstallData($output, $modules);
     }
 
-
-
     /**
      * Validate list of modules against installed composer packages and return error messages
      *

--- a/setup/src/Magento/Setup/Console/Command/ModuleUninstallCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ModuleUninstallCommand.php
@@ -198,7 +198,8 @@ class ModuleUninstallCommand extends AbstractModuleCommand
             $output->writeln(
                 '<error>You cannot run this command because the Magento application is not installed.</error>'
             );
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
 
         $modules = $input->getArgument(self::INPUT_KEY_MODULES);
@@ -206,14 +207,16 @@ class ModuleUninstallCommand extends AbstractModuleCommand
         $messages = $this->validate($modules);
         if (!empty($messages)) {
             $output->writeln($messages);
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
 
         // check dependencies
         $dependencyMessages = $this->checkDependencies($modules);
         if (!empty($dependencyMessages)) {
             $output->writeln($dependencyMessages);
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
 
         $helper = $this->getHelper('question');
@@ -257,6 +260,8 @@ class ModuleUninstallCommand extends AbstractModuleCommand
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             $output->writeln('<error>Please disable maintenance mode after you resolved above issues</error>');
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
     }
 

--- a/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
@@ -113,9 +113,9 @@ class RollbackCommand extends AbstractSetupCommand
                 || $input->getOption(self::INPUT_KEY_DB_BACKUP_FILE))) {
             $output->writeln("<info>No information is available: the Magento application is not installed.</info>");
             // we must have an exit code higher than zero to indicate something was wrong
-            return 255;
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
-        $returnValue = 0;
+        $returnValue = \Magento\Framework\Console\Cli::RETURN_SUCCESS;
         try {
             $output->writeln('<info>Enabling maintenance mode</info>');
             $this->maintenanceMode->set(true);
@@ -125,7 +125,7 @@ class RollbackCommand extends AbstractSetupCommand
                 false
             );
             if (!$helper->ask($input, $output, $question) && $input->isInteractive()) {
-                return;
+                return \Magento\Framework\Console\Cli::RETURN_FAILURE;
             }
             $this->doRollback($input, $output);
             $output->writeln('<info>Please set file permission of bin/magento to executable</info>');
@@ -133,7 +133,7 @@ class RollbackCommand extends AbstractSetupCommand
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             // we must have an exit code higher than zero to indicate something was wrong
-            $returnValue = 255;
+            $returnValue = \Magento\Framework\Console\Cli::RETURN_FAILURE;
         } finally {
             $output->writeln('<info>Disabling maintenance mode</info>');
             $this->maintenanceMode->set(false);

--- a/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/RollbackCommand.php
@@ -112,8 +112,10 @@ class RollbackCommand extends AbstractSetupCommand
         if (!$this->deploymentConfig->isAvailable() && ($input->getOption(self::INPUT_KEY_MEDIA_BACKUP_FILE)
                 || $input->getOption(self::INPUT_KEY_DB_BACKUP_FILE))) {
             $output->writeln("<info>No information is available: the Magento application is not installed.</info>");
-            return;
+            // we must have an exit code higher than zero to indicate something was wrong
+            return 255;
         }
+        $returnValue = 0;
         try {
             $output->writeln('<info>Enabling maintenance mode</info>');
             $this->maintenanceMode->set(true);
@@ -130,10 +132,13 @@ class RollbackCommand extends AbstractSetupCommand
 
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            // we must have an exit code higher than zero to indicate something was wrong
+            $returnValue = 255;
         } finally {
             $output->writeln('<info>Disabling maintenance mode</info>');
             $this->maintenanceMode->set(false);
         }
+        return $returnValue;
     }
 
     /**

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/CronRunCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/CronRunCommandTest.php
@@ -115,7 +115,7 @@ class CronRunCommandTest extends \PHPUnit_Framework_TestCase
         $this->deploymentConfig->expects($this->once())->method('isAvailable')->willReturn(true);
         $this->readinessCheck->expects($this->once())->method('runReadinessCheck')->willReturn(true);
         $this->status->expects($this->once())->method('isUpdateInProgress')->willReturn(false);
-        $this->status->expects($this->once())->method('isUpdateError')->willReturn(false);
+        $this->status->expects($this->exactly(2))->method('isUpdateError')->willReturn(false);
         $this->status->expects($this->exactly(2))->method('toggleUpdateInProgress');
     }
 


### PR DESCRIPTION
When you use bin/magento in a deployment flow it must return a non zero
exitcode when there was an error or an exception. Now the exceptions
caught and as a result the exitcode is 0. In a script we assume exit
code 0 to be all clear everything went fine.

So we must fix this here.

Signed-off-by: BlackEagle ike.devolder@gmail.com
