### PR TITLE
Enabled adding translation from theme to js dictionary

### DIFF
--- a/app/code/Magento/Translation/Model/Json/PreProcessor.php
+++ b/app/code/Magento/Translation/Model/Json/PreProcessor.php
@@ -12,9 +12,11 @@ use Magento\Framework\View\Asset\PreProcessor\Chain;
 use Magento\Framework\View\Asset\File\FallbackContext;
 use Magento\Framework\App\AreaList;
 use Magento\Framework\TranslateInterface;
+use Magento\Theme\Model\View\Design;
 
 /**
  * PreProcessor responsible for providing js translation dictionary
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class PreProcessor implements PreProcessorInterface
 {
@@ -43,21 +45,29 @@ class PreProcessor implements PreProcessorInterface
     protected $translate;
 
     /**
+     * @var Design
+     */
+    protected $design;
+
+    /**
      * @param Config $config
      * @param DataProviderInterface $dataProvider
      * @param AreaList $areaList
      * @param TranslateInterface $translate
+     * @param Design $design
      */
     public function __construct(
         Config $config,
         DataProviderInterface $dataProvider,
         AreaList $areaList,
-        TranslateInterface $translate
+        TranslateInterface $translate,
+        Design $design
     ) {
         $this->config = $config;
         $this->dataProvider = $dataProvider;
         $this->areaList = $areaList;
         $this->translate = $translate;
+        $this->design = $design;
     }
 
     /**
@@ -78,6 +88,7 @@ class PreProcessor implements PreProcessorInterface
                 $themePath = $context->getThemePath();
                 $areaCode = $context->getAreaCode();
                 $this->translate->setLocale($context->getLocale());
+                $this->design->setDesignTheme($themePath);
             }
 
             $area = $this->areaList->getArea($areaCode);

--- a/app/code/Magento/Translation/Test/Unit/Model/Json/PreProcessorTest.php
+++ b/app/code/Magento/Translation/Test/Unit/Model/Json/PreProcessorTest.php
@@ -36,17 +36,24 @@ class PreProcessorTest extends \PHPUnit_Framework_TestCase
      */
     protected $translateMock;
 
+    /**
+     * @var \Magento\Theme\Model\View\Design|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $designMock;
+
     protected function setUp()
     {
         $this->configMock = $this->getMock(\Magento\Translation\Model\Js\Config::class, [], [], '', false);
         $this->dataProviderMock = $this->getMock(\Magento\Translation\Model\Js\DataProvider::class, [], [], '', false);
         $this->areaListMock = $this->getMock(\Magento\Framework\App\AreaList::class, [], [], '', false);
         $this->translateMock = $this->getMockForAbstractClass(\Magento\Framework\TranslateInterface::class);
+        $this->designMock = $this->getMock(\Magento\Theme\Model\View\Design::class, [], [], '', false);
         $this->model = new PreProcessor(
             $this->configMock,
             $this->dataProviderMock,
             $this->areaListMock,
-            $this->translateMock
+            $this->translateMock,
+            $this->designMock
         );
     }
 
@@ -60,6 +67,7 @@ class PreProcessorTest extends \PHPUnit_Framework_TestCase
         $themePath = '*/*';
         $dictionary = ['hello' => 'bonjour'];
         $areaCode = 'adminhtml';
+        $locale = 'en_US';
         $area = $this->getMock(\Magento\Framework\App\Area::class, [], [], '', false);
 
         $chain->expects($this->once())
@@ -80,6 +88,16 @@ class PreProcessorTest extends \PHPUnit_Framework_TestCase
         $context->expects($this->once())
             ->method('getAreaCode')
             ->willReturn($areaCode);
+        $context->expects($this->once())
+            ->method('getLocale')
+            ->willReturn($locale);
+
+        $this->translateMock->expects($this->once())
+            ->method('setLocale')
+            ->with($locale);
+        $this->designMock->expects($this->once())
+            ->method('setDesignTheme')
+            ->with($themePath);
 
         $this->areaListMock->expects($this->once())
             ->method('getArea')


### PR DESCRIPTION
Translation from theme translation file was not considered during js translation dictionary generation.
This resulted in no ability to translate labels f.e. for minicart from theme.

This issue is fixed by setting correct theme to View Design model before loading area while dictionary generation.
Unit test is adjusted.
