### PR TITLE
Fix directory path being incorrectly generated

### DIFF
--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -197,8 +197,7 @@ class Storage extends \Magento\Framework\DataObject
             $subDirectories = $this->_directoryDatabaseFactory->create();
             $directories = $subDirectories->getSubdirectories($path);
             foreach ($directories as $directory) {
-                $fullPath = rtrim($path, '/') . '/' . $directory['name'];
-                $this->_directory->create($fullPath);
+                $this->_directory->create($directory['name']);
             }
         }
     }


### PR DESCRIPTION
This change will address an issue where both the [Magento\Cms\Model\Wysiwyg\Images\Storage::createSubDirectories()](https://github.com/magento/magento2/blob/2.0.4/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php#L200) and the [Magento\Framework\Filesystem\Directory\Write::create()](https://github.com/magento/magento2/blob/2.0.4/lib/internal/Magento/Framework/Filesystem/Directory/Write.php#L84) functions will try and convert the current file path into an absolute path. This double-up causes an incorrect absolute path, e.g. `/var/www/pub/media/var/www/pub/media/wysiwyg/doggy.jpg` as
opposed to `/var/www/pub/media/wysiwyg/doggy.jpg`.

You can replicate this issue by:
1. Switch to using the database (or my [S3 extension](https://github.com/arkadedigital/magento2-s3)) for file storage, i.e. all your images are uploaded to the database and there is nothing in the media folder in the file system
2. Edit a CMS page from the admin panel
3. Go to the image gallery modal
4. You should only be able to see the root folder and root images!
