### PR TITLE
Add HttpInterface methods and add up-casts for type safety

### DIFF
--- a/app/code/Magento/Backend/Model/View/Result/Redirect.php
+++ b/app/code/Magento/Backend/Model/View/Result/Redirect.php
@@ -10,6 +10,7 @@ use Magento\Backend\Model\Session;
 use Magento\Backend\Model\UrlInterface;
 use Magento\Framework\App;
 use Magento\Framework\App\ActionFlag;
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
 
 class Redirect extends \Magento\Framework\Controller\Result\Redirect
 {
@@ -56,7 +57,7 @@ class Redirect extends \Magento\Framework\Controller\Result\Redirect
     /**
      * {@inheritdoc}
      */
-    protected function render(App\ResponseInterface $response)
+    protected function render(HttpResponseInterface $response)
     {
         $this->session->setIsUrlNotice($this->actionFlag->get('', AbstractAction::FLAG_IS_URLS_CHECKED));
         return parent::render($response);

--- a/lib/internal/Magento/Framework/App/Response/HttpInterface.php
+++ b/lib/internal/Magento/Framework/App/Response/HttpInterface.php
@@ -18,10 +18,16 @@ interface HttpInterface extends \Magento\Framework\App\ResponseInterface
     public function setHttpResponseCode($code);
 
     /**
+     * Get HTTP response code
+     *
+     * @return int
+     */
+    public function getHttpResponseCode();
+
+    /**
      * Set a header
      *
-     * If $replace is true, replaces any headers already defined with that
-     * $name.
+     * If $replace is true, replaces any headers already defined with that $name.
      *
      * @param string $name
      * @param string $value
@@ -31,6 +37,34 @@ interface HttpInterface extends \Magento\Framework\App\ResponseInterface
     public function setHeader($name, $value, $replace = false);
 
     /**
+     * Get header value by name
+     * 
+     * Returns first found header by passed name.
+     * If header with specified name was not found returns false.
+     *
+     * @param string $name
+     * @return \Zend\Http\Header\HeaderInterface|bool
+     */
+    public function getHeader($name);
+
+    /**
+     * Remove header by name from header stack
+     *
+     * @param string $name
+     * @return self
+     */
+    public function clearHeader($name);
+
+    /**
+     * Allow granular setting of HTTP response status code, version and phrase
+     * 
+     * For example, a HTTP response as the following:
+     *     HTTP 200 1.1 Your response has been served
+     * Can be set with the arguments
+     *     $httpCode = 200
+     *     $version = 1.1
+     *     $phrase = 'Your response has been served'
+     * 
      * @param int|string $httpCode
      * @param null|int|string $version
      * @param null|string $phrase
@@ -39,12 +73,18 @@ interface HttpInterface extends \Magento\Framework\App\ResponseInterface
     public function setStatusHeader($httpCode, $version = null, $phrase = null);
 
     /**
+     * Append the given string to the response body
+     * 
      * @param string $value
      * @return self
      */
     public function appendBody($value);
 
     /**
+     * Set the response body to the given value
+     * 
+     * Any previously set contents will be replaced by the new content.
+     * 
      * @param string $value
      * @return self
      */
@@ -53,8 +93,7 @@ interface HttpInterface extends \Magento\Framework\App\ResponseInterface
     /**
      * Set redirect URL
      *
-     * Sets Location header and response code. Forces replacement of any prior
-     * redirects.
+     * Sets Location header and response code. Forces replacement of any prior redirects.
      *
      * @param string $url
      * @param int $code

--- a/lib/internal/Magento/Framework/App/Response/HttpInterface.php
+++ b/lib/internal/Magento/Framework/App/Response/HttpInterface.php
@@ -16,4 +16,49 @@ interface HttpInterface extends \Magento\Framework\App\ResponseInterface
      * @return void
      */
     public function setHttpResponseCode($code);
+
+    /**
+     * Set a header
+     *
+     * If $replace is true, replaces any headers already defined with that
+     * $name.
+     *
+     * @param string $name
+     * @param string $value
+     * @param boolean $replace
+     * @return self
+     */
+    public function setHeader($name, $value, $replace = false);
+
+    /**
+     * @param int|string $httpCode
+     * @param null|int|string $version
+     * @param null|string $phrase
+     * @return self
+     */
+    public function setStatusHeader($httpCode, $version = null, $phrase = null);
+
+    /**
+     * @param string $value
+     * @return self
+     */
+    public function appendBody($value);
+
+    /**
+     * @param string $value
+     * @return self
+     */
+    public function setBody($value);
+
+    /**
+     * Set redirect URL
+     *
+     * Sets Location header and response code. Forces replacement of any prior
+     * redirects.
+     *
+     * @param string $url
+     * @param int $code
+     * @return self
+     */
+    public function setRedirect($url, $code = 302);
 }

--- a/lib/internal/Magento/Framework/Controller/AbstractResult.php
+++ b/lib/internal/Magento/Framework/Controller/AbstractResult.php
@@ -7,6 +7,7 @@
 namespace Magento\Framework\Controller;
 
 use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
 
 abstract class AbstractResult implements ResultInterface
 {
@@ -83,10 +84,10 @@ abstract class AbstractResult implements ResultInterface
     }
 
     /**
-     * @param ResponseInterface $response
+     * @param HttpResponseInterface $response
      * @return $this
      */
-    protected function applyHttpHeaders(ResponseInterface $response)
+    protected function applyHttpHeaders(HttpResponseInterface $response)
     {
         if (!empty($this->httpResponseCode)) {
             $response->setHttpResponseCode($this->httpResponseCode);
@@ -105,7 +106,7 @@ abstract class AbstractResult implements ResultInterface
         }
         return $this;
     }
-
+    
     /**
      * @param ResponseInterface $response
      * @return $this
@@ -115,7 +116,7 @@ abstract class AbstractResult implements ResultInterface
     /**
      * Render content
      *
-     * @param ResponseInterface $response
+     * @param HttpResponseInterface|ResponseInterface $response
      * @return $this
      */
     public function renderResult(ResponseInterface $response)

--- a/lib/internal/Magento/Framework/Controller/AbstractResult.php
+++ b/lib/internal/Magento/Framework/Controller/AbstractResult.php
@@ -108,10 +108,10 @@ abstract class AbstractResult implements ResultInterface
     }
     
     /**
-     * @param ResponseInterface $response
+     * @param HttpResponseInterface $response
      * @return $this
      */
