### PR TITLE
Add underscore as dependency to quote.js

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js
@@ -3,8 +3,14 @@
  * See COPYING.txt for license details.
  */
 define(
-    ['ko'],
-    function (ko) {
+    [
+        'ko',
+        'underscore'
+    ],
+    function (
+        ko,
+        _
+    ) {
         'use strict';
         var billingAddress = ko.observable(null);
         var shippingAddress = ko.observable(null);


### PR DESCRIPTION
Underscore is used in `Magento_Checkout/view/frontend/web/js/model/quote.js` file, but it's not added as dependency.
