### PR TITLE
Fixed typo "attibute" -> "attribute" in Catalog Module

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
@@ -101,7 +101,7 @@
                                 </th>
                             <?php endif; ?>
                             <td class="cell product attribute">
-                                <div class="attibute value">
+                                <div class="attribute value">
                                     <?php switch ($_attribute->getAttributeCode()) {
                                         case "price": ?>
                                             <?php


### PR DESCRIPTION
Fixed a typo of the word attribute in the Catalog module. File: /view/frontend/templates/product/compare/list.phtml, line 104.
