### PR TITLE
Update /Setup/Module/I18n/Dictionary/Phrase.php to fix issue #3211

### DIFF
--- a/setup/src/Magento/Setup/Module/I18n/Dictionary/Phrase.php
+++ b/setup/src/Magento/Setup/Module/I18n/Dictionary/Phrase.php
@@ -270,11 +270,8 @@ class Phrase
     {
         $encloseQuote = $this->getQuote() == Phrase::QUOTE_DOUBLE ? Phrase::QUOTE_DOUBLE : Phrase::QUOTE_SINGLE;
         //find all occurrences of ' and ", with no \ before it.
-        preg_match_all('/(?<!\\\\)[\'"]/', $string, $matches);
-        if (count($matches[0]) % 2 !== 0) {
-            $string = addslashes($string);
-        }
-        $evalString = 'return ' . $encloseQuote . $string . $encloseQuote . ';';
+        //above comment does not work on all modules. thus, escape all quotes is safer option
+        $evalString = 'return ' . $encloseQuote . addslashes($string) . $encloseQuote . ';';
         $result = @eval($evalString);
         return is_string($result) ? $result :  $string;
     }


### PR DESCRIPTION
After installing magento2 and executing command:
bin/magento i18n:collect-phrases -m

It will generate error:
PHP Parse error:  syntax error, unexpected 'Gateway' (T_STRING), expecting ';' in /path/setup/src/Magento/Setup/Module/I18n/Dictionary/Phrase.php(276) : eval()'d code on line 1
Parse error: syntax error, unexpected 'Gateway' (T_STRING), expecting ';' in /path/setup/src/Magento/Setup/Module/I18n/Dictionary/Phrase.php(276) : eval()'d code on line 1
## Caused by unescaped single quote while trying to get php strings.
## update: latest version also has the same issue.

This should fix it. please test and verify.
