### PR TITLE
Billing address isn't updated when the user change the shipping address

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
@@ -219,14 +219,7 @@ define(
              * Apply resolved billing address to quote
              */
             applyBillingAddress: function () {
-                var shippingAddress;
-
-                if (quote.billingAddress()) {
-                    selectBillingAddress(quote.billingAddress());
-
-                    return;
-                }
-                shippingAddress = quote.shippingAddress();
+                var shippingAddress = quote.shippingAddress();
 
                 if (shippingAddress &&
                     shippingAddress.canUseForBilling() &&
@@ -234,6 +227,12 @@ define(
                 ) {
                     //set billing address same as shipping by default if it is not empty
                     selectBillingAddress(quote.shippingAddress());
+                }
+                
+                if (quote.billingAddress()) {
+                    selectBillingAddress(quote.billingAddress());
+
+                    return;
                 }
             }
         };


### PR DESCRIPTION
When the user modify the shipping address during the checkout proccess, the billing address isn't updated even if the checkbox is selected to "My billing and shipping address are the same".

How-to reproduce the bug
- User add a item in the cart
- User go to checkout page.
- User fills out the first step form and clicks on next.
- When the user is on the step 2, he clicks on the #1 Shipping button and go back to the step 1.
- User modify one field of the form and clicks on next.
- You can see the billing shipping address isn't updated
