### PR TITLE
Set getConnection() as public method 

### DIFF
--- a/lib/internal/Magento/Framework/Model/ResourceModel/AbstractResource.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/AbstractResource.php
@@ -36,7 +36,7 @@ abstract class AbstractResource
      *
      * @return \Magento\Framework\DB\Adapter\AdapterInterface
      */
-    abstract protected function getConnection();
+    abstract public function getConnection();
 
     /**
      * Start resource transaction

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/AbstractResourceStub.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/AbstractResourceStub.php
@@ -31,7 +31,7 @@ class AbstractResourceStub extends AbstractResource
      *
      * @return AdapterInterface
      */
-    protected function getConnection()
+    public function getConnection()
     {
         return $this->connectionAdapter;
     }


### PR DESCRIPTION
Method `\Magento\Framework\Model\ResourceModel\AbstractResource::getConnection` is defined as protected but all implementations are public.
