### PR TITLE
Fixes #5495 (Mobile navigation submenus need two clicks to open)

### DIFF
--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -390,7 +390,6 @@ define([
             
             return setTimeout(handlerProxy, delay || 0);
         },
-        ,
         expand: function( event ) {
             var newItem = this.active &&
                 this.active

--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -272,6 +272,9 @@ define([
                     if (!target.hasClass('level-top') || !target.has(".ui-menu").length) {
                         window.location.href = target.find('> a').attr('href');
                     }
+                },
+                "click .ui-menu-item:has(.ui-state-active)": function (event) {
+                    this.collapseAll(event, true);
                 }
             });
 
@@ -386,6 +389,40 @@ define([
             };
             
             return setTimeout(handlerProxy, delay || 0);
+        },
+        ,
+        expand: function( event ) {
+            var newItem = this.active &&
+                this.active
+                    .children( ".ui-menu " )
+                    .children( ".ui-menu-item" )
+                    .first();
+
+            if ( newItem && newItem.length ) {
+                if (newItem.closest( ".ui-menu" ).is( ":visible" )
+                    && newItem.closest( ".ui-menu" ).has( ".all-categories" )
+                ) {
+                    return;
+                }
+
+                this._open( newItem.parent() );
+
+                // Delay so Firefox will not hide activedescendant change in expanding submenu from AT
+                this._delay(function() {
+                    this.focus( event, newItem );
+                });
+            }
+        },
+        select: function( event ) {
+            this.active = this.active || $( event.target ).closest( ".ui-menu-item" );
+            if (this.active.is( ".all-category" )) {
+                this.active = $( event.target ).closest( ".ui-menu-item" );
+            }
+            var ui = { item: this.active };
+            if ( !this.active.has( ".ui-menu" ).length ) {
+                this.collapseAll( event, true );
+            }
+            this._trigger( "select", event, ui );
         }
     });
 


### PR DESCRIPTION
method `select` is overwritten to shift `this.active` from the `.all-categories` link to the clicked menu node. After opening a menu item `this.active` is filled with the `.all-categories` link and the `select` method does not expect that. It closes all menu items and skips the activation of the selected menu item.

A `collapseAll` event is triggered for mobile devices if an open menu item is clicked so it closes it again.
method `expand` is overwritten to skip expansion of the clicked menu node of the menu node was already open. This event would otherwise take place directly after the added `collapseAll`.

Although this is a working solution it does rewrite two major methods of the jQuery UI menu which I feel should not be necessary. So if someone would like to look into a different solution, be welcome.
