### PR TITLE
Fix filesystem permission issues

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Driver/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/File.php
@@ -843,6 +843,13 @@ class File implements DriverInterface
      */
     public function getAbsolutePath($basePath, $path, $scheme = null)
     {
+        // check if the path given is already an absolute path containing the
+        // basepath. so if the basepath starts at position 0 in the path, we
+        // must not concatinate them again because path is already absolute.
+        if (0 === strpos($path, $basePath)) {
+            return $this->getScheme($scheme) . $path;
+        }
+
         return $this->getScheme($scheme) . $basePath . ltrim($this->fixSeparator($path), '/');
     }
 

--- a/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
@@ -213,6 +213,13 @@ class Http extends File
      */
     public function getAbsolutePath($basePath, $path, $scheme = null)
     {
+        // check if the path given is already an absolute path containing the
+        // basepath. so if the basepath starts at position 0 in the path, we
+        // must not concatinate them again because path is already absolute.
+        if (0 === strpos($path, $basePath)) {
+            return $this->getScheme() . $path;
+        }
+
         return $this->getScheme() . $basePath . $path;
     }
 

--- a/lib/internal/Magento/Framework/Filesystem/Test/Unit/Driver/FileTest.php
+++ b/lib/internal/Magento/Framework/Filesystem/Test/Unit/Driver/FileTest.php
@@ -30,14 +30,14 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $file = new File();
         $this->assertEquals($expected, $file->getAbsolutePath($basePath, $path));
     }
-    
+
     public function dataProviderForTestGetAbsolutePath()
     {
         return [
             ['/root/path/', 'sub', '/root/path/sub'],
             ['/root/path/', '/sub', '/root/path/sub'],
             ['/root/path/', '../sub', '/root/path/../sub'],
-            ['/root/path/', '/root/path/sub', '/root/path/root/path/sub'],
+            ['/root/path/', '/root/path/sub', '/root/path/sub'],
         ];
     }
 


### PR DESCRIPTION
When you have configured some strict filesystem permissions to only allow the minimum required write access to the magento application there are some issues

for example:

we have an existing robots.txt that is writable, but the parent directory is writable.

When you create a sitemap and have the option checked to automatically add it to the robots.txt file, everything goes south. Because the assertWritable checks if the parent directory is writable which is totally not nescessary because the file is writable.

Additionally there were some inconsistencies in the filesystem directory stuff.

And as an extra there is an extra check to avoid concatinating the absolute basepath with a path that is already absolute. (this could for example cause basepath='/var/www/website', path='/var/www/website/robots.txt' if you pass in both to get the aboslute path the result would be '/var/www/website/var/www/website/robots.txt' which was not the goal, now it wil properly return '/var/www/website/robots.txt')

It would be nice to have these fixes backported to 2.0 and 2.1 because we have this sort of issues in our production environments at the moment.
