### PR TITLE
Remove faulty index subscription

### DIFF
--- a/app/code/Magento/Catalog/etc/mview.xml
+++ b/app/code/Magento/Catalog/etc/mview.xml
@@ -36,7 +36,6 @@
             <table name="catalog_product_entity_decimal" entity_column="entity_id" />
             <table name="catalog_product_entity_gallery" entity_column="entity_id" />
             <table name="catalog_product_entity_int" entity_column="entity_id" />
-            <table name="catalog_product_entity_media_gallery" entity_column="value_id" />
             <table name="catalog_product_entity_media_gallery_value" entity_column="entity_id" />
             <table name="catalog_product_entity_text" entity_column="entity_id" />
             <table name="catalog_product_entity_tier_price" entity_column="entity_id" />

--- a/app/code/Magento/CatalogRule/etc/mview.xml
+++ b/app/code/Magento/CatalogRule/etc/mview.xml
@@ -18,7 +18,6 @@
             <table name="catalog_product_entity_decimal" entity_column="entity_id" />
             <table name="catalog_product_entity_gallery" entity_column="entity_id" />
             <table name="catalog_product_entity_int" entity_column="entity_id" />
-            <table name="catalog_product_entity_media_gallery" entity_column="value_id" />
             <table name="catalog_product_entity_media_gallery_value" entity_column="entity_id" />
             <table name="catalog_product_entity_text" entity_column="entity_id" />
             <table name="catalog_product_entity_tier_price" entity_column="entity_id" />


### PR DESCRIPTION
The table catalog_product_entity_media_gallery does not have a column
that represents a product entity_id so it cannot be subscribed to
triggers for catalogrule_product or catalog_product_flat

The current value_id is not a product entity_id so https://github.com/magento/magento2/commit/88891edb1069cda1c8ac78286be308a4bec7175e
should have never been approved. Insead the whole subscription should
be removed. For now there is no way to trigger an indexer when the
name if an image changes. If the image gets deleted or added the
subscription on catalog_product_entity_media_gallery_value will
handle it.
