### PR TITLE
Fix E_NOTICE in Magento_Swatches extension

### DIFF
--- a/app/code/Magento/Swatches/Block/Product/Renderer/Listing/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Listing/Configurable.php
@@ -40,6 +40,7 @@ class Configurable extends \Magento\Swatches\Block\Product\Renderer\Configurable
     protected function getSwatchAttributesData()
     {
         $swatchAttributeData = parent::getSwatchAttributesData();
+        $result = [];
         foreach ($swatchAttributeData as $attributeId => $item) {
             if (!empty($item['used_in_product_listing'])) {
                 $result[$attributeId] = $item;


### PR DESCRIPTION
This pull request fixes this error:

```
Undefined variable: result in vendor/magento/module-swatches/Block/Product/Renderer/Listing/Configurable.php
```

I don't have time to document the exact steps to reproduce this problem, but it occurred on the product listing page on a project where visual swatches were being used. The pull request is simple enough where you shouldn't need to reproduce the error in order to accept this PR.
