### PR TITLE
Prevent 2 agreement checkboxes with the same id

### DIFF
--- a/app/code/Magento/Paypal/view/frontend/web/template/payment/express/billing-agreement.html
+++ b/app/code/Magento/Paypal/view/frontend/web/template/payment/express/billing-agreement.html
@@ -7,14 +7,17 @@
 <!-- ko if: getBillingAgreementCode() -->
 <input type="checkbox"
     data-bind='
-        attr: {id: getBillingAgreementCode(), name: "payment[" + getBillingAgreementCode() + "]"},
+        attr: {
+            id: getCode() + "_" + getBillingAgreementCode(),
+            name: "payment[" + getBillingAgreementCode() + "]"
+        },
         checked: billingAgreement
         enable: isActive($parent) && getBillingAgreementCode(),
         click: selectPaymentMethod'
     value="1" class="checkbox">
 <label
     data-bind='
-        attr: {for: getBillingAgreementCode()}'
+        attr: {for: getCode() + "_" + getBillingAgreementCode()}'
     class="label">
     <span><!-- ko i18n: 'Sign a billing agreement to streamline further purchases with PayPal.' --><!-- /ko --></span>
 </label>


### PR DESCRIPTION
This happens when PaypalExpress and PaypalCredit are enabled
at the same time.

This makes impossible to select agreement by clicking the label in second payment method:

![paypal_agreement_id](https://cloud.githubusercontent.com/assets/306080/17015386/970ab2b0-4f32-11e6-9fd2-771d9ef6d7c6.gif)
