### PR TITLE
Graceful component registrar

### DIFF
--- a/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
+++ b/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
@@ -45,13 +45,13 @@ class ComponentRegistrar implements ComponentRegistrarInterface
     public static function register($type, $componentName, $path)
     {
         self::validateType($type);
-        if (isset(self::$paths[$type][$componentName])) {
+        if (!isset(self::$paths[$type][$componentName])) {
+            self::$paths[$type][$componentName] = str_replace('\\', '/', $path);
+        } elseif (str_replace('\\', '/', $path) !== self::$paths[$type][$componentName]) {
             throw new \LogicException(
                 ucfirst($type) . ' \'' . $componentName . '\' from \'' . $path . '\' '
                 . 'has been already defined in \'' . self::$paths[$type][$componentName] . '\'.'
             );
-        } else {
-            self::$paths[$type][$componentName] = str_replace('\\', '/', $path);
         }
     }
 

--- a/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
+++ b/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
@@ -44,8 +44,8 @@ class ComponentRegistrar implements ComponentRegistrarInterface
      */
     public static function register($type, $componentName, $path)
     {
-        self::validateType($type);
         if (!isset(self::$paths[$type][$componentName])) {
+            self::validateType($type);
             self::$paths[$type][$componentName] = str_replace('\\', '/', $path);
         } elseif (str_replace('\\', '/', $path) !== self::$paths[$type][$componentName]) {
             throw new \LogicException(

--- a/lib/internal/Magento/Framework/Component/Test/Unit/ComponentRegistrarTest.php
+++ b/lib/internal/Magento/Framework/Component/Test/Unit/ComponentRegistrarTest.php
@@ -42,6 +42,12 @@ class ComponentRegistrarTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($expected['test_module_one'], $this->object->getPaths(ComponentRegistrar::MODULE));
         $this->assertContains($expected['test_module_two'], $this->object->getPaths(ComponentRegistrar::MODULE));
     }
+    
+    public function testDuplicateRegistrationIsNullOp()
+    {
+        ComponentRegistrar::register(ComponentRegistrar::MODULE, "test_module_three", "some/path/name/three");
+        ComponentRegistrar::register(ComponentRegistrar::MODULE, "test_module_three", "some/path/name/three");
+    }
 
     /**
      * @expectedException \LogicException


### PR DESCRIPTION
Some workflows can result in `ComponentRegistrar::register()` being called multiple times for the same component. In order to avoid messy, repeated boilerplate in client code, it makes sense for the `register()` method to be null-op in cases where the component has already been registered with the same path.

Related to #3871
