### PR TITLE
Fixing direct use of object manager with injected block factory.

### DIFF
--- a/app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
@@ -9,17 +9,17 @@ namespace Magento\Cms\Controller\Adminhtml\Block;
 class Delete extends \Magento\Cms\Controller\Adminhtml\Block
 {
     /**
-    * Injected Dependency Description
+    * Factory to access block delete methods
     * 
     * @var \Magento\Cms\Model\BlockFactory
     */
-    protected $modelBlockFactory;
+    protected $cmsBlockFactory;
 
     public function __construct(\Magento\Backend\App\Action\Context $context, \Magento\Framework\Registry $coreRegistry,
-        \Magento\Cms\Model\BlockFactory $modelBlockFactory)
+        \Magento\Cms\Model\BlockFactory $cmsBlockFactory)
     {
-        $this->modelBlockFactory = $modelBlockFactory;
-        return parent::__construct($context, $coreRegistry);
+        parent::__construct($context, $coreRegistry);
+        $this->cmsBlockFactory = $cmsBlockFactory;        
     }
     
     /**
@@ -36,7 +36,7 @@ class Delete extends \Magento\Cms\Controller\Adminhtml\Block
         if ($id) {
             try {
                 // init model and delete
-                $model = $this->modelBlockFactory->create();
+                $model = $this->cmsBlockFactory->create();
                 $model->load($id);
                 $model->delete();
                 // display success message

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
@@ -9,12 +9,17 @@ namespace Magento\Cms\Controller\Adminhtml\Block;
 class Delete extends \Magento\Cms\Controller\Adminhtml\Block
 {
     /**
-    * Factory to access block delete methods
-    * 
-    * @var \Magento\Cms\Model\BlockFactory
-    */
+     * Factory to access block delete methods
+     * 
+     * @var \Magento\Cms\Model\BlockFactory
+     */
     protected $cmsBlockFactory;
 
+    /**
+     * @param \Magento\Backend\App\Action\Context $context
+     * @param \Magento\Framework\Registry $coreRegistry
+     * @param \Magento\Cms\Model\BlockFactory $cmsBlockFactory
+     */
     public function __construct(\Magento\Backend\App\Action\Context $context, \Magento\Framework\Registry $coreRegistry,
         \Magento\Cms\Model\BlockFactory $cmsBlockFactory)
     {

--- a/app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
@@ -9,6 +9,20 @@ namespace Magento\Cms\Controller\Adminhtml\Block;
 class Delete extends \Magento\Cms\Controller\Adminhtml\Block
 {
     /**
+    * Injected Dependency Description
+    * 
+    * @var \Magento\Cms\Model\BlockFactory
+    */
+    protected $modelBlockFactory;
+
+    public function __construct(\Magento\Backend\App\Action\Context $context, \Magento\Framework\Registry $coreRegistry,
+        \Magento\Cms\Model\BlockFactory $modelBlockFactory)
+    {
+        $this->modelBlockFactory = $modelBlockFactory;
+        return parent::__construct($context, $coreRegistry);
+    }
+    
+    /**
      * Delete action
      *
      * @return \Magento\Framework\Controller\ResultInterface
@@ -22,7 +36,7 @@ class Delete extends \Magento\Cms\Controller\Adminhtml\Block
         if ($id) {
             try {
                 // init model and delete
-                $model = $this->_objectManager->create('Magento\Cms\Model\Block');
+                $model = $this->modelBlockFactory->create();
                 $model->load($id);
                 $model->delete();
                 // display success message

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/DeleteTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/DeleteTest.php
@@ -95,6 +95,7 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
+            
         $this->resultRedirectFactoryMock->expects($this->atLeastOnce())
             ->method('create')
             ->willReturn($this->resultRedirectMock);
@@ -114,10 +115,17 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
             ->method('getResultRedirectFactory')
             ->willReturn($this->resultRedirectFactoryMock);
 
+        $this->cmsBlockFactoryMock = $this->getMockBuilder(\Magento\Cms\Model\BlockFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+    
         $this->deleteController = $this->objectManager->getObject(
             'Magento\Cms\Controller\Adminhtml\Block\Delete',
             [
                 'context' => $this->contextMock,
+                'cmsBlockFactory' => $this->cmsBlockFactoryMock
+                
             ]
         );
     }
@@ -128,9 +136,8 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
             ->method('getParam')
             ->willReturn($this->blockId);
 
-        $this->objectManagerMock->expects($this->once())
+        $this->cmsBlockFactoryMock->expects($this->once())
             ->method('create')
-            ->with('Magento\Cms\Model\Block')
             ->willReturn($this->blockMock);
 
         $this->blockMock->expects($this->once())
@@ -179,11 +186,10 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
             ->method('getParam')
             ->willReturn($this->blockId);
 
-        $this->objectManagerMock->expects($this->once())
+        $this->cmsBlockFactoryMock->expects($this->once())
             ->method('create')
-            ->with('Magento\Cms\Model\Block')
             ->willThrowException(new \Exception(__($errorMsg)));
-
+            
         $this->messageManagerMock->expects($this->once())
             ->method('addError')
             ->with($errorMsg);


### PR DESCRIPTION
Statements by Magento team members have indicated that objects should **not** be instantiated directly in method code.  Instead, new objects should be **injected** via automatic constructor dependency injection.  

The following pull requests swaps a direct instantiation in 

```
app/code/Magento/Cms/Controller/Adminhtml/Block/Delete.php
```

with an injected factory object.  The object manager call itself is replaced with a call to the factory method's `create` method.  This moves this dependency into the controller class's constructor. 

This pull requests adds no new functionality, and fixes no new bugs.  It brings a single PHP file better into line with Magento's stated coding conventions.  

If these changes are not welcome, please indicate that in the ticket responses.

If these tickets **are** welcome, but there's addition unstated steps/context, please let me know what needs to be addressed.

This is a contribution to the Magento source code repository.  My contribution consists of code, files, and text  explicitly added to this GitHub pull request by myself.  My contribution does not consist of code, files, or text outside of this specific pull request, and nothing said in this pull request or elsewhere will be constituted as expanding the scope of this contribution. 
