### PR TITLE
Fix #4430 (wrong exception raising during URL Rewrites saving process).

### DIFF
--- a/app/code/Magento/UrlRewrite/Model/Storage/AbstractStorage.php
+++ b/app/code/Magento/UrlRewrite/Model/Storage/AbstractStorage.php
@@ -79,13 +79,7 @@ abstract class AbstractStorage implements StorageInterface
             return;
         }
 
-        try {
-            $this->doReplace($urls);
-        } catch (\Magento\Framework\Exception\AlreadyExistsException $e) {
-            throw new \Magento\Framework\Exception\AlreadyExistsException(
-                __('URL key for specified store already exists.')
-            );
-        }
+        $this->doReplace($urls);
     }
 
     /**


### PR DESCRIPTION
This PR is intended to fix the #4430 issue.

The problematic double exception raising is deleted since it should be manage by the `::doReplace` method as mentioned in its PHPDoc and as implemented into the `Magento\UrlRewrite\Model\Storage\DbStorage` class. 

The exception handling in `::doReplace` provides enough guarantees to avoid duplicate url keys.

I suspect some kind of bug into the PHP engine (tested with PHP 7.0.6) since the original code seems valid to me but I was not able to figure what was wrong.
