### PR TITLE
Add nl_BE and fr_BE languages for Belgium

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -50,6 +50,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'fa_IR', /*Persian (Iran)*/
         'fi_FI', /*Finnish (Finland)*/
         'fil_PH', /*Filipino (Philippines)*/
+        'fr_BE', /*French (Belgium)*/
         'fr_CA', /*French (Canada)*/
         'fr_FR', /*French (France)*/
         'gu_IN', /*Gujarati (India)*/
@@ -71,6 +72,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'mk_MK', /*Macedonian (Macedonia)*/
         'mn_Cyrl_MN', /*Mongolian (Mongolia)*/
         'ms_Latn_MY', /*Malaysian (Malaysia)*/
+        'nl_BE', /*Dutch (Belgium)*/
         'nl_NL', /*Dutch (Netherlands)*/
         'nb_NO', /*Norwegian BokmГ_l (Norway)*/
         'nn_NO', /*Norwegian Nynorsk (Norway)*/


### PR DESCRIPTION
For our Belgian customers it would be very nice if their languages were also supported. Although Belgians speak Dutch and French there is a profound difference between Dutch and Flemish (nl_BE) and between French and Walloon (fr_BE). They require different language packs.

Although nl_BE and fr_BE can be easily added with a plugin - which is my current solution - it's a small change to add it to the Magento code. I think the Belgians would be thankful.
