### PR TITLE
Fix small typo

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php
@@ -566,7 +566,7 @@ abstract class AbstractType
      */
     protected function _prepareOptions(\Magento\Framework\DataObject $buyRequest, $product, $processMode)
     {
-        $transport = new \StdClass();
+        $transport = new \stdClass();
         $transport->options = [];
         $options = null;
         if ($product->getHasOptions()) {


### PR DESCRIPTION
Although correct, let's keep it standardised.

Speaking of which, this is the first time I've seen `\stdClass` used as an observer transport reference, instead of `\Magento\Framework\DataObject`. That's not to say it's bad, but inconsistent.

PS: I've signed the CLA. A long time ago and just now.
