### PR TITLE
Admin product edit block getHeader is not used

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
@@ -251,19 +251,6 @@ class Edit extends \Magento\Backend\Block\Widget
     /**
      * @return string
      */
-    public function getHeader()
-    {
-        if ($this->getProduct()->getId()) {
-            $header = $this->escapeHtml($this->getProduct()->getName());
-        } else {
-            $header = __('New Product');
-        }
-        return $header;
-    }
-
-    /**
-     * @return string
-     */
     public function getAttributeSetName()
     {
         if ($setId = $this->getProduct()->getAttributeSetId()) {

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
@@ -247,7 +247,7 @@ class Edit extends \Magento\Backend\Block\Widget
     {
         return $this->getUrl('catalog/*/duplicate', ['_current' => true]);
     }
-    
+
     /**
      * @deprecated
      * @return string

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
@@ -247,6 +247,20 @@ class Edit extends \Magento\Backend\Block\Widget
     {
         return $this->getUrl('catalog/*/duplicate', ['_current' => true]);
     }
+    
+    /**
+     * @deprecated
+     * @return string
+     */
+    public function getHeader()
+    {
+        if ($this->getProduct()->getId()) {
+            $header = $this->escapeHtml($this->getProduct()->getName());
+        } else {
+            $header = __('New Product');
+        }
+        return $header;
+    }
 
     /**
      * @return string


### PR DESCRIPTION
Just removing this method since it's not used, so people don't get mislead into creating a plugin for that and wondering why it does not work.

`\Magento\Theme\Block\Html\Title::getPageTitle()` returns the title instead.
