### PR TITLE
Fix error with the WYSIWYG and Greek characters

### DIFF
--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
@@ -78,6 +78,7 @@ define([
             }
 
             var settings = {
+                entity_encoding: 'raw',
                 mode: (mode != undefined ? mode : 'none'),
                 elements: this.id,
                 theme: 'advanced',


### PR DESCRIPTION
This commit aims to be a fix to the error with the WYSIWYG editor (TinyMCE) that not store properly non latin characters (i.e. Greek letters).

Solution comes from http://stackoverflow.com/questions/33043516/magento-greek-characters-as-html-entities
