### PR TITLE
Added "strtolower" calls in Catalog Product Import Class

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2303,7 +2303,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                     || ($this->urlKeys[$storeId][$urlPath] == $rowData[self::COL_SKU])
                 ) {
                     $this->urlKeys[$storeId][$urlPath] = $rowData[self::COL_SKU];
-                    $this->rowNumbers[$storeId][$urlPath] = $rowNum;
+                    $this->rowNumbers[$storeId][strtolower($urlPath)] = $rowNum;
                 } else {
                     $this->addRowError(ValidatorInterface::ERROR_DUPLICATE_URL_KEY, $rowNum);
                 }
@@ -2474,7 +2474,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                     ->where('cpe.sku not in (?)', array_values($urlKeys))
             );
             foreach ($urlKeyDuplicates as $entityData) {
-                $rowNum = $this->rowNumbers[$entityData['store_id']][$entityData['request_path']];
+                $rowNum = $this->rowNumbers[$entityData['store_id']][strtolower($entityData['request_path'])];
                 $this->addRowError(ValidatorInterface::ERROR_DUPLICATE_URL_KEY, $rowNum);
             }
         }


### PR DESCRIPTION
Added "strtolower" calls in **Magento\CatalogImportExport\Model\Import\Product** class when appending to _**$this->rowNumbers**_ array in _**validateRow()**_ method and also when retrieving the Row Number value from the _**$this->rowNumbers**_ array in the _**checkUrlKeyDuplicates()**_ method
