### PR TITLE
Fix runner for JsTestDriver based tests on OS X

### DIFF
--- a/dev/tests/js/JsTestDriver/run_js_tests.php
+++ b/dev/tests/js/JsTestDriver/run_js_tests.php
@@ -30,6 +30,8 @@ if (isset($config['Browser'])) {
 } else {
     if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
         $browser = 'C:\Program Files (x86)\Mozilla Firefox\firefox.exe';
+    } elseif (PHP_OS === 'Darwin') {
+        $browser = '/Applications/Firefox.app/Contents/MacOS/firefox';
     } else {
         $browser = exec('which firefox');
     }


### PR DESCRIPTION
This PR introduces two changes:
1. Do not use Xvfb when running the tests on OS X
2. Use the correct path to the firefox executable under OS X
## Background

Only applications compiled for X11 can use Xvfb to run in headless mode, since actually it's not the browsers running in headless mode but the X11 server.
Firefox (or Chrome or Safari) on OS X do not use X11 but Aqua. This means they can not run in headless mode.
It is possible to install Xvfb on OS X using the XQuartz project, but even then the browsers will not use the headless X11 server.
It is possible to compile Firefox on OS X to use X11, but that is quite involved and should not be required to run the JS tests.
Under OS X the JsTestRunner should simply start an instance of Firefox in the background and run the tests.
