### PR TITLE
Fix importing customers with password field set

### DIFF
--- a/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
@@ -365,7 +365,7 @@ class Customer extends AbstractCustomer
 
         // password change/set
         if (isset($rowData['password']) && strlen($rowData['password'])) {
-            $entityRow['password_hash'] = $this->_customerModel->hashPassword($rowData['password']);
+            $rowData['password_hash'] = $this->_customerModel->hashPassword($rowData['password']);
         }
 
         // attribute values


### PR DESCRIPTION
Edited **Magento\CustomerImportExport\Model\Import\Customer** class in the Magento **CustomerImportExport** module. The `password_hash` key is being updated in the wrong array. The key should be set for the `$rowData` array instead of the `$entityRow` array.
