### PR TITLE
prevent double shipping method selection

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/shipping.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/shipping.html
@@ -98,8 +98,7 @@
                                                 attr: {
                                                     'id': 's_method_' + method.carrier_code + '_' + method.method_code,
                                                     'aria-labelledby': 'label_method_' + method.method_code + '_' + method.carrier_code + ' ' + 'label_carrier_' + method.method_code + '_' + method.carrier_code
-                                                },
-                                                click: $parent.selectShippingMethod"
+                                                }"
                                        class="radio"/>
                                 <!--/ko-->
                                 <!-- /ko -->


### PR DESCRIPTION
There already is a click handler on the `<tr>`, so there is no need to put
it on the radio input. This prevents selectShippingMethod from being
executed twice.

For more information, see issue #5814.

Closes #5814.
