### PR TITLE
(Improve) Checkout Refresh Shipping Methods

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
@@ -65,6 +65,10 @@ define(
                         self.bindHandler(elem, delay);
                         postcodeElement = elem;
                     }
+                    
+                    if (elem.index === 'region_id') {
+                        self.bindHandler(elem, delay);
+                    }
                 });
             },
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
@@ -66,7 +66,7 @@ define(
                         postcodeElement = elem;
                     }
                     
-                    if (elem.index === 'region_id') {
+                    if (elem.index === 'region_id') { 
                         self.bindHandler(elem, delay);
                     }
                 });


### PR DESCRIPTION
I notice that at Checkout/index only reload the shipping method when you change country or postcode fields. 
I know, the last step when you fill your address form should be the postcode. But I think it could be a problem with people who fill the postcode first, change the country next, and fill the region at last... 
Besides, I did a shipping method based on region and, at this step, when you change the region it didn't pass the paremeter region and it can't be validated by my code.
That's why I suggest to include REGION field condition like postcode at "bindChangeHandlers".
Meanwhile I will include these changes at my theme files.
