### PR TITLE
Dropped PHP 5.5 builds from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     - postfix
 language: php
 php:
-  - 5.5
   - 5.6
   - 7.0
 env:
@@ -26,8 +25,6 @@ cache:
   directories: $HOME/.composer/cache
 matrix:
   exclude:
-    - php: 5.6
-      env: TEST_SUITE=static
     - php: 7.0
       env: TEST_SUITE=static
 before_install: ./dev/travis/before_install.sh


### PR DESCRIPTION
TB for 2.1RC1 states PHP 5.5. is no longer supported, so it should be removed from the builds.

![magento ee 2 1 release candidate 1 rc1 release notes 2016-05-23 09-35-27](https://cloud.githubusercontent.com/assets/658281/15474519/c0dcb39a-20ca-11e6-832c-c0b6c8fabc96.png)
