### PR TITLE
[Framework][Translate] Better translation loading order

### DIFF
--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -177,8 +177,8 @@ class Translate implements \Magento\Framework\TranslateInterface
         $this->_data = [];
 
         $this->_loadModuleTranslation();
-        $this->_loadThemeTranslation();
         $this->_loadPackTranslation();
+        $this->_loadThemeTranslation();
         $this->_loadDbTranslation();
 
         $this->_saveCache();


### PR DESCRIPTION
Translation files of theme should be loaded after translation pack to allow the theme to override the  translation pack.
