### PR TITLE
Catch Exception when editing product and media file is not available

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
@@ -132,8 +132,12 @@ class Content extends \Magento\Backend\Block\Widget
             $images = $this->sortImagesByPosition($value['images']);
             foreach ($images as &$image) {
                 $image['url'] = $this->_mediaConfig->getMediaUrl($image['file']);
-                $fileHandler = $directory->stat($this->_mediaConfig->getMediaPath($image['file']));
-                $image['size'] = $fileHandler['size'];
+                try {
+                    $fileHandler = $directory->stat($this->_mediaConfig->getMediaPath($image['file']));
+                    $image['size'] = $fileHandler['size'];
+                } catch(\Magento\Framework\Exception\FileSystemException $e) {
+                    $image['size'] = 0;
+                }
             }
             return $this->_jsonEncoder->encode($images);
         }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
@@ -135,7 +135,7 @@ class Content extends \Magento\Backend\Block\Widget
                 try {
                     $fileHandler = $directory->stat($this->_mediaConfig->getMediaPath($image['file']));
                     $image['size'] = $fileHandler['size'];
-                } catch(\Magento\Framework\Exception\FileSystemException $e) {
+                } catch (\Magento\Framework\Exception\FileSystemException $e) {
                     $image['size'] = 0;
                 }
             }


### PR DESCRIPTION
When working on projects locally as a developer, you don't always have all media available, not catching the exception here prevents you from editing the product if an image is not available locally.

This is mostly an issue when working for multiple clients having to have all media on the local machine is very impractical.
