### PR TITLE
Fixed post var name for update attributes

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -132,7 +132,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                         $attributesData[$attributeCode] = $value;
                     } elseif ($attribute->getFrontendInput() == 'multiselect') {
                         // Check if 'Change' checkbox has been checked by admin for this attribute
-                        $isChanged = (bool)$this->getRequest()->getPost($attributeCode . '_checkbox');
+                        $isChanged = (bool)$this->getRequest()->getPost('toggle_' . $attributeCode);
                         if (!$isChanged) {
                             unset($attributesData[$attributeCode]);
                             continue;


### PR DESCRIPTION
Fixed request variable name for checking if attribute have been changed, so it matches template definition of this. Otherwise saving multiselect fields doesn't work when using update attributes from the dropdown in the default Product > Catalog Grid.
