### PR TITLE
Allow caching of product review list

### DIFF
--- a/app/code/Magento/Review/view/frontend/web/js/process-reviews.js
+++ b/app/code/Magento/Review/view/frontend/web/js/process-reviews.js
@@ -10,7 +10,8 @@ define([
     function processReviews(url, fromPages) {
         $.ajax({
             url: url,
-            dataType: 'html'
+            dataType: 'html',
+            cache: true
         }).done(function (data) {
             $('#product-review-container').html(data);
             $('[data-role="product-review"] .pages a').each(function (index, element) {


### PR DESCRIPTION
Product reviews are loaded via ajax, which is defeating the true value of varnish on anonymous product views since `mage/bootstrap.js` is calling `ajaxSetup` and setting `cache` to false, resulting in an anti-cache param being added to the URL by jQuery. The information here is public and catchable information which needs to be cached in varnish for proper performance and scaling. Removing the anti-cache header on this one request results in the entire product view page being catchable by varnish. The proper tags are in-fact already in place on the ajax request so that the content will be properly flushed when the catalog_product_ID tag is purged.
