### PR TITLE
Paypal Express Checkout: the old URL for select payment when user logged in is obsolete.

### DIFF
--- a/app/code/Magento/Paypal/view/frontend/web/js/action/set-payment-method.js
+++ b/app/code/Magento/Paypal/view/frontend/web/js/action/set-payment-method.js
@@ -35,11 +35,12 @@ define(
                 };
                 method = 'post';
             } else {
-                serviceUrl = urlBuilder.createUrl('/carts/mine/selected-payment-method', {});
+                serviceUrl = urlBuilder.createUrl('/carts/mine/set-payment-information', {});
                 payload = {
                     cartId: quote.getQuoteId(),
-                    method: paymentData
+                    paymentMethod: paymentData
                 };
+                method = 'post';
             }
             fullScreenLoader.startLoader();
 


### PR DESCRIPTION
Per http://devdocs.magento.com/guides/v2.1/rest/list.html, the URL for /carts/mine/selected-payment-method no longer exist.  Instead it is replaced with /carts/mine/set-payment-information. Also need to add paymentMethod field on the payload to make this call valid.
