### PR TITLE
CLI App Event Subscribers

### DIFF
--- a/setup/src/Magento/Setup/Model/Installer/Event/AbstractInstallerEvent.php
+++ b/setup/src/Magento/Setup/Model/Installer/Event/AbstractInstallerEvent.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Magento\Setup\Model\Installer\Event;
+
+use Magento\Framework\Setup\SetupInterface;
+use Magento\Setup\Exception;
+use Zend\EventManager\EventInterface;
+use Zend\EventManager\Exception\InvalidArgumentException;
+
+/**
+ * Provides base functionality for installer events.
+ *
+ * @author Gabriel Somoza <gabriel@strategery.io>
+ */
+abstract class AbstractInstallerEvent implements EventInterface
+{
+    /** @var bool */
+    private $isPropagationStopped = false;
+
+    /** @var mixed */
+    private $target;
+
+    /** @var SetupInterface */
+    private $setup;
+
+    /**
+     * @return SetupInterface
+     */
+    public function getSetup()
+    {
+        return $this->setup;
+    }
+
+    /**
+     * @param SetupInterface $setup
+     *
+     * @return void
+     */
+    protected function setSetup(SetupInterface $setup)
+    {
+        $this->setup = $setup;
+    }
+
+    /**
+     * Get a single parameter by name
+     *
+     * @param  string $name
+     * @param  mixed $default Default value to return if parameter does not exist
+     * @return mixed
+     */
+    public function getParam($name, $default = null)
+    {
+        $params = $this->getParams();
+        return isset($params[$name]) ? $params[$name] : $default;
+    }
+
+    /**
+     * @return array
+     */
+    abstract public function getParams();
+
+    /**
+     * Indicate whether or not the parent EventManagerInterface should stop propagating events. The only allowed method
+     * that mutates internal state.
+     *
+     * @param bool $flag
+     *
+     * @return void
+     */
+    public function stopPropagation($flag = true)
+    {
+        $this->isPropagationStopped = (bool) $flag;
+    }
+
+    /**
+     * Has this event indicated event propagation should stop?
+     *
+     * @return bool
+     */
+    public function propagationIsStopped()
+    {
+        return $this->isPropagationStopped;
+    }
+
+    /**
+     * Get target/context from which event was triggered
+     *
+     * @return null|string|object
+     */
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
+     * Set the event target/context
+     *
+     * @param  null|string|object $target
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws Exception
+     * @return void
+     */
+    public function setTarget($target)
+    {
+        throw new Exception("The internal state of this object is immutable, please don't use this method.");
+    }
+
+    /**
+     * Set the event name
+     *
+     * @param  string $name
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws Exception
+     * @return void
+     */
+    public function setName($name)
+    {
+        throw new Exception("The internal state of this object is immutable, please don't use this method.");
+    }
+
+    /**
+     * Set event parameters
+     *
+     * @param  string $params
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws Exception
+     * @return void
+     */
+    public function setParams($params)
+    {
+        throw new Exception("The internal state of this object is immutable, please don't use this method.");
+    }
+
+    /**
+     * Set a single parameter by key
+     *
+     * @param  string $name
+     * @param  mixed $value
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws Exception
+     * @return void
+     */
+    public function setParam($name, $value)
+    {
+        throw new Exception("The internal state of this object is immutable, please don't use this method.");
+    }
+
+    /**
+     * Use this to set the target on your constructor
+     *
+     * @param string|object $target
+     *
+     * @throws InvalidArgumentException
+     * @return void
+     */
+    protected function internalSetTarget($target)
+    {
+        if (!\is_object($target) && !\is_string($target)) {
+            throw new InvalidArgumentException('Parameter $target must be either a string or an object.');
+        }
+
+        $this->target = $target;
+    }
+}

