### PR TITLE
Fallback to project root directory when no path is resolved for i18n context

### DIFF
--- a/setup/src/Magento/Setup/Module/I18n/Context.php
+++ b/setup/src/Magento/Setup/Module/I18n/Context.php
@@ -111,6 +111,9 @@ class Context
             default:
                 throw new \InvalidArgumentException(sprintf('Invalid context given: "%s".', $type));
         }
+        if (!$path) {
+            $path = BP;
+        }
         return $path . '/' . self::LOCALE_DIRECTORY . '/';
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/ContextTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/ContextTest.php
@@ -121,7 +121,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
                 [Context::CONTEXT_TYPE_MODULE, 'Magento_Module'],
                 [[ComponentRegistrar::MODULE, 'Magento_Module', BP . '/app/code/Magento/Module']]
             ],
-            ['/i18n/', [Context::CONTEXT_TYPE_THEME, 'theme/test.phtml'], []],
+            [BP . '/i18n/', [Context::CONTEXT_TYPE_THEME, 'theme/test.phtml'], []],
             [BP . '/lib/web/i18n/', [Context::CONTEXT_TYPE_LIB, 'lib/web/module/test.phtml'], []],
         ];
     }


### PR DESCRIPTION
When unable to resolving the path for a module, the server root directory was used instead of the project root.

For me this was a problem when running `bin/magento i18n:pack`. For the module Magento_AdminGws, no path could be resolved, returned `null` and therefor the path resolved to /i18n.
