### PR TITLE
fix bug on newsletter subscription action when user use an existing email already subscribed

### DIFF
--- a/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
+++ b/app/code/Magento/Newsletter/Controller/Subscriber/NewAction.php
@@ -121,6 +121,15 @@ class NewAction extends \Magento\Newsletter\Controller\Subscriber
                 $this->validateGuestSubscription();
                 $this->validateEmailAvailable($email);
 
+                $subscriber = $this->_subscriberFactory->create()->loadByEmail($email);
+                if ($subscriber->getId()
+                    && $subscriber->getSubscriberStatus() == \Magento\Newsletter\Model\Subscriber::STATUS_SUBSCRIBED
+                ) {
+                    throw new \Magento\Framework\Exception\LocalizedException(
+                        __('This email address is already subscribed.')
+                    );
+                }
+
                 $status = $this->_subscriberFactory->create()->subscribe($email);
                 if ($status == \Magento\Newsletter\Model\Subscriber::STATUS_NOT_ACTIVE) {
                     $this->messageManager->addSuccess(__('The confirmation request has been sent.'));


### PR DESCRIPTION
I've fixed an existing bug on Magento 1: when an user try to subscribe with an existing email the output message is the same as a new subscriber.
Checked and passed PHP unit tests
