### PR TITLE
Country of Manufacture drop down is limited:issue:4579

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
@@ -63,7 +63,7 @@ class Countryofmanufacture extends AbstractSource implements OptionSourceInterfa
         if ($cache = $this->_configCacheType->load($cacheKey)) {
             $options = unserialize($cache);
         } else {
-            $collection = $this->_countryFactory->create()->getResourceCollection()->loadByStore();
+            $collection = $this->_countryFactory->create()->getResourceCollection();
             $options = $collection->toOptionArray();
             $this->_configCacheType->save(serialize($options), $cacheKey);
         }


### PR DESCRIPTION
Steps to reproduce

```
Configure M2 config to only sell to 1 (or 2 or 3 etc) countries.
Click on "country of manufacture" drop-down in product profile.
```

Expected result

```
A list of all countries (regardless of which countries we want to sell to) should be displayed
```

Actual result

```
Country list is restricted to the "Allowed Countries" list, as per the site configuration.
```

This above problem does not manifest in Magento 1 - it works as expected (i.e.: even if we have configured the site only to sell to "France", we can configure a product to be manufactured by any country).
