### PR TITLE
Bug fix: enable adding more than one image in editors

### DIFF
--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
@@ -240,10 +240,11 @@ define([
         openFileBrowser: function (o) {
             var typeTitle,
                 storeId = this.config['store_id'] !== null ? this.config['store_id'] : 0,
-                frameDialog = jQuery(o.win.frameElement).parents('[role="dialog"]'),
                 wUrl = this.config['files_browser_window_url'] +
                 'target_element_id/' + this.id + '/' +
                 'store/' + storeId + '/';
+            
+            window.frameDialog = jQuery(o.win.frameElement).parents('[role="dialog"]');
 
             this.mediaBrowserOpener = o.win;
             this.mediaBrowserTargetElementId = o.field;
@@ -255,7 +256,7 @@ define([
                 typeTitle = this.translate('Insert File...');
             }
 
-            frameDialog.hide();
+            window.frameDialog.hide();
             jQuery('#mceModalBlocker').hide();
 
             MediabrowserUtility.openDialog(wUrl, false, false, typeTitle, {
@@ -263,7 +264,7 @@ define([
                  * Closed.
                  */
                 closed: function () {
-                    frameDialog.show();
+                    window.frameDialog.show();
                     jQuery('#mceModalBlocker').show();
                 }
             });


### PR DESCRIPTION
Steps to reproduce:
- Edit a CMS page
- Add an image
- Add a second image

Result:
- After the image selection modal is closed a grey layover remains visible, but the tinymce image editor does not show anymore

Expected result:
- Tinymce editor is shown again after the image selection modal closes and I can add/edit my image

The error is that in the `closed: function() {` the variable `frameDialog` references to the first opened tinymce editor element. tinymce creates a new element every time you open it with a unique id, so the one you try to show the second time does not exist anymore.
I fixed it by declaring the frameDialog globally but feel free to solve this scope issue an other way if that's more conventional.
