### PR TITLE
Stop screen loader on payment error

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/action/place-order.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/action/place-order.js
@@ -47,6 +47,10 @@ define(
                     errorProcessor.process(response, messageContainer);
                     fullScreenLoader.stopLoader();
                 }
+            ).always(
+                function () {
+                    fullScreenLoader.stopLoader();
+                }
             );
         };
     }

--- a/app/code/Magento/Checkout/view/frontend/web/js/action/set-payment-information.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/action/set-payment-information.js
@@ -48,6 +48,7 @@ define(
             ).fail(
                 function (response) {
                     errorProcessor.process(response, messageContainer);
+                    fullScreenLoader.stopLoader();
                 }
             ).always(
                 function () {


### PR DESCRIPTION
Steps to reproduce:
- In backend - configure PayPal Payments Pro (Includes Express Checkout)
- Go to the frontend, login and add any product to the shopping cart
- Go to checkout page and choose Credit Cart (PayPal Payments Pro)
- Enter required values (I used data for sandbox)
- Click on Place Order button

Expected:
- Order is placed

Actual:
- Error message occured: Cannot place order (and disappeared in couple seconds). But screen loader is not hidden, message is under loader.

Fix for the cause of the error is proposed in PR 3748
