### PR TITLE
Improve developer exception HTTP response

### DIFF
--- a/lib/internal/Magento/Framework/App/Http.php
+++ b/lib/internal/Magento/Framework/App/Http.php
@@ -161,11 +161,41 @@ class Http implements \Magento\Framework\AppInterface
             }
             $this->_response->setHttpResponseCode(500);
             $this->_response->setHeader('Content-Type', 'text/plain');
-            $this->_response->setBody($exception->getMessage() . "\n" . $exception->getTraceAsString());
+            $this->_response->setBody($this->buildContentFromException($exception));
             $this->_response->sendResponse();
             return true;
         }
         return false;
+    }
+
+    /**
+     * build content based on an exception
+     *
+     * @param \Exception $exception
+     * @return string
+     */
+    private function buildContentFromException(\Exception $exception)
+    {
+        /** @var \Exception[] $exceptions */
+        $exceptions = [];
+        do {
+            $exceptions[] = $exception;
+        } while ($exception = $exception->getPrevious());
+
+        $buffer = sprintf("%d exception(s):\n", count($exceptions));
+
+        foreach ($exceptions as $index => $exception) {
+            $buffer .= sprintf("Exception #%d (%s): %s\n", $index, get_class($exception), $exception->getMessage());
+        }
+
+        foreach ($exceptions as $index => $exception) {
+            $buffer .= sprintf(
+                "\nException #%d (%s): %s\n%s\n", $index, get_class($exception), $exception->getMessage(),
+                $exception->getTraceAsString()
+            );
+        }
+
+        return $buffer;
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Test/Unit/HttpTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/HttpTest.php
@@ -205,7 +205,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
             ->will($this->throwException(new \Exception('strange error')));
         $this->responseMock->expects($this->once())->method('setHttpResponseCode')->with(500);
         $this->responseMock->expects($this->once())->method('setHeader')->with('Content-Type', 'text/plain');
-        $constraint = new \PHPUnit_Framework_Constraint_StringStartsWith('strange error');
+        $constraint = new \PHPUnit_Framework_Constraint_StringStartsWith('1 exception(s):');
         $this->responseMock->expects($this->once())->method('setBody')->with($constraint);
         $this->responseMock->expects($this->once())->method('sendResponse');
         $bootstrap = $this->getBootstrapNotInstalled();

--- a/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
@@ -251,6 +251,7 @@ class Block implements Layout\GeneratorInterface
      */
     protected function getBlockInstance($block, array $arguments = [])
     {
+        $e = null;
         if ($block && is_string($block)) {
             try {
                 $block = $this->blockFactory->createBlock($block, $arguments);
@@ -260,7 +261,8 @@ class Block implements Layout\GeneratorInterface
         }
         if (!$block instanceof \Magento\Framework\View\Element\AbstractBlock) {
             throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('Invalid block type: %1', [$block])
+                new \Magento\Framework\Phrase('Invalid block type: %1', [$block]),
+                $e
             );
         }
         return $block;


### PR DESCRIPTION
Show all exceptions incl. previous ones and also their types.

Do a summary first, listing all the details then.

Previously only the message and trace of the last exception has been shown.

Additionally add the previous exception (if any) in case a Block could not 
be instantiated.

Todo:
- [x] Wait for first travis build to finish
- [x] Fix typos in commit message
- [x] Wait for feedback
- [x] Wait for second, third travis build to finish
- [x] Fix tests
- [ ] Wait for restarting of some Travis build tasks
- [ ] Wait for feedback
