### PR TITLE
Fixed failing PHP 5.5 travis test due to syntax error

### DIFF
--- a/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
@@ -10,10 +10,14 @@ namespace Magento\Directory\Model\Currency\Import;
  */
 class FixerIo extends \Magento\Directory\Model\Currency\Import\AbstractImport
 {
-    /**
+    /**#@+
      * @var string
      */
-    const CURRENCY_CONVERTER_URL = 'http://api.fixer.io/latest?base={{CURRENCY_FROM}}&symbols={{CURRENCY_TO}}';
+    const CURRENCY_CONVERTER_ENDPOINT = 'http://api.fixer.io/latest';
+    const CURRENCY_CONVERTER_FROM_PARAM = 'base';
+    const CURRENCY_CONVERTER_TO_PARAM = 'symbols';
+    /**#@-*/
+
 
     /**
      * Http Client Factory
@@ -76,8 +80,9 @@ class FixerIo extends \Magento\Directory\Model\Currency\Import\AbstractImport
     private function convertBatch($data, $currencyFrom, $currenciesTo)
     {
         $currenciesStr = implode(',', $currenciesTo);
-        $url = str_replace('{{CURRENCY_FROM}}', $currencyFrom, self::CURRENCY_CONVERTER_URL);
-        $url = str_replace('{{CURRENCY_TO}}', $currenciesStr, $url);
+        $url = self::CURRENCY_CONVERTER_ENDPOINT . 
+            '?' . self::CURRENCY_CONVERTER_FROM_PARAM . '=' . $currencyFrom .
+            '&' . self::CURRENCY_CONVERTER_TO_PARAM . '=' . $currenciesStr;
 
         set_time_limit(0);
         $response = $this->getServiceResponse($url);
@@ -114,18 +119,15 @@ class FixerIo extends \Magento\Directory\Model\Currency\Import\AbstractImport
         $response = [];
 
         try {
-            $jsonResponse = $httpClient->setUri(
-                $url
-            )->setConfig(
-                [
+            $jsonResponse = $httpClient->setUri($url)
+                ->setConfig([
                     'timeout' => $this->scopeConfig->getValue(
                         'currency/fixerio/timeout',
                         \Magento\Store\Model\ScopeInterface::SCOPE_STORE
                     ),
-                ]
-            )->request(
-                'GET'
-            )->getBody();
+                ])
+                ->request('GET')
+                ->getBody();
 
             $response = json_decode($jsonResponse, true);
         } catch (\Exception $e) {

--- a/app/code/Magento/Directory/Model/Currency/Import/Webservicex.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/Webservicex.php
@@ -11,11 +11,13 @@ namespace Magento\Directory\Model\Currency\Import;
  */
 class Webservicex extends \Magento\Directory\Model\Currency\Import\AbstractImport
 {
-    /**
+    /**#@+
      * @var string
      */
-    const CURRENCY_CONVERTER_URL = 'http://www.webservicex.net/CurrencyConvertor.asmx/ConversionRate?' .
-        'FromCurrency={{CURRENCY_FROM}}&ToCurrency={{CURRENCY_TO}}';
+    const CURRENCY_CONVERTER_ENDPOINT = 'http://www.webservicex.net/CurrencyConvertor.asmx/ConversionRate';
+    const CURRENCY_CONVERTER_FROM_PARAM = 'FromCurrency';
+    const CURRENCY_CONVERTER_TO_PARAM = 'ToCurrency';
+    /**#@-*/
 
     /**
      * Http Client Factory
@@ -51,24 +53,23 @@ class Webservicex extends \Magento\Directory\Model\Currency\Import\AbstractImpor
      */
     protected function _convert($currencyFrom, $currencyTo, $retry = 0)
     {
-        $url = str_replace('{{CURRENCY_FROM}}', $currencyFrom, self::CURRENCY_CONVERTER_URL);
-        $url = str_replace('{{CURRENCY_TO}}', $currencyTo, $url);
+        $url = self::CURRENCY_CONVERTER_ENDPOINT . 
+            '?' . self::CURRENCY_CONVERTER_FROM_PARAM . '=' . $currencyFrom .
+            '&' . self::CURRENCY_CONVERTER_TO_PARAM . '=' . $currencyTo;
+
         /** @var \Magento\Framework\HTTP\ZendClient $httpClient */
         $httpClient = $this->getHttpClientFactory()->create();
 
         try {
-            $response = $httpClient->setUri(
-                $url
-            )->setConfig(
-                [
+            $response = $httpClient->setUri($url)
+                ->setConfig([
                     'timeout' => $this->scopeConfig->getValue(
                         'currency/webservicex/timeout',
                         \Magento\Store\Model\ScopeInterface::SCOPE_STORE
                     ),
-                ]
-            )->request(
-                'GET'
-            )->getBody();
+                ])
+                ->request('GET')
+                ->getBody();
 
             $xml = simplexml_load_string($response, null, LIBXML_NOERROR);
             if (!$xml) {

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/ObserverTest.php
@@ -8,6 +8,7 @@
 
 namespace Magento\Directory\Model;
 
+use Magento\Directory\Model\Currency\Import\Webservicex;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -61,13 +62,14 @@ class ObserverTest extends \PHPUnit_Framework_TestCase
     public function testScheduledUpdateCurrencyRates()
     {
         //skipping test if service is unavailable
-        $url = str_replace('{{CURRENCY_FROM}}', 'USD',
-            \Magento\Directory\Model\Currency\Import\Webservicex::CURRENCY_CONVERTER_URL);
-        $url = str_replace('{{CURRENCY_TO}}', 'GBP', $url);
+        $url = Webservicex::CURRENCY_CONVERTER_ENDPOINT . 
+            '?' . Webservicex::CURRENCY_CONVERTER_FROM_PARAM . '=USD' .
+            '&' . Webservicex::CURRENCY_CONVERTER_TO_PARAM . '=GBP';
+
         try {
             file_get_contents($url);
         } catch (\PHPUnit_Framework_Error_Warning $e) {
-            $this->markTestSkipped('http://www.webservicex.net is unavailable ');
+            $this->markTestSkipped(Webservicex::CURRENCY_CONVERTER_ENDPOINT . ' is unavailable ');
         }
 
         $allowedCurrencies = 'USD,GBP,EUR';


### PR DESCRIPTION
Fixed syntax error (introduced in 591f16e) which has been failing all travis tests on PHP 5.5
