### PR TITLE
Fix setup:di:compile errors from array arguments

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/BackslashTrim.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/BackslashTrim.php
@@ -57,7 +57,7 @@ class BackslashTrim implements ModificationInterface
         }
 
         foreach ($argument as $key => &$value) {
-            if (in_array($key, ['_i_', '_ins_'])) {
+            if (!is_array($value) && in_array($key, ['_i_', '_ins_'])) {
                 $value = ltrim($value, '\\');
                 continue;
             }

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/PreferencesResolving.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/PreferencesResolving.php
@@ -62,7 +62,7 @@ class PreferencesResolving implements ModificationInterface
      */
     private function resolvePreferenceRecursive(&$value, &$preferences)
     {
-        return isset($preferences[$value])
+        return !is_array($value) && isset($preferences[$value])
             ? $this->resolvePreferenceRecursive($preferences[$value], $preferences)
             : $value;
     }


### PR DESCRIPTION
Simple fixes. Here is a screenshot of the errors I've been encountering:
![2016-04-09-190848_1920x1080_scrot](https://cloud.githubusercontent.com/assets/7246591/14407086/5b9bc5c8-fe8a-11e5-9abc-4f4673254dbf.png)

Each of the cases of `$value` being an array are handled directly after these fixes, so this shouldn't break anything. Thanks, let me know if you need anything else from me.
