### PR TITLE
Removed inline JavaScript from template

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
@@ -50,28 +50,4 @@
         }
     }
 </script>
-<?php else : ?>
-<script>
-    require([
-        'jquery',
-        'mage/mage',
-        'Magento_Catalog/product/view/validation',
-        'Magento_Catalog/js/catalog-add-to-cart'
-    ], function ($) {
-        'use strict';
-
-        $('#product_addtocart_form').mage('validation', {
-            radioCheckboxClosest: '.nested',
-            submitHandler: function (form) {
-                var widget = $(form).catalogAddToCart({
-                    bindSubmit: false
-                });
-
-                widget.catalogAddToCart('submitForm', $(form));
-
-                return false;
-            }
-        });
-    });
-</script>
 <?php endif; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/form.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/form.phtml
@@ -17,7 +17,13 @@
 
 <div class="product-add-form">
     <form action="<?php /* @escapeNotVerified */ echo $block->getSubmitUrl($_product) ?>" method="post"
-          id="product_addtocart_form"<?php if ($_product->getOptions()): ?> enctype="multipart/form-data"<?php endif; ?>>
+          id="product_addtocart_form"<?php if ($_product->getOptions()): ?> enctype="multipart/form-data"<?php endif; ?>
+          data-mage-init='{
+            "catalogAddToCart":{
+                "radioCheckboxClosest": ".nested",
+                "bindSubmit": "false"
+            }
+          }'>
         <input type="hidden" name="product" value="<?php /* @escapeNotVerified */ echo $_product->getId() ?>" />
         <input type="hidden" name="selected_configurable_option" value="" />
         <input type="hidden" name="related_product" id="related-products-field" value="" />


### PR DESCRIPTION
## Problem

Difficult to extend the **catalogAddToCart** widget due to Inline JavaScript, something you strongly are against to according to: http://devdocs.magento.com/guides/v2.0/javascript-dev-guide/javascript/js_init.html
