### PR TITLE
Fixed Ui Export Search Result Iterator for zero keys

### DIFF
--- a/app/code/Magento/Ui/Model/Export/SearchResultIterator.php
+++ b/app/code/Magento/Ui/Model/Export/SearchResultIterator.php
@@ -58,6 +58,6 @@ class SearchResultIterator implements \Iterator
      */
     public function valid()
     {
-        return (bool)$this->key();
+        return !is_null($this->key());
     }
 }


### PR DESCRIPTION
Grid collections with id starting from zero are not exported to xml, because first iteration valid check (bool)$this->key() will return false (as key is 0).

From key() php function documentation: If the internal pointer points beyond the end of the elements list or the array is empty, key returns null.

So check for is_null is most appropriate here.
