### PR TITLE
Translation on validation form errors

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -709,7 +709,8 @@ define([
                 return true;
             },
             function() {
-                return 'Please enter a value less than or equal to %s.'.replace('%s', this.lteToVal);
+                var message = $.mage.__('Please enter a value less than or equal to %s.');
+                return message.replace('%s', this.lteToVal);
             }
         ],
         "greater-than-equals-to": [
@@ -721,7 +722,8 @@ define([
                 return true;
             },
             function() {
-                return 'Please enter a value greater than or equal to %s.'.replace('%s', this.gteToVal);
+                var message = $.mage.__('Please enter a value greater than or equal to %s.');
+                return message.replace('%s', this.gteToVal);
             }
         ],
         "validate-emails": [
@@ -737,7 +739,7 @@ define([
                     }
                 }
                 return true;
-            }, "Please enter valid email addresses, separated by commas. For example, johndoe@domain.com, johnsmith@domain.com."
+            },  $.mage.__("Please enter valid email addresses, separated by commas. For example, johndoe@domain.com, johnsmith@domain.com.")
         ],
         "validate-cc-number": [
             /**

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -226,13 +226,13 @@ define([
             function(value) {
                 return /^((([a-z]|\d|[!#\$%&\u0027\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&\u0027\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\u0022)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\u0022)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)*(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$/i.test(value);
             },
-            $.validator.messages.email
+            $.mage.__('Please enter a valid email address.')
         ],
         "url2": [
             function(value) {
                 return /^(https?|ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&\u0027\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)*(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&\u0027\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&\u0027\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&\u0027\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&\u0027\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test(value);
             },
-            $.validator.messages.url
+            $.mage.__('Please enter a valid URL.')
         ],
         "credit-card-types": [
             function(value, param) {
@@ -826,7 +826,7 @@ define([
             function (value, param) {
                 return value === $(param).val();
             },
-            $.validator.messages.equalTo
+            $.mage.__('Please enter the same value again.')
         ],
         'validate-file-type': [
             function (name, types) {

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -166,13 +166,13 @@
             function (value, element, params) {
                 return this.optional(element) || $.mage.stripHtml(value).match(/\b\w+\b/g).length < params;
             },
-            'Please enter {0} words or less.'
+            $.mage.__('Please enter {0} words or less.')
         ],
         "min-words": [
             function (value, element, params) {
                 return this.optional(element) || $.mage.stripHtml(value).match(/\b\w+\b/g).length >= params;
             },
-            'Please enter at least {0} words.'
+            $.mage.__('Please enter at least {0} words.')
         ],
         "range-words": [
             function (value, element, params) {
@@ -180,43 +180,43 @@
                     $.mage.stripHtml(value).match(/\b\w+\b/g).length >= params[0] &&
                     value.match(/bw+b/g).length < params[1];
             },
-            'Please enter between {0} and {1} words.'
+            $.mage.__('Please enter between {0} and {1} words.')
         ],
         "letters-with-basic-punc": [
             function (value, element) {
                 return this.optional(element) || /^[a-z\-.,()'\"\s]+$/i.test(value);
             },
-            'Letters or punctuation only please'
+            $.mage.__('Letters or punctuation only please')
         ],
         "alphanumeric": [
             function (value, element) {
                 return this.optional(element) || /^\w+$/i.test(value);
             },
-            'Letters, numbers, spaces or underscores only please'
+            $.mage.__('Letters, numbers, spaces or underscores only please')
         ],
         "letters-only": [
             function (value, element) {
                 return this.optional(element) || /^[a-z]+$/i.test(value);
             },
-            'Letters only please'
+            $.mage.__('Letters only please')
         ],
         "no-whitespace": [
             function (value, element) {
                 return this.optional(element) || /^\S+$/i.test(value);
             },
-            'No white space please'
+            $.mage.__('No white space please')
         ],
         "zip-range": [
             function (value, element) {
                 return this.optional(element) || /^90[2-5]-\d{2}-\d{4}$/.test(value);
             },
-            'Your ZIP-code must be in the range 902xx-xxxx to 905-xx-xxxx'
+            $.mage.__('Your ZIP-code must be in the range 902xx-xxxx to 905-xx-xxxx')
         ],
         "integer": [
             function (value, element) {
                 return this.optional(element) || /^-?\d+$/.test(value);
             },
-            'A positive or negative non-decimal number please'
+            $.mage.__('A positive or negative non-decimal number please')
         ],
         "vinUS": [
             function (v) {
@@ -259,7 +259,7 @@
                 }
                 return false;
             },
-            'The specified vehicle identification number (VIN) is invalid.'
+            $.mage.__('The specified vehicle identification number (VIN) is invalid.')
         ],
         "dateITA": [
             function (value, element) {
@@ -282,25 +282,25 @@
                 }
                 return this.optional(element) || check;
             },
-            'Please enter a correct date'
+            $.mage.__('Please enter a correct date')
         ],
         "dateNL": [
             function (value, element) {
                 return this.optional(element) || /^\d\d?[\.\/-]\d\d?[\.\/-]\d\d\d?\d?$/.test(value);
             },
-            'Vul hier een geldige datum in.'
+            $.mage.__('Vul hier een geldige datum in.')
         ],
         "time": [
             function (value, element) {
                 return this.optional(element) || /^([01]\d|2[0-3])(:[0-5]\d){0,2}$/.test(value);
             },
-            'Please enter a valid time, between 00:00 and 23:59'
+            $.mage.__('Please enter a valid time, between 00:00 and 23:59')
         ],
         "time12h": [
             function (value, element) {
                 return this.optional(element) || /^((0?[1-9]|1[012])(:[0-5]\d){0,2}(\ [AP]M))$/i.test(value);
             },
-            'Please enter a valid time, between 00:00 am and 12:00 pm'
+            $.mage.__('Please enter a valid time, between 00:00 am and 12:00 pm')
         ],
         "phoneUS": [
             function (phone_number, element) {
@@ -308,27 +308,27 @@
                 return this.optional(element) || phone_number.length > 9 &&
                     phone_number.match(/^(1-?)?(\([2-9]\d{2}\)|[2-9]\d{2})-?[2-9]\d{2}-?\d{4}$/);
             },
-            'Please specify a valid phone number'
+            $.mage.__('Please specify a valid phone number')
         ],
         "phoneUK": [
             function (phone_number, element) {
                 return this.optional(element) || phone_number.length > 9 &&
                     phone_number.match(/^(\(?(0|\+44)[1-9]{1}\d{1,4}?\)?\s?\d{3,4}\s?\d{3,4})$/);
             },
-            'Please specify a valid phone number'
+            $.mage.__('Please specify a valid phone number')
         ],
         "mobileUK": [
             function (phone_number, element) {
                 return this.optional(element) || phone_number.length > 9 &&
                     phone_number.match(/^((0|\+44)7(5|6|7|8|9){1}\d{2}\s?\d{6})$/);
             },
-            'Please specify a valid mobile number'
+            $.mage.__('Please specify a valid mobile number')
         ],
         "stripped-min-length": [
             function (value, element, param) {
                 return $(value).text().length >= param;
             },
-            'Please enter at least {0} characters'
+            $.mage.__('Please enter at least {0} characters')
         ],
         "email2": [
             function (value, element) {
@@ -407,25 +407,25 @@
                 }
                 return false;
             },
-            'Please enter a valid credit card number.'
+            $.mage.__('Please enter a valid credit card number.')
         ],
         "ipv4": [
             function (value, element) {
                 return this.optional(element) || /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/i.test(value);
             },
-            'Please enter a valid IP v4 address.'
+            $.mage.__('Please enter a valid IP v4 address.')
         ],
         "ipv6": [
             function (value, element) {
                 return this.optional(element) || /^((([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}:[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){5}:([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){4}:([0-9A-Fa-f]{1,4}:){0,2}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){3}:([0-9A-Fa-f]{1,4}:){0,3}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){2}:([0-9A-Fa-f]{1,4}:){0,4}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|(([0-9A-Fa-f]{1,4}:){0,5}:((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|(::([0-9A-Fa-f]{1,4}:){0,5}((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|([0-9A-Fa-f]{1,4}::([0-9A-Fa-f]{1,4}:){0,5}[0-9A-Fa-f]{1,4})|(::([0-9A-Fa-f]{1,4}:){0,6}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){1,7}:))$/i.test(value);
             },
-            'Please enter a valid IP v6 address.'
+            $.mage.__('Please enter a valid IP v6 address.')
         ],
         "pattern": [
             function (value, element, param) {
                 return this.optional(element) || param.test(value);
             },
-            'Invalid format.'
+            $.mage.__('Invalid format.')
         ],
         "allow-container-className": [
             function (element) {
@@ -439,67 +439,67 @@
             function (value) {
                 return !/<(\/)?\w+/.test(value);
             },
-            'HTML tags are not allowed.'
+            $.mage.__('HTML tags are not allowed.')
         ],
         "validate-select": [
             function (value) {
                 return ((value !== "none") && (value != null) && (value.length !== 0));
             },
-            'Please select an option.'
+            $.mage.__('Please select an option.')
         ],
         "validate-no-empty": [
             function (value) {
                 return !$.mage.isEmpty(value);
             },
-            'Empty Value.'
+            $.mage.__('Empty Value.')
         ],
         "validate-alphanum-with-spaces": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^[a-zA-Z0-9 ]+$/.test(v);
             },
-            'Please use only letters (a-z or A-Z), numbers (0-9) or spaces only in this field.'
+            $.mage.__('Please use only letters (a-z or A-Z), numbers (0-9) or spaces only in this field.')
         ],
         "validate-data": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^[A-Za-z]+[A-Za-z0-9_]+$/.test(v);
             },
-            'Please use only letters (a-z or A-Z), numbers (0-9) or underscore (_) in this field, and the first character should be a letter.'
+            $.mage.__('Please use only letters (a-z or A-Z), numbers (0-9) or underscore (_) in this field, and the first character should be a letter.')
         ],
         "validate-street": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^[ \w]{3,}([A-Za-z]\.)?([ \w]*\#\d+)?(\r\n| )[ \w]{3,}/.test(v);
             },
-            'Please use only letters (a-z or A-Z), numbers (0-9), spaces and "#" in this field.'
+            $.mage.__('Please use only letters (a-z or A-Z), numbers (0-9), spaces and "#" in this field.')
         ],
         "validate-phoneStrict": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^(\()?\d{3}(\))?(-|\s)?\d{3}(-|\s)\d{4}$/.test(v);
             },
-            'Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.'
+            $.mage.__('Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.')
         ],
         "validate-phoneLax": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^((\d[\-. ]?)?((\(\d{3}\))|\d{3}))?[\-. ]?\d{3}[\-. ]?\d{4}$/.test(v);
             },
-            'Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.'
+            $.mage.__('Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.')
         ],
         "validate-fax": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^(\()?\d{3}(\))?(-|\s)?\d{3}(-|\s)\d{4}$/.test(v);
             },
-            'Please enter a valid fax number (Ex: 123-456-7890).'
+            $.mage.__('Please enter a valid fax number (Ex: 123-456-7890).')
         ],
         "validate-email": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^([a-z0-9,!\#\$%&'\*\+\/=\?\^_`\{\|\}~-]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z0-9,!\#\$%&'\*\+\/=\?\^_`\{\|\}~-]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*@([a-z0-9-]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z0-9-]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*\.(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]){2,})$/i.test(v);
             },
-            'Please enter a valid email address (Ex: johndoe@domain.com).'
+            $.mage.__('Please enter a valid email address (Ex: johndoe@domain.com).')
         ],
         "validate-emailSender": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^[\S ]+$/.test(v);
             },
-            'Please enter a valid email address (Ex: johndoe@domain.com).'
+            $.mage.__('Please enter a valid email address (Ex: johndoe@domain.com).')
         ],
         "validate-password": [
             function (v) {
@@ -513,7 +513,7 @@
                 }
                 return !(pass.length > 0 && pass.length < 6);
             },
-            'Please enter 6 or more characters. Leading and trailing spaces will be ignored.'
+            $.mage.__('Please enter 6 or more characters. Leading and trailing spaces will be ignored.')
         ],
         "validate-admin-password": [
             function (v) {
@@ -533,7 +533,7 @@
                 }
                 return true;
             },
-            'Please enter 7 or more characters, using both numeric and alphabetic.'
+            $.mage.__('Please enter 7 or more characters, using both numeric and alphabetic.')
         ],
         "validate-customer-password": [
             function (v, elm) {
@@ -584,35 +584,35 @@
                 return (/^(http|https|ftp):\/\/(([A-Z0-9]([A-Z0-9_-]*[A-Z0-9]|))(\.[A-Z0-9]([A-Z0-9_-]*[A-Z0-9]|))*)(:(\d+))?(\/[A-Z0-9~](([A-Z0-9_~-]|\.)*[A-Z0-9~]|))*\/?(.*)?$/i).test(v);
 
             },
-            'Please enter a valid URL. Protocol is required (http://, https:// or ftp://).'
+            $.mage.__('Please enter a valid URL. Protocol is required (http://, https:// or ftp://).')
         ],
         "validate-clean-url": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^(http|https|ftp):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+.(com|org|net|dk|at|us|tv|info|uk|co.uk|biz|se)$)(:(\d+))?\/?/i.test(v) || /^(www)((\.[A-Z0-9][A-Z0-9_-]*)+.(com|org|net|dk|at|us|tv|info|uk|co.uk|biz|se)$)(:(\d+))?\/?/i.test(v);
 
             },
-            'Please enter a valid URL. For example http://www.example.com or www.example.com.'
+            $.mage.__('Please enter a valid URL. For example http://www.example.com or www.example.com.')
         ],
         "validate-xml-identifier": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^[A-Z][A-Z0-9_\/-]*$/i.test(v);
 
             },
-            'Please enter a valid XML-identifier (Ex: something_1, block5, id-4).'
+            $.mage.__('Please enter a valid XML-identifier (Ex: something_1, block5, id-4).')
         ],
         "validate-ssn": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^\d{3}-?\d{2}-?\d{4}$/.test(v);
 
             },
-            'Please enter a valid social security number (Ex: 123-45-6789).'
+            $.mage.__('Please enter a valid social security number (Ex: 123-45-6789).')
         ],
         "validate-zip-us": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(v);
 
             },
-            'Please enter a valid zip code (Ex: 90602 or 90602-1234).'
+            $.mage.__('Please enter a valid zip code (Ex: 90602 or 90602-1234).')
         ],
         "validate-date-au": [
             function (v) {
@@ -629,14 +629,14 @@
                     parseInt(RegExp.$3, 10) === d.getFullYear();
 
             },
-            'Please use this date format: dd/mm/yyyy. For example 17/03/2006 for the 17th of March, 2006.'
+            $.mage.__('Please use this date format: dd/mm/yyyy. For example 17/03/2006 for the 17th of March, 2006.')
         ],
         "validate-currency-dollar": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^\$?\-?([1-9]{1}[0-9]{0,2}(\,[0-9]{3})*(\.[0-9]{0,2})?|[1-9]{1}\d*(\.[0-9]{0,2})?|0(\.[0-9]{0,2})?|(\.[0-9]{1,2})?)$/.test(v);
 
             },
-            'Please enter a valid $ amount. For example $100.00.'
+            $.mage.__('Please enter a valid $ amount. For example $100.00.')
         ],
         "validate-not-negative-number": [
             function (v) {
@@ -647,7 +647,7 @@
                 return !isNaN(v) && v >= 0;
 
             },
-            'Please enter a number 0 or greater in this field.'
+            $.mage.__('Please enter a number 0 or greater in this field.')
         ],
         // validate-not-negative-number should be replaced in all places with this one and then removed
         "validate-zero-or-greater": [
@@ -659,7 +659,7 @@
                 return !isNaN(v) && v >= 0;
 
             },
-            'Please enter a number 0 or greater in this field.'
+            $.mage.__('Please enter a number 0 or greater in this field.')
         ],
         "validate-greater-than-zero": [
             function (v) {
@@ -669,7 +669,7 @@
                 v = $.mage.parseNumber(v);
                 return !isNaN(v) && v > 0;
             },
-            'Please enter a number greater than 0 in this field.'
+            $.mage.__('Please enter a number greater than 0 in this field.')
         ],
         "validate-css-length": [
             function (v) {
@@ -678,20 +678,20 @@
                 }
                 return true;
             },
-            'Please input a valid CSS-length (Ex: 100px, 77pt, 20em, .5ex or 50%).'
+            $.mage.__('Please input a valid CSS-length (Ex: 100px, 77pt, 20em, .5ex or 50%).')
         ],
         /** @description Additional methods */
         "validate-number": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || (!isNaN($.mage.parseNumber(v)) && /^\s*-?\d*(\.\d*)?\s*$/.test(v));
             },
