### PR TITLE
\Magento\CatalogInventory\Model\Stock\Status->getStockId() to return correct value

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Stock/Status.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Status.php
@@ -99,7 +99,7 @@ class Status extends AbstractExtensibleModel implements StockStatusInterface
      */
     public function getStockId()
     {
-        return $this->getData(self::KEY_WEBSITE_ID);
+        return $this->getData(self::KEY_STOCK_ID);
     }
 
     /**

--- a/app/code/Magento/CatalogInventory/Model/Stock/Status.php
+++ b/app/code/Magento/CatalogInventory/Model/Stock/Status.php
@@ -78,6 +78,7 @@ class Status extends AbstractExtensibleModel implements StockStatusInterface
     }
 
     //@codeCoverageIgnoreStart
+
     /**
      * @return int
      */
@@ -128,6 +129,7 @@ class Status extends AbstractExtensibleModel implements StockStatusInterface
     }
 
     //@codeCoverageIgnoreStart
+
     /**
      * @param int $productId
      * @return $this


### PR DESCRIPTION
\Magento\CatalogInventory\Model\Stock\Status->getStockId() is returning the website id instead of the stock id.
