### PR TITLE
Fix stripped-min-length check

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -326,7 +326,7 @@
         ],
         "stripped-min-length": [
             function (value, element, param) {
-                return $(value).text().length >= param;
+                return $(element).val().length >= param;
             },
             'Please enter at least {0} characters'
         ],


### PR DESCRIPTION
`$(value).text()` is wrong in here. Actually this will evaluate to `$("someinputtext").text()` where `$("someinputtext")` is an empty object and therefor the check will always return false as the upcoming method `.text()` returns an empty string.
`$(element)` is the input element and it needs `.val()` to retrieve the text from the input element.
