### PR TITLE
Update CatalogSearch Fulltext\Collection.php

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Fulltext/Collection.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Fulltext/Collection.php
@@ -270,6 +270,14 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
             $this->filterBuilder->setValue($condition);
             $this->searchCriteriaBuilder->addFilter($this->filterBuilder->create());
         } else {
+            if (array_key_exists('from', $condition)
+                && array_key_exists('to', $condition)
+                && empty($condition['from'])
+                && empty($condition['to'])) {
+                $this->filterBuilder->setField("{$field}.from");
+                $this->filterBuilder->setValue("0");
+                $this->searchCriteriaBuilder->addFilter($this->filterBuilder->create());
+            }
             if (!empty($condition['from'])) {
                 $this->filterBuilder->setField("{$field}.from");
                 $this->filterBuilder->setValue($condition['from']);


### PR DESCRIPTION
Fix the following bug: 
When only one product in catalog has a numeric attribute, layered navigation would not work on that attribute.
