### PR TITLE
Support store filter for ProductRepository::getList.

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -636,11 +636,15 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     ) {
         $fields = [];
         $categoryFilter = [];
+        $storeFilter = null;
         foreach ($filterGroup->getFilters() as $filter) {
             $conditionType = $filter->getConditionType() ? $filter->getConditionType() : 'eq';
 
             if ($filter->getField() == 'category_id') {
                 $categoryFilter[$conditionType][] = $filter->getValue();
+                continue;
+            } elseif ($filter->getField() == 'store_id' && $conditionType === 'eq') {
+                $storeFilter = $filter->getValue();
                 continue;
             }
             $fields[] = ['attribute' => $filter->getField(), $conditionType => $filter->getValue()];
@@ -648,6 +652,10 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
 
         if ($categoryFilter) {
             $collection->addCategoriesFilter($categoryFilter);
+        }
+
+        if ($storeFilter) {
+            $collection->addStoreFilter($storeFilter);
         }
 
         if ($fields) {


### PR DESCRIPTION
The current implementation of `\Magento\Catalog\Model\ProductRepository::getList` does not allow filter products by stores. When specify `store_id` filter in `$searchCriteria`, an exception throws `Invalid attribute name: store_id`.

This pull request adds support for store filtering by using the `\Magento\Catalog\Model\ResourceModel\Product\Collection::addStoreFilter` method.
