### PR TITLE
Return the same data on exit

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock.php
@@ -140,7 +140,7 @@ class Stock extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb impleme
     public function correctItemsQty(array $items, $websiteId, $operator)
     {
         if (empty($items)) {
-            return $this;
+            return;
         }
 
         $connection = $this->getConnection();


### PR DESCRIPTION
Function `correctItemsQty` returns $this in case of input argument `$items` is empty or nothing otherwise. I suppose return value should be the same in the both cases - $this or nothing.
