### PR TITLE
Issue #2361: Allow `AbstractAction` to handle `_isAllowed()` logic

### DIFF
--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification.php
@@ -9,11 +9,10 @@ namespace Magento\AdminNotification\Controller\Adminhtml;
 
 abstract class Notification extends \Magento\Backend\App\AbstractAction
 {
+
     /**
-     * @return bool
+     * Authorization level of a basic admin session
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_AdminNotification::show_list');
-    }
+    const ADMIN_RESOURCE = 'Magento_AdminNotification::show_list';
+
 }

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MarkAsRead.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MarkAsRead.php
@@ -9,6 +9,13 @@ namespace Magento\AdminNotification\Controller\Adminhtml\Notification;
 class MarkAsRead extends \Magento\AdminNotification\Controller\Adminhtml\Notification
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_AdminNotification::mark_as_read';
+
+    /**
      * @return void
      */
     public function execute()
@@ -35,13 +42,5 @@ class MarkAsRead extends \Magento\AdminNotification\Controller\Adminhtml\Notific
             return;
         }
         $this->_redirect('adminhtml/*/');
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_AdminNotification::mark_as_read');
     }
 }

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassMarkAsRead.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassMarkAsRead.php
@@ -8,6 +8,14 @@ namespace Magento\AdminNotification\Controller\Adminhtml\Notification;
 
 class MassMarkAsRead extends \Magento\AdminNotification\Controller\Adminhtml\Notification
 {
+
+    /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_AdminNotification::mark_as_read';
+
     /**
      * @return void
      */
@@ -37,13 +45,5 @@ class MassMarkAsRead extends \Magento\AdminNotification\Controller\Adminhtml\Not
             }
         }
         $this->_redirect('adminhtml/*/');
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_AdminNotification::mark_as_read');
     }
 }

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassRemove.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/MassRemove.php
@@ -8,6 +8,14 @@ namespace Magento\AdminNotification\Controller\Adminhtml\Notification;
 
 class MassRemove extends \Magento\AdminNotification\Controller\Adminhtml\Notification
 {
+
+    /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_AdminNotification::adminnotification_remove';
+
     /**
      * @return void
      */
@@ -32,13 +40,5 @@ class MassRemove extends \Magento\AdminNotification\Controller\Adminhtml\Notific
             }
         }
         $this->getResponse()->setRedirect($this->_redirect->getRedirectUrl($this->getUrl('*')));
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_AdminNotification::adminnotification_remove');
     }
 }

--- a/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/Remove.php
+++ b/app/code/Magento/AdminNotification/Controller/Adminhtml/Notification/Remove.php
@@ -8,6 +8,14 @@ namespace Magento\AdminNotification\Controller\Adminhtml\Notification;
 
 class Remove extends \Magento\AdminNotification\Controller\Adminhtml\Notification
 {
+
+    /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_AdminNotification::adminnotification_remove';
+
     /**
      * @return void
      */
@@ -34,13 +42,5 @@ class Remove extends \Magento\AdminNotification\Controller\Adminhtml\Notificatio
             return;
         }
         $this->_redirect('adminhtml/*/');
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_AdminNotification::adminnotification_remove');
     }
 }

--- a/app/code/Magento/Backend/Controller/Adminhtml/Cache.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Cache.php
@@ -11,6 +11,13 @@ use Magento\Framework\Exception\LocalizedException;
 abstract class Cache extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Backend::cache';
+
+    /**
      * @var \Magento\Framework\App\Cache\TypeListInterface
      */
     protected $_cacheTypeList;
@@ -68,15 +75,5 @@ abstract class Cache extends Action
         if (count($invalidTypes) > 0) {
             throw new LocalizedException(__('Specified cache type(s) don\'t exist: %1', join(', ', $invalidTypes)));
         }
-    }
-
-    /**
-     * Check if cache management is allowed
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Backend::cache');
     }
 }

--- a/app/code/Magento/Backend/Controller/Adminhtml/Dashboard.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Dashboard.php
@@ -14,10 +14,9 @@ namespace Magento\Backend\Controller\Adminhtml;
 abstract class Dashboard extends \Magento\Backend\App\Action
 {
     /**
-     * @return bool
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Backend::dashboard');
-    }
+    const ADMIN_RESOURCE = 'Magento_Backend::dashboard';
 }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System.php
@@ -15,10 +15,9 @@ use Magento\Backend\App\AbstractAction;
 abstract class System extends AbstractAction
 {
     /**
-     * @return bool
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Backend::system');
-    }
+    const ADMIN_RESOURCE = 'Magento_Backend::system';
 }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Account.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Account.php
@@ -15,10 +15,9 @@ use Magento\Backend\App\Action;
 abstract class Account extends Action
 {
     /**
-     * @return bool
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Backend::myaccount');
-    }
+    const ADMIN_RESOURCE = 'Magento_Backend::myaccount';
 }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Design.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Design.php
@@ -10,6 +10,13 @@ use Magento\Backend\App\Action;
 abstract class Design extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Backend::design';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -58,13 +65,5 @@ abstract class Design extends Action
         $this->resultForwardFactory = $resultForwardFactory;
         $this->resultPageFactory = $resultPageFactory;
         $this->resultLayoutFactory = $resultLayoutFactory;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Backend::design');
     }
 }

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
@@ -20,6 +20,13 @@ use Magento\Framework\Filesystem;
 abstract class Store extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Backend::store';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -75,14 +82,6 @@ abstract class Store extends Action
             ->addBreadcrumb(__('System'), __('System'))
             ->addBreadcrumb(__('Manage Stores'), __('Manage Stores'));
         return $resultPage;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Backend::store');
     }
 
     /**

--- a/app/code/Magento/Backup/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Backup/Controller/Adminhtml/Index.php
@@ -13,6 +13,13 @@ namespace Magento\Backup\Controller\Adminhtml;
 abstract class Index extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Backend::backup';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -61,15 +68,5 @@ abstract class Index extends \Magento\Backend\App\Action
         $this->_backupModelFactory = $backupModelFactory;
         $this->maintenanceMode = $maintenanceMode;
         parent::__construct($context);
-    }
-
-    /**
-     * Check Permissions for all actions
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Backup::backup');
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category.php
@@ -11,6 +11,13 @@ namespace Magento\Catalog\Controller\Adminhtml;
 abstract class Category extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Catalog::categories';
+
+    /**
      * Initialize requested category and put it into registry.
      * Root category can be returned, if inappropriate store/category is specified
      *
@@ -48,15 +55,5 @@ abstract class Category extends \Magento\Backend\App\Action
         $this->_objectManager->get('Magento\Cms\Model\Wysiwyg\Config')
             ->setStoreId($this->getRequest()->getParam('store'));
         return $category;
-    }
-
-    /**
-     * Check if admin has permissions to visit related pages
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::categories');
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Wysiwyg.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Wysiwyg.php
@@ -9,12 +9,9 @@ namespace Magento\Catalog\Controller\Adminhtml\Category;
 class Wysiwyg extends \Magento\Catalog\Controller\Adminhtml\Product\Wysiwyg
 {
     /**
-     * Check if admin has permissions to visit related pages
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::categories');
-    }
+    const ADMIN_RESOURCE = 'Magento_Catalog::categories';
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product.php
@@ -14,6 +14,13 @@ use Magento\Backend\App\Action;
 abstract class Product extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Catalog::products';
+
+    /**
      * @var Product\Builder
      */
     protected $productBuilder;
@@ -28,15 +35,5 @@ abstract class Product extends \Magento\Backend\App\Action
     ) {
         $this->productBuilder = $productBuilder;
         parent::__construct($context);
-    }
-
-    /**
-     * Check for is allowed
-     *
-     * @return boolean
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::products');
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute.php
@@ -16,6 +16,13 @@ use Magento\Backend\App\Action;
 abstract class Attribute extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Catalog::update_attributes';
+
+    /**
      *  @var \Magento\Catalog\Helper\Product\Edit\Action\Attribute
      */
     protected $attributeHelper;
@@ -52,13 +59,5 @@ abstract class Attribute extends Action
         }
 
         return !$error;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::update_attributes');
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute.php
@@ -15,6 +15,13 @@ use Magento\Framework\View\Result\PageFactory;
 abstract class Attribute extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Catalog::attributes_attributes';
+
+    /**
      * @var \Magento\Framework\Cache\FrontendInterface
      */
     protected $_attributeLabelCache;
@@ -122,15 +129,5 @@ abstract class Attribute extends \Magento\Backend\App\Action
             $code = 'attr_' . ($code ?: substr(md5(time()), 0, 8));
         }
         return $code;
-    }
-
-    /**
-     * ACL check
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::attributes_attributes');
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Gallery/Upload.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Gallery/Upload.php
@@ -11,6 +11,13 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class Upload extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Catalog::products';
+
+    /**
      * @var \Magento\Framework\Controller\Result\RawFactory
      */
     protected $resultRawFactory;
