### PR TITLE
Updated with ability to extend category image uploader controller

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Image/Upload.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Image/Upload.php
@@ -20,17 +20,27 @@ class Upload extends \Magento\Backend\App\Action
     protected $imageUploader;
 
     /**
+     * Name of variable to upload
+     *
+     * @var string
+     */
+    protected $fileUploadName;
+
+    /**
      * Upload constructor.
      *
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Catalog\Model\ImageUploader $imageUploader
+     * @param string $file
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
-        \Magento\Catalog\Model\ImageUploader $imageUploader
+        \Magento\Catalog\Model\ImageUploader $imageUploader,
+        $fileUploadName
     ) {
         parent::__construct($context);
         $this->imageUploader = $imageUploader;
+        $this->fileUploadName = $fileUploadName;
     }
 
     /**
@@ -51,7 +61,7 @@ class Upload extends \Magento\Backend\App\Action
     public function execute()
     {
         try {
-            $result = $this->imageUploader->saveFileToTmpDir('image');
+            $result = $this->imageUploader->saveFileToTmpDir($this->fileUploadName);
 
             $result['cookie'] = [
                 'name' => $this->_getSession()->getName(),

--- a/app/code/Magento/Catalog/etc/adminhtml/di.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/di.xml
@@ -16,6 +16,11 @@
             <argument name="attributeLabelCache" xsi:type="object">Magento\Framework\App\Cache\Type\Translate</argument>
         </arguments>
     </type>
+    <type name="Magento\Catalog\Controller\Adminhtml\Category\Image\Upload">
+        <arguments>
+            <argument name="fileUploadName" xsi:type="string">image</argument>
+        </arguments>
+    </type>
     <type name="Magento\Catalog\Block\Adminhtml\Product\Frontend\Product\Watermark">
         <arguments>
             <argument name="imageTypes" xsi:type="array">


### PR DESCRIPTION
Currently it is not possible to create utilise the existing upload controller for your own purpose without rewriting the entire execute method. 
