### PR TITLE
Product import with more than 100 rows may result in duplicated products

### DIFF
--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -2230,12 +2230,14 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
     /**
      * Retrieve product entities info as array
      *
-     * @param string|array $columns One or several columns
+     * @param string|array|null $columns One or several columns
+     * @param array|null $productSkuList List of skus
+     *
      * @return array
      */
-    public function getProductEntitiesInfo($columns = null)
+    public function getProductEntitiesInfo($columns = null, $productSkuList = null)
     {
-        return $this->_getResource()->getProductEntitiesInfo($columns);
+        return $this->_getResource()->getProductEntitiesInfo($columns, $productSkuList);
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product.php
@@ -511,9 +511,11 @@ class Product extends AbstractResource
      * Retrieve product entities info
      *
      * @param  array|string|null $columns
+     * @param  array|null $productSkuList
+     *
      * @return array
      */
-    public function getProductEntitiesInfo($columns = null)
+    public function getProductEntitiesInfo($columns = null, $productSkuList = null)
     {
         if (!empty($columns) && is_string($columns)) {
             $columns = [$columns];
@@ -524,6 +526,9 @@ class Product extends AbstractResource
 
         $connection = $this->getConnection();
         $select = $connection->select()->from($this->getTable('catalog_product_entity'), $columns);
+        if ($productSkuList) {
+            $select->where('sku in (?)', $productSkuList);
+        }
 
         return $connection->fetchAll($select);
     }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1323,13 +1323,17 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 array_keys($entityRowsIn)
             );
             $newProducts = $this->_connection->fetchAll($select);
+            $skusList = [];
             foreach ($newProducts as $data) {
                 $sku = $data['sku'];
+                $skusList[] = $sku;
                 unset($data['sku']);
                 foreach ($data as $key => $value) {
                     $this->skuProcessor->setNewSkuData($sku, $key, $value);
                 }
             }
+
+            $this->_oldSku = $this->skuProcessor->updateOldSkus($skusList)->getOldSkus();
         }
         return $this;
     }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -584,6 +584,20 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     protected $validatedRows;
 
     /**
+     * Array of row ids inserted (needed to check updated products).
+     *
+     * @var
+     */
+    protected $rowIdsInserted = [];
+
+    /**
+     * Array of row ids updated (needed to check updated products).
+     *
+     * @var
+     */
+    protected $rowIdsUpdated = [];
+
+    /**
      * @var \Psr\Log\LoggerInterface
      */
     private $_logger;
@@ -1304,13 +1318,25 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     {
         static $entityTable = null;
         $this->countItemsCreated += count($entityRowsIn);
-        $this->countItemsUpdated += count($entityRowsUp);
+        $updatedRowIds = [];
+        foreach ($entityRowsUp as $entityRowsUpData) {
+            if (isset($entityRowsUpData[$this->getProductEntityLinkField()])) {
+                $updatedRowIds[] = $entityRowsUpData[$this->getProductEntityLinkField()];
+            }
+        }
+        $updatedRowIds = array_unique($updatedRowIds);
+        $this->countItemsUpdated += count(
+            array_diff($updatedRowIds, $this->rowIdsInserted, $this->rowIdsUpdated)
+        );
 
         if (!$entityTable) {
             $entityTable = $this->_resourceFactory->create()->getEntityTable();
         }
         if ($entityRowsUp) {
             $this->_connection->insertOnDuplicate($entityTable, $entityRowsUp, ['updated_at']);
+            foreach ($entityRowsUp as $data) {
+                $this->rowIdsUpdated[] = $data[$this->getProductEntityLinkField()];
+            }
         }
         if ($entityRowsIn) {
             $this->_connection->insertMultiple($entityTable, $entityRowsIn);
@@ -1325,6 +1351,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
             $newProducts = $this->_connection->fetchAll($select);
             $skusList = [];
             foreach ($newProducts as $data) {
+                $this->rowIdsInserted[] = $data[$this->getProductEntityLinkField()];
                 $sku = $data['sku'];
                 $skusList[] = $sku;
                 unset($data['sku']);

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/SkuProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/SkuProcessor.php
@@ -102,6 +102,20 @@ class SkuProcessor
     }
 
     /**
+     * Update old skus by adding the data for $skus.
+     *
+     * @param array $skus
+     *
+     * @return $this
+     */
+    public function updateOldSkus($skus)
+    {
+        $this->oldSkus = array_merge($this->oldSkus, $this->_getSkus($skus));
+
+        return $this;
+    }
+
+    /**
      * @param string $sku
      * @param array $data
      * @return $this
@@ -141,16 +155,18 @@ class SkuProcessor
     /**
      * Get skus data.
      *
+     * @param array|null $skus
+     *
      * @return array
      */
-    protected function _getSkus()
+    protected function _getSkus($skus = null)
     {
         $oldSkus = [];
         $columns = ['entity_id', 'type_id', 'attribute_set_id', 'sku'];
         if ($this->getProductEntityLinkField() != $this->getProductIdentifierField()) {
             $columns[] = $this->getProductEntityLinkField();
         }
-        foreach ($this->productFactory->create()->getProductEntitiesInfo($columns) as $info) {
+        foreach ($this->productFactory->create()->getProductEntitiesInfo($columns, $skus) as $info) {
             $typeId = $info['type_id'];
             $sku = $info['sku'];
             $oldSkus[$sku] = [


### PR DESCRIPTION
This PR fixes issue described in https://github.com/magento/magento2/issues/5780.
### Preconditions:
- have latest M2.1 installed
- install demo data (using bin/magento demodata installation options)
### Issue:

Product import with more than 100 rows may result in duplicated products.
### How to replicate:
- Import a CSV file which has more than 100 rows where rows 100 and 101 belong to the same sku A (different values per store).
- After running the import, you will realise that in importexport_importdata table, sku A will appear in two batches: in the first batch which contains the first 100 rows and in the 2nd batch which contains the next 100 rows (which includes row 101).
#### Expected:
- Product with sku A is imported only once.
#### Actual:
- The import does incorrectly identify product with SKU A as new in both batches and, as a consequence, it does duplicate the product.
### Solution:
- Product with SKU A should be inserted in the first batch (new product) and it should updated in the 2nd batch (existing product).
- Note that the fix also changes the count of updated products following the idea:

> A sku in a batch should be  counted as an updated product only if this sku was not inserted or updated in a previous batch.
