### PR TITLE
Fix newsletter queue subscribers adding performance

### DIFF
--- a/app/code/Magento/Newsletter/Model/ResourceModel/Queue.php
+++ b/app/code/Magento/Newsletter/Model/ResourceModel/Queue.php
@@ -80,13 +80,13 @@ class Queue extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $subscriberIds
         );
 
-        $usedIds = $connection->fetchCol($select);
+        $usedIds = array_flip($connection->fetchCol($select));
+        $subscriberIds = array_flip($subscriberIds);
+        $newIds = array_diff_key($subscriberIds, $usedIds);
+        
         $connection->beginTransaction();
         try {
-            foreach ($subscriberIds as $subscriberId) {
-                if (in_array($subscriberId, $usedIds)) {
-                    continue;
-                }
+            foreach ($newIds as $subscriberId) {
                 $data = [];
                 $data['queue_id'] = $queue->getId();
                 $data['subscriber_id'] = $subscriberId;


### PR DESCRIPTION
I made some interesting benchmark for it :)

Benchmark:

``` php
<?php

$max = 100000;
$ids = range(1, $max);
$usedIds = range(1, $max, 10);
$result = [];

// Current Magento2 method
$start = microtime(true);
foreach ($ids as $id) {
    if (in_array($id, $usedIds)) {
        continue;
    }
    $result[] = $id;
}
$end = microtime(true);
var_dump($end-$start);
var_dump(count($result));

// Reset
$result = [];

// array_diff_key() method
$start = microtime(true);
$ids = array_flip($ids);
$usedIds = array_flip($usedIds);
$result = array_diff_key($ids, $usedIds);
$end = microtime(true);
var_dump($end-$start);
var_dump(count($result));
```

Output:

```
$ php benchmark.php
double(15.839307069778)
int(90000)
double(0.034869909286499)
int(90000)
```
