### PR TITLE
Add dispatching of view_block_abstract_to_html_after event

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Product/Options/AjaxTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Product/Options/AjaxTest.php
@@ -50,7 +50,7 @@ class AjaxTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->setMethods(['dispatch'])
             ->getMock();
-        $eventManager->expects($this->once())->method('dispatch')->will($this->returnValue(true));
+        $eventManager->expects($this->exactly(2))->method('dispatch')->will($this->returnValue(true));
 
         $scopeConfig = $this->getMockBuilder('\Magento\Framework\App\Config')
             ->setMethods(['getValue'])

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/Widget/NewWidgetTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/Widget/NewWidgetTest.php
@@ -170,7 +170,7 @@ class NewWidgetTest extends \PHPUnit_Framework_TestCase
 
     protected function generalGetProductCollection()
     {
-        $this->eventManager->expects($this->once())->method('dispatch')
+        $this->eventManager->expects($this->exactly(2))->method('dispatch')
             ->will($this->returnValue(true));
         $this->scopeConfig->expects($this->once())->method('getValue')->withAnyParameters()
             ->willReturn(false);

--- a/app/code/Magento/Paypal/Test/Unit/Block/Billing/AgreementsTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Block/Billing/AgreementsTest.php
@@ -227,9 +227,14 @@ class AgreementsTest extends \PHPUnit_Framework_TestCase
     public function testToHtml()
     {
         $this->eventManager
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('dispatch')
             ->with('view_block_abstract_to_html_before', ['block' => $this->block]);
+        $transport = new \Magento\Framework\DataObject(['html' => '']);
+        $this->eventManager
+            ->expects($this->at(1))
+            ->method('dispatch')
+            ->with('view_block_abstract_to_html_after', ['block' => $this->block, 'transport' => $transport]);
         $this->scopeConfig
             ->expects($this->once())
             ->method('getValue')

--- a/app/code/Magento/Persistent/Test/Unit/Block/Header/AdditionalTest.php
+++ b/app/code/Magento/Persistent/Test/Unit/Block/Header/AdditionalTest.php
@@ -264,7 +264,6 @@ class AdditionalTest extends \PHPUnit_Framework_TestCase
         $this->eventManagerMock->expects($this->at(0))
             ->method('dispatch')
             ->with('view_block_abstract_to_html_before', ['block' => $this->additional]);
-        $transport = new \Magento\Framework\DataObject(['html' => '']);
         $this->eventManagerMock->expects($this->at(1))
             ->method('dispatch')
             ->with('view_block_abstract_to_html_after');

--- a/app/code/Magento/Persistent/Test/Unit/Block/Header/AdditionalTest.php
+++ b/app/code/Magento/Persistent/Test/Unit/Block/Header/AdditionalTest.php
@@ -261,9 +261,13 @@ class AdditionalTest extends \PHPUnit_Framework_TestCase
         $this->additional->setData('cache_lifetime', 789);
         $this->additional->setData('cache_key', 'cache-key');
 
-        $this->eventManagerMock->expects($this->once())
+        $this->eventManagerMock->expects($this->at(0))
             ->method('dispatch')
             ->with('view_block_abstract_to_html_before', ['block' => $this->additional]);
+        $transport = new \Magento\Framework\DataObject(['html' => '']);
+        $this->eventManagerMock->expects($this->at(1))
+            ->method('dispatch')
+            ->with('view_block_abstract_to_html_after');
         $this->scopeConfigMock->expects($this->once())
             ->method('getValue')
             ->with(

--- a/app/code/Magento/Widget/Test/Unit/Block/Adminhtml/Widget/Instance/Edit/Chooser/ContainerTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Block/Adminhtml/Widget/Instance/Edit/Chooser/ContainerTest.php
@@ -66,7 +66,7 @@ class ContainerTest extends AbstractContainerTest
             . 'Main Content Area</option><option value="content.bottom" >Main Content Bottom</option>'
             . '<option value="content.top" >Main Content Top</option></select>';
 
-        $this->eventManagerMock->expects($this->once())->method('dispatch')->willReturn(true);
+        $this->eventManagerMock->expects($this->exactly(2))->method('dispatch')->willReturn(true);
         $this->scopeConfigMock->expects($this->once())->method('getValue')->willReturn(false);
 
         $this->themeCollectionFactoryMock->expects($this->once())
@@ -153,7 +153,7 @@ class ContainerTest extends AbstractContainerTest
             . '<option value="sidebar.additional" >Sidebar Additional</option>'
             . '<option value="sidebar.main" >Sidebar Main</option></select>';
 
-        $this->eventManagerMock->expects($this->once())->method('dispatch')->willReturn(true);
+        $this->eventManagerMock->expects($this->exactly(2))->method('dispatch')->willReturn(true);
         $this->scopeConfigMock->expects($this->once())->method('getValue')->willReturn(false);
 
         $this->themeCollectionFactoryMock->expects($this->once())
@@ -284,7 +284,7 @@ class ContainerTest extends AbstractContainerTest
             . '<option value="sidebar.additional" >Sidebar Additional</option>'
             . '<option value="sidebar.main" >Sidebar Main</option></select>';
 
-        $this->eventManagerMock->expects($this->once())->method('dispatch')->willReturn(true);
+        $this->eventManagerMock->expects($this->exactly(2))->method('dispatch')->willReturn(true);
         $this->scopeConfigMock->expects($this->once())->method('getValue')->willReturn(false);
 
         $this->themeCollectionFactoryMock->expects($this->once())
@@ -402,7 +402,7 @@ class ContainerTest extends AbstractContainerTest
             . '<option value="sidebar.additional" >Sidebar Additional</option><option value="sidebar.main" >'
             . 'Sidebar Main</option></select>';
 
-        $this->eventManagerMock->expects($this->once())->method('dispatch')->willReturn(true);
+        $this->eventManagerMock->expects($this->exactly(2))->method('dispatch')->willReturn(true);
         $this->scopeConfigMock->expects($this->once())->method('getValue')->willReturn(false);
 
         $this->themeCollectionFactoryMock->expects($this->once())

--- a/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
+++ b/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
@@ -665,6 +665,15 @@ abstract class AbstractBlock extends \Magento\Framework\DataObject implements Bl
         }
         $html = $this->_afterToHtml($html);
 
+        /** @var \Magento\Framework\DataObject */
+        $transportObject = new \Magento\Framework\DataObject(
+            [
+                'html' => $html,
+            ]
+        );
+        $this->_eventManager->dispatch('view_block_abstract_to_html_after', ['block' => $this, 'transport' => $transportObject]);
+        $html = $transportObject->getHtml();
+
         return $html;
     }
 


### PR DESCRIPTION
Just like it was in Magento 1 Mage_Core_Block_Abstract class, this change is aimed at having an event dispatched after the HTML is generated by the toHtml() method.

This can be used to change HTML without the need to implement a plugin for the Magento\Framework\View\Element\AbstractBlock class.
