### PR TITLE
Fix to product-list widget not rendering 'rules' correctly when re-configured in WYSIWYG form

### DIFF
--- a/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
@@ -54,11 +54,17 @@ class Conditions extends Template implements RendererInterface
     protected $_template = 'product/widget/conditions.phtml';
 
     /**
+     * @var \Magento\Widget\Helper\Conditions
+     */
+    protected $conditionsHelper;
+
+    /**
+     * @param Template\Context $context
      * @param \Magento\Framework\Data\Form\Element\Factory $elementFactory
      * @param \Magento\Rule\Block\Conditions $conditions
      * @param \Magento\CatalogWidget\Model\Rule $rule
      * @param \Magento\Framework\Registry $registry
-     * @param \Magento\Backend\Block\Template\Context $context
+     * @param \Magento\Widget\Helper\Conditions $conditionsHelper
      * @param array $data
      */
     public function __construct(
@@ -67,12 +73,14 @@ class Conditions extends Template implements RendererInterface
         \Magento\Rule\Block\Conditions $conditions,
         \Magento\CatalogWidget\Model\Rule $rule,
         \Magento\Framework\Registry $registry,
+        \Magento\Widget\Helper\Conditions $conditionsHelper,
         array $data = []
     ) {
         $this->elementFactory = $elementFactory;
         $this->conditions = $conditions;
         $this->rule = $rule;
         $this->registry = $registry;
+        $this->conditionsHelper = $conditionsHelper;
         parent::__construct($context, $data);
     }
 