-    abstract protected function render(ResponseInterface $response);
+    abstract protected function render(HttpResponseInterface $response);
 
     /**
      * Render content

--- a/lib/internal/Magento/Framework/Controller/Result/Forward.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Forward.php
@@ -7,7 +7,7 @@
 namespace Magento\Framework\Controller\Result;
 
 use Magento\Framework\App\RequestInterface;
-use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
 use Magento\Framework\Controller\AbstractResult;
 
 class Forward extends AbstractResult
@@ -99,7 +99,7 @@ class Forward extends AbstractResult
     /**
      * {@inheritdoc}
      */
-    protected function render(ResponseInterface $response)
+    protected function render(HttpResponseInterface $response)
     {
         return $this;
     }

--- a/lib/internal/Magento/Framework/Controller/Result/Json.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Json.php
@@ -6,8 +6,7 @@
 
 namespace Magento\Framework\Controller\Result;
 
-use Magento\Framework\App\Response\Http as HttpResponse;
-use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
 use Magento\Framework\Controller\AbstractResult;
 use Magento\Framework\Translate\InlineInterface;
 
@@ -60,22 +59,13 @@ class Json extends AbstractResult
     }
 
     /**
-     * @param HttpResponse|ResponseInterface $response
-     * @return $this
+     * {@inheritdoc}
      */
-    protected function render(ResponseInterface $response)
-    {
-        return $this->renderHttpResponse($response);
-    }
-
-    /**
-     * @param HttpResponse $response
-     * @return $this
-     */
-    private function renderHttpResponse(HttpResponse $response)
+    protected function render(HttpResponseInterface $response)
     {
         $this->translateInline->processResponseBody($this->json, true);
-        $response->representJson($this->json);
+        $response->setHeader('Content-Type', 'application/json', true);
+        $response->setBody($this->json);
         return $this;
     }
 }

--- a/lib/internal/Magento/Framework/Controller/Result/Json.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Json.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Framework\Controller\Result;
 
+use Magento\Framework\App\Response\Http as HttpResponse;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\AbstractResult;
 use Magento\Framework\Translate\InlineInterface;
@@ -59,9 +60,19 @@ class Json extends AbstractResult
     }
 
     /**
-     * {@inheritdoc}
+     * @param HttpResponse|ResponseInterface $response
+     * @return $this
      */
     protected function render(ResponseInterface $response)
