### PR TITLE
Resolves #2705: add explicit set of path component to generated uri

### DIFF
--- a/app/code/Magento/PageCache/Model/Cache/Server.php
+++ b/app/code/Magento/PageCache/Model/Cache/Server.php
@@ -5,16 +5,17 @@
  */
 namespace Magento\PageCache\Model\Cache;
 
-use Zend\Uri\Uri;
+use Magento\Framework\UrlInterface;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\App\RequestInterface;
+use Zend\Uri\Uri;
 use Zend\Uri\UriFactory;
 
 class Server
 {
     /**
-     * @var \Magento\Framework\UrlInterface
+     * @var UrlInterface
      */
     protected $urlBuilder;
 
@@ -33,12 +34,12 @@ class Server
     /**
      * Constructor
      *
-     * @param \Magento\Framework\UrlInterface $urlBuilder
+     * @param UrlInterface $urlBuilder
      * @param DeploymentConfig $config
      * @param RequestInterface $request
      */
     public function __construct(
-        \Magento\Framework\UrlInterface $urlBuilder,
+        UrlInterface $urlBuilder,
         DeploymentConfig $config,
         RequestInterface $request
     ) {
@@ -56,21 +57,25 @@ class Server
     {
         $servers = [];
         $configuredHosts = $this->config->get(ConfigOptionsListConstants::CONFIG_PATH_CACHE_HOSTS);
-        if (null == $configuredHosts) {
-            $httpHost = $this->request->getHttpHost();
-            $servers[] = $httpHost ?
-                UriFactory::factory('')->setHost($httpHost)->setPort(self::DEFAULT_PORT)->setScheme('http') :
-                UriFactory::factory($this->urlBuilder->getUrl('*', ['_nosid' => true])) // Don't use SID in building URL
-                    ->setScheme('http')
-                    ->setPath(null)
-                    ->setQuery(null);
 
-        } else {
+        if (is_array($configuredHosts)) {
             foreach ($configuredHosts as $host) {
-                $servers[] = UriFactory::factory('')->setHost($host['host'])
+                $servers[] = UriFactory::factory('')
+                    ->setHost($host['host'])
                     ->setPort(isset($host['port']) ? $host['port'] : self::DEFAULT_PORT)
-                    ->setScheme('http');
+                ;
             }
+        } elseif ($this->request->getHttpHost()) {
+            $servers[] = UriFactory::factory('')->setHost($this->request->getHttpHost())->setPort(self::DEFAULT_PORT);
+        } else {
+            $servers[] = UriFactory::factory($this->urlBuilder->getUrl('*', ['_nosid' => true]));
+        }
+
+        foreach ($servers as $key => $value) {
+            $servers[$key]->setScheme('http')
+                ->setPath('/')
+                ->setQuery(null)
+            ;
         }
         return $servers;
     }

--- a/app/code/Magento/PageCache/Test/Unit/Model/Cache/ServerTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Model/Cache/ServerTest.php
@@ -5,11 +5,13 @@
  */
 namespace Magento\PageCache\Test\Unit\Model\Cache;
 
+use \Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use \Magento\PageCache\Model\Cache\Server;
 use \Zend\Uri\UriFactory;
 
 class ServerTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var \Magento\PageCache\Model\Cache\Server */
+    /** @var Server */
     protected $model;
 
     /** @var \PHPUnit_Framework_MockObject_MockObject | \Magento\Framework\App\DeploymentConfig */
@@ -30,7 +32,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $objectManager = new ObjectManager($this);
         $this->model = $objectManager->getObject(
             'Magento\PageCache\Model\Cache\Server',
             [
@@ -56,12 +58,9 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $url,
         $hostConfig = null
     ) {
-        $this->configMock->expects($this->once())
-            ->method('get')
-            ->willReturn($hostConfig);
-        $this->requestMock->expects($this->exactly($getHttpHostCallCtr))
-            ->method('getHttpHost')
-            ->willReturn($httpHost);
+        $this->configMock->expects($this->once())->method('get')->willReturn($hostConfig);
+        $this->requestMock->expects($this->exactly($getHttpHostCallCtr))->method('getHttpHost')->willReturn($httpHost);
+
         $this->urlBuilderMock->expects($this->exactly($getUrlCallCtr))
             ->method('getUrl')
             ->with('*', ['_nosid' => true])
@@ -70,20 +69,22 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $uris = [];
         if (null === $hostConfig) {
             if (!empty($httpHost)) {
-                $uris[] = UriFactory::factory('')->setHost($httpHost)
-                    ->setPort(\Magento\PageCache\Model\Cache\Server::DEFAULT_PORT)
-                    ->setScheme('http');
+                $uris[] = UriFactory::factory('')->setHost($httpHost)->setPort(Server::DEFAULT_PORT);
             }
             if (!empty($url)) {
                 $uris[] = UriFactory::factory($url);
             }
         } else {
             foreach ($hostConfig as $host) {
-                $port = isset($host['port']) ? $host['port'] : \Magento\PageCache\Model\Cache\Server::DEFAULT_PORT;
-                $uris[] = UriFactory::factory('')->setHost($host['host'])
-                    ->setPort($port)
-                    ->setScheme('http');
+                $port = isset($host['port']) ? $host['port'] : Server::DEFAULT_PORT;
+                $uris[] = UriFactory::factory('')->setHost($host['host'])->setPort($port);
             }
+        }
+
+        foreach ($uris as $key => $value) {
+            $uris[$key]->setScheme('http')
+                ->setPath('/')
+                ->setQuery(null);
         }
 
         $this->assertEquals($uris, $this->model->getUris());
@@ -92,8 +93,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function getUrisDataProvider()
     {
         return [
-            'http host' => [1, '127.0.0.1', 0, '',],
-            'url' => [1, '', 1, 'http://host',],
+            'http host' => [2, '127.0.0.1', 0, ''],
+            'url' => [1, '', 1, 'http://host'],
             'config' => [
                 0,
                 '',


### PR DESCRIPTION
Resolves #2705 and #3315. Zend URI classes only add a / automatically if there is either a query or fragment present. There is no query or fragment on the URI for varnish purge requests, so we must explicitly set the path component for it to be correctly included in the request URI. See https://github.com/magento/magento2/issues/2705#issuecomment-181549658 for further details.
