### PR TITLE
Update elements.xsd

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
@@ -140,7 +140,7 @@
 
     <xs:simpleType name="elementNameType">
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z][a-zA-Z\d\-_\.]*"/>
+            <xs:pattern value="[a-zA-Z0-9][a-zA-Z\d\-_\.]*"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Looks like 'elementNameType' validator is very strict. I've got an exception in dev mode:
#0 (Magento\Framework\Config\Dom\ValidationException): Element 'block', attribute 'name': [facet 'pattern'] The value '4d072daa2b95b9d3fd3995d2faaf2993' is not accepted by the pattern '[a-zA-Z][a-zA-Z\d-_.]*'.

Line: 645
