### PR TITLE
fix double reference to PERMISSIONS_DIR class constant

### DIFF
--- a/app/code/Magento/Deploy/Model/Filesystem.php
+++ b/app/code/Magento/Deploy/Model/Filesystem.php
@@ -112,7 +112,7 @@ class Filesystem
                 DirectoryList::STATIC_VIEW
             ],
             self::PERMISSIONS_DIR,
-            self::PERMISSIONS_DIR
+            self::PERMISSIONS_FILE
         );
 
         // Trigger static assets compilation and deployment


### PR DESCRIPTION
I noticed when switching to production mode that the file permissions were set to 750, rather than 640 as common in most other areas. After updating this line it looks like the proper permissions are applied when switching modes via bin/magento deploy:mode:set .
