### PR TITLE
Access element through jQuery

### DIFF
--- a/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
+++ b/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
@@ -37,7 +37,7 @@ define([
                     case 9: // DOCUMENT_NODE
                         var hostName = window.location.hostname,
                             iFrameHostName = $('<a>')
-                                .prop('href', element.prop('src'))
+                                .prop('href', $(element).prop('src'))
                                 .prop('hostname');
 
                         if (hostName === iFrameHostName) {


### PR DESCRIPTION
The contents of element here is a regular DOM node rather than a jQuery object, and as such the .prop method isn't available, causing "element.prop() is not a function" errors in the browser. The solution is to just access it through jQuery.
