### PR TITLE
Disabling the "required-entry" JS validation when it can't be removed (run-time disabling)

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -758,7 +758,10 @@ define([
             }, $.mage.__('Please enter issue number or start date for switch/solo card type.')
         ],
         'required-entry': [
-            function(value) {
+            function(value, mandatoryCheck) {
+                if (mandatoryCheck === false) {
+                    return true;
+                }                
                 return !utils.isEmpty(value);
             }, $.mage.__('This is a required field.')
         ],


### PR DESCRIPTION
Currently, the `required-entry` JS validation is always active, because it's assumed that, whenever it exists, it should be checked.

But there are cases when it's harder (or impossible) to remove the said validation, e.g. via UIComponents XML:

``` xml
<item name="telephone" xsi:type="array">
    <item name="validation" xsi:type="array">
        <item name="required-entry" xsi:type="boolean">false</item>
    </item>
</item>
```

The above snippet will **not** work in checkout, although the system passes the second boolean `false` param to the [validator](https://github.com/magento/magento2/blob/a5fa3af3b16bb03dcc01068aed0c58d8993fd092/app/code/Magento/Ui/view/base/web/js/lib/validation/validator.js#L36).

By having the second param, the required validator **can** be disabled at run-time.

**Only** if the second param is boolean `false`, the check is omitted. For other values, like `true` or even `undefined`, the check is still made, so it acts as a default, to keep BC.