-            'Please enter a valid number in this field.'
+            $.mage.__('Please enter a valid number in this field.')
         ],
         "required-number": [
             function (v) {
                 return !!v.length;
             },
-            'Please enter a valid number in this field.'
+            $.mage.__('Please enter a valid number in this field.')
         ],
         "validate-number-range": [
             function (v, elm, param) {
@@ -731,14 +731,14 @@
 
                 return result;
             },
-            'The value is not within the specified range.',
+            $.mage.__('The value is not within the specified range.'),
             true
         ],
         "validate-digits": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || !/[^\d]/.test(v);
             },
-            'Please enter a valid number in this field.'
+            $.mage.__('Please enter a valid number in this field.')
         ],
         "validate-digits-range": [
             function (v, elm, param) {
@@ -778,7 +778,7 @@
 
                 return result;
             },
-            'The value is not within the specified range.',
+            $.mage.__('The value is not within the specified range.'),
             true
         ],
         'validate-range': [
@@ -819,31 +819,31 @@
                 }
                 return result;
             },
-            'The value is not within the specified range.'
+            $.mage.__('The value is not within the specified range.')
         ],
         "validate-alpha": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^[a-zA-Z]+$/.test(v);
             },
-            'Please use letters only (a-z or A-Z) in this field.'
+            $.mage.__('Please use letters only (a-z or A-Z) in this field.')
         ],
         "validate-code": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^[a-z]+[a-z0-9_]+$/.test(v);
             },
