### PR TITLE
Adminhtml sales view - Escape remoteIp

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/info.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/info.phtml
@@ -89,7 +89,7 @@ $orderStoreDate = $block->formatDate(
                 <?php if ($_order->getRemoteIp() && $block->shouldDisplayCustomerIp()): ?>
                     <tr>
                         <th><?php /* @escapeNotVerified */ echo __('Placed from IP') ?></th>
-                        <td><?php /* @escapeNotVerified */ echo $_order->getRemoteIp(); echo($_order->getXForwardedFor()) ? ' (' . $block->escapeHtml($_order->getXForwardedFor()) . ')' : ''; ?></td>
+                        <td><?php /* @escapeNotVerified */ echo $block->escapeHtml($_order->getRemoteIp()); echo($_order->getXForwardedFor()) ? ' (' . $block->escapeHtml($_order->getXForwardedFor()) . ')' : ''; ?></td>
                     </tr>
                 <?php endif; ?>
                 <?php if ($_order->getGlobalCurrencyCode() != $_order->getBaseCurrencyCode()): ?>


### PR DESCRIPTION
It is quite trivial to make the remoteIp field map to something other than the `REMOTE_ADDR` header. Adding the following to `app/etc/di.xml` will allow you to use `HTTP_X_FORWARDED_FOR` as the header you're interested in. With this change a customer can spoof their x forwarded header and inject javascript which will run when an admin views the order in the admin panel.

```
<type name="Magento\Framework\HTTP\PhpEnvironment\RemoteAddress">
    <arguments>
        <argument name="alternativeHeaders" xsi:type="array">
            <item name="http_x_forwarded_for" xsi:type="string">HTTP_X_FORWARDED_FOR</item>
        </argument>
    </arguments>
</type>
```

A developer may decide to make this change at some point when they want to force all calls to `RemoteAddress::getRemoteAddress()` to use the `X_FORWARDED_FOR` instead. Maybe they're working on a plugin that requires it, and have many proxies between the customer and the Magento server. Maybe they just want to hook into some useful related functionality. ¯_(ツ)_/¯

This vulnerability isn't in the wild for M2 as it requires specific developer changes but I know the plugin ecosystem for M1 had many strange modules, this small change should help protect us from future laziness/craziness.

Either way, this is easily preventable. Simply escaping the output with $block->escapeHtml() will do the trick.
