### PR TITLE
Update timeout time

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -105,7 +105,7 @@ define([
                     }
                 });
                 $.cookieStorage.set('section_data_ids', newSectionDataIds);
-            }, 50);
+            }, 250);
         });
 
         return target;

--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -105,7 +105,7 @@ define([
                     }
                 });
                 $.cookieStorage.set('section_data_ids', newSectionDataIds);
-            }, 3000);
+            }, 50);
         });
 
         return target;


### PR DESCRIPTION
A problem will occur when you are adding any success message and the quickly changing page, fx adding a product to cart and then going to another page before the 3 seconds pass. This is especially true when dealing with production mode sites with all cache enable.

I'm not a Javascript wizard so not sure any time is needed at all. But it should definitely be decreased. If their have been any thoughts on why this is 3 seconds I would love to know it.
