### PR TITLE
Fix configurable price indexer (wrong join column)

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Indexer/Price/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Indexer/Price/Configurable.php
@@ -189,7 +189,7 @@ class Configurable extends \Magento\Catalog\Model\ResourceModel\Product\Indexer\
         )->group(
             ['parent_id', 'i.customer_group_id', 'i.website_id', 'l.product_id']
         );
-        $priceColumn = $this->_addAttributeToSelect($select, 'price', 'l.product_id', 0, null, true);
+        $priceColumn = $this->_addAttributeToSelect($select, 'price', 'e.row_id', 0, null, true);
         $tierPriceColumn = $connection->getCheckSql("MIN(i.tier_price) IS NOT NULL", "i.tier_price", 'NULL');
 
         $select->columns(


### PR DESCRIPTION
Currently the configurable price indexer will execute this sql statement in line 200: 

`INSERT INTO `catalog_product_index_price_cfg_opt_agr_idx` SELECT `e`.`entity_id` AS `parent_id`, `l`.`product_id`, `i`.`customer_group_id`, `i`.`website_id`, IF(IFNULL(tas_price.value_id, -1) > 0, tas_price.value, tad_price.value) AS `price`, IF(MIN(i.tier_price) IS NOT NULL, i.tier_price, NULL) AS `tier_price` FROM `catalog_product_index_price_final_idx` AS `i` INNER JOIN `catalog_product_entity` AS `e``
 [...]

 `INNER JOIN `catalog_product_entity_decimal` AS `tad_price` ON tad_price.row_id = l.product_id AND tad_price.attribute_id = 74 AND tad_price.store_id = 0
 LEFT JOIN `catalog_product_entity_decimal` AS `tas_price` ON tas_price.row_id = l.product_id AND tas_price.attribute_id = 74 AND tas_price.store_id = 0`
 [...]

As you can see the INNER JOIN and LEFT JOIN are referencing `tad_price.row_id = l.product_id` and  `tas_price.row_id = l.product_id` which will cause that in some cases a wrong min_price (and maybe other prices) is calculated. 
Correctly it has to be `tad_price.row_id = e.row_id` and `tas_price.row_id = e.row_id`.
