### PR TITLE
Insert design/footer/absolute_footer before </body> tag (Fixes #3333)

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Footer.php
+++ b/app/code/Magento/Theme/Block/Html/Footer.php
@@ -20,6 +20,13 @@ class Footer extends \Magento\Framework\View\Element\Template implements \Magent
     protected $_copyright;
 
     /**
+     * Miscellaneous HTML information
+     *
+     * @var string
+     */
+    private $miscellaneousHtml;
+
+    /**
      * @var \Magento\Framework\App\Http\Context
      */
     protected $httpContext;
@@ -83,6 +90,22 @@ class Footer extends \Magento\Framework\View\Element\Template implements \Magent
             );
         }
         return $this->_copyright;
+    }
+
+    /**
+     * Retrieve Miscellaneous HTML information
+     *
+     * @return string
+     */
+    public function getMiscellaneousHtml()
+    {
+        if ($this->miscellaneousHtml === null) {
+            $this->miscellaneousHtml = $this->_scopeConfig->getValue(
+                'design/footer/absolute_footer',
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            );
+        }
+        return $this->miscellaneousHtml;
     }
 
     /**

--- a/app/code/Magento/Theme/view/frontend/layout/default.xml
+++ b/app/code/Magento/Theme/view/frontend/layout/default.xml
@@ -122,6 +122,9 @@
                 <block class="Magento\Framework\View\Element\Template" name="report.bugs" template="Magento_Theme::html/bugreport.phtml" />
             </container>
         </referenceContainer>
+        <referenceContainer name="before.body.end">
+            <block class="Magento\Theme\Block\Html\Footer" name="absolute_footer" template="html/absolute_footer.phtml" />
+        </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Framework\View\Element\FormKey" name="formkey"/>
         </referenceContainer>

--- a/app/code/Magento/Theme/view/frontend/templates/html/absolute_footer.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/absolute_footer.phtml
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+?>
+<?php /* @escapeNotVerified */ echo $block->getMiscellaneousHtml() ?>


### PR DESCRIPTION
The design/footer/absolute_footer content is not inserted before </body>. It is included in the config area of the admin, but in the rest of the code the 'absolute_footer' ain't used anywhere. This is a change to solve this issue. I'm not 100% sure this is the way Magento would like this feature to be inserted, but if so I'm happy to contribute. 
