### PR TITLE
File/Uploader :: rename can throw exception

### DIFF
--- a/lib/internal/Magento/Framework/File/Uploader.php
+++ b/lib/internal/Magento/Framework/File/Uploader.php
@@ -220,7 +220,16 @@ class Uploader
 
         $destinationFile = self::_addDirSeparator($destinationFile) . $fileName;
 
-        $this->_result = $this->_moveFile($this->_file['tmp_name'], $destinationFile);
+        try {
+            $this->_result = $this->_moveFile($this->_file['tmp_name'], $destinationFile);
+        } catch (\Exception $e) {
+            // if the file exists and we had an exception continue anyway
+            if (file_exists($destinationFile)) {
+                $this->_result = true;
+            } else {
+                throw $e;
+            }
+        }
 
         if ($this->_result) {
             $this->chmod($destinationFile);


### PR DESCRIPTION
When rename encouters a warning, where a chmod is not possible for
example, it will throw an exception when running with error_reporting
-1. When there was an exception, first go and check if the file is
there, if not rethrow the exception.

Signed-off-by: Ike Devolder ike.devolder@studioemma.eu
