### PR TITLE
Increase precision of USPS shipping weight ounces calculation

### DIFF
--- a/app/code/Magento/Usps/Model/Carrier.php
+++ b/app/code/Magento/Usps/Model/Carrier.php
@@ -317,7 +317,7 @@ class Carrier extends AbstractCarrierOnline implements \Magento\Shipping\Model\C
 
         $weight = $this->getTotalNumOfBoxes($request->getPackageWeight());
         $r->setWeightPounds(floor($weight));
-        $r->setWeightOunces(round(($weight - floor($weight)) * self::OUNCES_POUND, 1));
+        $r->setWeightOunces(round(($weight - floor($weight)) * self::OUNCES_POUND, 10));
         if ($request->getFreeMethodWeight() != $request->getPackageWeight()) {
             $r->setFreeMethodWeight($request->getFreeMethodWeight());
         }


### PR DESCRIPTION
This is a (potential) fix for issue #3465 

Essentially, a small shipping weight is rounded down to 0 lbs, 0 oz by the USPS shipping module, which kicks back an error from USPS. According to the USPS [pricing api docs](https://www.usps.com/business/web-tools-apis/rate-calculator-api.pdf), 10 digits are allowed to be passed to the ounces field.

This pull request changes the rounding precision to 10. This is not necessarily the best nor only way to fix this - I think there is an argument to be made that no rounding should be performed at all (there is no rounding performed on the FedEx shipping weight, for example). However, I wanted to err on the side of caution and merely change the precision of the `round` function rather than removing it entirely.

Reproducing the bug is simple:
- Activate USPS shipping module (turning on debug mode and watching `debug.log` is also helpful)
- Create a product whose weight is 0.0001 lbs.
- (As a customer) add product to cart, checkout, watch the error get kicked back from USPS that there is no package weight.
