### PR TITLE
Fixed Parse error when bin/magento setup:di:compile 

### DIFF
--- a/app/code/Magento/Directory/Model/Currency/Import/Webservicex.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/Webservicex.php
@@ -14,8 +14,7 @@ class Webservicex extends \Magento\Directory\Model\Currency\Import\AbstractImpor
     /**
      * @var string
      */
-    const CURRENCY_CONVERTER_URL = 'http://www.webservicex.net/CurrencyConvertor.asmx/ConversionRate?' .
-        'FromCurrency={{CURRENCY_FROM}}&ToCurrency={{CURRENCY_TO}}';
+    const CURRENCY_CONVERTER_URL = 'http://www.webservicex.net/CurrencyConvertor.asmx/ConversionRate?FromCurrency={{CURRENCY_FROM}}&ToCurrency={{CURRENCY_TO}}';
 
     /**
      * Http Client Factory
@@ -30,7 +29,6 @@ class Webservicex extends \Magento\Directory\Model\Currency\Import\AbstractImpor
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     private $scopeConfig;
-
     /**
      * @param \Magento\Directory\Model\CurrencyFactory $currencyFactory
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig


### PR DESCRIPTION
This fixes the described issue in [https://github.com/magento/magento2/issues/3668](https://github.com/magento/magento2/issues/3668)
To avoid that error i removed string concatination via "." in CURRENCY_CONVERTER_URL

Error was:
PHP Parse error:  syntax error, unexpected '.', expecting ',' or ';' in /vagrant/magento2/app/code/Magento/Directory/Model/Currency/Import/Webservicex.php on line 17