@@ -25,14 +32,6 @@ class Upload extends \Magento\Backend\App\Action
     ) {
         parent::__construct($context);
         $this->resultRawFactory = $resultRawFactory;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::products');
     }
 
     /**

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Group/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Group/Save.php
@@ -9,12 +9,11 @@ namespace Magento\Catalog\Controller\Adminhtml\Product\Group;
 class Save extends \Magento\Backend\App\Action
 {
     /**
-     * @return bool
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Catalog::products';
 
     /**
      * @return void

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set.php
@@ -13,6 +13,13 @@ namespace Magento\Catalog\Controller\Adminhtml\Product;
 abstract class Set extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Catalog::sets';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -40,13 +47,5 @@ abstract class Set extends \Magento\Backend\App\Action
             'entityType',
             $this->_objectManager->create('Magento\Catalog\Model\Product')->getResource()->getTypeId()
         );
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::sets');
     }
 }

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog.php
@@ -19,6 +19,13 @@ use Magento\Framework\Stdlib\DateTime\Filter\Date;
 abstract class Catalog extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_CatalogRule::promo_catalog';
+
+    /**
      * Dirty rules notice message
      *
      *
@@ -69,16 +76,6 @@ abstract class Catalog extends Action
             __('Promotions')
         );
         return $this;
-    }
-
-    /**
-     * Is access to section allowed
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_CatalogRule::promo_catalog');
     }
 
     /**

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Index.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Index.php
@@ -9,12 +9,11 @@ namespace Magento\CatalogRule\Controller\Adminhtml\Promo;
 class Index extends \Magento\Backend\App\Action
 {
     /**
-     * @return bool
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_CatalogRule::promo');
-    }
+    const ADMIN_RESOURCE = 'Magento_CatalogRule::promo';
 
     /**
      * @return void

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Widget.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Widget.php
@@ -10,10 +10,9 @@ use Magento\Backend\App\Action;
 abstract class Widget extends Action
 {
     /**
-     * @return bool
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_CatalogRule::promo_catalog');
-    }
+    const ADMIN_RESOURCE = 'Magento_CatalogRule::promo_catalog';
 }

--- a/app/code/Magento/CatalogWidget/Controller/Adminhtml/Product/Widget.php
+++ b/app/code/Magento/CatalogWidget/Controller/Adminhtml/Product/Widget.php
@@ -13,10 +13,9 @@ use Magento\Backend\App\Action;
 abstract class Widget extends Action
 {
     /**
-     * @return bool
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Widget::widget_instance');
-    }
+    const ADMIN_RESOURCE = 'Magento_Widget::widget_instance';
 }

--- a/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement.php
+++ b/app/code/Magento/CheckoutAgreements/Controller/Adminhtml/Agreement.php
@@ -8,6 +8,13 @@ namespace Magento\CheckoutAgreements\Controller\Adminhtml;
 abstract class Agreement extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_CheckoutAgreements::checkoutagreement';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -43,14 +50,5 @@ abstract class Agreement extends \Magento\Backend\App\Action
             __('Checkout Terms and Conditions')
         );
         return $this;
-    }
-
-    /**
-     * @return bool
-     * @codeCoverageIgnore
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_CheckoutAgreements::checkoutagreement');
     }
 }

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block.php
@@ -8,6 +8,13 @@ namespace Magento\Cms\Controller\Adminhtml;
 abstract class Block extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Cms::block';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -38,13 +45,4 @@ abstract class Block extends \Magento\Backend\App\Action
         return $resultPage;
     }
 
-    /**
-     * Check the permission to run it
-     *
-     * @return boolean
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Cms::block');
-    }
 }

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/Delete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/Delete.php
@@ -9,12 +9,11 @@ namespace Magento\Cms\Controller\Adminhtml\Page;
 class Delete extends \Magento\Backend\App\Action
 {
     /**
-     * {@inheritdoc}
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Cms::page_delete');
-    }
+    const ADMIN_RESOURCE = 'Magento_Cms::page_delete';
 
     /**
      * Delete action

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/Edit.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/Edit.php
@@ -11,6 +11,13 @@ use Magento\Backend\App\Action;
 class Edit extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Cms::save';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -35,14 +42,6 @@ class Edit extends \Magento\Backend\App\Action
         $this->resultPageFactory = $resultPageFactory;
         $this->_coreRegistry = $registry;
         parent::__construct($context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Cms::save');
     }
 
     /**

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/Index.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/Index.php
@@ -12,6 +12,13 @@ use Magento\Framework\View\Result\PageFactory;
 class Index extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Cms::page';
+
+    /**
      * @var PageFactory
      */
     protected $resultPageFactory;
@@ -26,15 +33,6 @@ class Index extends \Magento\Backend\App\Action
     ) {
         parent::__construct($context);
         $this->resultPageFactory = $resultPageFactory;
-    }
-    /**
-     * Check the permission to run it
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Cms::page');
     }
 
     /**

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/NewAction.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/NewAction.php
@@ -9,6 +9,13 @@ namespace Magento\Cms\Controller\Adminhtml\Page;
 class NewAction extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Cms::save';
+
+    /**
      * @var \Magento\Backend\Model\View\Result\Forward
      */
     protected $resultForwardFactory;
@@ -23,14 +30,6 @@ class NewAction extends \Magento\Backend\App\Action
     ) {
         $this->resultForwardFactory = $resultForwardFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Cms::save');
     }
 
     /**

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/Save.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/Save.php
@@ -14,6 +14,13 @@ use Magento\Framework\Exception\LocalizedException;
 class Save extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Cms::save';
+
+    /**
      * @var PostDataProcessor
      */
     protected $dataProcessor;
@@ -36,14 +43,6 @@ class Save extends \Magento\Backend\App\Action
         $this->dataProcessor = $dataProcessor;
         $this->dataPersistor = $dataPersistor;
         parent::__construct($context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Cms::save');
     }
 
     /**

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images.php
@@ -13,6 +13,13 @@ namespace Magento\Cms\Controller\Adminhtml\Wysiwyg;
 abstract class Images extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Cms::media_gallery';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -52,15 +59,5 @@ abstract class Images extends \Magento\Backend\App\Action
             $this->_coreRegistry->register('storage', $storage);
         }
         return $this->_coreRegistry->registry('storage');
-    }
-
-    /**
-     * Check current user permission on resource and privilege
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Cms::media_gallery');
     }
 }

--- a/app/code/Magento/Config/Controller/Adminhtml/System/AbstractConfig.php
+++ b/app/code/Magento/Config/Controller/Adminhtml/System/AbstractConfig.php
@@ -67,7 +67,7 @@ abstract class AbstractConfig extends \Magento\Backend\App\AbstractAction
     protected function _isAllowed()
     {
         $sectionId = $this->_request->getParam('section');
-        return $this->_isAllowed()
+        return $this->_authorization->isAllowed('Magento_Config::config')
             || $this->_configStructure->getElement($sectionId)->isAllowed();
     }
 

--- a/app/code/Magento/Config/Controller/Adminhtml/System/AbstractConfig.php
+++ b/app/code/Magento/Config/Controller/Adminhtml/System/AbstractConfig.php
@@ -18,7 +18,7 @@ abstract class AbstractConfig extends \Magento\Backend\App\AbstractAction
      *
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_Cms::config';
+    const ADMIN_RESOURCE = 'Magento_Config::config';
 
     /**
      * @var \Magento\Config\Model\Config\Structure

--- a/app/code/Magento/Config/Controller/Adminhtml/System/AbstractConfig.php
+++ b/app/code/Magento/Config/Controller/Adminhtml/System/AbstractConfig.php
@@ -14,6 +14,13 @@ use Magento\Config\Controller\Adminhtml\System\ConfigSectionChecker;
 abstract class AbstractConfig extends \Magento\Backend\App\AbstractAction
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Cms::config';
+
+    /**
      * @var \Magento\Config\Model\Config\Structure
      */
     protected $_configStructure;
@@ -60,7 +67,7 @@ abstract class AbstractConfig extends \Magento\Backend\App\AbstractAction
     protected function _isAllowed()
     {
         $sectionId = $this->_request->getParam('section');
-        return $this->_authorization->isAllowed('Magento_Config::config')
+        return $this->_isAllowed()
             || $this->_configStructure->getElement($sectionId)->isAllowed();
     }
 

--- a/app/code/Magento/ConfigurableProduct/Controller/Adminhtml/Product/Attribute/CreateOptions.php
+++ b/app/code/Magento/ConfigurableProduct/Controller/Adminhtml/Product/Attribute/CreateOptions.php
@@ -13,6 +13,13 @@ use Magento\Catalog\Model\ResourceModel\Eav\AttributeFactory;
 class CreateOptions extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Catalog::attributes_attributes';
+
+    /**
      * @var \Magento\Framework\Json\Helper\Data
      */
     protected $jsonHelper;
@@ -35,16 +42,6 @@ class CreateOptions extends Action
         $this->jsonHelper = $jsonHelper;
         $this->attributeFactory = $attributeFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * ACL check
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::attributes_attributes');
     }
 
     /**

--- a/app/code/Magento/ConfigurableProduct/Controller/Adminhtml/Product/Attribute/GetAttributes.php
+++ b/app/code/Magento/ConfigurableProduct/Controller/Adminhtml/Product/Attribute/GetAttributes.php
@@ -12,6 +12,13 @@ use Magento\ConfigurableProduct\Model\AttributesListInterface;
 class GetAttributes extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Catalog::attributes_attributes';
+
+    /**
      * Store manager
      *
      * @var \Magento\Store\Model\StoreManagerInterface
@@ -39,16 +46,6 @@ class GetAttributes extends Action
         $this->jsonHelper = $jsonHelper;
         $this->attributesList = $attributesList;
         parent::__construct($context);
-    }
-
-    /**
-     * ACL check
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::attributes_attributes');
     }
 
     /**

--- a/app/code/Magento/ConfigurableProduct/Controller/Adminhtml/Product/Attribute/SuggestConfigurableAttributes.php
+++ b/app/code/Magento/ConfigurableProduct/Controller/Adminhtml/Product/Attribute/SuggestConfigurableAttributes.php
@@ -12,6 +12,13 @@ use Magento\ConfigurableProduct\Model\SuggestedAttributeList;
 class SuggestConfigurableAttributes extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Catalog::attributes_attributes';
+
+    /**
      * @var \Magento\ConfigurableProduct\Model\SuggestedAttributeList
      */
     protected $attributeList;