@@ -87,6 +95,11 @@ class Conditions extends Template implements RendererInterface
             $widgetParameters = $widget->getWidgetParameters();
         } elseif($widgetOptions = $this->getLayout()->getBlock('wysiwyg_widget.options')) {
             $widgetParameters = $widgetOptions->getWidgetValues();
+        }
+
+        if (isset($widgetParameters['conditions_encoded'])) {
+            $widgetParameters['conditions'] = $this->conditionsHelper
+                ->decode($widgetParameters['conditions_encoded']);
         }
 
         if (isset($widgetParameters['conditions'])) {

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/LoadOptions.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/LoadOptions.php
@@ -6,10 +6,18 @@
  */
 namespace Magento\Widget\Controller\Adminhtml\Widget;
 
-use Magento\Framework\App\ObjectManager;
-
 class LoadOptions extends \Magento\Backend\App\Action
 {
+    /**
+     * @var \Magento\Framework\Json\Helper\Data
+     */
+    protected $jsonDataHelper;
+
+    /**
+     * @var \Magento\Widget\Model\Widget\InstanceFactory
+     */
+    protected $widgetInstanceFactory;
+
     /**
      * @var \Magento\Framework\Registry
      */
@@ -21,10 +29,14 @@ class LoadOptions extends \Magento\Backend\App\Action
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
+        \Magento\Framework\Json\Helper\Data $jsonDataHelper,
+        \Magento\Widget\Model\Widget\InstanceFactory $widgetInstanceFactory,
         \Magento\Framework\Registry $registry
     ) {
         parent::__construct($context);
 
+        $this->jsonDataHelper = $jsonDataHelper;
+        $this->widgetInstanceFactory = $widgetInstanceFactory;
         $this->coreRegistry = $registry;
     }
 
@@ -38,15 +50,16 @@ class LoadOptions extends \Magento\Backend\App\Action
         try {
             $this->_view->loadLayout();
             if ($paramsJson = $this->getRequest()->getParam('widget')) {
-                $request = $this->_objectManager->get(\Magento\Framework\Json\Helper\Data::class)
-                    ->jsonDecode($paramsJson);
+                $request = $this->jsonDataHelper->jsonDecode($paramsJson);
                 if (is_array($request)) {
                     $optionsBlock = $this->_view->getLayout()->getBlock('wysiwyg_widget.options');
                     $widgetInstance = null;
 
                     if (isset($request['widget_type'])) {
-                        $widgetInstance = $this->_objectManager->create($request['widget_type']);
+                        $widgetInstance = $this->widgetInstanceFactory->create();
+                        $widgetInstance->setType($request['widget_type']);
                         $optionsBlock->setWidgetType($request['widget_type']);
+                        $this->coreRegistry->register('current_widget_instance', $widgetInstance, true);
                     }
 
                     if (isset($request['values'])) {
@@ -58,17 +71,13 @@ class LoadOptions extends \Magento\Backend\App\Action
 
                         $optionsBlock->setWidgetValues($request['values']);
                     }
-
-                    if ($widgetInstance) {
-                        $this->coreRegistry->register('current_widget_instance', $widgetInstance, true);
-                    }
                 }
                 $this->_view->renderLayout();
             }
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $result = ['error' => true, 'message' => $e->getMessage()];
             $this->getResponse()->representJson(
-                $this->_objectManager->get(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($result)
+                $this->jsonDataHelper->jsonEncode($result)
             );
         }
     }

--- a/app/code/Magento/Widget/Test/Unit/Controller/Adminhtml/Widget/LoadOptionsTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Controller/Adminhtml/Widget/LoadOptionsTest.php
@@ -12,11 +12,11 @@ use Magento\Framework\App\ViewInterface;
 use Magento\Widget\Helper\Conditions as ConditionsHelper;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\App\ResponseInterface;
-use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\App\RequestInterface;
 
 /**
  * Test class for \Magento\Widget\Controller\Adminhtml\Widget\LoadOptions
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class LoadOptionsTest extends \PHPUnit_Framework_TestCase
 {
@@ -46,19 +46,34 @@ class LoadOptionsTest extends \PHPUnit_Framework_TestCase
     private $responseMock;
 
     /**
-     * @var ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $objectManagerMock;
-
-    /**
      * @var RequestInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $requestMock;
 
     /**
-     * @var LoadOptions
+     * @var \Magento\Framework\Json\Helper\Data
      */
-    private $loadOptions;
+    private $jsonDataHelperMock;
+
+    /**
+     * @var \Magento\Framework\View\Element\BlockInterface
+     */
+    private $optionsMock;
+
+    /**
+     * @var \Magento\Framework\View\LayoutInterface
+     */
+    private $layoutMock;
+
+    /**
+     * @var \Magento\Widget\Model\Widget\Instance
+     */
+    private $widgetInstanceMock;
+
+    /**
+     * @var \Magento\Framework\Registry
+     */
+    private $coreRegistryMock;
 
     /**
      * return void
@@ -66,7 +81,6 @@ class LoadOptionsTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->objectManagerHelper = new ObjectManagerHelper($this);
-        $this->objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
         $this->viewMock = $this->getMockForAbstractClass(ViewInterface::class);
         $this->requestMock = $this->getMockForAbstractClass(RequestInterface::class);
         $this->responseMock = $this->getMockBuilder(ResponseInterface::class)
@@ -84,32 +98,32 @@ class LoadOptionsTest extends \PHPUnit_Framework_TestCase
         $this->contextMock->expects($this->once())
             ->method('getResponse')
             ->willReturn($this->responseMock);
-        $this->contextMock->expects($this->once())
-            ->method('getObjectManager')
-            ->willReturn($this->objectManagerMock);
         $this->conditionsHelperMock = $this->getMockBuilder(ConditionsHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
-
-        $this->loadOptions = $this->objectManagerHelper->getObject(
-            LoadOptions::class,
-            ['context' => $this->contextMock]
-        );
+        $this->jsonDataHelperMock = $this->getMockBuilder(\Magento\Framework\Json\Helper\Data::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->optionsMock = $this->getMockBuilder(\Magento\Framework\View\Element\BlockInterface::class)
+            ->setMethods(['setWidgetType', 'setWidgetValues'])
+            ->getMockForAbstractClass();
+        $this->layoutMock = $this->getMockForAbstractClass(\Magento\Framework\View\LayoutInterface::class);
+        $this->widgetInstanceMock = $this->getMockBuilder(\Magento\Widget\Model\Widget\Instance::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setType', 'setWidgetParameters'])
+            ->getMock();
+        $this->coreRegistryMock = $this->getMockBuilder(\Magento\Framework\Registry::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['register'])
+            ->getMock();
     }
-
-    /**
-     * @return void
-     */
+    
     public function testExecuteWithException()
     {
         $jsonResult = '{"error":true,"message":"Some error"}';
         $errorMessage = 'Some error';
 
-        /** @var \Magento\Framework\Json\Helper\Data|\PHPUnit_Framework_MockObject_MockObject $jsonDataHelperMock */
-        $jsonDataHelperMock = $this->getMockBuilder(\Magento\Framework\Json\Helper\Data::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $jsonDataHelperMock->expects($this->once())
+        $this->jsonDataHelperMock->expects($this->once())
             ->method('jsonEncode')
             ->with(['error' => true, 'message' => $errorMessage])
             ->willReturn($jsonResult);
@@ -117,22 +131,20 @@ class LoadOptionsTest extends \PHPUnit_Framework_TestCase
         $this->viewMock->expects($this->once())
             ->method('loadLayout')
             ->willThrowException(new LocalizedException(__($errorMessage)));
-        $this->objectManagerMock->expects($this->once())
-            ->method('get')
-            ->with(\Magento\Framework\Json\Helper\Data::class)
-            ->willReturn($jsonDataHelperMock);
+
         $this->responseMock->expects($this->once())
             ->method('representJson')
-            ->with($jsonResult)
-            ->willReturnArgument(0);
+            ->with($jsonResult);
 
-        $this->loadOptions->execute();
+        $model = $this->objectManagerHelper->getObject(LoadOptions::class, [
+            'context' => $this->contextMock,
+            'jsonDataHelper' => $this->jsonDataHelperMock
+        ]);
+
+        $model->execute();
     }
 
-    /**
-     * @return void
-     */
-    public function testExecute()
+    protected function setupExecuteTest()
     {
         $widgetType = 'Magento\SomeWidget';
         $widgetJsonParams = '{"widget_type":"Magento\\Widget","values":{"title":"&quot;Test&quot;", "":}}';
@@ -142,59 +154,152 @@ class LoadOptionsTest extends \PHPUnit_Framework_TestCase
                 'title' => '&quot;Test&quot;'
             ],
         ];
-        $resultWidgetArrayParams = [
-            'widget_type' => $widgetType,
-            'values' => [
-                'title' => '"Test"'
-            ],
-        ];
 
-        /** @var \Magento\Framework\Json\Helper\Data|\PHPUnit_Framework_MockObject_MockObject $jsonDataHelperMock */
-        $jsonDataHelperMock = $this->getMockBuilder(\Magento\Framework\Json\Helper\Data::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $jsonDataHelperMock->expects($this->once())
+        $this->jsonDataHelperMock->expects($this->once())
             ->method('jsonDecode')
             ->with($widgetJsonParams)
             ->willReturn($widgetArrayParams);
 
-        $this->viewMock->expects($this->once())
-            ->method('loadLayout');
         $this->requestMock->expects($this->once())
             ->method('getParam')
             ->with('widget')
             ->willReturn($widgetJsonParams);
-        $this->objectManagerMock->expects($this->once())
-            ->method('get')
-            ->with(\Magento\Framework\Json\Helper\Data::class)
-            ->willReturn($jsonDataHelperMock);
 
-        /** @var \Magento\Framework\View\Element\BlockInterface|\PHPUnit_Framework_MockObject_MockObject $blockMock */
-        $blockMock = $this->getMockBuilder(\Magento\Framework\View\Element\BlockInterface::class)
-            ->setMethods(['setWidgetType', 'setWidgetValues'])
-            ->getMockForAbstractClass();
-        $blockMock->expects($this->once())
-            ->method('setWidgetType')
-            ->with($widgetType)
-            ->willReturnSelf();
-        $blockMock->expects($this->once())
-            ->method('setWidgetValues')
-            ->with($resultWidgetArrayParams['values'])
-            ->willReturnSelf();
-
-        /** @var \Magento\Framework\View\LayoutInterface|\PHPUnit_Framework_MockObject_MockObject $layoutMock */
-        $layoutMock = $this->getMockForAbstractClass(\Magento\Framework\View\LayoutInterface::class);
-        $layoutMock->expects($this->once())
+        $this->layoutMock->expects($this->once())
             ->method('getBlock')
             ->with('wysiwyg_widget.options')
-            ->willReturn($blockMock);
+            ->willReturn($this->optionsMock);
 
         $this->viewMock->expects($this->once())
             ->method('getLayout')
-            ->willReturn($layoutMock);
-        $this->viewMock->expects($this->once())
-            ->method('renderLayout');
+            ->willReturn($this->layoutMock);
 
-        $this->loadOptions->execute();
+        $instanceFactoryMock = $this->getMockBuilder(\Magento\Widget\Model\Widget\InstanceFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+
+        $instanceFactoryMock->expects($this->once())
+            ->method('create')
+            ->will($this->returnValue($this->widgetInstanceMock));
+
+        return $this->objectManagerHelper->getObject(LoadOptions::class, [
+            'context' => $this->contextMock,
+            'jsonDataHelper' => $this->jsonDataHelperMock,
+            'widgetInstanceFactory' => $instanceFactoryMock,
+            'coreRegistry' => $this->coreRegistryMock
+        ]);
+    }
+
+    public function testExecuteShouldPrepareWidgetOptionsBlock()
+    {
+        $this->optionsMock->expects($this->once())
+            ->method('setWidgetType')
+            ->with('Magento\SomeWidget');
+
+        $this->optionsMock->expects($this->once())
+            ->method('setWidgetValues')
+            ->with(['title' => '"Test"']);
+
+        $model = $this->setupExecuteTest();
+
+        $model->execute();
+    }
+
+    public function testExecuteShouldPrepareOptionsBlockBetweenLayoutLoadAndRender()
+    {
+        $callSequence = [];
+
+        $this->optionsMock->expects($this->once())
+            ->method('setWidgetType')
+            ->will($this->returnCallback(function() use (&$callSequence) {
+                $callSequence[] = 'setWidgetType';
+            }));
+
+        $this->optionsMock->expects($this->once())
+            ->method('setWidgetValues')
+            ->will($this->returnCallback(function() use (&$callSequence) {
+                $callSequence[] = 'setWidgetValues';
+            }));
+
+        $this->viewMock->expects($this->once())
+            ->method('loadLayout')
+            ->will($this->returnCallback(function() use (&$callSequence) {
+                $callSequence[] = 'loadLayout';
+            }));
+
+        $this->viewMock->expects($this->once())
+            ->method('renderLayout')
+            ->will($this->returnCallback(function() use (&$callSequence) {
+                $callSequence[] = 'renderLayout';
+            }));
+
+        $model = $this->setupExecuteTest();
+
+        $model->execute();
+
+        $this->assertEquals('loadLayout', reset($callSequence));
+        $this->assertEquals('renderLayout', end($callSequence));
+    }
+
+    public function testExecuteShouldRegisterWidgetInstanceWithRequestedOptions()
+    {
+        $this->widgetInstanceMock->expects($this->any())
+            ->method('setType')
+            ->with('Magento\SomeWidget');
+
+        $this->widgetInstanceMock->expects($this->once())
+            ->method('setWidgetParameters')
+            ->with(['title' => '"Test"']);
+
+        $this->coreRegistryMock->expects($this->once())
+            ->method('register')
+            ->with('current_widget_instance', $this->widgetInstanceMock);
+
+        $model = $this->setupExecuteTest();
+
+        $model->execute();
+    }
+
+    public function testExecuteShouldPrepareWidgetInstanceBetweenLayoutLoadAndRender()
+    {
+        $callSequence = [];
+
+        $this->widgetInstanceMock->expects($this->any())
+            ->method('setType')
+            ->will($this->returnCallback(function() use (&$callSequence) {
+                $callSequence[] = 'setType';
+            }));
+
+        $this->widgetInstanceMock->expects($this->once())
+            ->method('setWidgetParameters')
+            ->will($this->returnCallback(function() use (&$callSequence) {
+                $callSequence[] = 'setWidgetParameters';
+            }));
+
+        $this->coreRegistryMock->expects($this->once())
+            ->method('register')
+            ->will($this->returnCallback(function() use (&$callSequence) {
+                $callSequence[] = 'register';
+            }));
+
+        $this->viewMock->expects($this->once())
+            ->method('loadLayout')
+            ->will($this->returnCallback(function() use (&$callSequence) {
+                $callSequence[] = 'loadLayout';
+            }));
+
+        $this->viewMock->expects($this->once())
+            ->method('renderLayout')
+            ->will($this->returnCallback(function() use (&$callSequence) {
+                $callSequence[] = 'renderLayout';
+            }));
+
+        $model = $this->setupExecuteTest();
+
+        $model->execute();
+
+        $this->assertEquals('loadLayout', reset($callSequence));
+        $this->assertEquals('renderLayout', end($callSequence));
     }
 }

--- a/app/code/Magento/Widget/Test/Unit/Controller/Adminhtml/Widget/LoadOptionsTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Controller/Adminhtml/Widget/LoadOptionsTest.php
@@ -95,17 +95,12 @@ class LoadOptionsTest extends \PHPUnit_Framework_TestCase
             LoadOptions::class,
             ['context' => $this->contextMock]
         );