-            'Please use only letters (a-z), numbers (0-9) or underscore (_) in this field, and the first character should be a letter.'
+            $.mage.__('Please use only letters (a-z), numbers (0-9) or underscore (_) in this field, and the first character should be a letter.')
         ],
         "validate-alphanum": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^[a-zA-Z0-9]+$/.test(v);
             },
-            'Please use only letters (a-z or A-Z) or numbers (0-9) in this field. No spaces or other characters are allowed.'
+            $.mage.__('Please use only letters (a-z or A-Z) or numbers (0-9) in this field. No spaces or other characters are allowed.')
         ],
         "validate-date": [
             function (v) {
                 var test = new Date(v);
                 return $.mage.isEmptyNoTrim(v) || !isNaN(test);
-            }, 'Please enter a valid date.'
+            }, $.mage.__('Please enter a valid date.')
 
         ],
         "validate-date-range": [
@@ -866,7 +866,7 @@
                 return !dependentElements.length || $.mage.isEmptyNoTrim(dependentElements[0].value) ||
                     normalizedTime(v) <= normalizedTime(dependentElements[0].value);
             },
-            'Make sure the To Date is later than or the same as the From Date.'
+            $.mage.__('Make sure the To Date is later than or the same as the From Date.')
         ],
         "validate-cpassword": [
             function () {
@@ -887,13 +887,13 @@
                 }
                 return (pass.val() === conf.val());
             },
