### PR TITLE
Fixes invalid json objects in the order email templates.

### DIFF
--- a/app/code/Magento/Sales/view/frontend/email/order_new.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new.html
@@ -12,7 +12,7 @@
 "layout handle=\"sales_email_order_items\" order=$order area=\"frontend\"":"Order Items Grid",
 "var payment_html|raw":"Payment Details",
 "var formattedShippingAddress|raw":"Shipping Address",
-"var order.getShippingDescription()":"Shipping Description"
+"var order.getShippingDescription()":"Shipping Description",
 "var shipping_msg":"Shipping message"
 } @-->
 

--- a/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
@@ -14,7 +14,7 @@
 "layout handle=\"sales_email_order_items\" order=$order":"Order Items Grid",
 "var payment_html|raw":"Payment Details",
 "var formattedShippingAddress|raw":"Shipping Address",
-"var order.getShippingDescription()":"Shipping Description"
+"var order.getShippingDescription()":"Shipping Description",
 "var shipping_msg":"Shipping message"
 } @-->
 {{template config_path="design/email/header_template"}}

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/order_new.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/order_new.html
@@ -12,7 +12,7 @@
 "layout handle=\"sales_email_order_items\" order=$order area=\"frontend\"":"Order Items Grid",
 "var payment_html|raw":"Payment Details",
 "var formattedShippingAddress|raw":"Shipping Address",
-"var order.getShippingDescription()":"Shipping Description"
+"var order.getShippingDescription()":"Shipping Description",
 "var shipping_msg":"Shipping message"
 } @-->
 

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/order_new_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/order_new_guest.html
@@ -14,7 +14,7 @@
 "layout handle=\"sales_email_order_items\" order=$order":"Order Items Grid",
 "var payment_html|raw":"Payment Details",
 "var formattedShippingAddress|raw":"Shipping Address",
-"var order.getShippingDescription()":"Shipping Description"
+"var order.getShippingDescription()":"Shipping Description",
 "var shipping_msg":"Shipping message"
 } @-->
 {{template config_path="design/email/header_template"}}


### PR DESCRIPTION
This fixes a regression introduced in Magento 2.1-rc1.
Because of the invalid json objects, these email templates couldn't be loaded anymore in the backend of Magento.
Fixes #5101
