### PR TITLE
Prevent change log entry when nothing has changed

### DIFF
--- a/lib/internal/Magento/Framework/Mview/View/Subscription.php
+++ b/lib/internal/Magento/Framework/Mview/View/Subscription.php
@@ -192,7 +192,9 @@ class Subscription implements SubscriptionInterface
     protected function buildStatement($event, $changelog)
     {
         $columns = [];
-        if ($describe = $this->connection->describeTable($this->getTableName())) {
+        if ($this->connection->isTableExists($this->getTableName())
+            && $describe = $this->connection->describeTable($this->getTableName())
+        ) {
             foreach ($describe as $column) {
                 if (in_array($column['COLUMN_NAME'], $this->ignoredUpdateColumns)) {
                     continue;


### PR DESCRIPTION
Fixes #2987

If an entry has no changes but did get a MySQL UPDATE the trigger will not fire.
This prevents entities from being reindexed when they haven't changed.

This way the refresh index cron job finishes faster without any loss of functionality.
This updated_at column is ignored because this is the only column that will always change, even if no attribute has been edited.
