### PR TITLE
Multilanguage store specific baseurl

### DIFF
--- a/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php
+++ b/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php
@@ -89,18 +89,6 @@ class RequestPreprocessor
                         return $response;
                     }
                 }
-
-                if (isset($uri['path']) && '/' !== $uri['path']) {
-                    $newPath = str_replace(
-                        $uri['path'],
-                        '',
-                        $request->getPathInfo()
-                    );
-                    if ('/' !== substr($newPath, 0 ,1)) {
-                        $newPath = '/' . $newPath;
-                    }
-                    $request->setPathInfo($newPath);
-                }
             }
         }
         $request->setDispatched(false);

--- a/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php
+++ b/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php
@@ -87,6 +87,18 @@ class RequestPreprocessor
                     $response->setNoCacheHeaders();
                     return $response;
                 }
+
+                if (isset($uri['path']) && '/' !== $uri['path']) {
+                    $newPath = str_replace(
+                        $uri['path'],
+                        '',
+                        $request->getPathInfo()
+                    );
+                    if ('/' !== substr($newPath, 0 ,1)) {
+                        $newPath = '/' . $newPath;
+                    }
+                    $request->setPathInfo($newPath);
+                }
             }
         }
         $request->setDispatched(false);

--- a/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php
+++ b/app/code/Magento/Store/App/FrontController/Plugin/RequestPreprocessor.php
@@ -66,26 +66,28 @@ class RequestPreprocessor
         \Closure $proceed,
         \Magento\Framework\App\RequestInterface $request
     ) {
-        if (!$request->isPost() && $this->getBaseUrlChecker()->isEnabled()) {
+        if ($this->getBaseUrlChecker()->isEnabled()) {
             $baseUrl = $this->_storeManager->getStore()->getBaseUrl(
                 \Magento\Framework\UrlInterface::URL_TYPE_WEB,
                 $this->_storeManager->getStore()->isCurrentlySecure()
             );
             if ($baseUrl) {
                 $uri = parse_url($baseUrl);
-                if (!$this->getBaseUrlChecker()->execute($uri, $request)) {
-                    $redirectUrl = $this->_url->getRedirectUrl(
-                        $this->_url->getUrl(ltrim($request->getPathInfo(), '/'), ['_nosid' => true])
-                    );
-                    $redirectCode = (int)$this->_scopeConfig->getValue(
-                        'web/url/redirect_to_base',
-                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-                    ) !== 301 ? 302 : 301;
+                if (!$request->isPost()) {
+                    if (!$this->getBaseUrlChecker()->execute($uri, $request)) {
+                        $redirectUrl = $this->_url->getRedirectUrl(
+                            $this->_url->getUrl(ltrim($request->getPathInfo(), '/'), ['_nosid' => true])
+                        );
+                        $redirectCode = (int)$this->_scopeConfig->getValue(
+                            'web/url/redirect_to_base',
+                            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                        ) !== 301 ? 302 : 301;
 
-                    $response = $this->_responseFactory->create();
-                    $response->setRedirect($redirectUrl, $redirectCode);
-                    $response->setNoCacheHeaders();
-                    return $response;
+                        $response = $this->_responseFactory->create();
+                        $response->setRedirect($redirectUrl, $redirectCode);
+                        $response->setNoCacheHeaders();
+                        return $response;
+                    }
                 }
 
                 if (isset($uri['path']) && '/' !== $uri['path']) {

--- a/app/code/Magento/Store/App/Http/Plugin/StoreHttp.php
+++ b/app/code/Magento/Store/App/Http/Plugin/StoreHttp.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Magento\Store\App\Http\Plugin;
+
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\App\RequestInterface;
+
+class StoreHttp
+{
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    protected $_storeManager;
+
+    /**
+     * @var \Magento\Framework\UrlInterface
+     */
+    protected $_url;
+
+    /**
+     * @var \Magento\Framework\App\RequestInterface
+     */
+    protected $_request;
+
+    /**
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\UrlInterface $url
+     * @param \Magento\Framework\App\RequestInterface $request
+     */
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        UrlInterface $url,
+        RequestInterface $request
+    ) {
+        $this->_storeManager = $storeManager;
+        $this->_url = $url;
+        $this->_request = $request;
+    }
+
+	public function beforeLaunch(\Magento\Framework\App\Http $subject)
+    {
+        $baseUrl = $this->_storeManager->getStore()->getBaseUrl(
+            UrlInterface::URL_TYPE_WEB,
+            $this->_storeManager->getStore()->isCurrentlySecure()
+        );
+        if ($baseUrl) {
+            $uri = parse_url($baseUrl);
+            if (isset($uri['path']) && '/' !== $uri['path']) {
+                $newPath = str_replace(
+                    $uri['path'],
+                    '',
+                    $this->_request->getPathInfo()
+                );
+                if ('/' !== substr($newPath, 0 ,1)) {
+                    $newPath = '/' . $newPath;
+                }
+                $this->_request->setPathInfo($newPath);
+            }
+        }
+    }
+}

--- a/app/code/Magento/Store/App/Http/Plugin/StoreHttp.php
+++ b/app/code/Magento/Store/App/Http/Plugin/StoreHttp.php
@@ -38,7 +38,7 @@ class StoreHttp
         $this->_request = $request;
     }
 
-	public function beforeLaunch(\Magento\Framework\App\Http $subject)
+    public function beforeLaunch(\Magento\Framework\App\Http $subject)
     {
         $baseUrl = $this->_storeManager->getStore()->getBaseUrl(
             UrlInterface::URL_TYPE_WEB,
@@ -52,7 +52,7 @@ class StoreHttp
                     '',
                     $this->_request->getPathInfo()
                 );
-                if ('/' !== substr($newPath, 0 ,1)) {
+                if ('/' !== substr($newPath, 0, 1)) {
                     $newPath = '/' . $newPath;
                 }
                 $this->_request->setPathInfo($newPath);

--- a/app/code/Magento/Store/App/Http/Plugin/StoreHttp.php
+++ b/app/code/Magento/Store/App/Http/Plugin/StoreHttp.php
@@ -38,7 +38,15 @@ class StoreHttp
         $this->_request = $request;
     }
 
-    public function beforeLaunch(\Magento\Framework\App\Http $subject)
+    /**
+     * Update the request's pathInfo if we have a store on a url path
+     *
+     * This will make sure we match the correct area and so the requested url
+     * will be routed via the correct path.
+     *
+     * @return void
+     */
+    public function beforeLaunch()
     {
         $baseUrl = $this->_storeManager->getStore()->getBaseUrl(
             UrlInterface::URL_TYPE_WEB,

--- a/app/code/Magento/Store/App/Response/Redirect.php
+++ b/app/code/Magento/Store/App/Response/Redirect.php
@@ -224,8 +224,7 @@ class Redirect implements \Magento\Framework\App\Response\RedirectInterface
                 $linkFromOtherStoreview = false;
                 $stores = $this->_storeManager->getStores(true);
                 foreach ($stores as $store) {
-                    if ($currentStore->getId() !== $store->getId())
-                    {
+                    if ($currentStore->getId() !== $store->getId()) {
                         $unsecureBaseUrl = $store
                             ->getBaseUrl($directLinkType, false);
                         $secureBaseUrl = $store

--- a/app/code/Magento/Store/App/Response/Redirect.php
+++ b/app/code/Magento/Store/App/Response/Redirect.php
@@ -210,7 +210,36 @@ class Redirect implements \Magento\Framework\App\Response\RedirectInterface
             $directLinkType = \Magento\Framework\UrlInterface::URL_TYPE_DIRECT_LINK;
             $unsecureBaseUrl = $this->_storeManager->getStore()->getBaseUrl($directLinkType, false);
             $secureBaseUrl = $this->_storeManager->getStore()->getBaseUrl($directLinkType, true);
-            return (strpos($url, $unsecureBaseUrl) === 0) || (strpos($url, $secureBaseUrl) === 0);
+            $internal = (strpos($url, $unsecureBaseUrl) === 0) || (strpos($url, $secureBaseUrl) === 0);
+            if (true === $internal) {
+                /**
+                 * check if the referer belongs to another storeview
+                 */
+                $linkFromOtherStoreview = false;
+                $currentStore = $this->_storeManager->getStore();
+                $stores = $this->_storeManager->getStores(true);
+                foreach ($stores as $store) {
+                    if ($currentStore->getId() !== $store->getId())
+                    {
+                        $unsecureBaseUrl = $store
+                            ->getBaseUrl($directLinkType, false);
+                        $secureBaseUrl = $store
+                            ->getBaseUrl($directLinkType, true);
+                        $fromOtherStoreview = (
+                            strpos($url, $unsecureBaseUrl) === 0)
+                            || (strpos($url, $secureBaseUrl) === 0
+                        );
+                        if (true === $fromOtherStoreview
+                            && false === $linkFromOtherStoreview) {
+                            $linkFromOtherStoreview = true;
+                        }
+                    }
+                }
+                if (true === $linkFromOtherStoreview) {
+                    $internal = false;
+                }
+            }
+            return $internal;
         }
         return false;
     }

--- a/app/code/Magento/Store/Block/Switcher.php
+++ b/app/code/Magento/Store/Block/Switcher.php
@@ -221,7 +221,7 @@ class Switcher extends \Magento\Framework\View\Element\Template
     {
         $data[\Magento\Store\Api\StoreResolverInterface::PARAM_NAME] = $store->getCode();
         return $this->_postDataHelper->getPostData(
-            $this->getUrl('stores/store/switch'),
+            $this->getUrl('stores/store/switch', ['_scope' => $store]),
             $data
         );
     }

--- a/app/code/Magento/Store/Test/Unit/App/Response/RedirectTest.php
+++ b/app/code/Magento/Store/Test/Unit/App/Response/RedirectTest.php
@@ -82,6 +82,8 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
         $this->_requestMock->expects($this->any())->method('getParam')->will($this->returnValue(null));
         $this->_storeManagerMock->expects($this->any())->method('getStore')
             ->will($this->returnValue($testStoreMock));
+        $this->_storeManagerMock->expects($this->any())->method('getStores')
+            ->will($this->returnValue([$testStoreMock]));
         $this->assertEquals($baseUrl, $this->_model->success($successUrl));
     }
 

--- a/app/code/Magento/Store/etc/di.xml
+++ b/app/code/Magento/Store/etc/di.xml
@@ -24,6 +24,9 @@
     <preference for="Magento\Framework\App\ScopeFallbackResolverInterface" type="Magento\Store\Model\ScopeFallbackResolver"/>
     <preference for="Magento\Framework\App\ScopeTreeProviderInterface" type="Magento\Store\Model\ScopeTreeProvider"/>
     <preference for="Magento\Framework\App\ScopeValidatorInterface" type="Magento\Store\Model\ScopeValidator"/>
+    <type name="Magento\Framework\App\Http">
+        <plugin name="storePathInfo" type="Magento\Store\App\Http\Plugin\StoreHttp" sortOrder="50"/>
+    </type>
     <type name="Magento\Framework\App\Response\Http">
         <plugin name="genericHeaderPlugin" type="Magento\Framework\App\Response\HeaderManager"/>
     </type>


### PR DESCRIPTION
We have a website for example http://magento2.dev/

We have 3 stores,
locale nl_NL; uses same base_url as website
locale fr_FR; uses http://magento2.dev/fr/
locale en_US; uses http://magento2.dev/en/

when we go to the homepage and switch the language everything seems to
work.

But for example when we go to a category page outside the "default site"
url we get a 404.

This is normal because we find no match in the routing.

if our category page is /category/subcategory we match in the
UrlRewriteRouter to /catalog/categroy/view/id/x .

When we are in a storeview where there is /fr or /en in the beginning of
the path, we match nothing and result in a 404.
