### PR TITLE
Add a check so that modules can check if already registered or not

### DIFF
--- a/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
+++ b/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
@@ -56,6 +56,18 @@ class ComponentRegistrar implements ComponentRegistrarInterface
     }
 
     /**
+     * Returns if a component is already registered with the system
+     *
+     * @param $type
+     * @param $componentName
+     * @return bool
+     */
+    public static function checkRegisteredComponent($type, $componentName)
+    {
+        return isset(self::$paths[$type][$componentName]);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getPaths($type)

--- a/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
+++ b/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
@@ -58,8 +58,8 @@ class ComponentRegistrar implements ComponentRegistrarInterface
     /**
      * Returns if a component is already registered with the system
      *
-     * @param $type
-     * @param $componentName
+     * @param string $type component type
+     * @param string $componentName Fully-qualified component name
      * @return bool
      */
     public static function checkRegisteredComponent($type, $componentName)


### PR DESCRIPTION
While developing the Magento 2 Behat extension I encountered a problem where when writing features for a module only ( module installable via composer ) then I encountered the exception where component `module_name` was already registered. 

Upon debugging this I can see that composer creates in the main project folder `vendor/composer/autoload_files.php` all of the compiled files node references from each modules composer manifest file. 

Now because I ship and run the Behat features from the module directory as I want to distribute them via the module then the modules `vendor/composer/autoload_files.php` also contains a reference to these registration.php files that try to register against the component register again.

If accepted this will enable the functionality of [Behat-Init](https://github.com/jamescowie/behat-magento2-init) to work where Behat can have access to Magento 2 core in context files. 

To use this in a `registration.php` context you would:

``` php

if(!\Magento\Framework\Component\ComponentRegistrar:: checkRegisteredComponent(
    \Magento\Framework\Component\ComponentRegistrar::MODULE,
    'Jcowie_Test'
)) {
    \Magento\Framework\Component\ComponentRegistrar::register(
        \Magento\Framework\Component\ComponentRegistrar::MODULE,
        'Jcowie_Test',
        __DIR__
    );
}
```