@@ -44,16 +51,6 @@ class SuggestConfigurableAttributes extends Action
         $this->jsonHelper = $jsonHelper;
         $this->storeManager = $storeManager;
         parent::__construct($context);
-    }
-
-    /**
-     * ACL check
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::attributes_attributes');
     }
 
     /**

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency.php
@@ -14,6 +14,13 @@ namespace Magento\CurrencySymbol\Controller\Adminhtml\System;
 abstract class Currency extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_CurrencySymbol::currency_rates';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -28,15 +35,5 @@ abstract class Currency extends \Magento\Backend\App\Action
     {
         $this->_coreRegistry = $coreRegistry;
         parent::__construct($context);
-    }
-
-    /**
-     * Check if allowed
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_CurrencySymbol::currency_rates');
     }
 }

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol.php
@@ -14,12 +14,10 @@ namespace Magento\CurrencySymbol\Controller\Adminhtml\System;
 abstract class Currencysymbol extends \Magento\Backend\App\Action
 {
     /**
-     * Check the permission to run it
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_CurrencySymbol::symbols');
-    }
+    const ADMIN_RESOURCE = 'Magento_CurrencySymbol::symbols';
+
 }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Cart/Product/Composite/Cart.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Cart/Product/Composite/Cart.php
@@ -16,6 +16,13 @@ use Magento\Framework\Exception\LocalizedException;
 abstract class Cart extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::manage';
+
+    /**
      * Customer we're working with
      *
      * @var int id of the customer
@@ -92,15 +99,5 @@ abstract class Cart extends \Magento\Backend\App\Action
         }
 
         return $this;
-    }
-
-    /**
-     * Check the permission to Manage Customers
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Customer::manage');
     }
 }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Group.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Group.php
@@ -14,6 +14,13 @@ use Magento\Customer\Api\GroupRepositoryInterface;
 abstract class Group extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see \Magento\Backend\App\Action\_isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::group';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -64,15 +71,5 @@ abstract class Group extends \Magento\Backend\App\Action
         parent::__construct($context);
         $this->resultForwardFactory = $resultForwardFactory;
         $this->resultPageFactory = $resultPageFactory;
-    }
-
-    /**
-     * Determine if authorized to perform group actions.
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Customer::group');
     }
 }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index.php
@@ -27,6 +27,13 @@ use Magento\Framework\Api\DataObjectHelper;
 abstract class Index extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::manage';
+
+    /**
      * @var \Magento\Framework\Validator
      */
     protected $_validator;
@@ -298,15 +305,5 @@ abstract class Index extends \Magento\Backend\App\Action
             }
         }
         return $customersUpdated;
-    }
-
-    /**
-     * Customer access rights checking
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Customer::manage');
     }
 }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/AbstractMassAction.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/AbstractMassAction.php
@@ -19,6 +19,13 @@ use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
 abstract class AbstractMassAction extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::manage';
+
+    /**
      * @var string
      */
     protected $redirectUrl = '*/*/index';
@@ -62,16 +69,6 @@ abstract class AbstractMassAction extends \Magento\Backend\App\Action
             $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
             return $resultRedirect->setPath($this->redirectUrl);
         }
-    }
-
-    /**
-     * Check the permission to Manage Customers
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Customer::manage');
     }
 
     /**

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/InlineEdit.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/InlineEdit.php
@@ -15,6 +15,13 @@ use Magento\Customer\Api\CustomerRepositoryInterface;
  */
 class InlineEdit extends \Magento\Backend\App\Action
 {
+    /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::manage';
+
     /** @var CustomerInterface */
     private $customer;
 
@@ -249,15 +256,5 @@ class InlineEdit extends \Magento\Backend\App\Action
     protected function getErrorWithCustomerId($errorText)
     {
         return '[Customer ID: ' . $this->getCustomer()->getId() . '] ' . __($errorText);
-    }
-
-    /**
-     * Customer access rights checking
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Customer::manage');
     }
 }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Online/Index.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Online/Index.php
@@ -12,6 +12,13 @@ use Magento\Framework\View\Result\PageFactory;
 class Index extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::online';
+
+    /**
      * @var PageFactory
      */
     protected $resultPageFactory;
@@ -26,16 +33,6 @@ class Index extends \Magento\Backend\App\Action
     ) {
         parent::__construct($context);
         $this->resultPageFactory = $resultPageFactory;
-    }
-
-    /**
-     * Check the permission to run it
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Customer::online');
     }
 
     /**

--- a/app/code/Magento/Customer/Controller/Adminhtml/Wishlist/Product/Composite/Wishlist.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Wishlist/Product/Composite/Wishlist.php
@@ -13,6 +13,13 @@ use Magento\Framework\Exception\LocalizedException as CoreException;
 abstract class Wishlist extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::manage';
+
+    /**
      * Wishlist we're working with.
      *
      * @var \Magento\Wishlist\Model\Wishlist
@@ -52,15 +59,5 @@ abstract class Wishlist extends \Magento\Backend\App\Action
         $this->_wishlistItem = $wishlistItem;
 
         return $this;
-    }
-
-    /**
-     * Check the permission to Manage Customers
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Customer::manage');
     }
 }

--- a/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/File.php
+++ b/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/File.php
@@ -13,12 +13,9 @@ namespace Magento\Downloadable\Controller\Adminhtml\Downloadable;
 abstract class File extends \Magento\Backend\App\Action
 {
     /**
-     * Check admin permissions for this controller
+     * Authorization level of a basic admin session
      *
-     * @return boolean
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Catalog::products';
 }

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template.php
@@ -13,6 +13,12 @@ namespace Magento\Email\Controller\Adminhtml\Email;
 abstract class Template extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Email::template';
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -49,15 +55,5 @@ abstract class Template extends \Magento\Backend\App\Action
             $this->_coreRegistry->register('current_email_template', $model);
         }
         return $model;
-    }
-
-    /**
-     * Check if user has enough privileges
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Email::template');
     }
 }

--- a/app/code/Magento/GroupedProduct/Controller/Adminhtml/Edit/Popup.php
+++ b/app/code/Magento/GroupedProduct/Controller/Adminhtml/Edit/Popup.php
@@ -15,6 +15,13 @@ use Magento\Framework\Controller\ResultFactory;
 class Popup extends AbstractAction
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Catalog::products';
+
+    /**
      * @var \Magento\Framework\Registry
      */
     protected $registry;
@@ -45,16 +52,6 @@ class Popup extends AbstractAction
         $this->factory = $factory;
         $this->logger = $logger;
         parent::__construct($context);
-    }
-
-    /**
-     * Check for is allowed
-     *
-     * @return boolean
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Catalog::products');
     }
 
     /**

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export.php
@@ -13,12 +13,9 @@ use Magento\Backend\App\Action;
 abstract class Export extends Action
 {
     /**
-     * Check access (in the ACL) for current user
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_ImportExport::export');
-    }
+    const ADMIN_RESOURCE = 'Magento_ImportExport::export';
 }

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/History.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/History.php
@@ -13,12 +13,9 @@ use Magento\Backend\App\Action;
 abstract class History extends Action
 {
     /**
-     * Check access (in the ACL) for current user
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_ImportExport::history');
-    }
+    const ADMIN_RESOURCE = 'Magento_ImportExport::history';
 }

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import.php
@@ -19,5 +19,5 @@ abstract class Import extends Action
      *
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_Customer::import';
+    const ADMIN_RESOURCE = 'Magento_ImportExport::import';
 }

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import.php
@@ -15,12 +15,9 @@ use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingErrorAggregatorI
 abstract class Import extends Action
 {
     /**
-     * Check access (in the ACL) for current user.
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_ImportExport::import');
-    }
+    const ADMIN_RESOURCE = 'Magento_Customer::import';
 }

--- a/app/code/Magento/Integration/Controller/Adminhtml/Integration.php
+++ b/app/code/Magento/Integration/Controller/Adminhtml/Integration.php
@@ -15,6 +15,13 @@ use Magento\Integration\Api\OauthServiceInterface as IntegrationOauthService;
  */
 abstract class Integration extends Action
 {
+    /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Integration::integrations';
+
     /** Param Key for extracting integration id from Request */
     const PARAM_INTEGRATION_ID = 'id';
 
@@ -83,16 +90,6 @@ abstract class Integration extends Action
         $this->escaper = $escaper;
         $this->_integrationCollection = $integrationCollection;
         parent::__construct($context);
-    }
-
-    /**
-     * Check ACL.
-     *
-     * @return boolean
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Integration::integrations');
     }
 
     /**

--- a/app/code/Magento/Marketplace/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Marketplace/Controller/Adminhtml/Index.php
@@ -10,12 +10,9 @@ namespace Magento\Marketplace\Controller\Adminhtml;
 abstract class Index extends \Magento\Backend\App\Action
 {
     /**
-     * Check for is allowed
+     * Authorization level of a basic admin session
      *
-     * @return boolean
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Marketplace::index');
-    }
+    const ADMIN_RESOURCE = 'Magento_Marketplace::index';
 }

--- a/app/code/Magento/Marketplace/Controller/Adminhtml/Partners.php
+++ b/app/code/Magento/Marketplace/Controller/Adminhtml/Partners.php
@@ -10,12 +10,9 @@ namespace Magento\Marketplace\Controller\Adminhtml;
 abstract class Partners extends \Magento\Backend\App\Action
 {
     /**
-     * Check for is allowed
+     * Authorization level of a basic admin session
      *
-     * @return boolean
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Marketplace::partners');
-    }
+    const ADMIN_RESOURCE = 'Magento_Marketplace::partners';
 }

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Problem.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Problem.php
@@ -11,12 +11,9 @@ namespace Magento\Newsletter\Controller\Adminhtml;
 abstract class Problem extends \Magento\Backend\App\Action
 {
     /**
-     * Check if user has enough privileges
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Newsletter::problem');
-    }
+    const ADMIN_RESOURCE = 'Magento_Newsletter::problem';
 }

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Queue.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Queue.php
@@ -14,12 +14,9 @@ namespace Magento\Newsletter\Controller\Adminhtml;
 abstract class Queue extends \Magento\Backend\App\Action
 {
     /**
-     * Check if user has enough privileges
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Newsletter::queue');
-    }
+    const ADMIN_RESOURCE = 'Magento_Newsletter::queue';
 }

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber.php
@@ -11,6 +11,13 @@ namespace Magento\Newsletter\Controller\Adminhtml;
 abstract class Subscriber extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Newsletter::subscriber';
+
+    /**
      * @var \Magento\Framework\App\Response\Http\FileFactory
      */
     protected $_fileFactory;