+    {
+        return $this->renderHttpResponse($response);
+    }
+
+    /**
+     * @param HttpResponse $response
+     * @return $this
+     */
+    private function renderHttpResponse(HttpResponse $response)
     {
         $this->translateInline->processResponseBody($this->json, true);
         $response->representJson($this->json);

--- a/lib/internal/Magento/Framework/Controller/Result/Raw.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Raw.php
@@ -7,7 +7,6 @@
 namespace Magento\Framework\Controller\Result;
 
 use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
-use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\AbstractResult;
 
 /**
@@ -32,21 +31,11 @@ class Raw extends AbstractResult
     }
 
     /**
-     * @param HttpResponseInterface|ResponseInterface $response
-     * @return $this
+     * {@inheritdoc}
      */
-    protected function render(ResponseInterface $response)
+    protected function render(HttpResponseInterface $response)
     {
-        return $this->renderHttpResponse($response);
-    }
-
-    /**
-     * @param HttpResponseInterface $httpResponse
-     * @return $this
-     */
-    private function renderHttpResponse(HttpResponseInterface $httpResponse)
-    {
-        $httpResponse->setBody($this->contents);
+        $response->setBody($this->contents);
         return $this;
     }
 }

--- a/lib/internal/Magento/Framework/Controller/Result/Raw.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Raw.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Framework\Controller\Result;
 
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\AbstractResult;
 
@@ -31,11 +32,21 @@ class Raw extends AbstractResult
     }
 
     /**
-     * {@inheritdoc}
+     * @param HttpResponseInterface|ResponseInterface $response
+     * @return $this
      */
     protected function render(ResponseInterface $response)
     {
-        $response->setBody($this->contents);
+        return $this->renderHttpResponse($response);
+    }
+
+    /**
+     * @param HttpResponseInterface $httpResponse
+     * @return $this
+     */
+    private function renderHttpResponse(HttpResponseInterface $httpResponse)
+    {
+        $httpResponse->setBody($this->contents);
         return $this;
     }
 }

--- a/lib/internal/Magento/Framework/Controller/Result/Redirect.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Redirect.php
@@ -7,6 +7,8 @@
 namespace Magento\Framework\Controller\Result;
 
 use Magento\Framework\App;
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
+use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\AbstractResult;
 
 /**
@@ -90,11 +92,21 @@ class Redirect extends AbstractResult
     }
 
     /**
-     * {@inheritdoc}
+     * @param HttpResponseInterface|ResponseInterface $response
+     * @return $this
      */
-    protected function render(App\ResponseInterface $response)
+    protected function render(ResponseInterface $response)
     {
-        $response->setRedirect($this->url);
+        return $this->renderHttpResponse($response);
+    }
+
+    /**
+     * @param HttpResponseInterface $httpResponse
+     * @return $this
+     */
+    private function renderHttpResponse(HttpResponseInterface $httpResponse)
+    {
+        $httpResponse->setRedirect($this->url);
         return $this;
     }
 }

--- a/lib/internal/Magento/Framework/Controller/Result/Redirect.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Redirect.php
@@ -8,7 +8,6 @@ namespace Magento\Framework\Controller\Result;
 
 use Magento\Framework\App;
 use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
-use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\AbstractResult;
 
 /**
@@ -92,21 +91,11 @@ class Redirect extends AbstractResult
     }
 
     /**
-     * @param HttpResponseInterface|ResponseInterface $response
-     * @return $this
+     * {@inheritdoc}
      */
-    protected function render(ResponseInterface $response)
+    protected function render(HttpResponseInterface $response)
     {
-        return $this->renderHttpResponse($response);
-    }
-
-    /**
-     * @param HttpResponseInterface $httpResponse
-     * @return $this
-     */
-    private function renderHttpResponse(HttpResponseInterface $httpResponse)
-    {
-        $httpResponse->setRedirect($this->url);
+        $response->setRedirect($this->url);
         return $this;
     }
 }

--- a/lib/internal/Magento/Framework/Controller/Test/Unit/Result/JsonTest.php
+++ b/lib/internal/Magento/Framework/Controller/Test/Unit/Result/JsonTest.php
@@ -24,13 +24,14 @@ class JsonTest extends \PHPUnit_Framework_TestCase
         /** @var \Magento\Framework\Translate\InlineInterface|\PHPUnit_Framework_MockObject_MockObject
          * $translateInline
          */
