### PR TITLE
Fix multiple value separator for additional_images product import

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php
@@ -15,6 +15,8 @@ class Media extends AbstractImportValidator implements RowValidatorInterface
     const PATH_REGEXP = '#^(?!.*[\\/]\.{2}[\\/])(?!\.{2}[\\/])[-\w.\\/]+$#';
 
     const ADDITIONAL_IMAGES = 'additional_images';
+    
+    const ADDITIONAL_IMAGES_DELIMITER = ',';
 
     /** @var array */
     protected $mediaAttributes = ['image', 'small_image', 'thumbnail'];
@@ -102,7 +104,7 @@ class Media extends AbstractImportValidator implements RowValidatorInterface
     /**
      * @return string
      */
-    protected function getMultipleValueSeparator()
+    private function getMultipleValueSeparator()
     {
         return $this->context->getMultipleValueSeparator();
     }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php
@@ -16,8 +16,6 @@ class Media extends AbstractImportValidator implements RowValidatorInterface
 
     const ADDITIONAL_IMAGES = 'additional_images';
 
-    const ADDITIONAL_IMAGES_DELIMITER = ',';
-
     /** @var array */
     protected $mediaAttributes = ['image', 'small_image', 'thumbnail'];
 
@@ -83,7 +81,7 @@ class Media extends AbstractImportValidator implements RowValidatorInterface
             }
         }
         if (isset($value[self::ADDITIONAL_IMAGES]) && strlen($value[self::ADDITIONAL_IMAGES])) {
-            foreach (explode(self::ADDITIONAL_IMAGES_DELIMITER, $value[self::ADDITIONAL_IMAGES]) as $image) {
+            foreach (explode($this->getMultipleValueSeparator(), $value[self::ADDITIONAL_IMAGES]) as $image) {
                 if (!$this->checkPath($image) && !$this->checkValidUrl($image)) {
                     $this->_addMessages(
                         [
@@ -99,5 +97,13 @@ class Media extends AbstractImportValidator implements RowValidatorInterface
             }
         }
         return $valid;
+    }
+    
+    /**
+     * @return string
+     */
+    protected function getMultipleValueSeparator()
+    {
+        return $this->context->getMultipleValueSeparator();
     }
 }


### PR DESCRIPTION
When importing product, the multiple value separator for additional_images data is hardcoded in constant.
