### PR TITLE
Added Puerto Rico to the Directory module's install data script.

### DIFF
--- a/app/code/Magento/Directory/Setup/InstallData.php
+++ b/app/code/Magento/Directory/Setup/InstallData.php
@@ -221,6 +221,7 @@ class InstallData implements InstallDataInterface
             ['PH', 'PH', 'PHL'],
             ['PK', 'PK', 'PAK'],
             ['PL', 'PL', 'POL'],
+            ['PR', 'PR', 'PRI'],
             ['PM', 'PM', 'SPM'],
             ['PN', 'PN', 'PCN'],
             ['PS', 'PS', 'PSE'],


### PR DESCRIPTION
I recently came across an issue with UPS shipping rates not being populated when shipping to a Puerto Rican address. I had set up UPS with my shipping account info and shipper id and enabled all available shipping methods, but UPS would not return any shipping rates when using a Puerto Rico zip code/address. I opened a ticket with Enterprise Support (Ticket #03187690), and it is currently in an "escalated" state.

After digging a bit, I discovered the ship carrier was looking for Puerto Rico in the database but it does not exist. Apparently it _did_ exist in Magento 1 but looks to have not been included in Magento 2.  Adding the row for Puerto Rico to the database immediately solved UPS not returning shipping rates for Puerto Rico.

This update adds Puerto Rico back to the install data script.