@@ -25,15 +32,5 @@ abstract class Subscriber extends \Magento\Backend\App\Action
     ) {
         $this->_fileFactory = $fileFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * Check if user has enough privileges
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Newsletter::subscriber');
     }
 }

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Template.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Template.php
@@ -13,12 +13,9 @@ namespace Magento\Newsletter\Controller\Adminhtml;
 abstract class Template extends \Magento\Backend\App\Action
 {
     /**
-     * Check is allowed access
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Newsletter::template');
-    }
+    const ADMIN_RESOURCE = 'Magento_Newsletter::template';
 }

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement.php
@@ -11,6 +11,13 @@ namespace Magento\Paypal\Controller\Adminhtml\Billing;
 abstract class Agreement extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Paypal::billing_agreement';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -46,15 +53,5 @@ abstract class Agreement extends \Magento\Backend\App\Action
 
         $this->_coreRegistry->register('current_billing_agreement', $agreementModel);
         return $agreementModel;
-    }
-
-    /**
-     * Check currently called action by permissions for current user
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Paypal::billing_agreement');
     }
 }

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement/Cancel.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement/Cancel.php
@@ -9,6 +9,13 @@ namespace Magento\Paypal\Controller\Adminhtml\Billing\Agreement;
 class Cancel extends \Magento\Paypal\Controller\Adminhtml\Billing\Agreement
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Paypal::actions_manage';
+
+    /**
      * Cancel billing agreement action
      *
      * @return void
@@ -39,15 +46,5 @@ class Cancel extends \Magento\Paypal\Controller\Adminhtml\Billing\Agreement
             $this->_redirect('paypal/*/view', ['_current' => true]);
         }
         return $this->_redirect('paypal/*/');
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Paypal::actions_manage');
     }
 }

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement/Delete.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement/Delete.php
@@ -9,6 +9,13 @@ namespace Magento\Paypal\Controller\Adminhtml\Billing\Agreement;
 class Delete extends \Magento\Paypal\Controller\Adminhtml\Billing\Agreement
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Paypal::actions_manage';
+
+    /**
      * Delete billing agreement action
      *
      * @return void
@@ -39,15 +46,5 @@ class Delete extends \Magento\Paypal\Controller\Adminhtml\Billing\Agreement
             $this->_redirect('paypal/*/view', ['_current' => true]);
         }
         $this->_redirect('paypal/*/');
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Paypal::actions_manage');
     }
 }

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement/Grid.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement/Grid.php
@@ -9,6 +9,13 @@ namespace Magento\Paypal\Controller\Adminhtml\Billing\Agreement;
 class Grid extends \Magento\Paypal\Controller\Adminhtml\Billing\Agreement
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Paypal::billing_agreement_actions_view';
+
+    /**
      * Ajax action for billing agreements
      *
      * @return void
@@ -17,15 +24,5 @@ class Grid extends \Magento\Paypal\Controller\Adminhtml\Billing\Agreement
     {
         $this->_view->loadLayout(false);
         $this->_view->renderLayout();
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Paypal::billing_agreement_actions_view');
     }
 }

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement/Index.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement/Index.php
@@ -9,6 +9,13 @@ namespace Magento\Paypal\Controller\Adminhtml\Billing\Agreement;
 class Index extends \Magento\Paypal\Controller\Adminhtml\Billing\Agreement
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Paypal::billing_agreement_actions_view';
+
+    /**
      * Billing agreements
      *
      * @return void
@@ -21,13 +28,4 @@ class Index extends \Magento\Paypal\Controller\Adminhtml\Billing\Agreement
         $this->_view->renderLayout();
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Paypal::billing_agreement_actions_view');
-    }
 }

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement/View.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Billing/Agreement/View.php
@@ -9,6 +9,13 @@ namespace Magento\Paypal\Controller\Adminhtml\Billing\Agreement;
 class View extends \Magento\Paypal\Controller\Adminhtml\Billing\Agreement
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Paypal::billing_agreement_actions_view';
+
+    /**
      * View billing agreement action
      *
      * @return void
@@ -30,15 +37,5 @@ class View extends \Magento\Paypal\Controller\Adminhtml\Billing\Agreement
 
         $this->_redirect('paypal/*/');
         return;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Paypal::billing_agreement_actions_view');
     }
 }

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Paypal/Reports.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Paypal/Reports.php
@@ -11,6 +11,13 @@ namespace Magento\Paypal\Controller\Adminhtml\Paypal;
 abstract class Reports extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Paypal::paypal_settlement_reports';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -75,15 +82,5 @@ abstract class Reports extends \Magento\Backend\App\Action
         );
         $this->_view->getPage()->getConfig()->getTitle()->prepend(__('PayPal Settlement Reports'));
         return $this;
-    }
-
-    /**
-     * ACL check
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Paypal::paypal_settlement_reports');
     }
 }

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Paypal/Reports/Details.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Paypal/Reports/Details.php
@@ -9,6 +9,13 @@ namespace Magento\Paypal\Controller\Adminhtml\Paypal\Reports;
 class Details extends \Magento\Paypal\Controller\Adminhtml\Paypal\Reports
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Paypal::paypal_settlement_reports_view';
+
+    /**
      * View transaction details action
      *
      * @return void
@@ -31,15 +38,5 @@ class Details extends \Magento\Paypal\Controller\Adminhtml\Paypal\Reports
             )
         );
         $this->_view->renderLayout();
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Paypal::paypal_settlement_reports_view');
     }
 }

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Paypal/Reports/Fetch.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Paypal/Reports/Fetch.php
@@ -14,6 +14,13 @@ use Magento\Framework\Controller\ResultFactory;
 class Fetch extends \Magento\Paypal\Controller\Adminhtml\Paypal\Reports
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Paypal::fetch';
+
+    /**
      * Forced fetch reports action
      *
      * @return \Magento\Backend\Model\View\Result\Redirect
@@ -51,15 +58,5 @@ class Fetch extends \Magento\Paypal\Controller\Adminhtml\Paypal\Reports
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         return $resultRedirect->setPath('*/*/index');
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Paypal::fetch');
     }
 }

--- a/app/code/Magento/Paypal/Controller/Adminhtml/Paypal/Reports/Index.php
+++ b/app/code/Magento/Paypal/Controller/Adminhtml/Paypal/Reports/Index.php
@@ -9,6 +9,13 @@ namespace Magento\Paypal\Controller\Adminhtml\Paypal\Reports;
 class Index extends \Magento\Paypal\Controller\Adminhtml\Paypal\Reports
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Paypal::paypal_settlement_reports_view';
+
+    /**
      * Grid action
      *
      * @return void
@@ -17,15 +24,5 @@ class Index extends \Magento\Paypal\Controller\Adminhtml\Paypal\Reports
     {
         $this->_initAction();
         $this->_view->renderLayout();
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Paypal::paypal_settlement_reports_view');
     }
 }

--- a/app/code/Magento/Reports/Controller/Adminhtml/Index.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Index.php
@@ -14,6 +14,13 @@ namespace Magento\Reports\Controller\Adminhtml;
 abstract class Index extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Reports::report';
+
+    /**
      * @var \Magento\Framework\App\Response\Http\FileFactory
      */
     protected $_fileFactory;
