### PR TITLE
Update .htaccess files with recommended php memory values of 1024 MB

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -32,7 +32,7 @@
 ## adjust memory limit
 
 #    php_value memory_limit 64M
-    php_value memory_limit 768M
+    php_value memory_limit 1024M
     php_value max_execution_time 18000
 
 ############################################

--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -32,7 +32,7 @@
 ## adjust memory limit
 
 #    php_value memory_limit 64M
-    php_value memory_limit 256M
+    php_value memory_limit 1024M
     php_value max_execution_time 18000
 
 ############################################


### PR DESCRIPTION
Updating .htaccess file for php memory limit to be set to 1024 MB to be in accordance with recommended value from docs.
