### PR TITLE
Add dispatching of view_block_abstract_to_html_after event

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
+++ b/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
@@ -654,6 +654,15 @@ abstract class AbstractBlock extends \Magento\Framework\Object implements BlockI
             }
         }
         $html = $this->_afterToHtml($html);
+        
+        /** @var \Magento\Framework\DataObject */
+        $transportObject = new \Magento\Framework\DataObject(
+            [
+                'html' => $html,
+            ]
+        );
+        $this->_eventManager->dispatch('view_block_abstract_to_html_after', ['block' => $this, 'transport' => $transportObject]);
+        $html = $transportObject->getHtml();
 
         return $html;
     }


### PR DESCRIPTION
Just like it was in Magento 1 Mage_Core_Block_Abstract class, this change is aimed at having an event dispatched after the HTML is generated by the toHtml() method. 

This can be used to change HTML without the need to implement a plugin for the Magento\Framework\View\Element\AbstractBlock class.
