### PR TITLE
Product view translation fix

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
@@ -94,7 +94,7 @@
                         <argument name="at_call" xsi:type="string">getShortDescription</argument>
                         <argument name="at_code" xsi:type="string">short_description</argument>
                         <argument name="css_class" xsi:type="string">overview</argument>
-                        <argument name="at_label" translate="true" xsi:type="string">none</argument>
+                        <argument name="at_label" xsi:type="string">none</argument>
                         <argument name="title" translate="true" xsi:type="string">Overview</argument>
                         <argument name="add_attribute" xsi:type="string">itemprop="description"</argument>
                     </arguments>

--- a/app/code/Magento/Cms/view/frontend/layout/default.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/default.xml
@@ -13,7 +13,7 @@
         <referenceBlock name="footer_links">
             <block class="Magento\Framework\View\Element\Html\Link\Current" name="privacy-policy-link">
                 <arguments>
-                    <argument name="label" xsi:type="string">Privacy and Cookie Policy</argument>
+                    <argument name="label" xsi:type="string" translate="true">Privacy and Cookie Policy</argument>
                     <argument name="path" xsi:type="string">privacy-policy-cookie-restriction-mode</argument>
                 </arguments>
             </block>


### PR DESCRIPTION
There shouldn't be a translate='true' attribute on at_label, because when it is translated to other languages than EN, it appears on product view, where you check if the label should be visible or not.

<?php if ($_attributeLabel != 'none'): ?>
