### PR TITLE
Change value-assignment to a setValue call

### DIFF
--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
@@ -93,7 +93,7 @@ $_colspan = $block->isAddAfter() ? 2 : 1;
             var rowInputElementNames = Object.keys(rowData.column_values);
             for (var i = 0; i < rowInputElementNames.length; i++) {
                 if ($(rowInputElementNames[i])) {
-                    $(rowInputElementNames[i]).value = rowData.column_values[rowInputElementNames[i]];
+                    $(rowInputElementNames[i]).setValue(rowData.column_values[rowInputElementNames[i]]);
                 }
             }
         }


### PR DESCRIPTION
Is there any reason not to use Prototype's setValue call instead of assignment?
Plain assignment breaks in case of a multiselect element. 
In case of multiselect, and an array in
rowData.column_values[rowInputElementNames[i]]
the first element of that array will be taken and assigned as the only selected value on a multiselect, which is clearly a broken behaviour.
Prototype's setValue call will handle this case properly without breaking compatibility.
