### PR TITLE
Update minicart.phtml

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
@@ -14,7 +14,7 @@
        data-bind="scope: 'minicart_content'">
         <span class="text"><?php /* @escapeNotVerified */ echo __('My Cart'); ?></span>
         <span class="counter qty empty"
-              data-bind="css: { empty: !!getCartParam('summary_count') == false }, blockLoader: isLoading">
+              data-bind="css: { empty: !!getCartParam('summary_count') == false || !cart().summary_count }, blockLoader: isLoading">
             <span class="counter-number"><!-- ko text: getCartParam('summary_count') --><!-- /ko --></span>
             <span class="counter-label">
             <!-- ko if: getCartParam('summary_count') -->


### PR DESCRIPTION
Fix the intermittent bug with the red circle in the minicart.

Sometimes the red circle appears because the cart().summary_count isn't defined. Fix the conditionnal to resolve this problem
