### PR TITLE
Don't hardcode the Magento_Backend::admin index

### DIFF
--- a/app/code/Magento/Integration/Block/Adminhtml/Integration/Activate/Permissions/Tab/Webapi.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Integration/Activate/Permissions/Tab/Webapi.php
@@ -148,7 +148,11 @@ class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements
     public function getResourcesTreeJson()
     {
         $resources = $this->_resourceProvider->getAclResources();
-        $aclResourcesTree = $this->_integrationData->mapResources($resources[1]['children']);
+        $configResource = array_filter($resources, function($node) {
+            return $node['id'] == 'Magento_Backend::admin';
+        });
+        $configResource = reset($configResource);
+        $aclResourcesTree = $this->_integrationData->mapResources($configResource['children']);
 
         return $this->encoder->encode($aclResourcesTree);
     }
@@ -167,7 +171,11 @@ class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements
         $selectedResources = $this->_selectedResources;
         if ($this->isEverythingAllowed()) {
             $resources = $this->_resourceProvider->getAclResources();
-            $selectedResources = $this->_getAllResourceIds($resources[1]['children']);
+            $configResource = array_filter($resources, function($node) {
+                return $node['id'] == 'Magento_Backend::admin';
+            });
+            $configResource = reset($configResource);
+            $selectedResources = $this->_getAllResourceIds($configResource['children']);
         }
         return $this->encoder->encode($selectedResources);
     }

--- a/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit/Tab/Webapi.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit/Tab/Webapi.php
@@ -176,8 +176,12 @@ class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements
     public function getTree()
     {
         $resources = $this->aclResourceProvider->getAclResources();
+        $configResource = array_filter($resources, function($node) {
+            return $node['id'] == 'Magento_Backend::admin';
+        });
+        $configResource = reset($configResource);
         $rootArray = $this->integrationData->mapResources(
-            isset($resources[1]['children']) ? $resources[1]['children'] : []
+            isset($configResource['children']) ? $configResource['children'] : []
         );
         return $rootArray;
     }

--- a/app/code/Magento/User/Block/Role/Tab/Edit.php
+++ b/app/code/Magento/User/Block/Role/Tab/Edit.php
@@ -198,9 +198,13 @@ class Edit extends \Magento\Backend\Block\Widget\Form implements \Magento\Backen
      */
     public function getTree()
     {
-        $resources = $this->_aclResourceProvider->getAclResources();
-        $rootArray = $this->_integrationData->mapResources(
-            isset($resources[1]['children']) ? $resources[1]['children'] : []
+        $resources = $this->aclResourceProvider->getAclResources();
+        $configResource = array_filter($resources, function($node) {
+            return $node['id'] == 'Magento_Backend::admin';
+        });
+        $configResource = reset($configResource);
+        $rootArray = $this->integrationData->mapResources(
+            isset($configResource['children']) ? $configResource['children'] : []
         );
         return $rootArray;
     }


### PR DESCRIPTION
I encountered a problem with a third party module that specified `Magento_Adminhtml::admin` (incorrectly, I realise) as its root resource in `acl.xml` which, lacking a sortOrder, got shuffled to `$resources[0]` pushing the `Magento_Backend::admin` resource back to `$resources[2]`. This resulted in jstree rendering no ACL resources in adminhtml, as the `$resource[1]` being selected was `Magento_Backend::all` which has no children.

This could be argued to be an issue with the third party module, but selecting a hard-coded index out of a non-immutable array is problematic regardless, and it's not good that such a small error completely breaks ACL management. I submit this PR to specify the correct resource explicitly in relevant locations, rather than relying on an assumption about the resource array's indices.
