### PR TITLE
Cast string SKUs back to string

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1221,7 +1221,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 $linkId = $this->_connection->fetchOne(
                     $this->_connection->select()
                         ->from($this->getResource()->getTable('catalog_product_entity'))
-                        ->where('sku = ?', $sku)
+                        ->where('sku = ?', (string) $sku)
                         ->columns($this->getProductEntityLinkField())
                 );
 


### PR DESCRIPTION
Array keys cast to integer on string SKUs that could represent a PHP integer, however the Mysql comparison is string based for which - to prevent a cast in Mysql - it needs string quotes. These string quotes then need again the $sku as string.

This is fixed by casting to string.

Background: If you import many records with SKU that are numeric strings, Mysql performance is impacted negatively.
