### PR TITLE
Bugfix: Unable to activate search form on phone

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -58,6 +58,9 @@ define([
             this.element.attr('autocomplete', this.options.autocomplete);
 
             this.element.on('blur', $.proxy(function () {
+                if (!this.searchLabel.hasClass('active')) {
+                    return;
+                }
 
                 setTimeout($.proxy(function () {
                     if (this.autoComplete.is(':hidden')) {


### PR DESCRIPTION
This commit fixes the bug, when user was not able to activate search 
form on mobile device after two sequential clicks on search icon (label).

Bug description:
1. First click (Field should show up): `focus` event is triggered and form is shown.
2. Second click (Field should show off): `blur` and `focus` events are triggered
   2.1. Blur event set the timeout to hide the field.
   2.2. Focus event adds the `active` class to the field.
   2.3. Timeout function is called, `active` class name is removed and field becomes hidden.
   **(Field is still in `focus` state)**
3. **Third click (Field should show up): `blur` and `focus` events are triggered again,
   and field will not show up.**
   3.1 Blur event set the timeout to hide the field.
   ...

Proposed patch adds additional logic into 2.1 and 3.1:
Blur event will set the timeout to hide the field **if the field already has `active` class name**
