### PR TITLE
Fix minicart not cleared after order completion

### DIFF
--- a/app/code/Magento/Persistent/Model/QuoteManager.php
+++ b/app/code/Magento/Persistent/Model/QuoteManager.php
@@ -106,6 +106,7 @@ class QuoteManager
     public function expire()
     {
         $quote = $this->checkoutSession->setLoadInactive()->getQuote();
+        $this->checkoutSession->setLoadInactive(false);
         if ($quote->getIsActive() && $quote->getCustomerId()) {
             $this->checkoutSession->setCustomerData(null)->clearQuote()->clearStorage();
         } else {


### PR DESCRIPTION
Fixes #4460 Fixes #4416 Fixes #1461 Fixes #4969 Fixes MAGETWO-52593

This method is executed on `controller_action_predispatch`. The outcome of the following controller will be affected by leaving `$this->checkoutSession->setLoadInactive` set `true`.

After placing an order the `customer/section/load` page is called from the checkout overview page to update the minicart and messages sections. Because of the `controller_action_predispatch` and the passing of all checks in `\Magento\Persistent\Observer\CheckExpirePersistentQuoteObserver::execute` `setLoadInactive` is left set to true and the expired quote is loaded one more time in the minicart, resulting in expired quote data the browser storage for the success page to display.

By the way, I saw this comment:

``` php
!$observer->getControllerAction() instanceof \Magento\Checkout\Controller\Onepage
// persistent session does not expire on onepage checkout page to not spoil customer group id
```

customer/section/load is not a checkout onepage controller, but it most certainly is called in the checkout. So the check in `\Magento\Persistent\Observer\CheckExpirePersistentQuoteObserver::execute` does not fully fill the gap the way the comment implies.
