### PR TITLE
Improve parsing of Date Time coming from UPS in Tracking

### DIFF
--- a/app/code/Magento/Ups/Model/Carrier.php
+++ b/app/code/Magento/Ups/Model/Carrier.php
@@ -1049,26 +1049,16 @@ XMLAuth;
                         if (isset($activityTag->ActivityLocation->Address->CountryCode)) {
                             $addArr[] = (string)$activityTag->ActivityLocation->Address->CountryCode;
                         }
-                        $dateArr = [];
-                        $date = (string)$activityTag->Date;
-                        //YYYYMMDD
-                        $dateArr[] = substr($date, 0, 4);
-                        $dateArr[] = substr($date, 4, 2);
-                        $dateArr[] = substr($date, -2, 2);
 
-                        $timeArr = [];
-                        $time = (string)$activityTag->Time;
-                        //HHMMSS
-                        $timeArr[] = substr($time, 0, 2);
-                        $timeArr[] = substr($time, 2, 2);
-                        $timeArr[] = substr($time, -2, 2);
+                        // YYYYMMDD HHMMSS
+                        $dateTime = \DateTime::createFromFormat('Ymd His',
+                            (string)$activityTag->Date . ' ' . (string)$activityTag->Time);
 
                         if ($index === 1) {
                             $resultArr['status'] = (string)$activityTag->Status->StatusType->Description;
-                            $resultArr['deliverydate'] = implode('-', $dateArr);
-                            //YYYY-MM-DD
-                            $resultArr['deliverytime'] = implode(':', $timeArr);
-                            //HH:MM:SS
+                            $resultArr['deliverydate'] = $dateTime->format('Y-m-d');
+                            $resultArr['deliverytime'] = $dateTime->format('H:i:s');
+
                             $resultArr['deliverylocation'] = (string)$activityTag->ActivityLocation->Description;
                             $resultArr['signedby'] = (string)$activityTag->ActivityLocation->SignedForByName;
                             if ($addArr) {
@@ -1077,10 +1067,8 @@ XMLAuth;
                         } else {
                             $tempArr = [];
                             $tempArr['activity'] = (string)$activityTag->Status->StatusType->Description;
-                            $tempArr['deliverydate'] = implode('-', $dateArr);
-                            //YYYY-MM-DD
-                            $tempArr['deliverytime'] = implode(':', $timeArr);
-                            //HH:MM:SS
+                            $tempArr['deliverydate'] = $dateTime->format('Y-m-d');
+                            $tempArr['deliverytime'] = $dateTime->format('H:i:s');
                             if ($addArr) {
                                 $tempArr['deliverylocation'] = implode(', ', $addArr);
                             }


### PR DESCRIPTION
The original code was hard to understand as it basically did this:
- Take Date and cut it in an array of 3 pieces: year, month, day
- Take Time and cut it in an array of 3 pieces: hour, minute, second

Then later it uses implode() to take them together again, but in a different format. The native DateTime class of PHP does this in a more neat and readable format in my believe. And it's included in all PHP versions Magento 2 is targeting.

I didn't choose to use dependency injection in here as I think it basically comes down to doing the same as using functions. 
