### PR TITLE
Add .gitignore to preserve empty directories

### DIFF
--- a/app/code/Magento/.gitignore
+++ b/app/code/Magento/.gitignore
@@ -1,0 +1,1 @@
+# Keep empty directory

--- a/app/design/adminhtml/Magento/.gitignore
+++ b/app/design/adminhtml/Magento/.gitignore
@@ -1,0 +1,1 @@
+# Keep empty directory

--- a/app/design/frontend/Magento/.gitignore
+++ b/app/design/frontend/Magento/.gitignore
@@ -1,0 +1,1 @@
+# Keep empty directory

--- a/app/i18n/magento/.gitignore
+++ b/app/i18n/magento/.gitignore
@@ -1,0 +1,1 @@
+# Keep empty directory

--- a/lib/internal/Magento/.gitignore
+++ b/lib/internal/Magento/.gitignore
@@ -1,0 +1,1 @@
+# Keep empty directory


### PR DESCRIPTION
The magento2-base package contains a few empty directories. The addition
of these files ensures those directories existence if magento2-base is
repackaged by a third party.

References:
- Issue: #3248
- Fixup of PR: #3550
