### PR TITLE
Database port missing in Magento\TestFramework\Db\Mysql #3529

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
@@ -14,6 +14,11 @@ namespace Magento\TestFramework\Db;
 class Mysql extends \Magento\TestFramework\Db\AbstractDb
 {
     /**
+     * Default port
+     */
+    const DEFAULT_PORT = 3306;
+
+    /**
      * Defaults extra file name
      */
     const DEFAULTS_EXTRA_FILE_NAME = 'defaults_extra.cnf';
@@ -33,11 +38,24 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
     private $_defaultsExtraFile;
 
     /**
+     * Port number for connection
+     *
+     * @var integer
+     */
+    private $_port;
+
+    /**
      * {@inheritdoc}
      */
     public function __construct($host, $user, $password, $schema, $varPath, \Magento\Framework\Shell $shell)
     {
         parent::__construct($host, $user, $password, $schema, $varPath, $shell);
+        $this->_port = self::DEFAULT_PORT;
+        if (strpos($this->_host, ':') !== false) {
+            list($host, $port) = explode(':', $this->_host);
+            $this->_host = $host;
+            $this->_port = (int) $port;
+        }
         $this->_dbDumpFile = $this->_varPath . '/setup_dump_' . $this->_schema . '.sql';
         $this->_defaultsExtraFile = rtrim($this->_varPath, '\\/') . '/' . self::DEFAULTS_EXTRA_FILE_NAME;
     }
@@ -49,10 +67,11 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
     {
         $this->ensureDefaultsExtraFile();
         $this->_shell->execute(
-            'mysql --defaults-file=%s --host=%s %s -e %s',
+            'mysql --defaults-file=%s --host=%s --port=%s %s -e %s',
             [
                 $this->_defaultsExtraFile,
                 $this->_host,
+                $this->_port,
                 $this->_schema,
                 "DROP DATABASE `{$this->_schema}`; CREATE DATABASE `{$this->_schema}`"
             ]
@@ -86,8 +105,8 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
     {
         $this->ensureDefaultsExtraFile();
         $this->_shell->execute(
-            'mysqldump --defaults-file=%s --host=%s  %s > %s',
-            [$this->_defaultsExtraFile, $this->_host, $this->_schema, $this->getSetupDbDumpFilename()]
+            'mysqldump --defaults-file=%s --host=%s --port=%s %s > %s',
+            [$this->_defaultsExtraFile, $this->_host, $this->_port, $this->_schema, $this->getSetupDbDumpFilename()]
         );
     }
 
@@ -102,8 +121,8 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
             throw new \LogicException("DB dump file does not exist: " . $this->getSetupDbDumpFilename());
         }
         $this->_shell->execute(
-            'mysql --defaults-file=%s --host=%s %s < %s',
-            [$this->_defaultsExtraFile, $this->_host, $this->_schema, $this->getSetupDbDumpFilename()]
+            'mysql --defaults-file=%s --host=%s --port=%s %s < %s',
+            [$this->_defaultsExtraFile, $this->_host, $this->_port, $this->_schema, $this->getSetupDbDumpFilename()]
         );
     }
 


### PR DESCRIPTION
Fixes #3529

It is possible to configure Magento to connect a MySQL database using any port number.  It is also possible to configure Magento to use any port number for connecting to a MySQL database for running integration tests.  When using a port other than 3306 for integration tests PHPUnit will throw an error and not complete successfully.

**Steps to reproduce:**
- Configure integration tests to access a database running on a port other than 3306 (Set 'db-host' in install-config-mysql.php using host:port notation)

**Expected result:**
- Integration tests complete successfully 

**Actual result (before this fix):**
- Integration tests fail because the mysqldump and mysql clients are only given a host parameter and do not consider the possibility of a custom port
