### PR TITLE
Check for MD5 changes when deploying static content

### DIFF
--- a/lib/internal/Magento/Framework/App/View/Asset/Publisher.php
+++ b/lib/internal/Magento/Framework/App/View/Asset/Publisher.php
@@ -52,12 +52,16 @@ class Publisher
     public function isFileEquals(Asset\LocalInterface $asset)
     {
         $dir = $this->filesystem->getDirectoryRead(DirectoryList::STATIC_VIEW);
-        if ($dir->isExist($asset->getPath()) === false) {
+        $source = $asset->getSourceFile();
+        $destination = $dir->getAbsolutePath($asset->getPath());
+
+        if ($dir->isExist($source) === false) {
             return false;
         }
 
-        $source = $asset->getSourceFile();
-        $destination = $dir->getAbsolutePath($asset->getPath());
+        if ($dir->isExist($destination) === false) {
+            return false;
+        }
 
         $sourceSum = md5_file($source);
         $destinationSum = md5_file($destination);

--- a/lib/internal/Magento/Framework/App/View/Asset/Publisher.php
+++ b/lib/internal/Magento/Framework/App/View/Asset/Publisher.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © 2015 Magento. All rights reserved.
+ * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
 
@@ -42,12 +42,31 @@ class Publisher
      */
     public function publish(Asset\LocalInterface $asset)
     {
-        $dir = $this->filesystem->getDirectoryRead(DirectoryList::STATIC_VIEW);
-        if ($dir->isExist($asset->getPath())) {
+        if ($this->isFileEquals($asset)) {
             return true;
         }
 
         return $this->publishAsset($asset);
+    }
+
+    public function isFileEquals(Asset\LocalInterface $asset)
+    {
+        $dir = $this->filesystem->getDirectoryRead(DirectoryList::STATIC_VIEW);
+        if ($dir->isExist($asset->getPath()) === false) {
+            return false;
+        }
+
+        $source = $asset->getSourceFile();
+        $destination = $dir->getAbsolutePath($asset->getPath());
+
+        $sourceSum = md5_file($source);
+        $destinationSum = md5_file($destination);
+
+        if ($sourceSum !== $destinationSum) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/View/Asset/Publisher.php
+++ b/lib/internal/Magento/Framework/App/View/Asset/Publisher.php
@@ -49,6 +49,10 @@ class Publisher
         return $this->publishAsset($asset);
     }
 
+    /**
+     * @param Asset\LocalInterface $asset
+     * @return bool
+     */
     public function isFileEquals(Asset\LocalInterface $asset)
     {
         $dir = $this->filesystem->getDirectoryRead(DirectoryList::STATIC_VIEW);

--- a/lib/internal/Magento/Framework/App/View/Asset/Publisher.php
+++ b/lib/internal/Magento/Framework/App/View/Asset/Publisher.php
@@ -57,7 +57,7 @@ class Publisher
     {
         $dir = $this->filesystem->getDirectoryRead(DirectoryList::STATIC_VIEW);
         $source = $asset->getSourceFile();
-        $destination = $dir->getAbsolutePath($asset->getPath());
+        $destination = $asset->getPath();
 
         if ($dir->isExist($source) === false) {
             return false;
@@ -67,6 +67,7 @@ class Publisher
             return false;
         }
 
+        $destination = $dir->getAbsolutePath($destination);
         $sourceSum = md5_file($source);
         $destinationSum = md5_file($destination);
 


### PR DESCRIPTION
The old `Publisher` is copying files only from their original source to the `pub/static` folder, if the destination does not exist. This PR changes this, so that for each file the MD5 sum is used as well. Most developers do not want to wipe out files in `pub/static` when changing file. This fixes that for them. There are other patches underway as well (@denisristic) to add arguments to the deployment command to specify which parts need to be refreshed.
