### PR TITLE
Ensure composer.json exists

### DIFF
--- a/app/code/Magento/SampleData/Model/Dependency.php
+++ b/app/code/Magento/SampleData/Model/Dependency.php
@@ -88,6 +88,10 @@ class Dependency
         foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleDir) {
             $file = $moduleDir . '/composer.json';
 
+            if (!file_exists($file) || !is_readable($file)) {
+                continue;
+            }
+
             /** @var Package $package */
             $package = $this->getModuleComposerPackage($file);
             $suggest = json_decode(json_encode($package->get('suggest')), true);


### PR DESCRIPTION
Ensure composer.json exists before json encoding suggests. The current implementation forces all modules to have a composer.json file or they cannot install sample data.

I discovered this issue when I tried to install sample data after creating my own hello world module.
