### PR TITLE
$websiteId is replaced by getDefaultScopeId()

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/StockManagement.php
+++ b/app/code/Magento/CatalogInventory/Model/StockManagement.php
@@ -100,7 +100,7 @@ class StockManagement implements StockManagementInterface
                 continue;
             }
             if (!$stockItem->hasAdminArea()
-                && !$this->stockState->checkQty($productId, $orderedQty, $stockItem->getWebsiteId())
+                && !$this->stockState->checkQty($productId, $orderedQty)
             ) {
                 $this->getResource()->commit();
                 throw new \Magento\Framework\Exception\LocalizedException(
@@ -111,11 +111,8 @@ class StockManagement implements StockManagementInterface
                 $stockItem->setQty($stockItem->getQty() - $orderedQty);
             }
             $registeredItems[$productId] = $orderedQty;
-            if (!$this->stockState->verifyStock($productId, $stockItem->getWebsiteId())
-                || $this->stockState->verifyNotification(
-                    $productId,
-                    $stockItem->getWebsiteId()
-                )
+            if (!$this->stockState->verifyStock($productId)
+                || $this->stockState->verifyNotification($productId)
             ) {
                 $fullSaveItems[] = $stockItem;
             }


### PR DESCRIPTION
$websiteId/$scopeId is replaced by 

```
$scopeId = $this->stockConfiguration->getDefaultScopeId();
```

in the `$this->stockState->checkQty(...)`, `$this->stockState->verifyStock(...)` & `$this->stockState->verifyNotification(...)` methods. See `\Magento\CatalogInventory\Model\StockState::checkQty` for example:

```
public function checkQty($productId, $qty, $scopeId = null)
{
    // if ($scopeId === null) {
        $scopeId = $this->stockConfiguration->getDefaultScopeId();
    // }
    ...
}
```
