### PR TITLE
Remove an extra space while clearing indexed stock items.

### DIFF
--- a/app/code/Magento/CatalogInventory/Observer/ReindexQuoteInventoryObserver.php
+++ b/app/code/Magento/CatalogInventory/Observer/ReindexQuoteInventoryObserver.php
@@ -77,7 +77,7 @@ class ReindexQuoteInventoryObserver implements ObserverInterface
             $this->priceIndexer->reindexList($productIds);
         }
 
-        $this->itemsForReindex ->clear();
+        $this->itemsForReindex->clear();
         // Clear list of remembered items - we don't need it anymore
     }
 }


### PR DESCRIPTION
Remove an extra space while clearing indexed stock items.
It should be

```
$this->itemsForReindex->clear();
```

instead of:

```
$this->itemsForReindex ->clear();
```

I know that the compiler doesn't complain about this at all, but shall we make it prettier? :)