-            'Please make sure your passwords match.'
+            $.mage.__('Please make sure your passwords match.')
         ],
         "validate-identifier": [
             function (v) {
                 return $.mage.isEmptyNoTrim(v) || /^[a-z0-9][a-z0-9_\/-]+(\.[a-z0-9_-]+)?$/.test(v);
             },
-            'Please enter a valid URL Key (Ex: "example-page", "example-page.html" or "anotherlevel/example-page").'
+            $.mage.__('Please enter a valid URL Key (Ex: "example-page", "example-page.html" or "anotherlevel/example-page").')
         ],
         "validate-zip-international": [
             /*function(v) {
@@ -903,7 +903,7 @@
             function () {
                 return true;
             },
-            'Please enter a valid zip code.'
+            $.mage.__('Please enter a valid zip code.')
         ],
         "validate-one-required": [
             function (v, elm) {
@@ -913,13 +913,13 @@
                         return $(elm).val();
                     }).length > 0;
             },
-            'Please select one of the options above.'
+            $.mage.__('Please select one of the options above.')
         ],
         "validate-state": [
             function (v) {
                 return (v !== 0 || v === '');
             },
-            'Please select State/Province.'
+            $.mage.__('Please select State/Province.')
         ],
         "required-file": [
             function (v, elm) {
@@ -932,7 +932,7 @@
                 }
                 return result;
             },
-            'Please select a file.'
+            $.mage.__('Please select a file.')
         ],
         "validate-ajax-error": [
             function (v, element) {
@@ -961,7 +961,7 @@
                 }
                 return hasWithValue ^ hasWithNoValue;
             },
-            'The field isn\'t complete.'
+            $.mage.__('The field isn\'t complete.')
         ],
         "validate-required-datetime": [
             function (v, elm, param) {
@@ -973,7 +973,7 @@
                 }
                 return true;
             },
-            'This is a required field.'
+            $.mage.__('This is a required field.')
         ],
         "validate-one-required-by-name": [
             function (v, elm, selector) {
@@ -983,7 +983,7 @@
 
                 return !!container.querySelectorAll(selector).length;
             },
-            'Please select one of the options.'
+            $.mage.__('Please select one of the options.')
         ],
         "less-than-equals-to": [
             function (value, element, params) {
@@ -1024,7 +1024,7 @@
                     }
                 }
                 return true;
-            }, "Please enter valid email addresses, separated by commas. For example, johndoe@domain.com, johnsmith@domain.com."
+            }, $.mage.__("Please enter valid email addresses, separated by commas. For example, johndoe@domain.com, johnsmith@domain.com.")
         ],
 
         "validate-cc-type-select": [
@@ -1040,7 +1040,7 @@
                     return creditCartTypes[value][0].test($(params).val().replace(/\s+/g, ''));
                 }
                 return false;
-            }, 'Card type does not match credit card number.'
+            }, $.mage.__('Card type does not match credit card number.')
         ],
         "validate-cc-number": [
             /**
@@ -1053,7 +1053,7 @@
                     return validateCreditCard(value);
                 }
                 return false;
-            }, 'Please enter a valid credit card number.'
+            }, $.mage.__('Please enter a valid credit card number.')
         ],
         "validate-cc-type": [
             /**
@@ -1074,7 +1074,7 @@
                     }
                 }
                 return false;
-            }, 'Credit card number does not match credit card type.'
+            }, $.mage.__('Credit card number does not match credit card type.')
         ],
         "validate-cc-exp": [
             /**
@@ -1095,7 +1095,7 @@
                     isValid = !year || year > currentYear || (year == currentYear && month >= currentMonth);
                 }
                 return isValid;
-            }, 'Incorrect credit card expiration date.'
+            }, $.mage.__('Incorrect credit card expiration date.')
         ],
         "validate-cc-cvn": [
             /**
@@ -1113,7 +1113,7 @@
                     }
                 }
                 return false;
-            }, 'Please enter a valid credit card verification number.'
+            }, $.mage.__('Please enter a valid credit card verification number.')
         ],
         "validate-cc-ukss": [
             /**
@@ -1123,7 +1123,7 @@
              */
                 function (value) {
                 return value;
-            }, 'Please enter issue number or start date for switch/solo card type.'
+            }, $.mage.__('Please enter issue number or start date for switch/solo card type.')
         ],
 
         "validate-length": [
@@ -1162,7 +1162,7 @@
                 else
                     return true;
             },
