### PR TITLE
Previous is spelt incorrectly

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
+++ b/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dynamic-rows.js
@@ -380,7 +380,7 @@ define([
         },
 
         /**
-         * Change page to previos
+         * Change page to previous
          */
         previousPage: function () {
             this.currentPage(this.currentPage() - 1);

--- a/dev/tests/js/jasmine/tests/lib/mage/gallery.test.js
+++ b/dev/tests/js/jasmine/tests/lib/mage/gallery.test.js
@@ -99,7 +99,7 @@ define([
             expect($(navSelector + ':eq(1)').attr('data-active') === 'true').toBeTruthy();
         });
 
-        it('show previos', function () {
+        it('show previous', function () {
             galleryAPI.prev();
             expect($(navSelector + ':eq(0)').attr('data-active') === 'true').toBeTruthy();
         });

--- a/lib/web/mage/gallery/gallery.html
+++ b/lib/web/mage/gallery/gallery.html
@@ -8,7 +8,7 @@
     <div data-gallery-role="fotorama__focusable-start" tabindex="-1"></div>
     <div class="fotorama__wrap fotorama__wrap--css3 fotorama__wrap--slide fotorama__wrap--toggle-arrows">
         <div class="fotorama__stage" data-fotorama-stage="fotorama__stage">
-            <div class="fotorama__arr fotorama__arr--prev" tabindex="0" role="button" aria-label="Previos" data-gallery-role="arrow">
+            <div class="fotorama__arr fotorama__arr--prev" tabindex="0" role="button" aria-label="Previous" data-gallery-role="arrow">
                 <div class="fotorama__arr__arr"></div>
             </div>
             <div class="fotorama__stage__shaft" tabindex="0" data-gallery-role="stage-shaft">
@@ -25,7 +25,7 @@
         <div class="fotorama__nav-wrap" data-gallery-role="nav-wrap">
             <div class="fotorama__nav fotorama__nav--thumbs">
                 <div class="fotorama__fullscreen-icon" data-gallery-role="fotorama__fullscreen-icon" tabindex="0" aria-label="Exit fullscreen" role="button"></div>
-                <div class="fotorama__thumb__arr fotorama__thumb__arr--left" role="button" aria-label="Previos" data-gallery-role="arrow" tabindex = "-1">
+                <div class="fotorama__thumb__arr fotorama__thumb__arr--left" role="button" aria-label="Previous" data-gallery-role="arrow" tabindex = "-1">
                     <div class="fotorama__thumb--icon"></div>
                 </div>
                 <div class="fotorama__nav__shaft">


### PR DESCRIPTION
I noticed that previous is spelt incorrectly in a few files, I have corrected them. 

I've tested the product page carousel after making these changes and can't spot any changes on the front-end.
