### PR TITLE
Fix default values not being properly loaded for ArraySerialized fields

### DIFF
--- a/app/code/Magento/Config/Block/System/Config/Form.php
+++ b/app/code/Magento/Config/Block/System/Config/Form.php
@@ -309,17 +309,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         if (array_key_exists($path, $this->_configData)) {
             $data = $this->_configData[$path];
             $inherit = false;
-            
-            if ($field->hasBackendModel()) {
-                $backendModel = $field->getBackendModel();
-                $backendModel->setPath($path)
-                    ->setValue($data)
-                    ->setWebsite($this->getWebsiteCode())
-                    ->setStore($this->getStoreCode())
-                    ->afterLoad();
-                $data = $backendModel->getValue();
-            }
-            
         } elseif ($field->getConfigPath() !== null) {
             $data = $this->getConfigValue($field->getConfigPath());
         } else {
@@ -337,6 +326,16 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
 
         $elementName = $this->_generateElementName($field->getPath(), $fieldPrefix);
         $elementId = $this->_generateElementId($field->getPath($fieldPrefix));
+
+        if ($field->hasBackendModel()) {
+            $backendModel = $field->getBackendModel();
+            $backendModel->setPath($path)
+                ->setValue($data)
+                ->setWebsite($this->getWebsiteCode())
+                ->setStore($this->getStoreCode())
+                ->afterLoad();
+            $data = $backendModel->getValue();
+        }
 
         $dependencies = $field->getDependencies($fieldPrefix, $this->getStoreCode());
         $this->_populateDependenciesBlock($dependencies, $elementId, $elementName);

--- a/app/code/Magento/Config/Test/Unit/Block/System/Config/FormTest.php
+++ b/app/code/Magento/Config/Test/Unit/Block/System/Config/FormTest.php
@@ -581,7 +581,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [['section1/group1/field1' => 'some_value'], false, null, false, 'some_value', 1],
-            [[], 'Config Value', 'some/config/path', true, 'Config Value', 0]
+            [[], 'Config Value', 'some/config/path', true, 'Config Value', 1]
         ];
     }
 }


### PR DESCRIPTION
**Preconditions**:
- have latest M2.1 installed
- install demo data (using bin/magento demodata installation options)
- clean browser cookies for the domain you're at (to make sure we start from clean slate)
- make sure that you start with clean cache

**Bug**:
Default values are not properly loaded for fields with backend model \Magento\Config\Model\Config\Backend\Serialized\ArraySerialized.

**How to replicate**:
- Add system config field with backend _Magento\Config\Model\Config\Backend\Serialized\ArraySerialized_.

Example system.xml: 

``` xml
<?xml version="1.0"?>
<!--
 Copyright © 2009-2016 Vaimo AB. All rights reserved.
 See LICENSE.txt for license details.
-->
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
    <system>
        <tab id="import_export" translate="label" sortOrder="1000">
            <label>Import Export</label>
        </tab>
        <section id="export" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
            <label>Export</label>
            <tab>import_export</tab>
            <resource>Vaimo_HellyHansenImportExport::config</resource>
            <group id="product_export" translate="label" type="text" sortOrder="1000" showInDefault="1" showInWebsite="1" showInStore="1">
                <label>Product Export</label>
                <field id="remove_export_columns" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
                    <label>Remove Export Columns</label>
                    <frontend_model>Vaimo\HellyHansenImportExport\Block\System\Config\Form\Field\Columns</frontend_model>
                    <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
                    <comment>These columns will not be exported in Product Export.</comment>
                </field>
            </group>
        </section>
    </system>
</config>
```
- In order to make this work, we need to add the resource for it.

Example acl.xml:

``` xml
<?xml version="1.0"?>
<!--
 Copyright © 2009-2016 Vaimo AB. All rights reserved.
 See LICENSE.txt for license details.
-->
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
    <acl>
        <resources>
            <resource id="Magento_Backend::admin">
                <resource id="Magento_Backend::stores">
                    <resource id="Magento_Backend::stores_settings">
                        <resource id="Magento_Config::config">
                            <resource id="Vaimo_HellyHansenImportExport::config" title="Helly Hansen Import Export" sortOrder="50" />
                        </resource>
                    </resource>
                </resource>
            </resource>
        </resources>
    </acl>
</config>
```
- and also the frontend model:

``` php
<?php
/**
 * Copyright © 2009-2016 Vaimo AB. All rights reserved.
 * See LICENSE.txt for license details.
 */

namespace Vaimo\HellyHansenImportExport\Block\System\Config\Form\Field;

/**
 * Backend system config array field renderer
 *
 * @package Vaimo\HellyHansenItemExport\Block\System\Config\Form\Field
 */
class Columns extends \Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray
{
    /**
     * Initialise form fields.
     *
     * @return void
     */
    protected function _construct()
    {
        $this->addColumn('column', ['label' => __('Column')]);
        $this->_addAfter = false;
        parent::_construct();
    }
}

```
- Add default value in config.xml.

Example:

``` xml
<?xml version="1.0"?>
<!--
 Copyright © 2009-2016 Vaimo AB. All rights reserved.
 See LICENSE.txt for license details.
-->
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
    <default>
        <export>
            <product_export>
                <!--Remove image-related and bundle-related columns from export.-->
                <remove_export_columns><![CDATA[a:15:{i:0;a:1:{s:6:"column";s:10:"base_image";}i:1;a:1:{s:6:"column";s:16:"base_image_label";}i:2;a:1:{s:6:"column";s:11:"small_image";}i:3;a:1:{s:6:"column";s:17:"small_image_label";}i:4;a:1:{s:6:"column";s:15:"thumbnail_image";}i:5;a:1:{s:6:"column";s:21:"thumbnail_image_label";}i:6;a:1:{s:6:"column";s:12:"swatch_image";}i:7;a:1:{s:6:"column";s:18:"swatch_image_label";}i:8;a:1:{s:6:"column";s:17:"additional_images";}i:9;a:1:{s:6:"column";s:23:"additional_image_labels";}i:10;a:1:{s:6:"column";s:17:"bundle_price_type";}i:11;a:1:{s:6:"column";s:15:"bundle_sku_type";}i:12;a:1:{s:6:"column";s:17:"bundle_price_view";}i:13;a:1:{s:6:"column";s:18:"bundle_weight_type";}i:14;a:1:{s:6:"column";s:13:"bundle_values";}}]]></remove_export_columns>
            </product_export>
        </export>
    </default>
</config>
```
- Go to admin and open STORES -> Configuration -> IMPORT EXPORT -> Export:

**Expected**: default value is loaded
![configuration___settings___stores___magento_admin_-_correct](https://cloud.githubusercontent.com/assets/2362026/17775752/5f4faa2e-6562-11e6-9997-aac84bdf22ef.png)

**Actual**: default value is missing because afterLoad was not called on backend model when configuration existed **ONLY** as default value in config.xml
![configuration___settings___stores___magento_admin](https://cloud.githubusercontent.com/assets/2362026/17775634/d2d825f8-6561-11e6-8e9d-3cc5142ed2f9.png)

**Notes**:
- This issue was injected in https://github.com/magento/magento2/issues/3019 and all what it does is reverting the code merged by https://github.com/magento/magento2/pull/3020.
