### PR TITLE
Enable the HTTP ClientInterface as well as the Curl and Socket implementations of that interface to POST string payloads

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -223,7 +223,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
      * Make POST request
      *
      * @param string $uri
-     * @param array $params
+     * @param array|string $params
      * @return void
      *
      * @see \Magento\Framework\HTTP\Client#post($uri, $params)
@@ -329,7 +329,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
      * Make request
      * @param string $method
      * @param string $uri
-     * @param array $params
+     * @param array|string $params
      * @return void
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
@@ -339,8 +339,10 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
         $this->_ch = curl_init();
         $this->curlOption(CURLOPT_URL, $uri);
         if ($method == 'POST') {
+            $isQuery = is_object($params) || is_array($params);
+            $body = $isQuery ? http_build_query($params) : $params;
             $this->curlOption(CURLOPT_POST, 1);
-            $this->curlOption(CURLOPT_POSTFIELDS, http_build_query($params));
+            $this->curlOption(CURLOPT_POSTFIELDS, $body);
         } elseif ($method == "GET") {
             $this->curlOption(CURLOPT_HTTPGET, 1);
         } else {

--- a/lib/internal/Magento/Framework/HTTP/Client/Socket.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Socket.php
@@ -472,18 +472,22 @@ class Socket implements \Magento\Framework\HTTP\ClientInterface
         $isPost = $method == "POST";
 
         $appendHeaders = [];
-        $paramsStr = false;
+        $body = false;
         if ($isPost && count($params)) {
-            $paramsStr = http_build_query($params);
-            $appendHeaders['Content-type'] = 'application/x-www-form-urlencoded';
-            $appendHeaders['Content-length'] = strlen($paramsStr);
+            $isQuery = is_object($params) || is_array($params);
+            $body = $isQuery ? http_build_query($params) : $params;
+
+            if ($isQuery) {
+                $appendHeaders['Content-type'] = 'application/x-www-form-urlencoded';
+            }
+            $appendHeaders['Content-length'] = strlen($body);
         }
 
         $out = "{$method} {$uri} HTTP/1.1{$crlf}";
         $out .= $this->headersToString($appendHeaders);
         $out .= $crlf;
-        if ($paramsStr) {
-            $out .= $paramsStr . $crlf;
+        if ($body) {
+            $out .= $body . $crlf;
         }
 
         fwrite($this->_sock, $out);

--- a/lib/internal/Magento/Framework/HTTP/ClientInterface.php
+++ b/lib/internal/Magento/Framework/HTTP/ClientInterface.php
@@ -99,7 +99,7 @@ interface ClientInterface
      * Make POST request
      *
      * @param string $uri full uri
-     * @param array $params POST fields array
+     * @param array|string $params POST fields array, or POST body
      * @return void
      */
     public function post($uri, $params);


### PR DESCRIPTION
As of now the ClientInterface and it's implementations in the Magento2 framework do not support sending a string payload in a POST request.

It is very common for third party REST APIs to demand a JSON payload of data in a request, as opposed to form post.

This PR adds that ability by extending the existing `post` method to accept a string in such a way that does not break existing compatibility.  

I could not find any existing tests that covered this part of the framework, and am uncertain of how to create tests for it.
