### PR TITLE
Zend instead of regex in getGetterReturnType

### DIFF
--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -309,7 +309,7 @@ class TypeProcessor
         }
         /** @var \Zend\Code\Reflection\DocBlock\Tag\ReturnTag $returnAnnotation */
         $returnAnnotation = current($returnAnnotations);
-        $returnType = $returnAnnotation->getType();
+        // $returnType = $returnAnnotation->getType();
         /*
          * Adding this code as a workaround since \Zend\Code\Reflection\DocBlock\Tag\ReturnTag::initialize does not
          * detect and return correct type for array of objects in annotation.

--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -309,23 +309,13 @@ class TypeProcessor
         }
         /** @var \Zend\Code\Reflection\DocBlock\Tag\ReturnTag $returnAnnotation */
         $returnAnnotation = current($returnAnnotations);
-        // $returnType = $returnAnnotation->getType();
-        /*
-         * Adding this code as a workaround since \Zend\Code\Reflection\DocBlock\Tag\ReturnTag::initialize does not
-         * detect and return correct type for array of objects in annotation.
-         * eg @return \Magento\Webapi\Service\Entity\SimpleData[] is returned with type
-         * \Magento\Webapi\Service\Entity\SimpleData instead of \Magento\Webapi\Service\Entity\SimpleData[]
-         */
-        $escapedReturnType = str_replace('[]', '\[\]', $returnType);
-        $escapedReturnType = str_replace('\\', '\\\\', $escapedReturnType);
+        $types = $returnAnnotation->getTypes();
+        $returnType = current($types);
+        $nullable = in_array('null', $types);
 
-        if (preg_match("/.*\\@return\\s+({$escapedReturnType}).*/i", $methodDocBlock->getContents(), $matches)) {
-            $returnType = $matches[1];
-        }
-        $isNotRequired = (bool)preg_match("/.*\@return\s+\S+\|null.*/i", $methodDocBlock->getContents(), $matches);
         return [
             'type' => $returnType,
-            'isRequired' => !$isNotRequired,
+            'isRequired' => !$nullable,
             'description' => $returnAnnotation->getDescription(),
             'parameterCount' => $methodReflection->getNumberOfRequiredParameters()
         ];

--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -288,6 +288,7 @@ class TypeProcessor
      *     'type' => <string>$type,
      *     'isRequired' => $isRequired,
      *     'description' => $description
+     *     'parameterCount' => $numberOfRequiredParameters
      * )</pre>
      * @throws \InvalidArgumentException
      */


### PR DESCRIPTION
\Zend\Code\Reflection\DocBlock\Tag\ReturnTag::getType is deprecated from 2.0.4 
'getTypes' method should be used instead.
