### PR TITLE
Fulltext count is not the same as original count

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Fulltext/Collection.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Fulltext/Collection.php
@@ -344,8 +344,6 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
             []
         );
 
-        $this->_totalRecords = $this->searchResult->getTotalCount();
-
         if ($this->order && 'relevance' === $this->order['field']) {
             $this->getSelect()->order('search_result.'. TemporaryStorage::FIELD_SCORE . ' ' . $this->order['dir']);
         }


### PR DESCRIPTION
Fulltext results count can be more than original select results count (joinInner is used). Leave `$this->_totalRecords` empty to initialize later, after actual data have been loaded.
