### PR TITLE
Make CMS directive filtering error be more generic

### DIFF
--- a/app/code/Magento/Email/Model/Template/Filter.php
+++ b/app/code/Magento/Email/Model/Template/Filter.php
@@ -971,7 +971,7 @@ class Filter extends \Magento\Framework\Filter\Template
             if ($this->_appState->getMode() == \Magento\Framework\App\State::MODE_DEVELOPER) {
                 $value = sprintf(__('Error filtering template: %s'), $e->getMessage());
             } else {
-                $value = __("We're sorry, an error has occurred while generating this email.");
+                $value = __("We're sorry, an error has occurred while generating this content.");
             }
             $this->_logger->critical($e);
         }


### PR DESCRIPTION
When a site is in production mode and a CMS widget has an error in processing, this error message will be displayed: `We're sorry, an error has occurred while generating this email.`

![12-44-06 about us-5shvt](https://cloud.githubusercontent.com/assets/129031/16462512/3b749c0a-3df7-11e6-842a-010dc847fd41.png)

Since the \Magento\Email\Model\Template\Filter::filter method is inherited by several CMS classes (`\Magento\Cms\Model\Template\Filter` and `\Magento\Widget\Model\Template\Filter`), the error message should be changed to something more generic. This pull request changes the error message to: `We're sorry, an error has occurred while generating this content.`
