### PR TITLE
Update get.php

### DIFF
--- a/pub/get.php
+++ b/pub/get.php
@@ -18,13 +18,12 @@ $allowedResources = [];
 $configCacheFile = BP . '/var/resource_config.json';
 
 $isAllowed = function ($resource, array $allowedResources) {
-    $isResourceAllowed = false;
     foreach ($allowedResources as $allowedResource) {
         if (0 === stripos($resource, $allowedResource)) {
-            $isResourceAllowed = true;
+            return true;
         }
     }
-    return $isResourceAllowed;
+    return false;
 };
 
 $request = new \Magento\MediaStorage\Model\File\Storage\Request(


### PR DESCRIPTION
This change will stop Magento from unnecessarily looping through all the remaining allowed resources if it discovers that the resource in question is already allowed.