-            'Please enter positive number in this field.'
+            $.mage.__('Please enter positive number in this field.')
         ],
         'validate-per-page-value-list': [
             function (v) {
@@ -1175,7 +1175,7 @@
                 }
                 return isValid;
             },
-            'Please enter a valid value, ex: 10,20,30'
+            $.mage.__('Please enter a valid value, ex: 10,20,30')
         ],
         'validate-per-page-value': [
             function (v, elm) {
@@ -1185,7 +1185,7 @@
                 var values = $('#' + elm.id + '_values').val().split(',');
                 return values.indexOf(v) != -1;
             },
-            'Please enter a valid value from list'
+            $.mage.__('Please enter a valid value from list')
         ],
         'validate-new-password': [
             function (v) {
@@ -1198,7 +1198,7 @@
                 }
                 return true;
             },
-            'Please enter 6 or more characters. Leading and trailing spaces will be ignored.'
+            $.mage.__('Please enter 6 or more characters. Leading and trailing spaces will be ignored.')
         ],
         'required-if-not-specified': [
             function (value, element, params) {
@@ -1222,7 +1222,7 @@
 
                 return valid;
             },
-            'This is a required field.'
+            $.mage.__('This is a required field.')
         ],
         'required-if-all-sku-empty-and-file-not-loaded': [
             function (value, element, params) {
@@ -1250,7 +1250,7 @@
                 });
 
                 return valid;
