### PR TITLE
Schedule generation was broken

### DIFF
--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -486,7 +486,6 @@ class ProcessCronQueueObserver implements ObserverInterface
             if ($schedule->trySchedule()) {
                 // time matches cron expression
                 $schedule->save();
-                return;
             }
         }
     }

--- a/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
@@ -660,7 +660,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->any())->method('unsScheduleId')->willReturnSelf();
         $schedule->expects($this->any())->method('trySchedule')->willReturnSelf();
         $schedule->expects($this->any())->method('getCollection')->willReturn($this->_collection);
-        $schedule->expects($this->exactly(1))->method('save')->willReturnSelf();
+        $schedule->expects($this->atLeastOnce())->method('save')->willReturnSelf();
 
         $this->_collection->addItem(new \Magento\Framework\DataObject());
         $this->_collection->addItem($schedule);


### PR DESCRIPTION
Only one schedule entry was generated at schedule generation because of this `return;`.

fixes #4173
