### PR TITLE
Fix integration test syntax error

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Search/Adapter/Mysql/AdapterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Search/Adapter/Mysql/AdapterTest.php
@@ -36,7 +36,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     /**
      * @var string
      */
-    protected $requestConfig = __DIR__ . '/../../_files/requests.xml';
+    protected $requestConfig;
 
     /**
      * @var string
@@ -45,6 +45,8 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $this->requestConfig = __DIR__ . '/../../_files/requests.xml';
+
         $this->objectManager = Bootstrap::getObjectManager();
 
         /** @var \Magento\Framework\Search\Request\Config\Converter $converter */


### PR DESCRIPTION
Not sure how this one got into mainline, but it makes **all** CI integration tests fail.

And, no, phpstorm didn't pick it up as an error. :trollface: 
