### PR TITLE
Global border-box reset

### DIFF
--- a/lib/web/css/source/lib/_resets.less
+++ b/lib/web/css/source/lib/_resets.less
@@ -503,3 +503,17 @@
         vertical-align: middle;
     }
 }
+
+//
+//  Global border-box
+//  ---------------------------------------------
+
+.lib-borderbox() {
+    html {
+        box-sizing: border-box;
+    }
+
+    *, *:before, *:after {
+        box-sizing: inherit;
+    }
+}


### PR DESCRIPTION
When you set the width of an element, that's the width that it is. If you set the width to 25%, it will take up 1/4 of the horizontal space available in its parent element. That's not always the case. 

With the default box-sizing, as soon as an element has either padding or border applied, the actual rendered width is wider than the width you set. Actual width = width + border-left + border-right + padding-left + padding-right. 

With box-sizing: border-box the padding and border press their way inside the box rather than expand the box. The result is a box the exact width you set it to be and can count on. 

More info: https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ and http://www.paulirish.com/2012/box-sizing-border-box-ftw/
