### PR TITLE
Fix wishlist/cart/compare race condition

### DIFF
--- a/lib/web/mage/dataPost.js
+++ b/lib/web/mage/dataPost.js
@@ -7,7 +7,8 @@
 define([
     "jquery",
     "mage/template",
-    "jquery/ui"
+    "jquery/ui",
+    "Magento_Customer/js/customer-data"
 ], function($,mageTemplate){
     
     $.widget('mage.dataPost', {


### PR DESCRIPTION
Currently Mage_Customer, is expecting to catch ajaxCompletes and submits, if it loads too late however it can't do that, causing the cache not to be invalidated and failing to update the required sections.
