### PR TITLE
Additional info not shown at customer/account/edit

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
@@ -26,6 +26,9 @@
         <?php if ($_gender->isEnabled()): ?>
             <?php echo $_gender->setGender($block->getCustomer()->getGender())->toHtml() ?>
         <?php endif ?>
+        
+        <?php echo $block->getChildHtml('form_additional_info'); ?>
+        
         <div class="field choice">
             <input type="checkbox" name="change_email" id="change-email" data-role="change-email" value="1" title="<?php /* @escapeNotVerified */ echo __('Change Email') ?>" class="checkbox" />
             <label class="label" for="change-email"><span><?php /* @escapeNotVerified */ echo __('Change Email') ?></span></label>
@@ -77,7 +80,6 @@
                     autocomplete="off" />
             </div>
         </div>
-        <?php echo $block->getChildHtml('form_additional_info'); ?>
     </fieldset>
     <div class="actions-toolbar">
         <div class="primary">


### PR DESCRIPTION
Block's call to form.additional.info is hidden within collapsed password fieldset.
