### PR TITLE
Don't try to autoload classes that are not exist

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/InterceptableValidator.php
+++ b/lib/internal/Magento/Framework/ObjectManager/InterceptableValidator.php
@@ -39,7 +39,8 @@ class InterceptableValidator
     {
         return !is_subclass_of(
             $instanceName,
-            '\\' . \Magento\Framework\ObjectManager\Code\Generator\Proxy::NON_INTERCEPTABLE_INTERFACE
+            '\\' . \Magento\Framework\ObjectManager\Code\Generator\Proxy::NON_INTERCEPTABLE_INTERFACE,
+            false
         );
     }
 


### PR DESCRIPTION
There is an error "Source class "\Magento\CatalogSearch\Model\ResourceModel\Fulltext\SearchCollection" for "Magento\CatalogSearch\Model\ResourceModel\Fulltext\SearchCollectionFactory" generation does not exist." for URL like ".../index.php/catalogsearch/result/?q=prod" if plugin for factory class exists:

```
<!-- Interceptor to get error with full-text search -->
<type name="Magento\Catalog\Model\ResourceModel\Product\CollectionFactory">
    <plugin name="flancer32_sample_plugin" type="Flancer32\Sample\Plugin\Catalog\Model\ResourceModel\Product\CollectionFactory" sortOrder="100" disabled="false"/>
</type>
```

This is an error message:

```
Exception #0 (RuntimeException): Source class "\Magento\CatalogSearch\Model\ResourceModel\Fulltext\SearchCollection" for "Magento\CatalogSearch\Model\ResourceModel\Fulltext\SearchCollectionFactory" generation does not exist.
#0 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/Code/Generator.php(112): Magento\Framework\Code\Generator->tryToLoadSourceClass('Magento\\Catalog...', Object(Magento\Framework\ObjectManager\Code\Generator\Factory))
#1 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/Code/Generator/Autoloader.php(35): Magento\Framework\Code\Generator->generateClass('Magento\\Catalog...')
#2 [internal function]: Magento\Framework\Code\Generator\Autoloader->load('Magento\\Catalog...')
#3 [internal function]: spl_autoload_call('Magento\\Catalog...')
#4 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/InterceptableValidator.php(44): is_subclass_of('Magento\\Catalog...', '\\\\Magento\\Frame...', true)
#5 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/InterceptableValidator.php(16): Magento\Framework\ObjectManager\InterceptableValidator->isInterceptable('Magento\\Catalog...')
#6 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/Interception/ObjectManager/Config/Developer.php(62): Magento\Framework\ObjectManager\InterceptableValidator->validate('Magento\\Catalog...')
#7 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(70): Magento\Framework\Interception\ObjectManager\Config\Developer->getInstanceType('Magento\\Catalog...')
#8 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/ObjectManager.php(71): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->create('Magento\\Catalog...')
#9 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(126): Magento\Framework\ObjectManager\ObjectManager->get('Magento\\Catalog...')
#10 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(53): Magento\Framework\ObjectManager\Factory\AbstractFactory->resolveArgument(Array, 'Magento\\Catalog...', NULL, 'collectionFacto...', 'Magento\\Catalog...')
#11 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(82): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->_resolveArguments('Magento\\Catalog...', Array, Array)
#12 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/ObjectManager.php(71): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->create('Magento\\Catalog...')
#13 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(126): Magento\Framework\ObjectManager\ObjectManager->get('Magento\\Catalog...')
#14 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(53): Magento\Framework\ObjectManager\Factory\AbstractFactory->resolveArgument(Array, 'Magento\\Catalog...', NULL, 'collectionProvi...', 'Magento\\Catalog...')
#15 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(82): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->_resolveArguments('Magento\\Catalog...', Array, Array)
#16 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/ObjectManager.php(71): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->create('Magento\\Catalog...')
#17 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(126): Magento\Framework\ObjectManager\ObjectManager->get('Magento\\Catalog...')
#18 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(53): Magento\Framework\ObjectManager\Factory\AbstractFactory->resolveArgument(Array, 'Magento\\Catalog...', NULL, 'context', 'Magento\\Catalog...')
#19 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(82): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->_resolveArguments('Magento\\Catalog...', Array, Array)
#20 /home/alex/work/github/sample_mage2_module/work/vendor/magento/framework/ObjectManager/ObjectManager.php(57): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->create('Magento\\Catalog...', Array)
#21 /home/alex/work/github/sample_mage2_module/work/vendor/magento/module-catalog/Model/Layer/Resolver.php(59): Magento\Framework\ObjectManager\ObjectManager->create('Magento\\Catalog...')
#22 /home/alex/work/github/sample_mage2_module/work/vendor/magento/module-catalog-search/Controller/Result/Index.php(70): Magento\Catalog\Model\Layer\Resolver->create('search')
```