@@ -28,15 +35,5 @@ abstract class Index extends \Magento\Backend\App\Action
     ) {
         $this->_fileFactory = $fileFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * Determine if action is allowed for reports module
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report');
     }
 }

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Downloads.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Downloads.php
@@ -9,14 +9,11 @@ namespace Magento\Reports\Controller\Adminhtml\Report\Product;
 class Downloads extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report_products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::report_products';
 
     /**
      * Downloads action

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportDownloadsCsv.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportDownloadsCsv.php
@@ -11,14 +11,11 @@ use Magento\Framework\App\ResponseInterface;
 class ExportDownloadsCsv extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report_products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::report_products';
 
     /**
      * Export products downloads report to CSV format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportDownloadsExcel.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportDownloadsExcel.php
@@ -11,14 +11,11 @@ use Magento\Framework\App\ResponseInterface;
 class ExportDownloadsExcel extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report_products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::report_products';
 
     /**
      * Export products downloads report to XLS format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportLowstockCsv.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportLowstockCsv.php
@@ -12,14 +12,11 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class ExportLowstockCsv extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report_products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::report_products';
 
     /**
      * Export low stock products report to CSV format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportLowstockExcel.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportLowstockExcel.php
@@ -12,14 +12,11 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class ExportLowstockExcel extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report_products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::report_products';
 
     /**
      * Export low stock products report to XML format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportSoldCsv.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportSoldCsv.php
@@ -13,14 +13,11 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class ExportSoldCsv extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report_products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::report_products';
 
     /**
      * Export Sold Products report to CSV format action

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportSoldExcel.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportSoldExcel.php
@@ -13,14 +13,11 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class ExportSoldExcel extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report_products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::report_products';
 
     /**
      * Export Sold Products report to XML format action

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportViewedCsv.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportViewedCsv.php
@@ -12,14 +12,11 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class ExportViewedCsv extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report_products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::report_products';
 
     /**
      * Export products most viewed report to CSV format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportViewedExcel.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/ExportViewedExcel.php
@@ -12,14 +12,11 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class ExportViewedExcel extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report_products');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::report_products';
 
     /**
      * Export products most viewed report to XML format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Lowstock.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Lowstock.php
@@ -9,14 +9,11 @@ namespace Magento\Reports\Controller\Adminhtml\Report\Product;
 class Lowstock extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::lowstock');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::lowstock';
 
     /**
      * Low stock action

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Sold.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Sold.php
@@ -9,14 +9,11 @@ namespace Magento\Reports\Controller\Adminhtml\Report\Product;
 class Sold extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::sold');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::sold';
 
     /**
      * Sold Products Report Action

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Viewed.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Product/Viewed.php
@@ -11,14 +11,11 @@ use Magento\Reports\Model\Flag;
 class Viewed extends \Magento\Reports\Controller\Adminhtml\Report\Product
 {
     /**
-     * Check is allowed for report
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::viewed');
-    }
+    const ADMIN_RESOURCE = 'Magento_Reports::viewed';
 
     /**
      * Most viewed products

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics.php
@@ -17,6 +17,13 @@ use Magento\Backend\Model\Session;
 abstract class Statistics extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Reports::statistics';
+
+    /**
      * Admin session model
      *
      * @var null|AuthSession
@@ -87,16 +94,6 @@ abstract class Statistics extends \Magento\Backend\App\Action
             $out[] = $this->reportTypes[$code];
         }
         return $out;
-    }
-
-    /**
-     * Determine if action is allowed for reports module
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::statistics');
     }
 
     /**

--- a/app/code/Magento/Review/Controller/Adminhtml/Rating.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Rating.php
@@ -15,6 +15,13 @@ use Magento\Framework\Registry;
 abstract class Rating extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Review::ratings';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -42,13 +49,5 @@ abstract class Rating extends Action
             'entityId',
             $this->_objectManager->create('Magento\Review\Model\Rating\Entity')->getIdByCode('product')
         );
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Review::ratings');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Email.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Email.php
@@ -13,12 +13,11 @@ namespace Magento\Sales\Controller\Adminhtml\Creditmemo\AbstractCreditmemo;
 class Email extends \Magento\Backend\App\Action
 {
     /**
-     * @return bool
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
 
     /**
      * Notify user

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Grid.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Grid.php
@@ -8,6 +8,13 @@ namespace Magento\Sales\Controller\Adminhtml\Creditmemo\AbstractCreditmemo;
 class Grid extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var \Magento\Framework\View\Result\LayoutFactory
      */
     protected $resultLayoutFactory;
@@ -22,14 +29,6 @@ class Grid extends \Magento\Backend\App\Action
     ) {
         $this->resultLayoutFactory = $resultLayoutFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Index.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Index.php
@@ -8,6 +8,13 @@ namespace Magento\Sales\Controller\Adminhtml\Creditmemo\AbstractCreditmemo;
 class Index extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var \Magento\Framework\View\Result\PageFactory
      */
     protected $resultPageFactory;
@@ -22,14 +29,6 @@ class Index extends \Magento\Backend\App\Action
     ) {
         $this->resultPageFactory = $resultPageFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Pdfcreditmemos.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/Pdfcreditmemos.php
@@ -22,6 +22,13 @@ use Magento\Sales\Model\ResourceModel\Order\Creditmemo\CollectionFactory;
 class Pdfcreditmemos extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassAction
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var FileFactory
      */
     protected $fileFactory;
@@ -57,14 +64,6 @@ class Pdfcreditmemos extends \Magento\Sales\Controller\Adminhtml\Order\AbstractM
         $this->dateTime = $dateTime;
         $this->collectionFactory = $collectionFactory;
         parent::__construct($context, $filter);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/PrintAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/PrintAction.php
@@ -12,6 +12,13 @@ use Magento\Sales\Api\CreditmemoRepositoryInterface;
 class PrintAction extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var \Magento\Framework\App\Response\Http\FileFactory
      */
     protected $_fileFactory;
@@ -42,14 +49,6 @@ class PrintAction extends \Magento\Backend\App\Action
         $this->resultForwardFactory = $resultForwardFactory;
         $this->creditmemoRepository = $creditmemoRepository;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/View.php
@@ -8,6 +8,13 @@ namespace Magento\Sales\Controller\Adminhtml\Creditmemo\AbstractCreditmemo;
 class View extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var \Magento\Backend\Model\View\Result\ForwardFactory
      */
     protected $resultForwardFactory;
@@ -22,14 +29,6 @@ class View extends \Magento\Backend\App\Action
     ) {
         $this->resultForwardFactory = $resultForwardFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Email.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Email.php
@@ -14,6 +14,13 @@ namespace Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice;
 abstract class Email extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_invoice';
+
+    /**
      * @var \Magento\Backend\Model\View\Result\ForwardFactory
      */
     protected $resultForwardFactory;
@@ -28,16 +35,6 @@ abstract class Email extends \Magento\Backend\App\Action
     ) {
         parent::__construct($context);
         $this->resultForwardFactory = $resultForwardFactory;
-    }
-
-    /**
-     * Check if email sending is allowed for the current user
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_invoice');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Grid.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Grid.php
@@ -9,6 +9,13 @@ namespace Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice;
 abstract class Grid extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_invoice';
+
+    /**
      * @var \Magento\Framework\View\Result\LayoutFactory
      */
     protected $resultLayoutFactory;
@@ -23,14 +30,6 @@ abstract class Grid extends \Magento\Backend\App\Action
     ) {
         parent::__construct($context);
         $this->resultLayoutFactory = $resultLayoutFactory;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_invoice');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Index.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Index.php
@@ -9,6 +9,13 @@ namespace Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice;
 abstract class Index extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_invoice';
+
+    /**
      * @var \Magento\Framework\View\Result\PageFactory
      */
     protected $resultPageFactory;
@@ -23,14 +30,6 @@ abstract class Index extends \Magento\Backend\App\Action
     ) {
         parent::__construct($context);
         $this->resultPageFactory = $resultPageFactory;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_invoice');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Pdfinvoices.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/Pdfinvoices.php
@@ -22,6 +22,13 @@ use Magento\Sales\Model\ResourceModel\Order\Invoice\CollectionFactory;
 abstract class Pdfinvoices extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassAction
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_invoice';
+
+    /**
      * @var FileFactory
      */
     protected $fileFactory;
@@ -57,14 +64,6 @@ abstract class Pdfinvoices extends \Magento\Sales\Controller\Adminhtml\Order\Abs
         $this->pdfInvoice = $pdfInvoice;
         $this->collectionFactory = $collectionFactory;
         parent::__construct($context, $filter);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_invoice');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/PrintAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/PrintAction.php
@@ -12,6 +12,13 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 abstract class PrintAction extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_invoice';
+
+    /**
      * @var \Magento\Framework\App\Response\Http\FileFactory
      */
     protected $_fileFactory;
@@ -34,14 +41,6 @@ abstract class PrintAction extends \Magento\Backend\App\Action
         $this->_fileFactory = $fileFactory;
         parent::__construct($context);
         $this->resultForwardFactory = $resultForwardFactory;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_invoice');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Invoice/AbstractInvoice/View.php
@@ -12,6 +12,13 @@ use Magento\Framework\Registry;
 abstract class View extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_invoice';
+
+    /**
      * @var Registry
      */
     protected $registry;
@@ -34,14 +41,6 @@ abstract class View extends \Magento\Backend\App\Action
         $this->registry = $registry;
         parent::__construct($context);
         $this->resultForwardFactory = $resultForwardFactory;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_invoice');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order.php
@@ -22,6 +22,13 @@ use Psr\Log\LoggerInterface;
 abstract class Order extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_order';
+
+    /**
      * Array of actions which can be processed without secret key validation
      *
      * @var string[]
@@ -158,14 +165,6 @@ abstract class Order extends \Magento\Backend\App\Action
         $this->_coreRegistry->register('sales_order', $order);
         $this->_coreRegistry->register('current_order', $order);
         return $order;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_order');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddComment.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddComment.php
@@ -12,6 +12,13 @@ use Magento\Sales\Model\Order\Email\Sender\OrderCommentSender;
 class AddComment extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::comment';
+
+    /**
      * Add order comment action
      *
      * @return \Magento\Framework\Controller\ResultInterface
@@ -56,13 +63,5 @@ class AddComment extends \Magento\Sales\Controller\Adminhtml\Order
             }
         }
         return $this->resultRedirectFactory->create()->setPath('sales/*/');
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::comment');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Address.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Address.php
@@ -9,6 +9,13 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 class Address extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
+
+    /**
      * Edit order address form
      *
      * @return \Magento\Backend\Model\View\Result\Page|\Magento\Backend\Model\View\Result\Redirect
@@ -30,13 +37,5 @@ class Address extends \Magento\Sales\Controller\Adminhtml\Order
         } else {
             return $this->resultRedirectFactory->create()->setPath('sales/*/');
         }
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -9,6 +9,13 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
+
+    /**
      * Save order address
      *
      * @return \Magento\Backend\Model\View\Result\Redirect
@@ -41,13 +48,5 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
         } else {
             return $resultRedirect->setPath('sales/*/');
         }
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Cancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Cancel.php
@@ -9,6 +9,13 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 class Cancel extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::cancel';
+
+    /**
      * Cancel order
      *
      * @return \Magento\Backend\Model\View\Result\Redirect
@@ -34,13 +41,5 @@ class Cancel extends \Magento\Sales\Controller\Adminhtml\Order
             return $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getId()]);
         }
         return $resultRedirect->setPath('sales/*/');
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::cancel');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/AddComment.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/AddComment.php
@@ -11,6 +11,13 @@ use Magento\Sales\Model\Order\Email\Sender\CreditmemoCommentSender;
 class AddComment extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var \Magento\Sales\Controller\Adminhtml\Order\CreditmemoLoader
      */
     protected $creditmemoLoader;
