### PR TITLE
Disabled Output of Magento_Review leads to LocalizedException

### DIFF
--- a/app/code/Magento/Review/Test/Unit/Ui/DataProvider/Product/Form/Modifier/ReviewTest.php
+++ b/app/code/Magento/Review/Test/Unit/Ui/DataProvider/Product/Form/Modifier/ReviewTest.php
@@ -30,7 +30,8 @@ class ReviewTest extends AbstractModifierTest
         parent::setUp();
         $this->urlBuilderMock = $this->getMockBuilder(UrlInterface::class)
             ->getMockForAbstractClass();
-        $this->moduleManager = $this->getMockBuilder(Manager::class);
+        $this->moduleManager = $this->getMockBuilder(Manager::class)
+            ->getMock();
     }
 
     protected function createModel()

--- a/app/code/Magento/Review/Test/Unit/Ui/DataProvider/Product/Form/Modifier/ReviewTest.php
+++ b/app/code/Magento/Review/Test/Unit/Ui/DataProvider/Product/Form/Modifier/ReviewTest.php
@@ -30,8 +30,13 @@ class ReviewTest extends AbstractModifierTest
         parent::setUp();
         $this->urlBuilderMock = $this->getMockBuilder(UrlInterface::class)
             ->getMockForAbstractClass();
-        $this->moduleManager = $this->getMockBuilder(Manager::class)
-            ->getMock();
+        $this->moduleManager = $this->getMock(
+            'Magento\Framework\Module\Manager',
+            [],
+            [],
+            '',
+            false
+        );
     }
 
     protected function createModel()

--- a/app/code/Magento/Review/Test/Unit/Ui/DataProvider/Product/Form/Modifier/ReviewTest.php
+++ b/app/code/Magento/Review/Test/Unit/Ui/DataProvider/Product/Form/Modifier/ReviewTest.php
@@ -94,10 +94,6 @@ class ReviewTest extends AbstractModifierTest
         $this->productMock->expects($this->exactly(3))
             ->method('getId')
             ->willReturn($productId);
-        $this->moduleManager->expects($this->exactly(3))
-            ->method('isOutputEnabled')
-            ->with('Magento_Review')
-            ->willReturn(1);
 
         $this->assertArrayHasKey($productId, $this->getModel()->modifyData([]));
         $this->assertArrayHasKey(Review::DATA_SOURCE_DEFAULT, $this->getModel()->modifyData([])[$productId]);

--- a/app/code/Magento/Review/Ui/DataProvider/Product/Form/Modifier/Review.php
+++ b/app/code/Magento/Review/Ui/DataProvider/Product/Form/Modifier/Review.php
@@ -10,8 +10,9 @@ namespace Magento\Review\Ui\DataProvider\Product\Form\Modifier;
  */
 use Magento\Catalog\Model\Locator\LocatorInterface;
 use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
-use Magento\Ui\Component\Form;
+use Magento\Framework\Module\Manager;
 use Magento\Framework\UrlInterface;
