### PR TITLE
Fix newsletter multi language in block template.

### DIFF
--- a/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
+++ b/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
@@ -8,7 +8,7 @@
 
 ?>
 <div class="block newsletter">
-    <div class="title"><strong>Newsletter</strong></div>
+    <div class="title"><strong><?php /* @escapeNotVerified */ echo __('Newsletter') ?></strong></div>
     <div class="content">
         <form class="form subscribe"
             novalidate


### PR DESCRIPTION
This fixes i18n for newsletter title in the newsletter block used mostly in the footer (e.g. in the luma theme).
