### PR TITLE
Fix grid export bug

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Export.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Export.php
@@ -257,6 +257,7 @@ class Export extends \Magento\Backend\Block\Widget implements \Magento\Backend\B
         $break = false;
 
         while ($break !== true) {
+            $originalCollection->clear();
             $originalCollection->setPageSize($this->getExportPageSize());
             $originalCollection->setCurPage($page);
             $originalCollection->load();


### PR DESCRIPTION
fix for export grid with the number of lines > 1000 (collection not loaded second time)