+use Magento\Ui\Component\Form;
 
 /**
  * Class Review
@@ -35,15 +36,24 @@ class Review extends AbstractModifier
     protected $urlBuilder;
 
     /**
+     * Module manager
+     *
+     * @var \Magento\Framework\Module\Manager
+     */
+    private $moduleManager;
+
+    /**
      * @param LocatorInterface $locator
      * @param UrlInterface $urlBuilder
      */
     public function __construct(
         LocatorInterface $locator,
-        UrlInterface $urlBuilder
+        UrlInterface $urlBuilder,
+        Manager $moduleManager
     ) {
         $this->locator = $locator;
         $this->urlBuilder = $urlBuilder;
+        $this->moduleManager = $moduleManager;
     }
 
     /**
@@ -51,7 +61,7 @@ class Review extends AbstractModifier
      */
     public function modifyMeta(array $meta)
     {
-        if (!$this->locator->getProduct()->getId()) {
+        if (!($this->locator->getProduct()->getId() && $this->moduleManager->isOutputEnabled('Magento_Review'))) {
             return $meta;
         }
 

--- a/app/code/Magento/Review/Ui/DataProvider/Product/Form/Modifier/Review.php
+++ b/app/code/Magento/Review/Ui/DataProvider/Product/Form/Modifier/Review.php
@@ -45,6 +45,7 @@ class Review extends AbstractModifier
     /**
      * @param LocatorInterface $locator
      * @param UrlInterface $urlBuilder
+     * @param Manager $moduleManager
      */
     public function __construct(
         LocatorInterface $locator,


### PR DESCRIPTION
If visiting `admin/catalog/product/edit` and if the output of module `Magento_Review` is disabled, Magento says `Attention Something went wrong.`. Problem is a ajax request to `http://hostname/admin/mui/index/render/key/foo/?namespace=review_listing&isAjax=true` that returns a `500` status code with the following response:

```
1 exception(s):
Exception #0 (Magento\Framework\Exception\LocalizedException): Object DOMDocument should be created.

Exception #0 (Magento\Framework\Exception\LocalizedException): Object DOMDocument should be created.
#0 /vendor/magento/framework/View/Element/UiComponent/Config/Reader.php(100): Magento\Framework\View\Element\UiComponent\Config\DomMerger->getDom()
#1 /vendor/magento/module-ui/Model/Manager.php(263): Magento\Framework\View\Element\UiComponent\Config\Reader->read()
#2 /vendor/magento/module-ui/Model/Manager.php(166): Magento\Ui\Model\Manager->prepare('review_listing')
#3 /vendor/magento/framework/View/Element/UiComponentFactory.php(144): Magento\Ui\Model\Manager->prepareData('review_listing')
#4 /vendor/magento/module-ui/Controller/Adminhtml/Index/Render.php(30): Magento\Framework\View\Element\UiComponentFactory->create('review_listing')
#5 /var/generation/Magento/Ui/Controller/Adminhtml/Index/Render/Interceptor.php(24): Magento\Ui\Controller\Adminhtml\Index\Render->execute()
#6 /vendor/magento/framework/App/Action/Action.php(102): Magento\Ui\Controller\Adminhtml\Index\Render\Interceptor->execute()
#7 /vendor/magento/module-backend/App/AbstractAction.php(226): Magento\Framework\App\Action\Action->dispatch(Object(Magento\Framework\App\Request\Http))
#8 /vendor/magento/framework/Interception/Interceptor.php(74): Magento\Backend\App\AbstractAction->dispatch(Object(Magento\Framework\App\Request\Http))
#9 /vendor/magento/framework/Interception/Chain/Chain.php(70): Magento\Ui\Controller\Adminhtml\Index\Render\Interceptor->___callParent('dispatch', Array)
#10 /vendor/magento/framework/Interception/Chain/Chain.php(63): Magento\Framework\Interception\Chain\Chain->invokeNext('Magento\\Ui\\Cont...', 'dispatch', Object(Magento\Ui\Controller\Adminhtml\Index\Render\Interceptor), Array, 'adminAuthentica...')
#11 /vendor/magento/module-backend/App/Action/Plugin/Authentication.php(143): Magento\Framework\Interception\Chain\Chain->Magento\Framework\Interception\Chain\{closure}(Object(Magento\Framework\App\Request\Http))
#12 /vendor/magento/framework/Interception/Chain/Chain.php(67): Magento\Backend\App\Action\Plugin\Authentication->aroundDispatch(Object(Magento\Ui\Controller\Adminhtml\Index\Render\Interceptor), Object(Closure), Object(Magento\Framework\App\Request\Http))
#13 /vendor/magento/framework/Interception/Interceptor.php(138): Magento\Framework\Interception\Chain\Chain->invokeNext('Magento\\Ui\\Cont...', 'dispatch', Object(Magento\Ui\Controller\Adminhtml\Index\Render\Interceptor), Array, 'adminMassaction...')
#14 /vendor/magento/module-backend/App/Action/Plugin/MassactionKey.php(33): Magento\Ui\Controller\Adminhtml\Index\Render\Interceptor->Magento\Framework\Interception\{closure}(Object(Magento\Framework\App\Request\Http))
#15 /vendor/magento/framework/Interception/Interceptor.php(142): Magento\Backend\App\Action\Plugin\MassactionKey->aroundDispatch(Object(Magento\Ui\Controller\Adminhtml\Index\Render\Interceptor), Object(Closure), Object(Magento\Framework\App\Request\Http))
#16 /var/generation/Magento/Ui/Controller/Adminhtml/Index/Render/Interceptor.php(52): Magento\Ui\Controller\Adminhtml\Index\Render\Interceptor->___callPlugins('dispatch', Array, Array)
#17 /vendor/magento/framework/App/FrontController.php(55): Magento\Ui\Controller\Adminhtml\Index\Render\Interceptor->dispatch(Object(Magento\Framework\App\Request\Http))
#18 /vendor/magento/framework/Interception/Interceptor.php(74): Magento\Framework\App\FrontController->dispatch(Object(Magento\Framework\App\Request\Http))
#19 /vendor/magento/framework/Interception/Chain/Chain.php(70): Magento\Framework\App\FrontController\Interceptor->___callParent('dispatch', Array)
#20 /vendor/magento/framework/Interception/Interceptor.php(138): Magento\Framework\Interception\Chain\Chain->invokeNext('Magento\\Framewo...', 'dispatch', Object(Magento\Framework\App\FrontController\Interceptor), Array, 'install')
#21 /vendor/magento/framework/Module/Plugin/DbStatusValidator.php(69): Magento\Framework\App\FrontController\Interceptor->Magento\Framework\Interception\{closure}(Object(Magento\Framework\App\Request\Http))
#22 /vendor/magento/framework/Interception/Interceptor.php(142): Magento\Framework\Module\Plugin\DbStatusValidator->aroundDispatch(Object(Magento\Framework\App\FrontController\Interceptor), Object(Closure), Object(Magento\Framework\App\Request\Http))
#23 /var/generation/Magento/Framework/App/FrontController/Interceptor.php(26): Magento\Framework\App\FrontController\Interceptor->___callPlugins('dispatch', Array, Array)
#24 /vendor/magento/framework/App/Http.php(135): Magento\Framework\App\FrontController\Interceptor->dispatch(Object(Magento\Framework\App\Request\Http))
#25 /vendor/magento/framework/Interception/Interceptor.php(146): Magento\Framework\App\Http->launch()
#26 /var/generation/Magento/Framework/App/Http/Interceptor.php(26): Magento\Framework\App\Http\Interceptor->___callPlugins('launch', Array, Array)
#27 /vendor/magento/framework/App/Bootstrap.php(258): Magento\Framework\App\Http\Interceptor->launch()
#28 /pub/index.php(37): Magento\Framework\App\Bootstrap->run(Object(Magento\Framework\App\Http\Interceptor))
#29 {main}
```

The problem is that [Magento\Framework\View\Element\UiComponent\Config\DomMerger::getDom](https://github.com/magento/magento2/blob/2.1.0/lib/internal/Magento/Framework/View/Element/UiComponent/Config/DomMerger.php#L405) has an empty `domDocument` property. With enabled output of module `Magento_Review` the `domDocument` property would have the content of [review_listing.xml](https://github.com/magento/magento2/blob/2.1.0/app/code/Magento/Review/view/adminhtml/ui_component/review_listing.xml).
This can happen, cause [Magento\Framework\View\File\Collector\Decorator\ModuleOutput::getFiles](https://github.com/magento/magento2/blob/2.1.0/lib/internal/Magento/Framework/View/File/Collector/Decorator/ModuleOutput.php#L56) is filtering files that are contained in modules with disabled output.

[Magento\Review\Ui\DataProvider\Product\Form\Modifier\Review::modifyMeta](https://github.com/magento/magento2/blob/2.1.0/app/code/Magento/Review/Ui/DataProvider/Product/Form/Modifier/Review.php#L52) should only modify the meta if the output of module `Magento_Review` is enabled to prevent the behavior from above.
