### PR TITLE
Fix 'Track your order' i18n.

### DIFF
--- a/app/code/Magento/Shipping/i18n/en_US.csv
+++ b/app/code/Magento/Shipping/i18n/en_US.csv
@@ -179,3 +179,4 @@ City,City
 "Apply custom Shipping Policy","Apply custom Shipping Policy"
 "Shipping Policy","Shipping Policy"
 "Shipping Methods","Shipping Methods"
+"Track your order","Track your order"

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_guest_reorder.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_guest_reorder.xml
@@ -10,7 +10,7 @@
         <referenceBlock name="sales.order.view">
             <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="tracking/link.phtml">
                 <arguments>
-                    <argument name="label" xsi:type="string">Track your order</argument>
+                    <argument name="label" xsi:type="string" translate="true">Track your order</argument>
                 </arguments>
             </block>
         </referenceBlock>

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_guest_view.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_guest_view.xml
@@ -10,7 +10,7 @@
         <referenceBlock name="sales.order.view">
             <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="tracking/link.phtml">
                 <arguments>
-                    <argument name="label" xsi:type="string">Track your order</argument>
+                    <argument name="label" xsi:type="string" translate="true">Track your order</argument>
                 </arguments>
             </block>
         </referenceBlock>

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_order_reorder.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_order_reorder.xml
@@ -10,7 +10,7 @@
         <referenceBlock name="sales.order.view">
             <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="tracking/link.phtml">
                 <arguments>
-                    <argument name="label" xsi:type="string">Track your order</argument>
+                    <argument name="label" xsi:type="string" translate="true">Track your order</argument>
                 </arguments>
             </block>
         </referenceBlock>

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_order_view.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_order_view.xml
@@ -10,7 +10,7 @@
         <referenceBlock name="sales.order.view">
             <block class="Magento\Shipping\Block\Tracking\Link" name="tracking-info-link" template="tracking/link.phtml">
                 <arguments>
-                    <argument name="label" xsi:type="string">Track your order</argument>
+                    <argument name="label" xsi:type="string" translate="true">Track your order</argument>
                 </arguments>
             </block>
         </referenceBlock>


### PR DESCRIPTION
This fixes i18n string for "Track your order".
### Location of string

![track_order](https://cloud.githubusercontent.com/assets/131546/17397090/bc5d255c-5a36-11e6-8989-5c9a0ffbc3e3.png)
