### PR TITLE
Update method to match doc comments

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -485,7 +485,7 @@ class Item extends AbstractModel implements OrderItemInterface
         if (isset($options[$code])) {
             return $options[$code];
         }
-        return []];
+        return [];
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -485,7 +485,7 @@ class Item extends AbstractModel implements OrderItemInterface
         if (isset($options[$code])) {
             return $options[$code];
         }
-        return null;
+        return []];
     }
 
     /**


### PR DESCRIPTION
When using the "reorder" functionality from the customer account page, if the order contains items that do not have required options. The following error is displayed: 

<b>Fatal error</b>:  Uncaught TypeError: Argument 1 passed to Magento\Framework\DataObject::__construct() must be of the type array, null given, called in htdocs/vendor/magento/module-checkout/Model/Cart.php on line 264 and defined in htdocs/vendor/magento/framework/DataObject.php:38
Stack trace:
#0 htdocs/vendor/magento/module-checkout/Model/Cart.php(264): Magento\Framework\DataObject-&gt;__construct(NULL)
#1 htdocs/var/generation/Magento/Checkout/Model/Cart/Interceptor.php(102): Magento\Checkout\Model\Cart-&gt;addOrderItem(Object(Magento\Sales\Model\Order\Item), NULL)
#2 htdocs/vendor/magento/module-sales/Controller/AbstractController/Reorder.php(59): Magento\Checkout\Model\Cart\Interceptor-&gt;addOrderItem(Object(Magento\Sales\Model\Order\Item))
#3 htdocs/var/generation/Magento/Sales/Controller/Order/Reorder/Interceptor.php(24): Magento\Sales\Controller\AbstractController\Reorder-&gt;execute()
#4 htdocs/vend in <b>htdocs/vendor/magento/framework/DataObject.php</b> on line <b>38</b>
