### PR TITLE
map, filter & reduce collection helpers

### DIFF
--- a/lib/internal/Magento/Framework/Data/Collection.php
+++ b/lib/internal/Magento/Framework/Data/Collection.php
@@ -527,6 +527,48 @@ class Collection implements \IteratorAggregate, \Countable, ArrayInterface, Coll
     }
 
     /**
+     * Applies the given callable to each element in the collection.
+     *
+     * @param callable $callback
+     * @return static
+     */
+    public function map(callable $callback)
+    {
+        $this->load();
+        $new = clone $this;
+        $new->_items = array_map($callback, $this->_items);
+        return $new;
+    }
+
+    /**
+     * Applies the given callable to each element in the collection and removes items
+     * which do not pass the callable criteria.
+     *
+     * @param callable $callback
+     * @return static
+     */
+    public function filter(callable  $callback)
+    {
+        $this->load();
+        $new = clone $this;
+        $new->_items = array_filter($this->_items, $callback);
+        return $new;
+    }
+
+    /**
+     * Return a single result from all of the elements in the collection. Optionally takes an initial value.
+     *
+     * @param callable $callback
+     * @param mixed $initial
+     * @return mixed
+     */
+    public function reduce(callable $callback, $initial = null)
+    {
+        $this->load();
+        return array_reduce($this->_items, $callback, $initial);
+    }
+
+    /**
      * Setting data for all collection items
      *
      * @param   mixed $key

--- a/lib/internal/Magento/Framework/Data/Test/Unit/CollectionTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/CollectionTest.php
@@ -167,4 +167,63 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $this->_model->removeAllItems();
         $this->assertEquals([], $this->_model->getItems());
     }
+
+    public function testMap()
+    {
+        $item1 = new \Magento\Framework\DataObject();
+        $item2 = new \Magento\Framework\DataObject();
+
+        $this->_model->addItem($item1);
+        $this->_model->addItem($item2);
+        $this->assertCount(2, $this->_model->getItems());
+
+        $mapped = $this->_model->map(function (\Magento\Framework\DataObject $obj) {
+            return $obj->setData('map_test', true);
+        });
+
+        $this->assertNotSame($mapped, $this->_model);
+        $this->assertTrue($item1->getData('map_test'));
+        $this->assertTrue($item2->getData('map_test'));
+    }
+
+    public function testFilter()
+    {
+        $item1 = new \Magento\Framework\DataObject(['price' => 10]);
+        $item2 = new \Magento\Framework\DataObject(['price' => 20]);
+        $item3 = new \Magento\Framework\DataObject(['price' => 30]);
+
+        $this->_model->addItem($item1);
+        $this->_model->addItem($item2);
+        $this->_model->addItem($item3);
+
+        $this->assertCount(3, $this->_model->getItems());
+
+        $filtered = $this->_model->filter(function (\Magento\Framework\DataObject $obj) {
+            return $obj->getData('price') >= 20;
+        });
+
+        $this->assertNotSame($filtered, $this->_model);
+        $this->assertCount(2, $filtered->getItems());
+        $this->assertCount(3, $this->_model->getItems());
+
+    }
+
+    public function testReduce()
+    {
+        $item1 = new \Magento\Framework\DataObject(['price' => 10]);
+        $item2 = new \Magento\Framework\DataObject(['price' => 20]);
+        $item3 = new \Magento\Framework\DataObject(['price' => 30]);
+
+        $this->_model->addItem($item1);
+        $this->_model->addItem($item2);
+        $this->_model->addItem($item3);
+
+        $this->assertCount(3, $this->_model->getItems());
+
+        $totalPrice = $this->_model->reduce(function ($carry, \Magento\Framework\DataObject $obj) {
+            return $carry + $obj->getData('price');
+        }, 0);
+
+        $this->assertEquals(60, $totalPrice);
+    }
 }


### PR DESCRIPTION
### Map, Filter & Reduce functions for Collections.

We all know it is impossible to use the `array_` functions from PHP std library with user land collections. This PR is purely syntactical sugar, as there are other ways to achieve the same results without these additions.

However, providing these methods is fairly common practise in userland collection implementations and can be immensely useful, see these popular implementations: 
- https://github.com/doctrine/collections/blob/master/lib/Doctrine/Common/Collections/Collection.php
- https://github.com/illuminate/support/blob/master/Collection.php
- https://github.com/morrisonlevi/Ardent
### Some examples:

``` php
$collection = new \Magento\Framework\Data\Collection();
$collection->addItem($item1);
$collection->addItem($item2);

$collection->map(function ($item) {
    return $item->setData('some_key', 'some_value');
});

$collection->filter(function ($item) {
    return $item->getData('price') > 0;
});

$total = $collection->reduce(function ($carry, $item) {
    return $carry + $item->getData('price');
}, 0);
```

It is possible to achieve this already, but the process is rather cumbersome and requires much more code and more variables. This more functional approach is clean and concise. 

I see this as really useful for just manipulating collections without having to convert them to their basic PHP array format. Code becomes more expressive and it's intent is clear through these API's.
### Caveats
1. There are quite a few methods with `filter` in there name in the various collections throughout Magento. The method `filter` may be slightly ambiguous. I am open for suggestions - however, this name is used in many programming languages and libraries for this very purpose.
2. There are already ways to get the same results.
### Future

We could add more methods in the future for a slick, clean OO API, such as `contains`, `slice`, `chunk` and so on, or we add nothing more at all.  
