### PR TITLE
&& is shorter then ||

### DIFF
--- a/lib/internal/Magento/Framework/Reflection/MethodsMap.php
+++ b/lib/internal/Magento/Framework/Reflection/MethodsMap.php
@@ -174,9 +174,12 @@ class MethodsMap
      */
     private function isSuitableMethod($method)
     {
-        $isSuitableMethodType = !($method->isConstructor() || $method->isFinal()
-            || $method->isStatic() || $method->isDestructor());
-
+        $isSuitableMethodType = (
+            !$method->isStatic() &&
+            !$method->isFinal() &&
+            !$method->isConstructor() &&
+            !$method->isDestructor()
+        );
         $isExcludedMagicMethod = strpos($method->getName(), '__') === 0;
         return $isSuitableMethodType && !$isExcludedMagicMethod;
     }


### PR DESCRIPTION
'&&' usage is shorter then '||', if first part of the equity is 'false' then all equity is 'false'