@@ -57,14 +64,6 @@ class AddComment extends \Magento\Backend\App\Action
         $this->resultJsonFactory = $resultJsonFactory;
         $this->resultRawFactory = $resultRawFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Cancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Cancel.php
@@ -9,6 +9,12 @@ use Magento\Backend\App\Action;
 
 class Cancel extends \Magento\Backend\App\Action
 {
+    /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
 
     /**
      * @var \Magento\Backend\Model\View\Result\ForwardFactory
@@ -25,14 +31,6 @@ class Cancel extends \Magento\Backend\App\Action
     ) {
         $this->resultForwardFactory = $resultForwardFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/NewAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/NewAction.php
@@ -10,6 +10,13 @@ use Magento\Backend\App\Action;
 class NewAction extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var \Magento\Sales\Controller\Adminhtml\Order\CreditmemoLoader
      */
     protected $creditmemoLoader;
@@ -40,14 +47,6 @@ class NewAction extends \Magento\Backend\App\Action
         $this->resultPageFactory = $resultPageFactory;
         $this->resultForwardFactory = $resultForwardFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Save.php
@@ -12,6 +12,13 @@ use Magento\Sales\Model\Order\Email\Sender\CreditmemoSender;
 class Save extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var \Magento\Sales\Controller\Adminhtml\Order\CreditmemoLoader
      */
     protected $creditmemoLoader;
@@ -42,14 +49,6 @@ class Save extends \Magento\Backend\App\Action
         $this->creditmemoSender = $creditmemoSender;
         $this->resultForwardFactory = $resultForwardFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Start.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Start.php
@@ -8,12 +8,11 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Creditmemo;
 class Start extends \Magento\Backend\App\Action
 {
     /**
-     * @return bool
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
 
     /**
      * Start create creditmemo action

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/UpdateQty.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/UpdateQty.php
@@ -10,6 +10,13 @@ use Magento\Backend\App\Action;
 class UpdateQty extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var \Magento\Sales\Controller\Adminhtml\Order\CreditmemoLoader
      */
     protected $creditmemoLoader;
@@ -48,14 +55,6 @@ class UpdateQty extends \Magento\Backend\App\Action
         $this->resultJsonFactory = $resultJsonFactory;
         $this->resultRawFactory = $resultRawFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/View.php
@@ -10,6 +10,13 @@ use Magento\Backend\App\Action;
 class View extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var \Magento\Sales\Controller\Adminhtml\Order\CreditmemoLoader
      */
     protected $creditmemoLoader;
@@ -40,14 +47,6 @@ class View extends \Magento\Backend\App\Action
         $this->resultPageFactory = $resultPageFactory;
         $this->resultForwardFactory = $resultForwardFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Void.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Void.php
@@ -10,6 +10,13 @@ use Magento\Backend\App\Action;
 class Void extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+
+    /**
      * @var \Magento\Sales\Controller\Adminhtml\Order\CreditmemoLoader
      */
     protected $creditmemoLoader;
@@ -32,14 +39,6 @@ class Void extends \Magento\Backend\App\Action
         $this->creditmemoLoader = $creditmemoLoader;
         $this->resultForwardFactory = $resultForwardFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_creditmemo');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemos.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemos.php
@@ -8,6 +8,13 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 class Creditmemos extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::creditmemo';
+
+    /**
      * Generate credit memos grid for ajax request
      *
      * @return \Magento\Framework\View\Result\Layout
@@ -17,13 +24,5 @@ class Creditmemos extends \Magento\Sales\Controller\Adminhtml\Order
         $this->_initOrder();
         $resultLayout = $this->resultLayoutFactory->create();
         return $resultLayout;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::creditmemo');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/AddConfigured.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/AddConfigured.php
@@ -9,12 +9,9 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class AddConfigured extends \Magento\Sales\Controller\Adminhtml\Order\Create\AddConfigured
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Cancel.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Cancel.php
@@ -9,12 +9,9 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class Cancel extends \Magento\Sales\Controller\Adminhtml\Order\Create\Cancel
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/ConfigureProductToAdd.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/ConfigureProductToAdd.php
@@ -9,12 +9,9 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class ConfigureProductToAdd extends \Magento\Sales\Controller\Adminhtml\Order\Create\ConfigureProductToAdd
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/ConfigureQuoteItems.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/ConfigureQuoteItems.php
@@ -9,12 +9,9 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class ConfigureQuoteItems extends \Magento\Sales\Controller\Adminhtml\Order\Create\ConfigureQuoteItems
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Index.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Index.php
@@ -8,14 +8,11 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class Index extends \Magento\Sales\Controller\Adminhtml\Order\Create\Index
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 
     /**
      * Index page

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/LoadBlock.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/LoadBlock.php
@@ -9,12 +9,9 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class LoadBlock extends \Magento\Sales\Controller\Adminhtml\Order\Create\LoadBlock
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/ProcessData.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/ProcessData.php
@@ -9,12 +9,9 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class ProcessData extends \Magento\Sales\Controller\Adminhtml\Order\Create\ProcessData
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Reorder.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Reorder.php
@@ -9,12 +9,9 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class Reorder extends \Magento\Sales\Controller\Adminhtml\Order\Create\Reorder
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Save.php
@@ -9,12 +9,9 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class Save extends \Magento\Sales\Controller\Adminhtml\Order\Create\Save
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/ShowUpdateResult.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/ShowUpdateResult.php
@@ -9,12 +9,9 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class ShowUpdateResult extends \Magento\Sales\Controller\Adminhtml\Order\Create\ShowUpdateResult
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Start.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Edit/Start.php
@@ -8,14 +8,11 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Edit;
 class Start extends \Magento\Sales\Controller\Adminhtml\Order\Create\Start
 {
     /**
-     * Acl check for admin
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_edit');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 
     /**
      * Start edit order initialization

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Email.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Email.php
@@ -8,6 +8,13 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 class Email extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::email';
+
+    /**
      * Notify user
      *
      * @return \Magento\Backend\Model\View\Result\Redirect
@@ -33,13 +40,5 @@ class Email extends \Magento\Sales\Controller\Adminhtml\Order
             );
         }
         return $this->resultRedirectFactory->create()->setPath('sales/*/');
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::email');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Hold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Hold.php
@@ -8,6 +8,13 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 class Hold extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::hold';
+
+    /**
      * Hold order
      *
      * @return \Magento\Backend\Model\View\Result\Redirect
@@ -34,13 +41,5 @@ class Hold extends \Magento\Sales\Controller\Adminhtml\Order
         }
         $resultRedirect->setPath('sales/*/');
         return $resultRedirect;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::hold');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/NewAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/NewAction.php
@@ -14,6 +14,13 @@ use Magento\Sales\Model\Service\InvoiceService;
 class NewAction extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_invoice';
+
+    /**
      * @var Registry
      */
     protected $registry;
@@ -44,14 +51,6 @@ class NewAction extends \Magento\Backend\App\Action
         $this->resultPageFactory = $resultPageFactory;
         parent::__construct($context);
         $this->invoiceService = $invoiceService;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_invoice');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
@@ -21,6 +21,13 @@ use Magento\Sales\Model\Service\InvoiceService;
 class Save extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::sales_invoice';
+
+    /**
      * @var InvoiceSender
      */
     protected $invoiceSender;
@@ -67,14 +74,6 @@ class Save extends \Magento\Backend\App\Action
         $this->shipmentFactory = $shipmentFactory;
         $this->invoiceService = $invoiceService;
         parent::__construct($context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::sales_invoice');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/ReviewPayment.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/ReviewPayment.php
@@ -10,6 +10,13 @@ use Magento\Backend\App\Action;
 class ReviewPayment extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::review_payment';
+
+    /**
      * Manage payment state
      *
      * Either denies or approves a payment that is in "review" state
@@ -59,13 +66,5 @@ class ReviewPayment extends \Magento\Sales\Controller\Adminhtml\Order
         }
         $resultRedirect->setPath('sales/order/view', ['order_id' => $order->getEntityId()]);
         return $resultRedirect;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::review_payment');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Status.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Status.php
@@ -11,6 +11,13 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 abstract class Status extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::order_statuses';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -43,15 +50,5 @@ abstract class Status extends \Magento\Backend\App\Action
             $status = false;
         }
         return $status;
-    }
-
-    /**
-     * Check current user permission on resource and privilege
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::order_statuses');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Unhold.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Unhold.php
@@ -8,6 +8,13 @@ namespace Magento\Sales\Controller\Adminhtml\Order;
 class Unhold extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::unhold';
+
+    /**
      * Unhold order
      *
      * @return \Magento\Backend\Model\View\Result\Redirect
@@ -37,13 +44,5 @@ class Unhold extends \Magento\Sales\Controller\Adminhtml\Order
         }
         $resultRedirect->setPath('sales/*/');
         return $resultRedirect;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::unhold');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/View.php
@@ -10,6 +10,13 @@ use Magento\Backend\App\Action;
 class View extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::actions_view';
+
+    /**
      * View order detail
      *
      * @return \Magento\Backend\Model\View\Result\Page|\Magento\Backend\Model\View\Result\Redirect
@@ -33,13 +40,5 @@ class View extends \Magento\Sales\Controller\Adminhtml\Order
         }
         $resultRedirect->setPath('sales/*/');
         return $resultRedirect;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::actions_view');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Shipment/AbstractShipment/Index.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Shipment/AbstractShipment/Index.php
@@ -12,6 +12,13 @@ use Magento\Framework\View\Result\PageFactory;
 abstract class Index extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var PageFactory
      */
     protected $resultPageFactory;
@@ -26,14 +33,6 @@ abstract class Index extends \Magento\Backend\App\Action
     ) {
         parent::__construct($context);
         $this->resultPageFactory = $resultPageFactory;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Shipment/AbstractShipment/Pdfshipments.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Shipment/AbstractShipment/Pdfshipments.php
@@ -19,6 +19,13 @@ use Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory;
 abstract class Pdfshipments extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassAction
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var FileFactory
      */
     protected $fileFactory;
@@ -54,14 +61,6 @@ abstract class Pdfshipments extends \Magento\Sales\Controller\Adminhtml\Order\Ab
         $this->pdfShipment = $shipment;
         $this->collectionFactory = $collectionFactory;
         parent::__construct($context, $filter);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Shipment/AbstractShipment/PrintAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Shipment/AbstractShipment/PrintAction.php
@@ -15,6 +15,13 @@ use Magento\Backend\Model\View\Result\ForwardFactory;
 abstract class PrintAction extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var FileFactory
      */
     protected $_fileFactory;
@@ -37,14 +44,6 @@ abstract class PrintAction extends \Magento\Backend\App\Action
         $this->_fileFactory = $fileFactory;
         $this->resultForwardFactory = $resultForwardFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Shipment/AbstractShipment/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Shipment/AbstractShipment/View.php
@@ -12,6 +12,13 @@ use Magento\Backend\Model\View\Result\ForwardFactory;
 abstract class View extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var ForwardFactory
      */
     protected $resultForwardFactory;
@@ -26,14 +33,6 @@ abstract class View extends \Magento\Backend\App\Action
     ) {
         parent::__construct($context);
         $this->resultForwardFactory = $resultForwardFactory;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Transactions.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Transactions.php
@@ -19,6 +19,13 @@ use Magento\Sales\Api\OrderPaymentRepositoryInterface;
 abstract class Transactions extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::transactions';
+
+    /**
      * Core registry
      *
      * @var Registry
@@ -86,15 +93,5 @@ abstract class Transactions extends \Magento\Backend\App\Action
 
         $this->_coreRegistry->register('current_transaction', $txn);
         return $txn;
-    }
-
-    /**
-     * Check currently called action by permissions for current user
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::transactions');
     }
 }

--- a/app/code/Magento/Sales/Controller/Adminhtml/Transactions/Fetch.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Transactions/Fetch.php
@@ -13,6 +13,13 @@ use Magento\Framework\Controller\ResultFactory;
 class Fetch extends \Magento\Sales\Controller\Adminhtml\Transactions
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::transactions_fetch';
+
+    /**
      * Fetch transaction details action
      *
      * @return Redirect
@@ -37,13 +44,5 @@ class Fetch extends \Magento\Sales\Controller\Adminhtml\Transactions
         }
 
         return $resultRedirect->setPath('sales/transactions/view', ['_current' => true]);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::transactions_fetch');
     }
 }

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote.php
@@ -8,6 +8,13 @@ namespace Magento\SalesRule\Controller\Adminhtml\Promo;
 abstract class Quote extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_SalesRule::quote';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -74,15 +81,5 @@ abstract class Quote extends \Magento\Backend\App\Action
         $this->_view->loadLayout();
         $this->_setActiveMenu('Magento_SalesRule::promo_quote')->_addBreadcrumb(__('Promotions'), __('Promotions'));
         return $this;
-    }
-
-    /**
-     * Returns result of current user permission check on resource and privilege
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_SalesRule::quote');
     }
 }

--- a/app/code/Magento/Search/Controller/Adminhtml/Term.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term.php
@@ -11,6 +11,13 @@ use Magento\Framework\Controller\ResultFactory;
 abstract class Term extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Search::search';
+
+    /**
      * @return \Magento\Backend\Model\View\Result\Page
      */
     protected function createPage()
@@ -22,11 +29,4 @@ abstract class Term extends Action
         return $resultPage;
     }
 
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Search::search');
-    }
 }

