### PR TITLE
Add 'yyyy' to nomalizedDate method map for adminhtml i18n

### DIFF
--- a/lib/web/mage/utils/misc.js
+++ b/lib/web/mage/utils/misc.js
@@ -38,6 +38,7 @@ define([
         'EEEE': 'dddd',
         'EEE': 'ddd',
         'e': 'd',
+        'yyyy': 'YYYY',
         'y': 'YYYY',
         'a': 'A'
     };


### PR DESCRIPTION
- Sample Code

```
<?php


$t = (new \IntlDateFormatter(
   'ja_JP',
   \IntlDateFormatter::MEDIUM,
   \IntlDateFormatter::NONE
))->getPattern();

echo $t, PHP_EOL;
```

Mac homebrew php56 + php56-intl result: `y/MM/dd`
But, Amazon Linux 2015.09: php56 + php56-intl result: `yyyy/MM/dd`

Adminhtml datetime Correct: "2016/02/28 20:21:59"
Adminhtml datetime Result: "2016yyy/02/28 20:21:59"

in Japanese Locale Admin User on Amazon Linux.
