### PR TITLE
moved errorCount to beginning to account for errors in all themes, no…

### DIFF
--- a/app/code/Magento/Deploy/Model/Deployer.php
+++ b/app/code/Magento/Deploy/Model/Deployer.php
@@ -207,6 +207,7 @@ class Deployer
      */
     public function deploy(ObjectManagerFactory $omFactory, array $locales, array $deployableAreaThemeMap = [])
     {
+        $this->errorCount = 0;
         $this->omFactory = $omFactory;
 
         if ($this->getOption(Options::DRY_RUN)) {
@@ -223,7 +224,6 @@ class Deployer
 
                     $this->output->writeln("=== {$area} -> {$themePath} -> {$locale} ===");
                     $this->count = 0;
-                    $this->errorCount = 0;
 
                     /** @var \Magento\Theme\Model\View\Design $design */
                     $design = $this->objectManager->create(\Magento\Theme\Model\View\Design::class);


### PR DESCRIPTION
For deployment, we need `bin/magento` to exit with a return code != 0 to indicate if something went wrong.

As far as I am aware this issue is at least related to following other issues:
- https://github.com/magento/magento2/issues/3060
- https://github.com/magento/magento2/pull/3189

The above pull request already addresses the issue that `\Magento\Framework\Console\Cli::RETURN_FAILURE` will be used if `$this->errorCount > 0`.
However, the current develop branch sets `$this->errorCount = 0;` for every iteration, which clears errors from previous themes.
I would suggest moving the errorCount to the beginning of deploy function, to account for all errors in all steps, because otherwise it gets reset everytime and only the last step in the loop will count.

Preconditions
1. Tested on Magento 2.1.0 latest dev version on 903dcbb
## Steps to reproduce
1. Produce a syntax error in less, e.g. by creating an empty less: `mkdir -p app/design/frontend/Magento/luma/Magento_Email/web/css/ && touch app/design/frontend/Magento/luma/Magento_Email/web/css/email.less`
2. Run `bin/magento setup:static-content:deploy`
3. See error in output: e.g. `Successful: 2138 files; errors: 1`
## Expected result
1. Status code `echo $?` should be `!=0` after running task
## Actual result
1. Status code `echo $?` is `0`
