### PR TITLE
Fix undefined offset notice when no order states are set

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -248,6 +248,9 @@ class Config
     protected function _getStatuses($visibility)
     {
         if ($this->statuses == null) {
+            
+            $this->statuses = [ true => [], false => [] ];
+            
             foreach ($this->_getCollection() as $item) {
                 $visible = (bool) $item->getData('visible_on_front');
                 $this->statuses[$visible][] = $item->getData('status');

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -247,7 +247,7 @@ class Config
      */
     protected function _getStatuses($visibility)
     {
-        if ($this->statuses == null) {
+        if ($this->statuses === null) {
             
             $this->statuses = [ true => [], false => [] ];
             


### PR DESCRIPTION
When the DB has no order states (or just missing non-visible, or visible ones), M2 throws with `Notice: Undefined offset: 1/0 in /vagrant/vendor/magento/module-sales/Model/Order/Config.php on line 256`.

You can argue that M2 shouldn't take into consideration invalid DBs, and I would just slightly agree with you there, but, for such a small fix, why bother arguing that in the first place, eh? I've also added an un-related strict checking.
