### PR TITLE
addresses #6347: String "Example:" is not translated with whitespaces in it

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
@@ -155,7 +155,7 @@ define(
                     warnMessage = $t('Provided Zip/Postal Code seems to be invalid.');
 
                     if (postcodeValidator.validatedPostCodeExample.length) {
-                        warnMessage += $t(' Example: ') + postcodeValidator.validatedPostCodeExample.join('; ') + '. ';
+                        warnMessage += ' ' + $t('Example:') + ' ' + postcodeValidator.validatedPostCodeExample.join('; ') + '. ';
                     }
                     warnMessage += $t('If you believe it is the right one you can ignore this notice.');
                     postcodeElement.warn(warnMessage);


### PR DESCRIPTION
Please refer to issue description #6347
