### PR TITLE
Fixed street.0 field validation bug in Checkout

### DIFF
--- a/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
+++ b/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
@@ -272,10 +272,11 @@ class AttributeMerger
                         ['required-entry' => (bool)$attributeConfig['required']],
                         $attributeConfig['validation']
                     )
-                    : $attributeConfig['validation'],
-                'additionalClasses' => $isFirstLine ? 'field' : 'additional'
-
+                    : $attributeConfig['validation']
             ];
+            if (!$isFirstLine) {
+                $line['additionalClasses'] = 'additional';
+            }
             if ($isFirstLine && isset($attributeConfig['default']) && $attributeConfig['default'] != null) {
                 $line['value'] = $attributeConfig['default'];
             }


### PR DESCRIPTION
This might apply to other situations similar to this, where multiline control is being used. Suggesting to check the whole codebase for similar issue.

**Explanation of the problem**
In checkout shipping address entry (customer + guest), when a validation error occurs, the first "street" field is not properly marked with "red" colour. This appears to be due the fact that appropriate classes are not being applied.
See:
![checkoutnoredborder](https://cloud.githubusercontent.com/assets/1692860/18087310/37b65b8e-6ebd-11e6-9ef8-90d9deae9321.png)

The problem originates from how the field config is being constructed.
it appears to be taking place in Magento/Checkout/Block/Checkout/AttributeMerger.php

Observe the line 275
`'additionalClasses' => $isFirstLine ? : 'additional'`

Apparently the additionalClasses value is always set to some value, however in case of field "street.0" we need to "inherit" this value from base config.

The PR here will take care of this. By only setting the value in case it needs to be set to 'additional', otherwise it is not touching it at all.
