### PR TITLE
missing testsuites-tag in phpunit config

### DIFF
--- a/dev/tests/unit/phpunit.xml.dist
+++ b/dev/tests/unit/phpunit.xml.dist
@@ -10,18 +10,20 @@
          colors="true"
          bootstrap="./framework/bootstrap.php"
         >
-    <testsuite name="Magento Unit Tests">
-        <directory suffix="Test.php">../../../app/code/*/*/Test/Unit</directory>
-        <directory suffix="Test.php">../../../dev/tools/*/*/Test/Unit</directory>
-        <directory suffix="Test.php">../../../dev/tools/*/*/*/Test/Unit</directory>
-        <directory suffix="Test.php">../../../lib/internal/*/*/Test/Unit</directory>
-        <directory suffix="Test.php">../../../lib/internal/*/*/*/Test/Unit</directory>
-        <directory suffix="Test.php">../../../setup/src/*/*/Test/Unit</directory>
-        <directory suffix="Test.php">../../../update/app/code/*/*/Test/Unit</directory>
-        <directory suffix="Test.php">../../../vendor/*/module-*/Test/Unit</directory>
-        <directory suffix="Test.php">../../../vendor/*/framework/Test/Unit</directory>
-        <directory suffix="Test.php">../../../vendor/*/framework/*/Test/Unit</directory>
-    </testsuite>
+    <testsuites>
+        <testsuite name="Magento Unit Tests">
+            <directory suffix="Test.php">../../../app/code/*/*/Test/Unit</directory>
+            <directory suffix="Test.php">../../../dev/tools/*/*/Test/Unit</directory>
+            <directory suffix="Test.php">../../../dev/tools/*/*/*/Test/Unit</directory>
+            <directory suffix="Test.php">../../../lib/internal/*/*/Test/Unit</directory>
+            <directory suffix="Test.php">../../../lib/internal/*/*/*/Test/Unit</directory>
+            <directory suffix="Test.php">../../../setup/src/*/*/Test/Unit</directory>
+            <directory suffix="Test.php">../../../update/app/code/*/*/Test/Unit</directory>
+            <directory suffix="Test.php">../../../vendor/*/module-*/Test/Unit</directory>
+            <directory suffix="Test.php">../../../vendor/*/framework/Test/Unit</directory>
+            <directory suffix="Test.php">../../../vendor/*/framework/*/Test/Unit</directory>
+        </testsuite>
+    <testsuites>
     <php>
         <ini name="date.timezone" value="America/Los_Angeles"/>
         <ini name="xdebug.max_nesting_level" value="200"/>


### PR DESCRIPTION
following the PHPUnit documentation, the <testsuite>'s should be inside a <testsuites> tag, even if there's only one testsuite.
