### PR TITLE
Update AbstractTemplate.php

### DIFF
--- a/app/code/Magento/Email/Model/AbstractTemplate.php
+++ b/app/code/Magento/Email/Model/AbstractTemplate.php
@@ -669,7 +669,7 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
      */
     public function emulateDesign($storeId, $area = self::DEFAULT_DESIGN_AREA)
     {
-        if ($storeId) {
+        if ($storeId !== false) {
             // save current design settings
             $this->emulatedDesignConfig = clone $this->getDesignConfig();
             if (


### PR DESCRIPTION
**Added strict comparison for $storeID**

Regarding issues #5288, #5666 and #5703.

**Issue**:
Global Design Configuration does not save.

**Scenario**:
When the design configuration for the Global Scope is saved, the configuration tries to validate the transactional email header and footer templates through  https://github.com/magento/magento2/blob/2.1/app/code/Magento/Theme/Model/Design/Config/Validator.php#L69.
For email templates, the $template is an object of Magento\Email\Model\Template which is inherited from [Magento\Email\Model\AbstractTemplate](https://github.com/magento/magento2/blob/2.1/app/code/Magento/Email/Model/AbstractTemplate.php) . And in line [670](https://github.com/magento/magento2/blob/2.1/app/code/Magento/Email/Model/AbstractTemplate.php#L670) is the `emulateDesign` function. 
When the design is saved from the global scope, the $storeId being passed is `0`, so `false` is returned even when an actual value is being passed. 

**Solution**:
Change the [if condition](https://github.com/magento/magento2/blob/2.1/app/code/Magento/Email/Model/AbstractTemplate.php#L672) to `if ($storeId !== false)`.
