### PR TITLE
Fixed column description for "website_id" column

### DIFF
--- a/app/code/Magento/CatalogInventory/Setup/InstallSchema.php
+++ b/app/code/Magento/CatalogInventory/Setup/InstallSchema.php
@@ -249,7 +249,7 @@ class InstallSchema implements InstallSchemaInterface
                 \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
                 5,
                 ['unsigned' => true, 'nullable' => false, 'default' => 0],
-                'Is Divided into Multiple Boxes for Shipping'
+                'Website ID'
             )
             ->addIndex(
                 $installer->getIdxName(


### PR DESCRIPTION
Table: cataloginventory_stock_item

Currently says "Is Divided into Multiple Boxes for Shipping". That's wrong. :-) Changed it to "Website ID". 

May need to be put into an upgrade schema instead.
