### PR TITLE
Wrong parameters for LogicException

### DIFF
--- a/app/code/Magento/Email/Model/AbstractTemplate.php
+++ b/app/code/Magento/Email/Model/AbstractTemplate.php
@@ -352,7 +352,7 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
             $result = $processor->filter($this->getTemplateText());
         } catch (\Exception $e) {
             $this->cancelDesignConfig();
-            throw new \LogicException(__($e->getMessage()), $e);
+            throw new \LogicException(__($e->getMessage()), $e->getCode(), $e);
         }
         if ($isDesignApplied) {
             $this->cancelDesignConfig();


### PR DESCRIPTION
One of our clients got this error.
PHP Fatal error:  Uncaught Error: Wrong parameters for LogicException([string $message [, long $code [, Throwable $previous = NULL]]]) 

The second argument should be the exception code, not the previous exception
