### PR TITLE
Make JS jasmine tests usable for third-party developers

### DIFF
--- a/dev/tests/js/jasmine/spec_runner/index.js
+++ b/dev/tests/js/jasmine/spec_runner/index.js
@@ -53,7 +53,10 @@ function init(grunt, options) {
     tasks = Object.keys(themes);
 
     config.themes = themes;
-
+    
+    config.filter = grunt.option('filter');
+    config.filter && grunt.option('filter', null);
+    
     enableTasks(grunt, config);
 }
 

--- a/dev/tests/js/jasmine/spec_runner/settings.json
+++ b/dev/tests/js/jasmine/spec_runner/settings.json
@@ -8,7 +8,7 @@
      * This node is replaced by formatted theme configuration by 'dev/tests/jasmine/spec_runner' module
      */
     "themes": "dev/tools/grunt/configs/themes",
-    
+
     "files": {
         /**
          * Path to RequireJS library. Relative to "server.base" config.
@@ -40,6 +40,10 @@
             "<%= root %>/tests/lib/**/*.test.js",
             "<%= root %>/tests/app/code/**/base/**/*.test.js",
             "<%= root %>/tests/app/code/**/<%= area %>/**/*.test.js",
+            "app/code/**/Test/Js/base/**/*.test.js",
+            "app/code/**/Test/Js/<%= area %>/**/*.test.js",
+            "vendor/*/module-**/Test/Js/base/**/*.test.js",
+            "vendor/*/module-**/Test/Js/<%= area %>/**/*.test.js",
             "<%= root %>/tests/app/design/<%= area %>/<%= name %>/**/*.test.js"
         ]
     },
@@ -56,6 +60,8 @@
         "serveAsIs": [
             "^\/_SpecRunner.html",
             "^\/dev\/tests",
+            "^\/app\/code\/.+\/Test\/Js",
+            "^\/vendor\/.+\/Test\/Js",
             "^\/.grunt",
             "^\/pub\/static"
         ],

--- a/dev/tests/js/jasmine/spec_runner/tasks/jasmine.js
+++ b/dev/tests/js/jasmine/spec_runner/tasks/jasmine.js
@@ -22,13 +22,18 @@ function init(config) {
     _.each(themes, function (themeData, themeName) {
         var specs,
             configs,
-            render;
+            render,
+            filter;
 
         _.extend(themeData, { root: root });
 
+        filter = new RegExp(config.filter);
+
         render  = renderTemplate.bind(null, themeData);
         specs   = files.specs.map(render);
-        specs   = expand(specs).map(cutJsExtension);
+        specs   = expand(specs).map(cutJsExtension).filter(function(spec) {
+            return filter.test(spec);
+        });
         configs = files.requirejsConfigs.map(render);
 
         tasks[themeName] = {

--- a/package.json.sample
+++ b/package.json.sample
@@ -18,7 +18,7 @@
         "grunt-contrib-connect": "^0.9.0",
         "grunt-contrib-cssmin": "^0.10.0",
         "grunt-contrib-imagemin": "^0.9.2",
-        "grunt-contrib-jasmine": "^0.8.1",
+        "grunt-contrib-jasmine": "^1.0.0",
         "grunt-contrib-less": "^0.12.0",
         "grunt-contrib-watch": "^0.6.1",
         "grunt-eslint": "17.3.1",


### PR DESCRIPTION
This PR does 3 related things:
- Fix dependency on broken grunt-jasmine-contrib version (see #5044 and #5091)
- Add option to apply --filter to jasmine specs (even though they are 'helpers' not 'specs')
  This allows to run only selected tests, bypassing the currently broken core tests.
- Allow jasmine tests to reside in `app/code/**/Test/Js` and `vendor/module-**/Test/Js`
  This allows third party modules to include jasmine specs to be executed during CI

Example of using `--filter`:

``` bash
$ cp package.json.sample package.json && cp Gruntfile.js.sample Gruntfile.js
$ npm install
$ bin/magento setup:static-content:deploy
$ grunt spec --filter "ThirdParty/Example|PageCache"
```

This example invocation executes all jasmine tests from the modules ThirdParty/Example and the PageCache module.

I'm not aware of any backward compatibility being broken by this PR.

Fixes #5044.
