### PR TITLE
Static Block Widget - use identifier instead of id

### DIFF
--- a/app/code/Magento/Cms/Block/Adminhtml/Block/Widget/Chooser.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Block/Widget/Chooser.php
@@ -100,11 +100,11 @@ class Chooser extends \Magento\Backend\Block\Widget\Grid\Extended
         $js = '
             function (grid, event) {
                 var trElement = Event.findElement(event, "tr");
-                var blockId = trElement.down("td").innerHTML.replace(/^\s+|\s+$/g,"");
                 var blockTitle = trElement.down("td").next().innerHTML;
+                var blockIdentifier = trElement.down("td").next().next().innerHTML.trim();
                 ' .
             $chooserJsObject .
-            '.setElementValue(blockId);
+            '.setElementValue(blockIdentifier);
                 ' .
             $chooserJsObject .
             '.setElementLabel(blockTitle);


### PR DESCRIPTION
Adding a CMS Block Widget on a CMS Page results in a widget definition with a static block referenced by its id.
Given that the block is loaded by ID, you can't insert different blocks for different store views here.
Manually changing the id to the actual block identifier does work and then loads the static block by identifier.

This change does insert the identifier instead of the id from the block widget chooser.
