### PR TITLE
Fixed layout for customer authentication popup

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/template/authentication-popup.html
+++ b/app/code/Magento/Customer/view/frontend/web/template/authentication-popup.html
@@ -78,7 +78,6 @@
                     <!-- ko foreach: getRegion('additional-login-form-fields') -->
                     <!-- ko template: getTemplate() --><!-- /ko -->
                     <!-- /ko -->
-                    </div>
                     <div class="actions-toolbar">
                         <input name="context" type="hidden" value="checkout" />
                         <div class="primary">


### PR DESCRIPTION
Removed an unnecessary extra closing div tag in authentication popup layout. Nothing critical but might cause layout issues on some browsers. 
