### PR TITLE
Change pub/.htaccess MAGE_MODE comment

### DIFF
--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -2,7 +2,8 @@
 ## Optional override of deployment mode. We recommend you use the
 ## command bin/magento deploy:mode:set to switch modes instead
 
-#   SetEnv MAGE_MODE default # or production or developer
+    # Options are default, production, or developer
+#   SetEnv MAGE_MODE default
 
 ############################################
 ## Uncomment these lines for CGI mode.


### PR DESCRIPTION
In Magento 2.1, the `pub/.htaccess` file was changes to include a comment demonstrating how a developer could change the `MAGE_MODE` to any of the three modes:

```
#   SetEnv MAGE_MODE default # or production or developer
```

 This change was great, however simply uncommenting the line in the .htaccess file resulted in this line:

```
   SetEnv MAGE_MODE default # or production or developer
```

The line above results in an Apache Internal Server 500 error, as it is invalid. My pull request moves the comment above the commented-out command so that developers don't accidentally cause an error.
