### PR TITLE
Missing a slash in SFTP file listing id

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Io/Sftp.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/Sftp.php
@@ -239,7 +239,7 @@ class Sftp extends AbstractIo
         $currentWorkingDir = $this->pwd();
         $result = [];
         foreach ($list as $name) {
-            $result[] = ['text' => $name, 'id' => "{$currentWorkingDir}{$name}"];
+            $result[] = ['text' => $name, 'id' => "{$currentWorkingDir}/{$name}"];
         }
         return $result;
     }


### PR DESCRIPTION
The output is now 

```
  [7765]=>
  array(2) {
    ["text"]=>
    string(48) "6112290001-lgm_score_shirts-chasin-riser-l_2.jpg"
    ["id"]=>
    string(120) "/var/www/dev/magento2/new6112290001-lgm_score_shirts-chasin-riser-l_2.jpg"
  }
  [7766]=>
  array(2) {
    ["text"]=>
    string(57) "9a10500056-090_score_accessoires-g-star-raw-ladd-belt.JPG"
    ["id"]=>
    string(129) "/var/www/dev/magento2/new9a10500056-090_score_accessoires-g-star-raw-ladd-belt.JPG"
  }
  [7767]=>
  array(2) {
    ["text"]=>
    string(53) "5211500548-flm_score_t-shirts-g-star-raw-nerx-r_2.JPG"
    ["id"]=>
    string(125) "/var/www/dev/magento2/new5211500548-flm_score_t-shirts-g-star-raw-nerx-r_2.JPG"
  }
```

instead of 

```
  [7765]=>
  array(2) {
    ["text"]=>
    string(48) "6112290001-lgm_score_shirts-chasin-riser-l_2.jpg"
    ["id"]=>
    string(120) "/var/www/dev/magento2/new/6112290001-lgm_score_shirts-chasin-riser-l_2.jpg"
  }
  [7766]=>
  array(2) {
    ["text"]=>
    string(57) "9a10500056-090_score_accessoires-g-star-raw-ladd-belt.JPG"
    ["id"]=>
    string(129) "/var/www/dev/magento2/new/9a10500056-090_score_accessoires-g-star-raw-ladd-belt.JPG"
  }
  [7767]=>
  array(2) {
    ["text"]=>
    string(53) "5211500548-flm_score_t-shirts-g-star-raw-nerx-r_2.JPG"
    ["id"]=>
    string(125) "/var/www/dev/magento2/new/5211500548-flm_score_t-shirts-g-star-raw-nerx-r_2.JPG"
  }
```
