### PR TITLE
Create private content version cookie when required

### DIFF
--- a/lib/internal/Magento/Framework/App/PageCache/Version.php
+++ b/lib/internal/Magento/Framework/App/PageCache/Version.php
@@ -75,7 +75,7 @@ class Version
      */
     public function process()
     {
-        if ($this->request->isPost()) {
+        if ($this->request->isPost() || is_null($this->cookieManager->getCookie(self::COOKIE_NAME))) {
             $publicCookieMetadata = $this->cookieMetadataFactory->createPublicCookieMetadata()
                 ->setDuration(self::COOKIE_PERIOD)
                 ->setPath('/')


### PR DESCRIPTION
The private-content-version cookie is required for the front-end JS to AJAX fetch private block content. Relevant JS snippet from page-cache.js:95:

```
  _create: function () {
            var placeholders,
                version = $.mage.cookies.get(this.options.versionCookieName);

            if (!version) {
                return;
            }
            placeholders = this._searchPlaceholders(this.element.comments());

            if (placeholders && placeholders.length) {
                this._ajax(placeholders, version);
            }
  }
```

Current behaviour dictates that only POST requests will generate the cookie, leaving sessions initially lacking it and causing private content to remain unloaded. See issue #3890 for one case where this is causing problems, I've added some steps to reproduce as a [comment](https://github.com/magento/magento2/issues/3890#issuecomment-242609763)

Note: This change conforms with the function's phpdoc (see below), which up until now has not been true. "_Set cookie if it is not set_" was never implemented but clearly was part of the intended design.

```
    /**
     * Handle private content version cookie
     * Set cookie if it is not set.
     * Increment version on post requests.
     * In all other cases do nothing.
     *
     * @return void
     */
```
