### PR TITLE
Single backslash in double-quotes

### DIFF
--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -192,7 +192,7 @@ class TypeProcessor
             $this->_types[$typeName]['documentation'] = $docBlock ? $this->getDescription($docBlock) : '';
             /** @var MethodReflection $methodReflection */
             foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $methodReflection) {
-                if ($methodReflection->class === "Magento\Framework\Model\AbstractModel") {
+                if ($methodReflection->class === 'Magento\Framework\Model\AbstractModel') {
                     continue;
                 }
                 $this->_processMethod($methodReflection, $typeName);

--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -192,7 +192,7 @@ class TypeProcessor
             $this->_types[$typeName]['documentation'] = $docBlock ? $this->getDescription($docBlock) : '';
             /** @var MethodReflection $methodReflection */
             foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $methodReflection) {
-                if ($methodReflection->class === 'Magento\Framework\Model\AbstractModel') {
+                if ($methodReflection->class === \Magento\Framework\Model\AbstractModel::class) {
                     continue;
                 }
                 $this->_processMethod($methodReflection, $typeName);


### PR DESCRIPTION
This is wrong string I suppose:

```
"Magento\Framework\Model\AbstractModel"
```

should be 

```
'Magento\Framework\Model\AbstractModel'
```

or 

```
"Magento\\Framework\\Model\\AbstractModel"
```
