### PR TITLE
Rename $websiteId to $scopeId

### DIFF
--- a/app/code/Magento/CatalogInventory/Helper/Stock.php
+++ b/app/code/Magento/CatalogInventory/Helper/Stock.php
@@ -82,8 +82,8 @@ class Stock
     public function assignStatusToProduct(Product $product, $status = null)
     {
         if ($status === null) {
-            $websiteId = $this->getStockConfiguration()->getDefaultScopeId();
-            $stockStatus = $this->stockRegistryProvider->getStockStatus($product->getId(), $websiteId);
+            $scopeId = $this->getStockConfiguration()->getDefaultScopeId();
+            $stockStatus = $this->stockRegistryProvider->getStockStatus($product->getId(), $scopeId);
             $status = $stockStatus->getStockStatus();
         }
         $product->setIsSalable($status);
@@ -98,10 +98,10 @@ class Stock
      */
     public function addStockStatusToProducts(AbstractCollection $productCollection)
     {
-        $websiteId = $this->getStockConfiguration()->getDefaultScopeId();
+        $scopeId = $this->getStockConfiguration()->getDefaultScopeId();
         foreach ($productCollection as $product) {
             $productId = $product->getId();
-            $stockStatus = $this->stockRegistryProvider->getStockStatus($productId, $websiteId);
+            $stockStatus = $this->stockRegistryProvider->getStockStatus($productId, $scopeId);
             $status = $stockStatus->getStockStatus();
             $product->setIsSalable($status);
         }


### PR DESCRIPTION
This is a definition of the "\Magento\CatalogInventory\Model\Spi\StockRegistryProviderInterface::getStockStatus" method:

```
/**
 * @param int $productId
 * @param int $scopeId
 * @return \Magento\CatalogInventory\Api\Data\StockStatusInterface
 */
public function getStockStatus($productId, $scopeId);
```

Wrong variable name was used for this data in the file Stock.php