-        $translateInline = $this->getMock(\Magento\Framework\Translate\InlineInterface::class, [], [], '', false);
+        $translateInline = $this->getMock(\Magento\Framework\Translate\InlineInterface::class);
         $translateInline->expects($this->any())->method('processResponseBody')->with($json, true)->will(
             $this->returnValue($translatedJson)
         );
 
-        $response = $this->getMock(\Magento\Framework\App\Response\Http::class, ['representJson'], [], '', false);
-        $response->expects($this->atLeastOnce())->method('representJson')->with($json)->will($this->returnSelf());
+        $response = $this->getMock(\Magento\Framework\App\Response\HttpInterface::class);
+        $response->expects($this->atLeastOnce())->method('setHeader')->with('Content-Type', 'application/json', true);
+        $response->expects($this->atLeastOnce())->method('setBody')->with($json);
 
         /** @var \Magento\Framework\Controller\Result\Json $resultJson */
         $resultJson = (new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this))

--- a/lib/internal/Magento/Framework/Controller/Test/Unit/Result/RawTest.php
+++ b/lib/internal/Magento/Framework/Controller/Test/Unit/Result/RawTest.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Framework\Controller\Test\Unit\Result;
 
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 
 class RawTest extends \PHPUnit_Framework_TestCase
@@ -13,7 +14,7 @@ class RawTest extends \PHPUnit_Framework_TestCase
     /** @var \Magento\Framework\Controller\Result\Raw */
     protected $raw;
 
-    /** @var \Magento\Framework\App\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject*/
+    /** @var HttpResponseInterface|\PHPUnit_Framework_MockObject_MockObject*/
     protected $response;
 
     /** @var ObjectManagerHelper */
@@ -24,15 +25,13 @@ class RawTest extends \PHPUnit_Framework_TestCase
         $this->objectManagerHelper = new ObjectManagerHelper($this);
 
         $this->response = $this->getMock(
-            \Magento\Framework\App\ResponseInterface::class,
-            ['setBody', 'sendResponse'],
+            HttpResponseInterface::class,
+            [],
             [],
             '',
             false
         );
-        $this->raw = $this->objectManagerHelper->getObject(
-            \Magento\Framework\Controller\Result\Raw::class
-        );
+        $this->raw = $this->objectManagerHelper->getObject(\Magento\Framework\Controller\Result\Raw::class);
     }
 
     public function testSetContents()

--- a/lib/internal/Magento/Framework/Controller/Test/Unit/Result/RedirectTest.php
+++ b/lib/internal/Magento/Framework/Controller/Test/Unit/Result/RedirectTest.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Framework\Controller\Test\Unit\Result;
 
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
 use \Magento\Framework\Controller\Result\Redirect;
 
 class RedirectTest extends \PHPUnit_Framework_TestCase
