### PR TITLE
#5236 fixes "The configuration parameter "componentType" is a required for "advanced_pricing_button" component"

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePrice.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePrice.php
@@ -92,7 +92,10 @@ class ConfigurablePrice extends AbstractModifier
                             self::$advancedPricingButton => [
                                 'arguments' => [
                                     'data' => [
-                                        'config' => $visibilityConfig,
+                                        'config' => [
+                                            'componentType' => 'container',
+                                            $visibilityConfig
+                                        ],
                                     ],
                                 ],
                             ],


### PR DESCRIPTION
fixes "The configuration parameter "componentType" is a required for "advanced_pricing_button" component"
