### PR TITLE
.lib-popup-button-close-icon() misses a leading underscore

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/source/_popups.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_popups.less
@@ -28,7 +28,7 @@
                     top: 0;
                     width: 40px;
                     z-index: 1001;
-                    .lib-popup-button-close-icon(
+                    ._lib-popup-button-close-icon(
                     @popup-button-close__icon,
                     @popup-icon-font__content,
                     @popup-icon-font,

--- a/app/design/frontend/Magento/luma/web/css/source/_popups.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_popups.less
@@ -29,7 +29,7 @@
                     width: 40px;
                     z-index: 1001;
                     
-                    .lib-popup-button-close-icon(
+                    ._lib-popup-button-close-icon(
                     @popup-button-close__icon,
                     @popup-icon-font__content,
                     @popup-icon-font,

--- a/lib/web/css/source/lib/_popups.less
+++ b/lib/web/css/source/lib/_popups.less
@@ -114,7 +114,7 @@
     .popup-actions {
         .action.close {
             .lib-css(position, @_popup-button-close-position);
-            .lib-popup-button-close-icon(
+            ._lib-popup-button-close-icon(
                 @_popup-button-close-icon,
                 @_popup-icon-font-content,
                 @_popup-icon-font,
@@ -280,7 +280,7 @@
 }
 
 //  Popup close button use icon
-.lib-popup-button-close-icon(
+._lib-popup-button-close-icon(
     @_popup-button-close-icon,
     @_popup-icon-font-content,
     @_popup-icon-font,


### PR DESCRIPTION
Added underscore to `.lib-popup-button-close-icon()`
