### PR TITLE
Fix for PyaPal Payflow Pro transparent redirect

### DIFF
--- a/app/code/Magento/Paypal/Controller/Transparent/Response.php
+++ b/app/code/Magento/Paypal/Controller/Transparent/Response.php
@@ -80,7 +80,7 @@ class Response extends \Magento\Framework\App\Action\Action
     {
         $parameters = [];
         try {
-            $response = $this->transaction->getResponseObject($this->getRequest()->getPostValue());
+            $response = $this->transaction->getResponseObject($this->getRequest()->getParams());
             $this->responseValidator->validate($response, $this->transparent);
             $this->transaction->savePaymentInQuote($response);
         } catch (LocalizedException $exception) {


### PR DESCRIPTION
Steps to reproduce:
- In backend - configure PayPal Payments Pro (Includes Express Checkout)
- Go to the frontend, login and add any product to the shopping cart
- Go to checkout page and choose Credit Cart (PayPal Payments Pro)
- Enter required values (I used data for sandbox)
- Click on Place Order button

Expected:
- Order is placed

Actual:
- Error message occured: Cannot place order (and disappeared in couple seconds) 

I investigated the issue and found that \Magento\Paypal\Controller\Transparent\Response gets Post Data but to the controller are passed only Get Data. After changing from `$this->getRequest()->getPostValue()` to `$this->getRequest()->getParams()` order is placed.