-        $this->objectManagerHelper->setBackwardCompatibleProperty(
-            $this->loadOptions,
-            'conditionsHelper',
-            $this->conditionsHelperMock
-        );
     }
 
     /**
      * @return void
      */
-    public function dtestExecuteWithException()
+    public function testExecuteWithException()
     {
         $jsonResult = '{"error":true,"message":"Some error"}';
         $errorMessage = 'Some error';
@@ -140,26 +135,17 @@ class LoadOptionsTest extends \PHPUnit_Framework_TestCase
     public function testExecute()
     {
         $widgetType = 'Magento\SomeWidget';
-        $conditionsEncoded = 'a:3:{s:5:"value";i:1;s:8:"operator";s:2:"==";s:9:"attribute";s:2:"id";}';
-        $conditionsDecoded = [
-            'value' => 1,
-            'operator' => '==',
-            'attribute' => 'id',
-        ];
         $widgetJsonParams = '{"widget_type":"Magento\\Widget","values":{"title":"&quot;Test&quot;", "":}}';
         $widgetArrayParams = [
             'widget_type' => $widgetType,
             'values' => [
-                'title' => '&quot;Test&quot;',
-                'conditions_encoded' => $conditionsEncoded,
+                'title' => '&quot;Test&quot;'
             ],
         ];
         $resultWidgetArrayParams = [
             'widget_type' => $widgetType,
             'values' => [
-                'title' => '"Test"',
-                'conditions_encoded' => $conditionsEncoded,
-                'conditions' => $conditionsDecoded,
+                'title' => '"Test"'
             ],
         ];
 
@@ -203,10 +189,6 @@ class LoadOptionsTest extends \PHPUnit_Framework_TestCase
             ->with('wysiwyg_widget.options')
             ->willReturn($blockMock);
 
-        $this->conditionsHelperMock->expects($this->once())
-            ->method('decode')
-            ->with($conditionsEncoded)
-            ->willReturn($conditionsDecoded);
         $this->viewMock->expects($this->once())
             ->method('getLayout')
             ->willReturn($layoutMock);


### PR DESCRIPTION
This was somewhat fixed already in the develop branch, but it was fixed in generic controller action rather than in the widget that actually was broken and was responsible for rendering and encoding the before-mentioned options.

Related issue: https://github.com/magento/magento2/issues/5398
