### PR TITLE
BugFix js-translation.json generation

### DIFF
--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -255,7 +255,9 @@ class Translate implements \Magento\Framework\TranslateInterface
         $allModulesExceptCurrent = array_diff($this->_moduleList->getNames(), [$currentModule]);
 
         $this->loadModuleTranslationByModulesList($allModulesExceptCurrent);
-        $this->loadModuleTranslationByModulesList([$currentModule]);
+        if ($currentModule !== null) {
+            $this->loadModuleTranslationByModulesList([$currentModule]);
+        }
         return $this;
     }
 


### PR DESCRIPTION
During the generation of js-translation.json, `$currentModule` is `null` and down the road it will try to load `/i18n/locale.csv`, causing an exception.
I had this error while in dev mode.
