### PR TITLE
Added typo correction for table name comment

### DIFF
--- a/app/code/Magento/ProductVideo/Setup/InstallSchema.php
+++ b/app/code/Magento/ProductVideo/Setup/InstallSchema.php
@@ -11,7 +11,7 @@ use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Catalog\Model\ResourceModel\Product\Gallery;
 
 /**
- * Class InstallSchema adds new table `eav_attribute_option_swatch`
+ * Class InstallSchema adds new table `catalog_product_entity_media_gallery_value_video`
  */
 class InstallSchema implements InstallSchemaInterface
 {


### PR DESCRIPTION
Changed the class comment:

Previously:

```
/**
 * Class InstallSchema adds new table `eav_attribute_option_swatch`
 */
```

Now: 

```
/**
 * Class InstallSchema adds new table `catalog_product_entity_media_gallery_value_video`
 */
```

to match the module table name
