### PR TITLE
`cms_index_noroute` does not exist

### DIFF
--- a/app/code/Magento/Cms/etc/frontend/page_types.xml
+++ b/app/code/Magento/Cms/etc/frontend/page_types.xml
@@ -10,6 +10,6 @@
     <type id="cms_index_defaultnoroute" label="CMS No-Route Default Page"/>
     <type id="cms_index_index" label="CMS Home Page"/>
     <type id="cms_index_nocookies" label="CMS No-Cookies Page"/>
-    <type id="cms_index_noroute" label="CMS No-Route Page"/>
+    <type id="cms_noroute_index" label="CMS No-Route Page"/>
     <type id="cms_page_view" label="CMS Pages (All)"/>
 </page_types>


### PR DESCRIPTION
Based on `\Magento\Cms\Controller\Noroute\Index` I believe it should be `cms_noroute_index`
