### PR TITLE
ConfigurableProduct validator, first check if array item exists

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Product/Validator/Plugin.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Validator/Plugin.php
@@ -112,9 +112,11 @@ class Plugin
             $product->addData($productData);
             $product->setCollectExceptionMessages(true);
             $configurableAttribute = [];
-            $encodedData = $productData['configurable_attribute'];
-            if ($encodedData) {
-                $configurableAttribute = $this->jsonHelper->jsonDecode($encodedData);
+            if (!empty($productData['configurable_attribute'])) {
+                $encodedData = $productData['configurable_attribute'];
+                if ($encodedData) {
+                    $configurableAttribute = $this->jsonHelper->jsonDecode($encodedData);
+                }
             }
             $configurableAttribute = implode('-', $configurableAttribute);
 


### PR DESCRIPTION
$productData['configurable_attribute'] is not required but its assumed
to be set. This can give issues when its not set at all. Here we just
check if its set before using it.

Signed-off-by: Ike Devolder ike.devolder@studioemma.eu
