### PR TITLE
Fix for swatch attributes on wishlist product view

### DIFF
--- a/app/code/Magento/Swatches/etc/module.xml
+++ b/app/code/Magento/Swatches/etc/module.xml
@@ -9,6 +9,7 @@
     <module name="Magento_Swatches" setup_version="2.0.1">
         <sequence>
             <module name="Magento_Catalog"/>
+	    <module name="Magento_Wishlist"/>
             <module name="Magento_ConfigurableProduct"/>
             <module name="Magento_Eav"/>
             <module name="Magento_Customer"/>

--- a/app/code/Magento/Swatches/view/frontend/layout/wishlist_index_configure_type_configurable.xml
+++ b/app/code/Magento/Swatches/view/frontend/layout/wishlist_index_configure_type_configurable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <css src="Magento_Swatches::css/swatches.css"/>
+    </head>
+    <body>
+        <referenceContainer name="product.info.options.configurable" remove="true"/>
+        <referenceBlock name="product.info.options.wrapper">
+            <block class="Magento\Swatches\Block\Product\Renderer\Configurable" name="product.info.options.swatches" as="swatch_options" before="-" />
+        </referenceBlock>
+    </body>
+</page>


### PR DESCRIPTION
Currently when you use swatch attributes for product it shows on wishlist/index/configure as dropdown select. I've added the swatch block to the wishlist page and Wishlist to Swatches load sequence.
