### PR TITLE
Add translation to newsletter subscribe template

### DIFF
--- a/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
+++ b/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
@@ -8,7 +8,7 @@
 
 ?>
 <div class="block newsletter">
-    <div class="title"><strong>Newsletter</strong></div>
+    <div class="title"><strong><?php echo __('Newsletter') ?></strong></div>
     <div class="content">
         <form class="form subscribe"
             novalidate


### PR DESCRIPTION
Pretty trivial. No associated GitHub issue.

This PR adds the translation wrapper method to a title, so a localised translation can be added.
