### PR TITLE
Fixed position of validation messages for swatches

### DIFF
--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -280,11 +280,6 @@ define([
                         '<span class="' + classes.attributeSelectedOptionLabelClass + '"></span>';
                 }
 
-                if ($widget.productForm) {
-                    $widget.productForm.append(input);
-                    input = '';
-                }
-
                 // Create new control
                 container.append(
                     '<div class="' + classes.attributeClass + ' ' + item.code +
@@ -296,6 +291,9 @@ define([
                         '</div>' + input +
                     '</div>'
                 );
+
+                container.append(input);
+                input = '';
 
                 $widget.optionsMap[item.id] = {};
 


### PR DESCRIPTION
This is the fix for the following issue:

Steps to Reproduce:
- Create a configurable product based on ~ 2 swatch attributes
- Opend created product on frontend
- Do not select any swatches
- Click "Add to cart" button

Actual Result:
"This is required field" messages appears under "Add to cart" button

Expected Result:
Validation messages should appear under corresponding swatches
