### PR TITLE
Make NL zipcode pattern less strict

### DIFF
--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -318,7 +318,7 @@
     </zip>
     <zip countryCode="NL">
         <codes>
-            <code id="pattern_1" active="true" example="1234 AB">^[0-9]{4}\s[a-zA-Z]{2}$</code>
+            <code id="pattern_1" active="true" example="1234 AB">^[0-9]{4}\s?[a-zA-Z]{2}$</code>
         </codes>
     </zip>
     <zip countryCode="NO">


### PR DESCRIPTION
The NL zipcode is too strict. 
Magento 2 advises `1234 AB`, while it's very common to enter it like `1234AB`.
That's why I made the space character optional.
