### PR TITLE
Avoid compiling non-files and empty files

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/Code/Reader/ClassesScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Reader/ClassesScanner.php
@@ -55,7 +55,9 @@ class ClassesScanner implements ClassesScannerInterface
         $classes = [];
         foreach ($recursiveIterator as $fileItem) {
             /** @var $fileItem \SplFileInfo */
-            if ($fileItem->getExtension() !== 'php') {
+            if (!$fileItem->isFile() ||
+                0 === $fileItem->getSize() ||
+                $fileItem->getExtension() !== 'php') {
                 continue;
             }
             foreach ($this->excludePatterns as $excludePatterns) {


### PR DESCRIPTION
Prevents the **No tokens were provided** issue while running 
`bin/magento setup:di:compile`