--- a/app/code/Magento/Search/Controller/Adminhtml/Term/Report.php
+++ b/app/code/Magento/Search/Controller/Adminhtml/Term/Report.php
@@ -11,6 +11,13 @@ use Magento\Framework\Controller\ResultFactory;
 class Report extends ReportsIndexController
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Reports::report_search';
+
+    /**
      * Search terms report action
      *
      * @return \Magento\Backend\Model\View\Result\Page
@@ -25,13 +32,5 @@ class Report extends ReportsIndexController
             ->addBreadcrumb(__('Search Terms'), __('Search Terms'));
         $resultPage->getConfig()->getTitle()->set(__('Search Terms Report'));
         return $resultPage;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Reports::report_search');
     }
 }

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/AddComment.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/AddComment.php
@@ -13,6 +13,13 @@ use Magento\Framework\View\Result\LayoutFactory;
 class AddComment extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -43,14 +50,6 @@ class AddComment extends \Magento\Backend\App\Action
         $this->shipmentCommentSender = $shipmentCommentSender;
         $this->resultLayoutFactory = $resultLayoutFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/AddTrack.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/AddTrack.php
@@ -11,6 +11,13 @@ use Magento\Backend\App\Action;
 class AddTrack extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -25,14 +32,6 @@ class AddTrack extends \Magento\Backend\App\Action
     ) {
         $this->shipmentLoader = $shipmentLoader;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/CreateLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/CreateLabel.php
@@ -11,6 +11,13 @@ use Magento\Backend\App\Action;
 class CreateLabel extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -33,14 +40,6 @@ class CreateLabel extends \Magento\Backend\App\Action
         $this->shipmentLoader = $shipmentLoader;
         $this->labelGenerator = $labelGenerator;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Email.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Email.php
@@ -17,6 +17,13 @@ use Magento\Framework\Controller\ResultFactory;
 class Email extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -31,16 +38,6 @@ class Email extends \Magento\Backend\App\Action
     ) {
         $this->shipmentLoader = $shipmentLoader;
         parent::__construct($context);
-    }
-
-    /**
-     * Check if email sending is allowed for the current user
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/GetShippingItemsGrid.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/GetShippingItemsGrid.php
@@ -12,6 +12,13 @@ use Magento\Framework\App\ResponseInterface;
 class GetShippingItemsGrid extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -26,14 +33,6 @@ class GetShippingItemsGrid extends \Magento\Backend\App\Action
     ) {
         $this->shipmentLoader = $shipmentLoader;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/MassPrintShippingLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/MassPrintShippingLabel.php
@@ -24,6 +24,13 @@ use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 class MassPrintShippingLabel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassAction
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var LabelGenerator
      */
     protected $labelGenerator;
@@ -64,14 +71,6 @@ class MassPrintShippingLabel extends \Magento\Sales\Controller\Adminhtml\Order\A
         $this->shipmentCollectionFactory = $shipmentCollectionFactory;
         $this->labelGenerator = $labelGenerator;
         parent::__construct($context, $filter);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/NewAction.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/NewAction.php
