### PR TITLE
Add logo folder to list of allowed resources

### DIFF
--- a/app/code/Magento/Theme/etc/config.xml
+++ b/app/code/Magento/Theme/etc/config.xml
@@ -60,6 +60,7 @@ Disallow: /*SID=
             <media_storage_configuration>
                 <allowed_resources>
                     <site_favicons>favicon</site_favicons>
+                    <site_logos>logo</site_logos>
                 </allowed_resources>
             </media_storage_configuration>
         </system>


### PR DESCRIPTION
This change fixes an issue where the logo folder isn't an allowed resource! If you're using my [S3 file storage extension](https://github.com/arkadedigital/magento2-s3) or even just Magento's built-in database file then you'll find that you'll get a 404 error even though the file exists!
