### PR TITLE
Support newline in javascript translates

### DIFF
--- a/app/code/Magento/Translation/etc/di.xml
+++ b/app/code/Magento/Translation/etc/di.xml
@@ -58,7 +58,7 @@
         <arguments>
             <argument name="patterns" xsi:type="array">
                 <item name="i18n_translation" xsi:type="string"><![CDATA[~i18n\:\s*(["'])(.*?)(?<!\\)\1~]]></item>
-                <item name="mage_translation_widget" xsi:type="string">~\$\.mage\.__\((['"])(.+?)\1\)~</item>
+                <item name="mage_translation_widget" xsi:type="string">~\$\.mage\.__\((?s)[^'"]*?(['"])(.+?)\1(?s).*?\)~</item>
                 <item name="mage_translation_static" xsi:type="string">~\$t\((["'])(.+?)\1\)~</item>
             </argument>
         </arguments>

--- a/app/code/Magento/Translation/etc/di.xml
+++ b/app/code/Magento/Translation/etc/di.xml
@@ -59,7 +59,7 @@
             <argument name="patterns" xsi:type="array">
                 <item name="i18n_translation" xsi:type="string"><![CDATA[~i18n\:\s*(["'])(.*?)(?<!\\)\1~]]></item>
                 <item name="mage_translation_widget" xsi:type="string">~\$\.mage\.__\((?s)[^'"]*?(['"])(.+?)\1(?s).*?\)~</item>
-                <item name="mage_translation_static" xsi:type="string">~\$t\((["'])(.+?)\1\)~</item>
+                <item name="mage_translation_static" xsi:type="string">~\$t\((?s)[^'"]*?(["'])(.+?)\1(?s).*?\)~</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Currently it's not possible to add translates in js-translation.json if you use a newline after the opening brackets of the translate helper function in your templates.

This pull requests adds support for the following cases:

```
$.mage.__(
    'This is a string'
);
$.mage.__(
    "This is a string"
);

$t(
    "This is a string"
);
$t(
    'This is a string'
);
```
