### PR TITLE
respect depends declaration in system.xml for form element

### DIFF
--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
@@ -15,7 +15,7 @@ $_colspan = $block->isAddAfter() ? 2 : 1;
 
 <div class="design_theme_ua_regexp" id="grid<?php /* @escapeNotVerified */ echo $_htmlId; ?>">
     <div class="admin__control-table-wrapper">
-        <table class="admin__control-table">
+        <table class="admin__control-table" id="<?php /* @escapeNotVerified */ echo $block->getElement()->getId(); ?>">
             <thead>
             <tr>
                 <?php foreach ($block->getColumns() as $columnName => $column): ?>


### PR DESCRIPTION
The Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray class uses Magento_Config::system/config/form/field/array.phtml to render the form element. It is used e.g. to render design exceptions in the system configuration.

If you use the <depends> declaration within the system.xml for a form element and use a block class that relies on AbstractFieldArray as source_model the JavaScript to toggle the depending form elements (FormElementDependenceController) won't have any effect. In fact a JavaScript error is caused as no HTML element is found with the ID matching the name of form element.

The PR assigns the ID of the form element to the table surrounding the field array. That allows the FormElementDependenceController to toggle the form element according to the <depend> declaration.

While <depends> is not used with such form fields in the core it would increase reusability of the template file.
