### PR TITLE
Remove duplicate switchIsFilterable

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
@@ -337,7 +337,6 @@ window.setRowVisibility = setRowVisibility;
 window.showDefaultRows = showDefaultRows;
 window.switchDefaultValueField = switchDefaultValueField;
 window.switchIsFilterable = switchIsFilterable;
-window.switchIsFilterable = switchIsFilterable;
 window.bindAttributeInputType = bindAttributeInputType;
 window.checkOptionsPanelVisibility = checkOptionsPanelVisibility;
 window.getFrontTab = getFrontTab;


### PR DESCRIPTION
Remove duplicate line

```
window.switchIsFilterable = switchIsFilterable;
```

in file `app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml`.