@@ -22,7 +23,7 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
     /** @var \Magento\Framework\UrlInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $urlInterface;
 
-    /** @var \Magento\Framework\App\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var HttpResponseInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $response;
 
     protected function setUp()
@@ -49,8 +50,8 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
             false
         );
         $this->response = $this->getMock(
-            \Magento\Framework\App\ResponseInterface::class,
-            ['setRedirect', 'sendResponse'],
+            HttpResponseInterface::class,
+            [],
             [],
             '',
             false

--- a/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Response.php
+++ b/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Response.php
@@ -16,12 +16,7 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
     protected $isRedirect = false;
 
     /**
-     * Get header value by name.
-     * Returns first found header by passed name.
-     * If header with specified name was not found returns false.
-     *
-     * @param string $name
-     * @return \Zend\Http\Header\HeaderInterface|bool
+     * {@inheritdoc}
      */
     public function getHeader($name)
     {
@@ -45,8 +40,7 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
     }
 
     /**
-     * @param string $value
-     * @return $this
+     * {@inheritdoc}
      */
     public function appendBody($value)
     {
@@ -56,8 +50,7 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
     }
 
     /**
-     * @param string $value
-     * @return $this
+     * {@inheritdoc}
      */
     public function setBody($value)
     {
@@ -76,15 +69,7 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
     }
 
     /**
-     * Set a header
-     *
-     * If $replace is true, replaces any headers already defined with that
-     * $name.
-     *
-     * @param string $name
-     * @param string $value
-     * @param boolean $replace
-     * @return $this
+     * {@inheritdoc}
      */
     public function setHeader($name, $value, $replace = false)
     {
@@ -99,10 +84,7 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
     }
 
     /**
-     * Remove header by name from header stack
-     *
-     * @param string $name
-     * @return $this
+     * {@inheritdoc}
      */
     public function clearHeader($name)
     {
@@ -117,6 +99,7 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
 
     /**
      * Remove all headers
+     * 
      * @return $this
      */
     public function clearHeaders()
@@ -128,14 +111,7 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
     }
 
     /**
-     * Set redirect URL
-     *
-     * Sets Location header and response code. Forces replacement of any prior
-     * redirects.
-     *
-     * @param string $url
-     * @param int $code
-     * @return $this
+     * {@inheritdoc}
      */
     public function setRedirect($url, $code = 302)
     {
@@ -146,10 +122,7 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
     }
 
     /**
-     * Set HTTP response code to use with headers
-     *
-     * @param int $code
-     * @return $this
+     * {@inheritdoc}
      */
     public function setHttpResponseCode($code)
     {
@@ -164,10 +137,7 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
     }
 
     /**
-     * @param int|string $httpCode
-     * @param null|int|string $version
-     * @param null|string $phrase
-     * @return $this
+     * {@inheritdoc}
      */
     public function setStatusHeader($httpCode, $version = null, $phrase = null)
     {
@@ -182,9 +152,7 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
     }
 
     /**
-     * Get response code
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getHttpResponseCode()
     {

--- a/lib/internal/Magento/Framework/View/Result/Layout.php
+++ b/lib/internal/Magento/Framework/View/Result/Layout.php
@@ -7,6 +7,7 @@
 namespace Magento\Framework\View\Result;
 
 use Magento\Framework;
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\AbstractResult;
 use Magento\Framework\View;
@@ -152,10 +153,19 @@ class Layout extends AbstractResult
     /**
      * Render current layout
      *
-     * @param ResponseInterface $response
+     * @param HttpResponseInterface|ResponseInterface $response
      * @return $this
      */
     public function renderResult(ResponseInterface $response)
+    {
+        return $this->renderHttpResult($response);
+    }
+
+    /**
+     * @param HttpResponseInterface $httpResponse
+     * @return $this
+     */
+    private function renderHttpResult(HttpResponseInterface $httpResponse)
     {
         \Magento\Framework\Profiler::start('LAYOUT');
         \Magento\Framework\Profiler::start('layout_render');
@@ -163,8 +173,8 @@ class Layout extends AbstractResult
         $this->eventManager->dispatch('layout_render_before');
         $this->eventManager->dispatch('layout_render_before_' . $this->request->getFullActionName());
         
-        $this->applyHttpHeaders($response);
-        $this->render($response);
+        $this->applyHttpHeaders($httpResponse);
+        $this->render($httpResponse);
 
         \Magento\Framework\Profiler::stop('layout_render');
         \Magento\Framework\Profiler::stop('LAYOUT');
@@ -174,14 +184,23 @@ class Layout extends AbstractResult
     /**
      * Render current layout
      *
-     * @param ResponseInterface $response
+     * @param HttpResponseInterface|ResponseInterface $response
      * @return $this
      */
     protected function render(ResponseInterface $response)
     {
+        return $this->renderHttpResponse($response);
+    }
+
+    /**
+     * @param HttpResponseInterface $httpResponse
+     * @return $this
+     */
+    private function renderHttpResponse(HttpResponseInterface $httpResponse)
+    {
         $output = $this->layout->getOutput();
         $this->translateInline->processResponseBody($output);
-        $response->appendBody($output);
+        $httpResponse->appendBody($output);
         return $this;
     }
 }

