### PR TITLE
Fix Call to a member function getCode() on string for convert method

### DIFF
--- a/app/code/Magento/Directory/Model/Currency.php
+++ b/app/code/Magento/Directory/Model/Currency.php
@@ -233,7 +233,13 @@ class Currency extends \Magento\Framework\Model\AbstractModel
             return $price * $rate;
         }
 
-        throw new \Exception(__('Undefined rate from "%1-%2".', $this->getCode(), $toCurrency->getCode()));
+        throw new \Exception(
+            __(
+                'Undefined rate from "%1-%2".',
+                $this->getCode(),
+                (is_string($toCurrency)) ? $toCurrency : $toCurrency->getCode()
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
Should fix the following error found in our error logs:
"Fatal Error: 'Call to a member function getCode() on string' in '/var/www/app/code/Magento/Directory/Model/Currency.php' on line 236";

It's possible that $toCurrency is a string of a object.
