### PR TITLE
Fixes get.php 

### DIFF
--- a/app/code/Magento/MediaStorage/Model/File/Storage/Request.php
+++ b/app/code/Magento/MediaStorage/Model/File/Storage/Request.php
@@ -21,7 +21,7 @@ class Request
      */
     public function __construct(HttpRequest $request)
     {
-        $this->pathInfo = str_replace('..', '', ltrim($request->getPathInfo(), '/'));
+        $this->pathInfo = str_replace('..', '', ltrim($request->getPathInfo(), '/media/'));
     }
 
     /**


### PR DESCRIPTION
Fixes #5872 .

Making the database media storage usable. And cloud based installations applicable ( removing the need for filesystem storage ). 

catalog wysiwyg can not be compared with media/catalog etc.

See #5872  for more info.