-            }, 'Please enter valid SKU key.'
+            }, $.mage.__('Please enter valid SKU key.')
         ],
         'required-if-specified': [
             function (value, element, params) {
@@ -1275,7 +1275,7 @@
 
                 return valid;
             },
-            'This is a required field.'
+            $.mage.__('This is a required field.')
         ],
         'required-number-if-specified': [
             function (value, element, params) {
@@ -1294,19 +1294,19 @@
 
                 return valid ? !!value.length : true;
             },
-            'Please enter a valid number.'
+            $.mage.__('Please enter a valid number.')
         ],
         'required-text-swatch-entry': [
             tableSingleValidation,
-            'Swatch and Admin are the required fields in the each row.'
+            $.mage.__('Swatch and Admin are the required fields in the each row.')
         ],
         'required-visual-swatch-entry': [
             tableSingleValidation,
-            'Admin is a required field in the each row.'
+            $.mage.__('Admin is a required field in the each row.')
         ],
         'required-dropdown-attribute-entry': [
             tableSingleValidation,
-            'Admin is a required field in the each row.'
+            $.mage.__('Admin is a required field in the each row.')
         ],
         'validate-item-quantity': [
             function (value, element, params) {


### PR DESCRIPTION
Not all validation errors message was translated. I added the  $.mage.__('') where it was missing. 
