### PR TITLE
new phpseclib SFTP constants in ~0.3 -> 2.x upgrade

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Io/Sftp.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/Sftp.php
@@ -184,7 +184,7 @@ class Sftp extends AbstractIo
      */
     public function write($filename, $source, $mode = null)
     {
-        $mode = is_readable($source) ? NET_SFTP_LOCAL_FILE : NET_SFTP_STRING;
+        $mode = is_readable($source) ? \phpseclib\Net\SFTP::SOURCE_LOCAL_FILE : \phpseclib\Net\SFTP::SOURCE_STRING;
         return $this->_connection->put($filename, $source, $mode);
     }
 


### PR DESCRIPTION
The `NET_SFTP_*` constants here are a holdover from 2.0 using phpseclib ~0.3, they need to be changed in ~2.1 for phpseclib 2.x.
