### PR TITLE
Set return code for SetModeCommand

### DIFF
--- a/app/code/Magento/Deploy/Console/Command/SetModeCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/SetModeCommand.php
@@ -104,6 +104,8 @@ class SetModeCommand extends Command
                     throw new LocalizedException(__('Cannot switch into given mode "%1"', $toMode));
             }
             $output->writeln('Enabled ' . $toMode . ' mode.');
+            
+            return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {


### PR DESCRIPTION
In case of running the `bin/magento deploy:mode:set production` command
in a shell script this will return an error code 129 and all other
commands after this will not be executed.
