### PR TITLE
Wrapped 'element' with jQuery

### DIFF
--- a/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
+++ b/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
@@ -37,7 +37,7 @@ define([
                     case 9: // DOCUMENT_NODE
                         var hostName = window.location.hostname,
                             iFrameHostName = $('<a>')
-                                .prop('href', element.prop('src'))
+                                .prop('href', $(element).prop('src'))
                                 .prop('hostname');
 
                         if (hostName === iFrameHostName) {


### PR DESCRIPTION
I found a bug when you have an iFrame on the page.

> Uncaught TypeError: element.prop is not a function

This is caused by the fact that _element_ is not wrapped in jQuery when the function is called recursively. The easiest and most likely fix is simply to wrap the _element_ in jQuery when working with iFrames.
