### PR TITLE
Fix path check on moving category

### DIFF
--- a/app/code/Magento/Catalog/Model/CategoryManagement.php
+++ b/app/code/Magento/Catalog/Model/CategoryManagement.php
@@ -113,7 +113,7 @@ class CategoryManagement implements \Magento\Catalog\Api\CategoryManagementInter
             $afterId = ($afterId === null || $afterId > $lastId) ? $lastId : $afterId;
         }
 
-        if (strpos($parentCategory->getPath(), $model->getPath()) === 0) {
+        if (strpos($parentCategory->getPath() . "/", $model->getPath()) === 0) {
             throw new \Magento\Framework\Exception\LocalizedException(
                 __('Operation do not allow to move a parent category to any of children category')
             );


### PR DESCRIPTION
This commit fixes throwing exception when category moving is possible but the path of category to move and its parent match as follows in this example:

model category path = 1/2/30
parent category path = 1/2/3
