### PR TITLE
Fix overwrite default value image/file with NULL

### DIFF
--- a/app/code/Magento/Config/Model/Config/Backend/File.php
+++ b/app/code/Magento/Config/Model/Config/Backend/File.php
@@ -109,6 +109,8 @@ class File extends \Magento\Framework\App\Config\Value
         } else {
             if (is_array($value) && !empty($value['delete'])) {
                 $this->setValue('');
+            } elseif (is_array($value) && !empty($value['value'])) {
+                $this->setValue($value['value']);
             } else {
                 $this->unsValue();
             }


### PR DESCRIPTION
## Steps to reproduce
1. Install Magento from `develop` branch.
2. Add config field with type `image`.
3. Add default config value for that field.
4. Save the config field without uploading a new file.
## Expected result
1. New record created in the database table `core_config_data` with default value.
## Actual result
1. New record created in the database table `core_config_data` with value NULL.

If you set a default value for a config field type image/file and you save it. It won't set the default value in the database. Instead it will save NULL and so overwrite the default config.

With this change the default value will be set as value.
