### PR TITLE
validateCategory() should check for valid return types of validate() function

### DIFF
--- a/app/code/Magento/Catalog/Model/CategoryRepository.php
+++ b/app/code/Magento/Catalog/Model/CategoryRepository.php
@@ -190,6 +190,9 @@ class CategoryRepository implements \Magento\Catalog\Api\CategoryRepositoryInter
         $category->setData('use_post_data_config', $useConfigFields);
         $validate = $category->validate();
         if ($validate !== true) {
+            if (!is_array($validate)) {
+                throw new \Exception('Wrong validation result supplied, should be array.');
+            }
             foreach ($validate as $code => $error) {
                 if ($error === true) {
                     $attribute = $this->categoryResource->getAttribute($code)->getFrontend()->getLabel();


### PR DESCRIPTION
The validate() function returns true or an array. If not true, it assumes an array. But e.g. in some unit tests (Catalog/Test/Unit/Model/CategoryRepositoryTest.php) the validate() output is set to false. That means a false is inserted in the foreach() call, which results in a warning and could break the tests.
