### PR TITLE
requirejs-config.js files only generated for default locale

### DIFF
--- a/app/code/Magento/Deploy/Model/Deployer.php
+++ b/app/code/Magento/Deploy/Model/Deployer.php
@@ -135,6 +135,10 @@ class Deployer
                     $this->count = 0;
                     $this->errorCount = 0;
 
+                    /** @var \Magento\Framework\Locale\Resolver */
+                    $localeResolver = $this->objectManager->get('Magento\Framework\Locale\ResolverInterface');
+                    $localeResolver->setLocale($locale);
+
                     /** @var \Magento\Theme\Model\View\Design $design */
                     $design = $this->objectManager->create('Magento\Theme\Model\View\Design');
                     $design->setDesignTheme($themePath, $area);


### PR DESCRIPTION
When we deploy the static files, the requirejs-config.js files are only
generated for the default locale, no matter what locales are required in
the deployment.

For example, we have a Belgian shop with 4 locales nl_NL, fr_FR, de_DE
and en_US. Where we have nl_NL set as default locale for the shop.

we run:
$ bin/magento setup:static-content:deploy en_US nl_NL fr_FR de_DE

we only get the following requirejs-config files:

./pub/static/_requirejs/
./pub/static/_requirejs/adminhtml/
./pub/static/_requirejs/adminhtml/Magento/
./pub/static/_requirejs/adminhtml/Magento/backend/
./pub/static/_requirejs/adminhtml/Magento/backend/nl_NL/
./pub/static/_requirejs/adminhtml/Magento/backend/nl_NL/requirejs-config.js
./pub/static/_requirejs/frontend/
./pub/static/_requirejs/frontend/Magento/
./pub/static/_requirejs/frontend/Magento/blank/
./pub/static/_requirejs/frontend/Magento/blank/nl_NL/
./pub/static/_requirejs/frontend/Magento/blank/nl_NL/requirejs-config.js

This fix makes sure the localeresolver is set to the desired locale for
deploying resulting in:

./pub/static/_requirejs/
./pub/static/_requirejs/adminhtml/
./pub/static/_requirejs/adminhtml/Magento/
./pub/static/_requirejs/adminhtml/Magento/backend/
./pub/static/_requirejs/adminhtml/Magento/backend/nl_NL/
./pub/static/_requirejs/adminhtml/Magento/backend/nl_NL/requirejs-config.js
./pub/static/_requirejs/adminhtml/Magento/backend/en_US/
./pub/static/_requirejs/adminhtml/Magento/backend/en_US/requirejs-config.js
./pub/static/_requirejs/adminhtml/Magento/backend/fr_FR/
./pub/static/_requirejs/adminhtml/Magento/backend/fr_FR/requirejs-config.js
./pub/static/_requirejs/adminhtml/Magento/backend/de_DE/
./pub/static/_requirejs/adminhtml/Magento/backend/de_DE/requirejs-config.js
./pub/static/_requirejs/frontend/
./pub/static/_requirejs/frontend/Magento/
./pub/static/_requirejs/frontend/Magento/blank/
./pub/static/_requirejs/frontend/Magento/blank/nl_NL/
./pub/static/_requirejs/frontend/Magento/blank/nl_NL/requirejs-config.js
./pub/static/_requirejs/frontend/Magento/blank/en_US/
./pub/static/_requirejs/frontend/Magento/blank/en_US/requirejs-config.js
./pub/static/_requirejs/frontend/Magento/blank/fr_FR/
./pub/static/_requirejs/frontend/Magento/blank/fr_FR/requirejs-config.js
./pub/static/_requirejs/frontend/Magento/blank/de_DE/
./pub/static/_requirejs/frontend/Magento/blank/de_DE/requirejs-config.js

fixes MAG2DBCEN-21

Signed-off-by: Ike Devolder ike.devolder@studioemma.eu
