### PR TITLE
table rate fix:issue:4597

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate/RateQuery.php
+++ b/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate/RateQuery.php
@@ -32,7 +32,7 @@ class RateQuery
         $select->where(
             'website_id = :website_id'
         )->order(
-            ['dest_country_id DESC', 'dest_region_id DESC', 'dest_zip DESC']
+            ['dest_country_id DESC', 'dest_region_id DESC', 'dest_zip DESC','condition_value DESC']
         )->limit(
             1
         );


### PR DESCRIPTION
For "Table Rate" shipping method on setting "condition" field as "Price vs Destination" and later after importing csv file with correct values to a website doesn't display correct shipping prices for table rate method while creating new order, it will always display first shipping price value.
Here I have attached screenshot for csv I have imported for a website shipping methods.
p19

Here in all cases it shows shipping cost as "2.5"
