### PR TITLE
Add translate around telephone tooltip description in checkout

### DIFF
--- a/app/code/Magento/Checkout/Block/Checkout/LayoutProcessor.php
+++ b/app/code/Magento/Checkout/Block/Checkout/LayoutProcessor.php
@@ -173,7 +173,7 @@ class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcesso
                                     'telephone' => [
                                         'config' => [
                                             'tooltip' => [
-                                                'description' => 'For delivery questions.',
+                                                'description' => __('For delivery questions.'),
                                             ],
                                         ],
                                     ],


### PR DESCRIPTION
Translates the tooltip associated with the telephone number on the checkout. Without it, it's not possible to translate the tooltip.