--- a/lib/internal/Magento/Framework/View/Result/Layout.php
+++ b/lib/internal/Magento/Framework/View/Result/Layout.php
@@ -102,7 +102,7 @@ class Layout extends AbstractResult
     /**
      * Get layout instance for current page
      *
-     * @return \Magento\Framework\View\Layout
+     * @return \Magento\Framework\View\LayoutInterface
      */
     public function getLayout()
     {
@@ -153,19 +153,10 @@ class Layout extends AbstractResult
     /**
      * Render current layout
      *
-     * @param HttpResponseInterface|ResponseInterface $response
+     * @param HttpResponseInterface|ResponseInterface $httpResponse
      * @return $this
      */
-    public function renderResult(ResponseInterface $response)
-    {
-        return $this->renderHttpResult($response);
-    }
-
-    /**
-     * @param HttpResponseInterface $httpResponse
-     * @return $this
-     */
-    private function renderHttpResult(HttpResponseInterface $httpResponse)
+    public function renderResult(ResponseInterface $httpResponse)
     {
         \Magento\Framework\Profiler::start('LAYOUT');
         \Magento\Framework\Profiler::start('layout_render');
@@ -182,25 +173,13 @@ class Layout extends AbstractResult
     }
 
     /**
-     * Render current layout
-     *
-     * @param HttpResponseInterface|ResponseInterface $response
-     * @return $this
+     * {@inheritdoc}
      */
-    protected function render(ResponseInterface $response)
-    {
-        return $this->renderHttpResponse($response);
-    }
-
-    /**
-     * @param HttpResponseInterface $httpResponse
-     * @return $this
-     */
-    private function renderHttpResponse(HttpResponseInterface $httpResponse)
+    protected function render(HttpResponseInterface $response)
     {
         $output = $this->layout->getOutput();
         $this->translateInline->processResponseBody($output);
-        $httpResponse->appendBody($output);
+        $response->appendBody($output);
         return $this;
     }
 }

--- a/lib/internal/Magento/Framework/View/Result/Page.php
+++ b/lib/internal/Magento/Framework/View/Result/Page.php
@@ -7,6 +7,7 @@
 namespace Magento\Framework\View\Result;
 
 use Magento\Framework;
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\View;
 
@@ -219,10 +220,19 @@ class Page extends Layout
     }
 
     /**
-     * @param ResponseInterface $response
+     * @param HttpResponseInterface|ResponseInterface $response
      * @return $this
      */
     protected function render(ResponseInterface $response)
+    {
+        return $this->renderHttpResponse($response);
+    }
+
+    /**
+     * @param HttpResponseInterface $httpResponse
+     * @return $this
+     */
+    private function renderHttpResponse(HttpResponseInterface $httpResponse)
     {
         $this->pageConfig->publicBuild();
         if ($this->getPageLayout()) {
@@ -244,9 +254,9 @@ class Page extends Layout
             $this->assign('layoutContent', $output);
             $output = $this->renderPage();
             $this->translateInline->processResponseBody($output);
-            $response->appendBody($output);
+            $httpResponse->appendBody($output);
         } else {
-            parent::render($response);
+            parent::render($httpResponse);
         }
         return $this;
     }

--- a/lib/internal/Magento/Framework/View/Result/Page.php
+++ b/lib/internal/Magento/Framework/View/Result/Page.php
@@ -8,7 +8,6 @@ namespace Magento\Framework\View\Result;
 
 use Magento\Framework;
 use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
-use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\View;
 
 /**
@@ -220,19 +219,9 @@ class Page extends Layout
     }
 
     /**
-     * @param HttpResponseInterface|ResponseInterface $response
-     * @return $this
+     * {@inheritdoc}
      */
-    protected function render(ResponseInterface $response)
-    {
-        return $this->renderHttpResponse($response);
-    }
-
-    /**
-     * @param HttpResponseInterface $httpResponse
-     * @return $this
-     */
-    private function renderHttpResponse(HttpResponseInterface $httpResponse)
+    protected function render(HttpResponseInterface $response)
     {
         $this->pageConfig->publicBuild();
         if ($this->getPageLayout()) {
@@ -254,9 +243,9 @@ class Page extends Layout
             $this->assign('layoutContent', $output);
             $output = $this->renderPage();
             $this->translateInline->processResponseBody($output);
-            $httpResponse->appendBody($output);
+            $response->appendBody($output);
         } else {
-            parent::render($httpResponse);
+            parent::render($response);
         }
         return $this;
     }


### PR DESCRIPTION
This PR does not add any functionality. Its only purpose is to make the usage of the `HttpInterface` response more type safe.  
As far as I can tell there should be no backward incompatible changes, except for the HTTP related methods from `\Magento\Framework\Controller\AbstractResult` being moved into a new `\Magento\Framework\Controller\AbstractHttpResult` child class.  

All core classes extending `AbstractResult` but referencing HTTP methods now extend the new `AbstractHttpResult`. Any non-web result type can still extend `AbstractResult` without having `applyHttpHeaders()` caled during rendering.

Please reference issue #3737 for further information.