--- a/setup/src/Magento/Setup/Model/Installer/Event/AfterDataWasInstalled.php
+++ b/setup/src/Magento/Setup/Model/Installer/Event/AfterDataWasInstalled.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Magento\Setup\Model\Installer\Event;
+
+use ArrayAccess;
+use Magento\Framework\Model\ResourceModel\Db\Context;
+use Magento\Framework\Setup\SetupInterface;
+
+/**
+ * Event fired after data was installed during setup
+ */
+class AfterDataWasInstalled extends AbstractInstallerEvent
+{
+    /** @var Context */
+    private $context;
+
+    /**
+     * @param string|object $target
+     * @param SetupInterface $setup
+     * @param Context $context
+     */
+    public function __construct($target, SetupInterface $setup, Context $context)
+    {
+        $this->internalSetTarget($target);
+        $this->setSetup($setup);
+        $this->context = $context;
+    }
+
+    /**
+     * Get event name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'setup:after_data_was_installed';
+    }
+
+    /**
+     * Get parameters passed to the event
+     *
+     * @return array|ArrayAccess
+     */
+    public function getParams()
+    {
+        return [
+            'target' => $this->getTarget(),
+            'setup' => $this->getSetup(),
+            'context' => $this->getContext(),
+        ];
+    }
+
+    /**
+     * @return Context
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+}

--- a/setup/src/Magento/Setup/Model/Installer/Event/AfterSchemaWasInstalled.php
+++ b/setup/src/Magento/Setup/Model/Installer/Event/AfterSchemaWasInstalled.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Magento\Setup\Model\Installer\Event;
+
+use ArrayAccess;
+use Magento\Framework\Model\ResourceModel\Db\Context;
+use Magento\Framework\Setup\SetupInterface;
+use Zend\EventManager\EventInterface;
+use Zend\EventManager\Exception\InvalidArgumentException;
+
+/**
+ * Event fired during setup after schema was installed
+ */
+class AfterSchemaWasInstalled extends AbstractInstallerEvent
+{
+    /** @var Context */
+    private $context;
+
+    /**
+     * BeforeModuleIsProcessed constructor.
+     * @param object|string $target
+     * @param SetupInterface $setup
+     * @param Context $context
+     */
+    public function __construct($target, SetupInterface $setup, Context $context)
+    {
+        $this->internalSetTarget($target);
+        $this->setSetup($setup);
+        $this->context = $context;
+    }
+
+    /**
+     * Get event name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'setup:after_schema_was_installed';
+    }
+
+    /**
+     * Get parameters passed to the event
+     *
+     * @return array|ArrayAccess
+     */
+    public function getParams()
+    {
+        return [
+            'target' => $this->getTarget(),
+            'setup' => $this->getSetup(),
+            'context' => $this->getContext(),
+        ];
+    }
+
+    /**
+     * @return Context
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+}

--- a/setup/src/Magento/Setup/Model/Installer/Event/BeforeModuleIsProcessed.php
+++ b/setup/src/Magento/Setup/Model/Installer/Event/BeforeModuleIsProcessed.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Magento\Setup\Model\Installer\Event;
+
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SetupInterface;
+use Zend\EventManager\Exception\InvalidArgumentException;
+
+/**
+ * Event fired during setup before each module is processed
+ */
+class BeforeModuleIsProcessed extends AbstractInstallerEvent
+{
+    /** @var string */
+    private $installType;
+
+    /** @var ModuleContextInterface */
+    private $context;
+
+    /**
+     * @param object|string $target
+     * @param SetupInterface $setup
+     * @param ModuleContextInterface $context
+     * @param string $installType
+     */
+    public function __construct($target, SetupInterface $setup, ModuleContextInterface $context, $installType)
+    {
+        if (!\is_string($installType)) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected parameter $installType to be a string.'
+            ));
+        }
+
+        $this->internalSetTarget($target);
+        $this->setSetup($setup);
+        $this->context = $context;
+        $this->installType = (string) $installType;
+    }
+
+    /**
+     * Get event name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'setup:before_module_is_processed';
+    }
+
+    /**
+     * Get parameters passed to the event
+     *
+     * @return array|\ArrayAccess
+     */
+    public function getParams()
+    {
+        return [
+            'target' => $this->getTarget(),
+            'setup' => $this->getSetup(),
+            'context' => $this->getContext(),
+            'installType' => $this->getInstallType(),
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getInstallType()
+    {
+        return $this->installType;
+    }
+
+    /**
+     * @return ModuleContextInterface
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+}

--- a/setup/src/Magento/Setup/Model/InstallerFactory.php
+++ b/setup/src/Magento/Setup/Model/InstallerFactory.php
@@ -6,10 +6,10 @@
 
 namespace Magento\Setup\Model;
 
+use Zend\EventManager\EventManagerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Magento\Setup\Module\ResourceFactory;
 use Magento\Framework\App\ErrorHandler;
-use Magento\Framework\App\State\CleanupFiles;
 use Magento\Framework\Setup\LoggerInterface;
 
 /**
@@ -52,6 +52,10 @@ class InstallerFactory
      */
     public function create(LoggerInterface $log)
     {
+        /** @var \Zend\Mvc\ApplicationInterface $application */
+        $application = $this->serviceLocator->get('Application');
+        $eventManager = $application->getEventManager();
+
         return new Installer(
             $this->serviceLocator->get(\Magento\Framework\Setup\FilePermissions::class),
             $this->serviceLocator->get(\Magento\Framework\App\DeploymentConfig\Writer::class),
@@ -77,7 +81,8 @@ class InstallerFactory
             $this->serviceLocator->get(\Magento\Setup\Module\DataSetupFactory::class),
             $this->serviceLocator->get(\Magento\Framework\Setup\SampleData\State::class),
             new \Magento\Framework\Component\ComponentRegistrar(),
-            $this->serviceLocator->get(\Magento\Setup\Model\PhpReadinessCheck::class)
+            $this->serviceLocator->get(\Magento\Setup\Model\PhpReadinessCheck::class),
+            $eventManager
         );
     }
 

--- a/setup/src/Magento/Setup/Test/Unit/Model/InstallerFactoryTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/InstallerFactoryTest.php
@@ -7,6 +7,8 @@
 namespace Magento\Setup\Test\Unit\Model;
 
 use \Magento\Setup\Model\InstallerFactory;
+use Zend\EventManager\EventManagerInterface;
+use Zend\Mvc\ApplicationInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -44,6 +46,10 @@ class InstallerFactoryTest extends \PHPUnit_Framework_TestCase
      */
     private function getReturnValueMap()
     {
+        $eventManagerMock = $this->getMock(EventManagerInterface::class);
+        $applicationMock = $this->getMock(ApplicationInterface::class);
+        $applicationMock->expects($this->once())->method('getEventManager')->willReturn($eventManagerMock);
+
         return [
             [
                 \Magento\Framework\Setup\FilePermissions::class,
@@ -130,6 +136,10 @@ class InstallerFactoryTest extends \PHPUnit_Framework_TestCase
             [
                 \Magento\Setup\Model\PhpReadinessCheck::class,
                 $this->getMock(\Magento\Setup\Model\PhpReadinessCheck::class, [], [], '', false),
+            ],
+            [
+                'Application',
+                $applicationMock
             ],
         ];
     }


### PR DESCRIPTION
Add the possibility to attach EventSubscribers to the Magento CLI application directly from components. This allows components to listen to Symfony Console events in order to trigger custom behaviour.

This PR was made to support the following initiative: https://github.com/magento-hackathon/MagentoMigrations
## How it works

The PR uses a `SubscriberManager` class during the application's bootstrap process. This class receives an array of `subscribers` during instantiation, so it can be configured easily in one or more component's `di.xml` file:

``` xml
<?xml version="1.0"?>

<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
    <type name="Magento\Framework\Console\SubscriberManager">
        <arguments>
            <argument name="subscribers" xsi:type="array">
                <item name="upgradeSubscriber" xsi:type="string">MagentoHackathon\MagentoMigrations\Cli\Subscriber\UpgradeSubscriber</item>
            </argument>
        </arguments>
    </type>
</config>
```

A sample subscriber would look as follows:

``` php
<?php
namespace MagentoHackathon\MagentoMigrations\Cli\Subscriber;
final class UpgradeSubscriber implements EventSubscriberInterface, ServiceLocatorAwareInterface
{
    use ServiceLocatorAwareTrait;

    /**
     * getSubscribedEvents
     * @return array
     */
    public static function getSubscribedEvents()
    {
        return [
            ConsoleEvents::COMMAND => 'onCommand',
        ];
    }

    /**
     * afterSetupUpgrade
     * @return void
     */
    public function onCommand(ConsoleCommandEvent $event)
    {
        if ($event->getCommand()->getName() === 'setup:upgrade') {
            // do something before this commands run
            $sm = $this->getServiceLocator();
        }
    }
}
```
