### PR TITLE
Shipping rate registry

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
@@ -44,6 +44,7 @@ define(
              */
             validateAddressData: function (address) {
                 var validators = shippingRatesRegistry.get(VALIDATORS);
+
                 return validators.some(function (validator) {
                     return validator.validate(address);
                 });

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
@@ -17,10 +17,10 @@ define(
     function ($, ko, shippingRatesValidationRules, addressConverter, selectShippingAddress, postcodeValidator, shippingRatesRegistry, $t) {
         'use strict';
 
-        var checkoutConfig = window.checkoutConfig;
-        var OBSERVED_ELEMENTS = 'shipping-rates-validator:observedElements';
-        var POSTCODE_ELEMENT = 'shipping-rates-validator:postcode_element';
-        var VALIDATORS = 'shipping-rates-validator:validators';
+        var checkoutConfig = window.checkoutConfig,
+            OBSERVED_ELEMENTS = 'shipping-rates-validator:observedElements',
+            POSTCODE_ELEMENT = 'shipping-rates-validator:postcode_element',
+            VALIDATORS = 'shipping-rates-validator:validators';
 
         return {
             validateAddressTimeout: 0,


### PR DESCRIPTION
Use 'shipping-rate-registry' except of local variables in 'shipping-rates-validator'. This is needed because of impossibility of extending this model (impossibility of overriding some methods).
