### PR TITLE
Save shipping discount in $total

### DIFF
--- a/app/code/Magento/SalesRule/Model/Quote/Discount.php
+++ b/app/code/Magento/SalesRule/Model/Quote/Discount.php
@@ -131,6 +131,8 @@ class Discount extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
             $this->calculator->processShippingAmount($address);
             $total->addTotalAmount($this->getCode(), -$address->getShippingDiscountAmount());
             $total->addBaseTotalAmount($this->getCode(), -$address->getBaseShippingDiscountAmount());
+            $total->setShippingDiscountAmount($address->getShippingDiscountAmount());
+            $total->setBaseShippingDiscountAmount($address->getBaseShippingDiscountAmount());
         }
 
         $this->calculator->prepareDescription($address);


### PR DESCRIPTION
Shipping discount should be accounted in the \Magento\Tax\Model\Sales\Total\Quote\CommonTaxCollector::getShippingDataObject:

```
        if ($total->getShippingDiscountAmount()) {
            if ($useBaseCurrency) {
                $itemDataObject->setDiscountAmount($total->getBaseShippingDiscountAmount());
            } else {
                $itemDataObject->setDiscountAmount($total->getShippingDiscountAmount());
            }
        }
```

but is not initialized in $total. Shipping tax (and tax for whole order) is wrong when shipping discount is used in sales rules cause shipping amount is not decreased to discount amount before tax calculation.

#4585