@@ -11,6 +11,13 @@ use Magento\Backend\App\Action;
 class NewAction extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -25,14 +32,6 @@ class NewAction extends \Magento\Backend\App\Action
     ) {
         $this->shipmentLoader = $shipmentLoader;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/PrintLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/PrintLabel.php
@@ -13,6 +13,13 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class PrintLabel extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -43,14 +50,6 @@ class PrintLabel extends \Magento\Backend\App\Action
         $this->labelGenerator = $labelGenerator;
         $this->_fileFactory = $fileFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/PrintPackage.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/PrintPackage.php
@@ -13,6 +13,13 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class PrintPackage extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -35,14 +42,6 @@ class PrintPackage extends \Magento\Backend\App\Action
         $this->shipmentLoader = $shipmentLoader;
         $this->_fileFactory = $fileFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/RemoveTrack.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/RemoveTrack.php
@@ -11,6 +11,13 @@ use Magento\Backend\App\Action;
 class RemoveTrack extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -25,14 +32,6 @@ class RemoveTrack extends \Magento\Backend\App\Action
     ) {
         $this->shipmentLoader = $shipmentLoader;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Save.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Save.php
@@ -12,6 +12,13 @@ use Magento\Sales\Model\Order\Email\Sender\ShipmentSender;
 class Save extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -42,14 +49,6 @@ class Save extends \Magento\Backend\App\Action
         $this->labelGenerator = $labelGenerator;
         $this->shipmentSender = $shipmentSender;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Start.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/Start.php
@@ -9,12 +9,11 @@ namespace Magento\Shipping\Controller\Adminhtml\Order\Shipment;
 class Start extends \Magento\Backend\App\Action
 {
     /**
-     * @return bool
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
-    }
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
 
     /**
      * Start create shipment action

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/View.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/View.php
@@ -11,6 +11,13 @@ use Magento\Backend\App\Action;
 class View extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var \Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoader
      */
     protected $shipmentLoader;
@@ -41,14 +48,6 @@ class View extends \Magento\Backend\App\Action
         $this->resultPageFactory = $resultPageFactory;
         $this->resultForwardFactory = $resultForwardFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Shipment/MassPrintShippingLabel.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Shipment/MassPrintShippingLabel.php
@@ -20,6 +20,13 @@ use Magento\Sales\Model\ResourceModel\Order\Shipment\CollectionFactory;
 class MassPrintShippingLabel extends \Magento\Sales\Controller\Adminhtml\Order\AbstractMassAction
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sales::shipment';
+
+    /**
      * @var LabelGenerator
      */
     protected $labelGenerator;
@@ -47,14 +54,6 @@ class MassPrintShippingLabel extends \Magento\Sales\Controller\Adminhtml\Order\A
         $this->fileFactory = $fileFactory;
         $this->labelGenerator = $labelGenerator;
         parent::__construct($context, $filter);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sales::shipment');
     }
 
     /**

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap.php
@@ -11,6 +11,12 @@ namespace Magento\Sitemap\Controller\Adminhtml;
 abstract class Sitemap extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Sitemap::sitemap';
+    /**
      * Init actions
      *
      * @return $this
@@ -29,15 +35,5 @@ abstract class Sitemap extends \Magento\Backend\App\Action
             __('XML Sitemap')
         );
         return $this;
-    }
-
-    /**
-     * Check the permission to run it
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Sitemap::sitemap');
     }
 }

--- a/app/code/Magento/Swatches/Controller/Adminhtml/Iframe/Show.php
+++ b/app/code/Magento/Swatches/Controller/Adminhtml/Iframe/Show.php
@@ -13,6 +13,13 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class Show extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Swatches::iframe';
+
+    /**
      * Helper to move image from tmp to catalog
      *
      * @var \Magento\Swatches\Helper\Media
@@ -102,16 +109,5 @@ class Show extends \Magento\Backend\App\Action
             $result = ['error' => $e->getMessage(), 'errorcode' => $e->getCode()];
             $this->getResponse()->setBody(json_encode($result));
         }
-    }
-
-    /**
-     * Check if user has enough privileges
-     *
-     * @codeCoverageIgnore
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Swatches::iframe');
     }
 }

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rate.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rate.php
@@ -16,6 +16,13 @@ use Magento\Framework\Controller\ResultFactory;
 abstract class Rate extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Tax::manage_tax';
+
+    /**
      * @var \Magento\Framework\Registry
      */
     protected $_coreRegistry;
@@ -79,13 +86,5 @@ abstract class Rate extends \Magento\Backend\App\Action
             ->addBreadcrumb(__('Sales'), __('Sales'))
             ->addBreadcrumb(__('Tax'), __('Tax'));
         return $resultPage;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Tax::manage_tax');
     }
 }

--- a/app/code/Magento/Tax/Controller/Adminhtml/Rule.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Rule.php
@@ -17,6 +17,13 @@ use Magento\Framework\Controller\ResultFactory;
 abstract class Rule extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Tax::manage_tax';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -59,16 +66,6 @@ abstract class Rule extends \Magento\Backend\App\Action
             ->addBreadcrumb(__('Tax'), __('Tax'))
             ->addBreadcrumb(__('Tax Rules'), __('Tax Rules'));
         return $resultPage;
-    }
-
-    /**
-     * Check if sales rule is allowed
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Tax::manage_tax');
     }
 
     /**

--- a/app/code/Magento/Tax/Controller/Adminhtml/Tax.php
+++ b/app/code/Magento/Tax/Controller/Adminhtml/Tax.php
@@ -16,6 +16,13 @@ use Magento\Framework\Exception\InputException;
 abstract class Tax extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Tax::manage_tax';
+
+    /**
      * @var \Magento\Tax\Api\TaxClassRepositoryInterface
      */
     protected $taxClassRepository;
@@ -54,15 +61,5 @@ abstract class Tax extends \Magento\Backend\App\Action
             throw new InputException(__('Invalid name of tax class specified.'));
         }
         return $className;
-    }
-
-    /**
-     * Check current user permission on resource and privilege
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Tax::manage_tax');
     }
 }

--- a/app/code/Magento/TaxImportExport/Controller/Adminhtml/Rate.php
+++ b/app/code/Magento/TaxImportExport/Controller/Adminhtml/Rate.php
@@ -11,6 +11,13 @@ namespace Magento\TaxImportExport\Controller\Adminhtml;
 abstract class Rate extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Tax::manage_tax';
+
+    /**
      * @var \Magento\Framework\App\Response\Http\FileFactory
      */
     protected $fileFactory;
@@ -25,13 +32,5 @@ abstract class Rate extends \Magento\Backend\App\Action
     ) {
         $this->fileFactory = $fileFactory;
         parent::__construct($context);
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Tax::manage_tax');
     }
 }

--- a/app/code/Magento/TaxImportExport/Controller/Adminhtml/Rate/ImportExport.php
+++ b/app/code/Magento/TaxImportExport/Controller/Adminhtml/Rate/ImportExport.php
@@ -10,6 +10,13 @@ use Magento\Framework\Controller\ResultFactory;
 class ImportExport extends \Magento\TaxImportExport\Controller\Adminhtml\Rate
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_TaxImportExport::import_export';
+
+    /**
      * Import and export Page
      *
      * @return \Magento\Backend\Model\View\Result\Page
@@ -29,13 +36,5 @@ class ImportExport extends \Magento\TaxImportExport\Controller\Adminhtml\Rate
         $resultPage->getConfig()->getTitle()->prepend(__('Tax Zones and Rates'));
         $resultPage->getConfig()->getTitle()->prepend(__('Import and Export Tax Rates'));
         return $resultPage;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_TaxImportExport::import_export');
     }
 }

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme.php
@@ -12,6 +12,13 @@ namespace Magento\Theme\Controller\Adminhtml\System\Design;
 abstract class Theme extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Theme::theme';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -52,15 +59,5 @@ abstract class Theme extends \Magento\Backend\App\Action
         $this->_assetRepo = $assetRepo;
         $this->_appFileSystem = $appFileSystem;
         parent::__construct($context);
-    }
-
-    /**
-     * Check the permission to manage themes
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Theme::theme');
     }
 }

--- a/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite.php
+++ b/app/code/Magento/UrlRewrite/Controller/Adminhtml/Url/Rewrite.php
@@ -14,6 +14,13 @@ use Magento\Catalog\Model\Product;
  */
 abstract class Rewrite extends Action
 {
+    /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_UrlRewrite::urlrewrite';
+
     /**#@+
      * Entity types
      */
@@ -42,16 +49,6 @@ abstract class Rewrite extends Action
      * @var \Magento\UrlRewrite\Model\UrlRewrite
      */
     protected $_urlRewrite;
-
-    /**
-     * Check whether this contoller is allowed in admin permissions
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_UrlRewrite::urlrewrite');
-    }
 
     /**
      * Get Category from request

--- a/app/code/Magento/User/Controller/Adminhtml/Locks.php
+++ b/app/code/Magento/User/Controller/Adminhtml/Locks.php
@@ -12,12 +12,9 @@ namespace Magento\User\Controller\Adminhtml;
 abstract class Locks extends \Magento\Backend\App\Action
 {
     /**
-     * Check whether access is allowed for current admin session
+     * Authorization level of a basic admin session
      *
-     * @return bool
+     * @see _isAllowed()
      */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_User::locks');
-    }
+    const ADMIN_RESOURCE = 'Magento_User::locks';
 }

--- a/app/code/Magento/User/Controller/Adminhtml/User.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User.php
@@ -8,6 +8,13 @@ namespace Magento\User\Controller\Adminhtml;
 abstract class User extends \Magento\Backend\App\AbstractAction
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_User::acl_users';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -75,13 +82,5 @@ abstract class User extends \Magento\Backend\App\AbstractAction
             unset($data['password_confirmation']);
         }
         return $data;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_User::acl_users');
     }
 }

--- a/app/code/Magento/User/Controller/Adminhtml/User/Role.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Role.php
@@ -10,6 +10,13 @@ use Magento\Authorization\Model\Acl\Role\Group as RoleGroup;
 abstract class Role extends \Magento\Backend\App\AbstractAction
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_User::acl_roles';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -107,15 +114,5 @@ abstract class Role extends \Magento\Backend\App\AbstractAction
 
         $this->_coreRegistry->register('current_role', $role);
         return $this->_coreRegistry->registry('current_role');
-    }
-
-    /**
-     * Acl checking
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_User::acl_roles');
     }
 }

--- a/app/code/Magento/Variable/Controller/Adminhtml/System/Variable.php
+++ b/app/code/Magento/Variable/Controller/Adminhtml/System/Variable.php
@@ -15,6 +15,13 @@ use Magento\Backend\App\Action;
 abstract class Variable extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Variable::variable';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -95,15 +102,5 @@ abstract class Variable extends Action
         }
         $this->_coreRegistry->register('current_variable', $variable);
         return $variable;
-    }
-
-    /**
-     * Check current user permission
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Variable::variable');
     }
 }

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/Instance.php
@@ -12,6 +12,13 @@ namespace Magento\Widget\Controller\Adminhtml\Widget;
 abstract class Instance extends \Magento\Backend\App\Action
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Widget::widget_instance';
+
+    /**
      * Core registry
      *
      * @var \Magento\Framework\Registry
@@ -122,15 +129,5 @@ abstract class Instance extends \Magento\Backend\App\Action
         $this->_translateInline->processResponseBody($body);
 
         $this->getResponse()->setBody($body);
-    }
-
-    /**
-     * Check is allowed access to action
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Widget::widget_instance');
     }
 }


### PR DESCRIPTION
Now `AbstractAction::_isAllowed()` is using a static binding, we can simply define the `ADMIN_RESOURCE` constant in our controllers.

I can see you have implemented my recommendation of a static binding on the `develop` branch. However I would like to take it one step further and define the constant in each controller, if this gets accepted I will update the dev docs to represent this.

This issue relates to:

https://github.com/magento/magento2/issues/2361
