### PR TITLE
Allow \DateTimeInterface as input to Magento\Framework\Stdlib\DateTime classes

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime.php
@@ -37,14 +37,14 @@ class DateTime
     /**
      * Format date to internal format
      *
-     * @param string|\DateTime|bool|null $date
+     * @param string|\DateTimeInterface|bool|null $date
      * @param boolean $includeTime
      * @return string|null
      * @api
      */
     public function formatDate($date, $includeTime = true)
     {
-        if ($date instanceof \DateTime) {
+        if ($date instanceof \DateTimeInterface) {
             $format = $includeTime ? self::DATETIME_PHP_FORMAT : self::DATE_PHP_FORMAT;
             return $date->format($format);
         } elseif (empty($date)) {

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/DateTime.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/DateTime.php
@@ -92,14 +92,13 @@ class DateTime
         if ($format === null) {
             $format = 'Y-m-d H:i:s';
         }
-        $result = date($format, $this->timestamp($input));
-        return $result;
+        return date($format, $this->timestamp($input));
     }
 
     /**
      * Forms GMT timestamp
      *
-     * @param  int|string $input date in current timezone
+     * @param  int|string|\DateTimeInterface $input date in current timezone
      * @return int
      */
     public function gmtTimestamp($input = null)
@@ -108,6 +107,8 @@ class DateTime
             return (int)gmdate('U');
         } elseif (is_numeric($input)) {
             $result = $input;
+        } elseif ($input instanceof \DateTimeInterface) {
+            $result = $input->getTimestamp();
         } else {
             $result = strtotime($input);
         }
@@ -134,13 +135,13 @@ class DateTime
             $result = $this->gmtTimestamp();
         } elseif (is_numeric($input)) {
             $result = $input;
+        } elseif ($input instanceof \DateTimeInterface) {
+            $result = $input->getTimestamp();
         } else {
             $result = strtotime($input);
         }
         $date = $this->_localeDate->date($result);
-        $timestamp = $date->getTimestamp();
-        unset($date);
-        return $timestamp;
+        return $date->getTimestamp();
     }
 
     /**

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/DateTimeTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/DateTimeTest.php
@@ -6,27 +6,47 @@
 namespace Magento\Framework\Stdlib\Test\Unit\DateTime;
 
 use \Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 
 /**
  * Magento\Framework\Stdlib\DateTimeTest test case
  */
 class DateTimeTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @test
-     */
-    public function testGmtTimestamp()
-    {
-        $timezone = $this->getMockBuilder('Magento\Framework\Stdlib\DateTime\TimezoneInterface')->getMock();
-        $timezone->expects($this->any())
-            ->method('date')
-            ->willReturn(new \DateTime('2015-04-02 21:03:00'));
-        /** @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface $timezone */
+    private $testDate = '2015-04-02 21:03:00';
 
-        $dateTime = new DateTime($timezone);
-        $this->assertEquals(
-            gmdate('U', strtotime('2015-04-02 21:03:00')),
-            $dateTime->gmtTimestamp('2015-04-02 21:03:00')
-        );
+    /**
+     * @dataProvider dateTimeInputDataProvider
+     */
+    public function testGmtTimestamp($input)
+    {
+        /** @var TimezoneInterface|\PHPUnit_Framework_MockObject_MockObject $timezone */
+        $timezone = $this->getMock(TimezoneInterface::class);
+        $timezone->method('date')->willReturn(new \DateTime($this->testDate));
+
+        $expected = gmdate('U', strtotime($this->testDate));
+        $this->assertEquals($expected, (new DateTime($timezone))->gmtTimestamp($input));
+    }
+
+    /**
+     * @dataProvider dateTimeInputDataProvider
+     */
+    public function testTimestamp($input)
+    {
+        /** @var TimezoneInterface|\PHPUnit_Framework_MockObject_MockObject $timezone */
+        $timezone = $this->getMock(TimezoneInterface::class);
+        $timezone->method('date')->willReturn(new \DateTime($this->testDate));
+
+        $expected = gmdate('U', strtotime($this->testDate));
+        $this->assertEquals($expected, (new DateTime($timezone))->timestamp($input));
+    }
+
+    public function dateTimeInputDataProvider()
+    {
+        return [
+            'string' => [$this->testDate],
+            'int' => [strtotime($this->testDate)],
+            '\\DateTimeInterface' => [new \DateTimeImmutable($this->testDate)],
+        ];
     }
 }


### PR DESCRIPTION
I often use `\DateTimeImmutable` as a constructor argument if I need a current timestamp in a class. 
Unfortunately that is not a valid input to `Magento\Framework\Stdlib\DateTime` or `Magento\Framework\Stdlib\DateTime\DateTime`. The former only allows `\DateTime` and the latter only takes int or string input.
This PR changes adds the ability to use any `\DateTimeInterface` implementation as input, which includes both `\DateTime` and `\DateTimeImmutable`.
There are no backward compatibility breaks.
