### PR TITLE
ExtensionAttributesProcessor::buildOutputDataArray: Add array keys

### DIFF
--- a/lib/internal/Magento/Framework/Reflection/ExtensionAttributesProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/ExtensionAttributesProcessor.php
@@ -120,14 +120,14 @@ class ExtensionAttributesProcessor
             } elseif (is_array($value)) {
                 $valueResult = [];
                 $arrayElementType = substr($returnType, 0, -2);
-                foreach ($value as $singleValue) {
+                foreach ($value as $singleKey => $singleValue) {
                     if (is_object($singleValue) && !($singleValue instanceof Phrase)) {
                         $singleValue = $this->dataObjectProcessor->buildOutputDataArray(
                             $singleValue,
                             $arrayElementType
                         );
                     }
-                    $valueResult[] = $this->typeCaster->castValueToType($singleValue, $arrayElementType);
+                    $valueResult[$singleKey] = $this->typeCaster->castValueToType($singleValue, $arrayElementType);
                 }
                 $value = $valueResult;
             } else {


### PR DESCRIPTION
Expected would be an output array including the array keys but keys get
lost. This PR fixes the issue.
More detailed information regarding the bug in the printscreen.

![screen shot 2016-07-21 at 16 46 29](https://cloud.githubusercontent.com/assets/372027/17064769/9007051a-503e-11e6-821a-ac205206e455.png)
