### PR TITLE
Fix handling is_region_required key as optional

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/region.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/region.js
@@ -36,7 +36,7 @@ define([
                 this.validation['required-entry'] = false;
                 this.required(false);
             } else {
-                if (!option['is_region_required']) {
+                if (!('is_region_required' in option) || !option['is_region_required']) {
                     this.error(false);
                     this.validation = _.omit(this.validation, 'required-entry');
                 } else {


### PR DESCRIPTION
Handle the condition that is_region_required is missing when the country does not require region.
Ref: https://github.com/magento/magento2/issues/2933
