### PR TITLE
Fixed popular search terms not displaying on frontend.

### DIFF
--- a/app/code/Magento/Search/Block/Term.php
+++ b/app/code/Magento/Search/Block/Term.php
@@ -91,8 +91,8 @@ class Term extends Template
                     continue;
                 }
                 $term->setRatio(($term->getPopularity() - $this->_minPopularity) / $range);
-                $temp[$term->getName()] = $term;
-                $termKeys[] = $term->getName();
+                $temp[$term->getQueryText()] = $term;
+                $termKeys[] = $term->getQueryText();
             }
             natcasesort($termKeys);
 
@@ -124,7 +124,7 @@ class Term extends Template
          * url encoding will be done in Url.php http_build_query
          * so no need to explicitly called urlencode for the text
          */
-        $url->setQueryParam('q', $obj->getName());
+        $url->setQueryParam('q', $obj->getQueryText());
         return $url->getUrl('catalogsearch/result');
     }
 

--- a/app/code/Magento/Search/view/frontend/templates/term.phtml
+++ b/app/code/Magento/Search/view/frontend/templates/term.phtml
@@ -13,7 +13,7 @@
             <li class="item">
                 <a href="<?php /* @escapeNotVerified */ echo $block->getSearchUrl($_term) ?>"
                    style="font-size:<?php /* @escapeNotVerified */ echo $_term->getRatio()*70+75 ?>%;">
-                    <?php echo $block->escapeHtml($_term->getName()) ?>
+                    <?php echo $block->escapeHtml($_term->getQueryText()) ?>
                 </a>
             </li>
         <?php endforeach; ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

This update fixes an issue where search terms are not displaying on the **Search Terms** page.
## Steps to Reproduce
1. Create a searchable product or just install sample data.
2. Search for a product and confirm you have at least one result.
3. Click the **Search Terms** link in the footer or visit [http://example.com/search/term/popular/](http://example.com/search/term/popular/).
