### PR TITLE
Add check for object since getHeader can return bool

### DIFF
--- a/app/code/Magento/PageCache/Model/App/FrontController/BuiltinPlugin.php
+++ b/app/code/Magento/PageCache/Model/App/FrontController/BuiltinPlugin.php
@@ -91,10 +91,9 @@ class BuiltinPlugin
     {
         $cacheControlHeader = $result->getHeader('Cache-Control');
         if ($cacheControlHeader instanceof \Zend\Http\Header\HeaderInterface) {
-            $cacheControl = $cacheControlHeader->getFieldValue();
-            $this->addDebugHeader($result, 'X-Magento-Cache-Control', $cacheControl);
-            $this->addDebugHeader($result, 'X-Magento-Cache-Debug', 'MISS', true);
+            $this->addDebugHeader($result, 'X-Magento-Cache-Control', $cacheControlHeader->getFieldValue());
         }
+        $this->addDebugHeader($result, 'X-Magento-Cache-Debug', 'MISS', true);
         return $result;
     }
 

--- a/app/code/Magento/PageCache/Model/App/FrontController/BuiltinPlugin.php
+++ b/app/code/Magento/PageCache/Model/App/FrontController/BuiltinPlugin.php
@@ -89,9 +89,12 @@ class BuiltinPlugin
      */
     protected function addDebugHeaders(ResponseHttp $result)
     {
-        $cacheControl = $result->getHeader('Cache-Control')->getFieldValue();
-        $this->addDebugHeader($result, 'X-Magento-Cache-Control', $cacheControl);
-        $this->addDebugHeader($result, 'X-Magento-Cache-Debug', 'MISS', true);
+        $cacheControlHeader = $result->getHeader('Cache-Control');
+        if ($cacheControlHeader instanceof \Zend\Http\Header\HeaderInterface) {
+            $cacheControl = $cacheControlHeader->getFieldValue();
+            $this->addDebugHeader($result, 'X-Magento-Cache-Control', $cacheControl);
+            $this->addDebugHeader($result, 'X-Magento-Cache-Debug', 'MISS', true);
+        }
         return $result;
     }
 

--- a/app/code/Magento/PageCache/Model/Controller/Result/BuiltinPlugin.php
+++ b/app/code/Magento/PageCache/Model/Controller/Result/BuiltinPlugin.php
@@ -73,12 +73,11 @@ class BuiltinPlugin
         }
 
         if ($this->state->getMode() == \Magento\Framework\App\State::MODE_DEVELOPER) {
-            $cacheControlHeader = $result->getHeader('Cache-Control');
+            $cacheControlHeader = $response->getHeader('Cache-Control');
             if ($cacheControlHeader instanceof \Zend\Http\Header\HeaderInterface) {
-                $cacheControl = $cacheControlHeader->getFieldValue();
-                $response->setHeader('X-Magento-Cache-Control', $cacheControl);
-                $response->setHeader('X-Magento-Cache-Debug', 'MISS', true);
+                $response->setHeader('X-Magento-Cache-Control', $cacheControlHeader->getFieldValue());
             }
+            $response->setHeader('X-Magento-Cache-Debug', 'MISS', true);
         }
 
         $tagsHeader = $response->getHeader('X-Magento-Tags');

--- a/app/code/Magento/PageCache/Model/Controller/Result/BuiltinPlugin.php
+++ b/app/code/Magento/PageCache/Model/Controller/Result/BuiltinPlugin.php
@@ -73,9 +73,12 @@ class BuiltinPlugin
         }
 
         if ($this->state->getMode() == \Magento\Framework\App\State::MODE_DEVELOPER) {
-            $cacheControl = $response->getHeader('Cache-Control')->getFieldValue();
-            $response->setHeader('X-Magento-Cache-Control', $cacheControl);
-            $response->setHeader('X-Magento-Cache-Debug', 'MISS', true);
+            $cacheControlHeader = $result->getHeader('Cache-Control');
+            if ($cacheControlHeader instanceof \Zend\Http\Header\HeaderInterface) {
+                $cacheControl = $cacheControlHeader->getFieldValue();
+                $response->setHeader('X-Magento-Cache-Control', $cacheControl);
+                $response->setHeader('X-Magento-Cache-Debug', 'MISS', true);
+            }
         }
 
         $tagsHeader = $response->getHeader('X-Magento-Tags');


### PR DESCRIPTION
This issue happened to me when I used plugin to return `Redirect` result without setting `Cache-Control` header. 
In this case `getHeader` will return `false` and cause:

```
PHP Fatal error:  Call to a member function getFieldValue() on boolean
```
