### PR TITLE
Integration Tests should use --default-file for mysql commands

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
@@ -49,7 +49,7 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
     {
         $this->ensureDefaultsExtraFile();
         $this->_shell->execute(
-            'mysql --defaults-extra-file=%s --host=%s %s -e %s',
+            'mysql --defaults-file=%s --host=%s %s -e %s',
             [
                 $this->_defaultsExtraFile,
                 $this->_host,
@@ -86,7 +86,7 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
     {
         $this->ensureDefaultsExtraFile();
         $this->_shell->execute(
-            'mysqldump --defaults-extra-file=%s --host=%s  %s > %s',
+            'mysqldump --defaults-file=%s --host=%s  %s > %s',
             [$this->_defaultsExtraFile, $this->_host, $this->_schema, $this->getSetupDbDumpFilename()]
         );
     }
@@ -102,7 +102,7 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
             throw new \LogicException("DB dump file does not exist: " . $this->getSetupDbDumpFilename());
         }
         $this->_shell->execute(
-            'mysql --defaults-extra-file=%s --host=%s %s < %s',
+            'mysql --defaults-file=%s --host=%s %s < %s',
             [$this->_defaultsExtraFile, $this->_host, $this->_schema, $this->getSetupDbDumpFilename()]
         );
     }


### PR DESCRIPTION
In `Magento\TestFramework\Db\Mysql` for all mysql commands --defaults-extra-file is used to define a custom .cnf file providing the mysql configuration.
Problem is, that the cnf-file provided using the parameter  --default-extra-file is overwriten by a configuration under ~/my.cnf. Thus resulting in a invalid mysql connection configuration and furthermore  the tests will fail.
To prevent an error due this issue, this pull request will change the parameter to --defaults-file which is not overwritten by other configuration files.

Also see mysql docs here: http://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_defaults-extra-file
