### PR TITLE
Fixed sub menus detection in the Magento Menu jQuery Widget

### DIFF
--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -86,7 +86,7 @@ define([
         //Add class for expanded option
         isExpanded: function () {
             var subMenus = this.element.find(this.options.menus),
-                expandedMenus = subMenus.find('ul');
+                expandedMenus = subMenus.find(this.options.menus);
 
             expandedMenus.addClass('expanded');
         },
@@ -105,7 +105,7 @@ define([
                 return value.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
             }
 
-            if (this.active.closest('ul').attr('aria-expanded') != 'true') {
+            if (this.active.closest(this.options.menus).attr('aria-expanded') != 'true') {
 
                 switch (event.keyCode) {
                     case $.ui.keyCode.PAGE_UP:
@@ -334,15 +334,16 @@ define([
                 },
                 "mouseenter .ui-menu-item": function (event) {
                     var target = $(event.currentTarget),
+                        submenu = this.options.menus,
                         ulElement,
                         ulElementWidth,
                         width,
                         targetPageX,
                         rightBound;
 
-                    if (target.has('ul')) {
-                        ulElement = target.find('ul');
-                        ulElementWidth = target.find('ul').outerWidth(true);
+                    if (target.has(submenu)) {
+                        ulElement = target.find(submenu);
+                        ulElementWidth = ulElement.outerWidth(true);
                         width = target.outerWidth() * 2;
                         targetPageX = target.offset().left;
                         rightBound = $(window).width();


### PR DESCRIPTION
# Problem Statement

The Menu Widget  from jQuery UI library allows to specify selector for sub menu container. It might be done via specifying _menus_ option:

``` html
<ul data-mage-init='{"menu":{"responsive":true, "expanded":true, "position":{"my":"left top","at":"left bottom"}, "menus": "ul.submenu"}}'>
```

This option gives a flexible solution when Menu HTML markup requires changes.
The mage.menu Widget extends jQuery Menu Widget with few modifications which do not allow to properly use Menu Widget without overriding menu.js file.
# Solution

In order to use _mage.menu_ Widget out of box and easily specify container ID for submenu in custom theme all _ul_ elements used to identify submenus should be changed with _this.options.menus_ option.
