### PR TITLE
Fix integration test expectation to match count of countries in the database

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Form/AddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Form/AddressTest.php
@@ -24,11 +24,13 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     /**
      * @return int
      */
-    private function getNumberOfCountries()
+    private function getNumberOfCountryOptions()
     {
-        /** @var \Magento\Directory\Api\CountryInformationAcquirerInterface $countryInfo */
-        $countryInfo = $this->_objectManager->create(\Magento\Directory\Api\CountryInformationAcquirerInterface::class);
-        return count($countryInfo->getCountriesInfo());
+        /** @var \Magento\Directory\Model\ResourceModel\Country\Collection $countryCollection */
+        $countryCollection = $this->_objectManager->create(
+            \Magento\Directory\Model\ResourceModel\Country\Collection::class
+        );
+        return count($countryCollection->toOptionArray());
     }
 
     protected function setUp()
@@ -192,7 +194,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
 
         /** @var \Magento\Framework\Data\Form\Element\Select $countryIdField */
         $countryIdField = $fieldset->getElements()->searchById('country_id');
-        $this->assertSelectCount('option', $this->getNumberOfCountries(), $countryIdField->getElementHtml());
+        $this->assertSelectCount('option', $this->getNumberOfCountryOptions(), $countryIdField->getElementHtml());
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Form/AddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Form/AddressTest.php
@@ -21,6 +21,16 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     /** @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Customer\Api\AddressRepositoryInterface */
     protected $addressRepository;
 
+    /**
+     * @return int
+     */
+    private function getNumberOfCountries()
+    {
+        /** @var \Magento\Directory\Api\CountryInformationAcquirerInterface $countryInfo */
+        $countryInfo = $this->_objectManager->create(\Magento\Directory\Api\CountryInformationAcquirerInterface::class);
+        return count($countryInfo->getCountriesInfo());
+    }
+
     protected function setUp()
     {
         $this->_objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
@@ -182,7 +192,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
 
         /** @var \Magento\Framework\Data\Form\Element\Select $countryIdField */
         $countryIdField = $fieldset->getElements()->searchById('country_id');
-        $this->assertSelectCount('option', 246, $countryIdField->getElementHtml());
+        $this->assertSelectCount('option', $this->getNumberOfCountries(), $countryIdField->getElementHtml());
     }
 
     /**


### PR DESCRIPTION
This PR applies to the 2.1.0-rc3 and develop branches.  
It probably already is fixed upstream though since it is a simple test failure due to a hardcoded expectation that actually is a value from the database.  

**Details:**
The number of countries in the database seems to have changed.  
The test `\Magento\Sales\Block\Adminhtml\Order\Create\Form\AddressTest::testGetForm()` hardcoded the expected number of options in the country select to 246.  
The number of records created in that table by `\Magento\Directory\Setup\InstallData::install()` is 245.  
This PR adjusts the test so it expects the number of options in the select to match the number countries in the system country directory.
