### PR TITLE
Fix "minimum-length" option of the "validate-length" JS validation

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1139,7 +1139,7 @@
                         validator.attrLength = length;
                         result = (v.length <= length);
                     }
-                    if (name.match(reMin) && result && $.mage.isEmpty(v)) {
+                    if (name.match(reMin) && result && !$.mage.isEmpty(v)) {
                         length = name.split('-')[2];
                         result = v.length >= length;
                     }


### PR DESCRIPTION
The `minimum-length` option was incorrectly used because the value **had to be empty** first in order to be checked, and that's illogical.
