### PR TITLE
Added missing translation to range grid filter

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/filters/range.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/filters/range.js
@@ -6,8 +6,9 @@ define([
     'underscore',
     'uiLayout',
     'mageUtils',
-    'Magento_Ui/js/form/components/group'
-], function (_, layout, utils, Group) {
+    'Magento_Ui/js/form/components/group',
+    'mage/translate'
+], function (_, layout, utils, Group, $t) {
     'use strict';
 
     return Group.extend({
@@ -29,11 +30,11 @@ define([
                 },
                 ranges: {
                     from: {
-                        label: 'from',
+                        label: $t('from'),
                         dataScope: 'from'
                     },
                     to: {
-                        label: 'to',
+                        label: $t('to'),
                         dataScope: 'to'
                     }
                 }


### PR DESCRIPTION
Added missing translation to range grid filter labels 'from' and 'to'.
