### PR TITLE
Fix support for GLOB_BRACE on non-GNU Linux systems

### DIFF
--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -9,6 +9,7 @@ namespace Magento\Framework\App\Utility;
 use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\DirSearch;
 use Magento\Framework\View\Design\Theme\ThemePackageList;
+use Zend\Stdlib\Glob;
 
 /**
  * A helper to gather specific kind of files in Magento application
@@ -1192,8 +1193,8 @@ class Files
         $result = [];
         foreach ($dirPatterns as $oneDirPattern) {
             $oneDirPattern  = str_replace('\\', '/', $oneDirPattern);
-            $entriesInDir = glob("{$oneDirPattern}/{$fileNamePattern}", GLOB_NOSORT | GLOB_BRACE);
-            $subDirs = glob("{$oneDirPattern}/*", GLOB_ONLYDIR | GLOB_NOSORT | GLOB_BRACE);
+            $entriesInDir = Glob::glob("{$oneDirPattern}/{$fileNamePattern}", Glob::GLOB_NOSORT | Glob::GLOB_BRACE);
+            $subDirs = Glob::glob("{$oneDirPattern}/*", Glob::GLOB_ONLYDIR | Glob::GLOB_NOSORT | Glob::GLOB_BRACE);
             $filesInDir = array_diff($entriesInDir, $subDirs);
 
             if ($recursive) {
@@ -1212,10 +1213,10 @@ class Files
      */
     public function getDiConfigs($asDataSet = false)
     {
-        $primaryConfigs = glob(BP . '/app/etc/{di.xml,*/di.xml}', GLOB_BRACE);
+        $primaryConfigs = Glob::glob(BP . '/app/etc/{di.xml,*/di.xml}', Glob::GLOB_BRACE);
         $moduleConfigs = [];
         foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
-            $moduleConfigs = array_merge($moduleConfigs, glob($moduleDir . '/etc/{di,*/di}.xml', GLOB_BRACE));
+            $moduleConfigs = array_merge($moduleConfigs, Glob::glob($moduleDir . '/etc/{di,*/di}.xml', Glob::GLOB_BRACE));
         }
         $configs = array_merge($primaryConfigs, $moduleConfigs);
 
@@ -1456,7 +1457,7 @@ class Files
                  * Note that glob() for directories will be returned as is,
                  * but passing directory is supported by the tools (phpcpd, phpmd, phpcs)
                  */
-                $files = glob(BP . '/' . $pattern, GLOB_BRACE);
+                $files = Glob::glob(BP . '/' . $pattern, Glob::GLOB_BRACE);
             } else {
                 throw new \UnexpectedValueException(
                     "Incorrect pattern record '$pattern'. Supported formats: "
@@ -1501,7 +1502,7 @@ class Files
             } else {
                 $componentDir = $this->componentRegistrar->getPath($type, $componentName);
                 if (!empty($componentDir)) {
-                    $files = array_merge($files, glob($componentDir . '/' . $pathPattern, GLOB_BRACE));
+                    $files = array_merge($files, Glob::glob($componentDir . '/' . $pathPattern, Glob::GLOB_BRACE));
                 }
             }
         }

--- a/lib/internal/Magento/Framework/Filesystem/Driver/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/File.php
@@ -9,6 +9,7 @@ namespace Magento\Framework\Filesystem\Driver;
 
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem\DriverInterface;
+use Zend\Stdlib\Glob;
 
 /**
  * Class File
@@ -268,7 +269,7 @@ class File implements DriverInterface
     {
         clearstatcache();
         $globPattern = rtrim($path, '/') . '/' . ltrim($pattern, '/');
-        $result = @glob($globPattern, GLOB_BRACE);
+        $result = @Glob::glob($globPattern, Glob::GLOB_BRACE);
         return is_array($result) ? $result : [];
     }
 


### PR DESCRIPTION
Which's core usage of glob with GLOB_BRACE to utilize Zend classes which gracefully handle systems without GLOB_BRACE support.

This resolves issue #2130. 
