### PR TITLE
Admin static files not generated

### DIFF
--- a/app/code/Magento/Store/Model/Config/StoreView.php
+++ b/app/code/Magento/Store/Model/Config/StoreView.php
@@ -68,7 +68,7 @@ class StoreView
     }
 
     /**
-     * Retrieves a unique list of locales that are used by store views
+     * Retrieves a unique list of locales that are used by store views and in default
      *
      * @return array
      */
@@ -76,6 +76,11 @@ class StoreView
     {
         $stores = $this->storeManager->getStores();
         $locales = [];
+
+        /**
+         * Default value might differ from any store scope
+         */
+        $locales[] = $this->scopeConfig->getValue(Data::XML_PATH_DEFAULT_LOCALE);
 
         /** @var \Magento\Store\Api\Data\StoreInterface $store */
         foreach ($stores as $store) {


### PR DESCRIPTION
I found a bug here admin scope didn't get its static content generated by the deployment process (bin/magento deploy:mode:set production). After a little debugging i found this method, responsable for fetching all current languages used. 

This works great if your admin is the same language as any of your stores. But on our project it differs, we hav the backend in English and frontend in Danish, since we will have people from different countries in the backend but no frontend at the first stage of our project.
