### PR TITLE
Use PHP_VERSION_ID to check the minimum required version

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -12,7 +12,7 @@ error_reporting(E_ALL);
 umask(0);
 
 /* PHP version validation */
-if (version_compare(phpversion(), '5.5.0', '<') === true) {
+if (PHP_VERSION_ID < 50500) {
     if (PHP_SAPI == 'cli') {
         echo 'Magento supports PHP 5.5.0 or later. ' .
             'Please read http://devdocs.magento.com/guides/v1.0/install-gde/system-requirements.html';

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -12,7 +12,7 @@ error_reporting(E_ALL);
 umask(0);
 
 /* PHP version validation */
-if (PHP_VERSION_ID < 50500) {
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50500) {
     if (PHP_SAPI == 'cli') {
         echo 'Magento supports PHP 5.5.0 or later. ' .
             'Please read http://devdocs.magento.com/guides/v1.0/install-gde/system-requirements.html';

--- a/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/WebapiAbstract.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/WebapiAbstract.php
@@ -115,9 +115,7 @@ abstract class WebapiAbstract extends \PHPUnit_Framework_TestCase
     public static function tearDownAfterClass()
     {
         //clear garbage in memory
-        if (version_compare(PHP_VERSION, '5.3', '>=')) {
-            gc_collect_cycles();
-        }
+        gc_collect_cycles();
 
         $fixtureNamespace = self::_getFixtureNamespace();
         if (isset(self::$_classLevelFixtures[$fixtureNamespace])


### PR DESCRIPTION
This is a micro-optimisation, but it avoids the overhead of two function calls to determine whether the minimum required version of PHP is present which happens on each request.

I have also removed the conditional around the a call to `gc_collect_cycles` within the tests since it checks for version 5.3+, and the minimum version required to run Magento 2 should already satisfy that condition.
