### PR TITLE
Fix SortOrderBuilder::create return type hint

### DIFF
--- a/lib/internal/Magento/Framework/Api/SortOrderBuilder.php
+++ b/lib/internal/Magento/Framework/Api/SortOrderBuilder.php
@@ -9,7 +9,7 @@ namespace Magento\Framework\Api;
 
 /**
  * Builder for sort order data object.
- *
+ * @method SortOrder create()
  */
 class SortOrderBuilder extends AbstractSimpleObjectBuilder
 {


### PR DESCRIPTION
The return type hint of `SortOrderBuilder::create()` is inherited from  `AbstractSimpleObjectBuilder::create()`.
This causes PHPStorm to display a warning when passing the `SortOrder` instance to `SearchCriteriaBuilder::addSortOrder()`.

<img width="589" alt="bildschirmfoto 2016-03-11 um 16 19 45" src="https://cloud.githubusercontent.com/assets/72463/13706374/1bf1e336-e7a5-11e5-8bfe-8d9abc68454a.png">

This simple PR corrects the return type by overriding the `create()` method PHPDoc and changing the return type to `\Magento\Framework\Api\SortOrder`.

As a result PHPStorm no longer thinks there is a type mismatch.

<img width="586" alt="bildschirmfoto 2016-03-11 um 16 21 49" src="https://cloud.githubusercontent.com/assets/72463/13706448/6c8316f8-e7a5-11e5-95d9-b31a41607640.png">
