### PR TITLE
Correction: variable naming for user roles & role id

### DIFF
--- a/app/code/Magento/User/Block/User/Edit/Tab/Roles.php
+++ b/app/code/Magento/User/Block/User/Edit/Tab/Roles.php
@@ -143,19 +143,19 @@ class Roles extends \Magento\Backend\Block\Widget\Grid\Extended
         //checking if we have this data and we
         //don't need load it through resource model
         if ($user->hasData('roles')) {
-            $uRoles = $user->getData('roles');
+            $userRoles = $user->getData('roles');
         } else {
-            $uRoles = $user->getRoles();
+            $userRoles = $user->getRoles();
         }
 
         if ($json) {
             $jsonRoles = [];
-            foreach ($uRoles as $urid) {
-                $jsonRoles[$urid] = 0;
+            foreach ($userRoles as $roleId) {
+                $jsonRoles[$roleId] = 0;
             }
             return $this->_jsonEncoder->encode((object)$jsonRoles);
         } else {
-            return $uRoles;
+            return $userRoles;
         }
     }
 }

--- a/app/code/Magento/User/Controller/Adminhtml/User/Save.php
+++ b/app/code/Magento/User/Controller/Adminhtml/User/Save.php
@@ -26,9 +26,9 @@ class Save extends \Magento\User\Controller\Adminhtml\User
             return;
         }
         $model->setData($this->_getAdminUserData($data));
-        $uRoles = $this->getRequest()->getParam('roles', []);
-        if (count($uRoles)) {
-            $model->setRoleId($uRoles[0]);
+        $userRoles = $this->getRequest()->getParam('roles', []);
+        if (count($userRoles)) {
+            $model->setRoleId($userRoles[0]);
         }
 
         /** @var $currentUser \Magento\User\Model\User */


### PR DESCRIPTION
Just to avoid the short hands from variable names. Variable names should be meaningful.
