### PR TITLE
Product import reload oldSku after bunch saved

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1713,6 +1713,8 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 $attributes
             );
 
+            $this->_oldSku = $this->skuProcessor->reloadOldSkus()->getOldSkus();
+
             $this->_eventManager->dispatch(
                 'catalog_product_import_bunch_save_after',
                 ['adapter' => $this, 'bunch' => $bunch]


### PR DESCRIPTION
When importing products with different values for different storeviews the following is happening. 
Bunch size is specified at 100 rows. When a product is in two different bunches due to having rows for multiple storeviews the product is added twice to the catalog_product_entity table.

This can be fixed by reloading oldSku from the database after the bunch is processed.
