### PR TITLE
Escape Js Quote for layout updates

### DIFF
--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/DesignAbstraction.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/DesignAbstraction.php
@@ -49,6 +49,18 @@ class DesignAbstraction extends \Magento\Framework\View\Element\Html\Select
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * Add escapeJsQuote on $label
+     */
+    public function addOption($value, $label, $params = [])
+    {
+        $label = $this->escapeJsQuote($label);
+
+        return parent::addOption($value, $label, $params);
+    }
+
+    /**
      * Add necessary options
      *
      * @return \Magento\Framework\View\Element\AbstractBlock

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Layout.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Chooser/Layout.php
@@ -33,6 +33,18 @@ class Layout extends \Magento\Framework\View\Element\Html\Select
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * Add escapeJsQuote on $label
+     */
+    public function addOption($value, $label, $params = [])
+    {
+        $label = $this->escapeJsQuote($label);
+
+        return parent::addOption($value, $label, $params);
+    }
+
+    /**
      * Add necessary options
      *
      * @return \Magento\Framework\View\Element\AbstractBlock


### PR DESCRIPTION
On Widget creation page (Content > Widgets), an error occurred if you have a `'` in page name (for ex in french: "Page d'accueil CMS"). 
The JS template for "layout update" is broken

![image](https://cloud.githubusercontent.com/assets/829364/15603617/a970f58c-23f3-11e6-93c3-862d89f231d9.png)

FYI: this issue was in M1...
