### PR TITLE
Refactor Option ResourceModel to allow price supporting types to be intercepted

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Option.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Option.php
@@ -105,13 +105,7 @@ class Option extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
          * If there is not price skip saving price
          */
 
-        if ($object->getType() == \Magento\Catalog\Model\Product\Option::OPTION_TYPE_FIELD ||
-            $object->getType() == \Magento\Catalog\Model\Product\Option::OPTION_TYPE_AREA ||
-            $object->getType() == \Magento\Catalog\Model\Product\Option::OPTION_TYPE_FILE ||
-            $object->getType() == \Magento\Catalog\Model\Product\Option::OPTION_TYPE_DATE ||
-            $object->getType() == \Magento\Catalog\Model\Product\Option::OPTION_TYPE_DATE_TIME ||
-            $object->getType() == \Magento\Catalog\Model\Product\Option::OPTION_TYPE_TIME
-        ) {
+        if (in_array($object->getType(), $this->getPriceTypes())) {
             //save for store_id = 0
             if (!$object->getData('scope', 'price')) {
                 $statement = $connection->select()->from(
@@ -558,6 +552,23 @@ class Option extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         }
 
         return $searchData;
+    }
+    
+    /**
+     * All Option Types that support price and price_type
+     * 
+     * @return string[]
+     */
+    public function getPriceTypes()
+    {
+        return [
+            \Magento\Catalog\Model\Product\Option::OPTION_TYPE_FIELD,
+            \Magento\Catalog\Model\Product\Option::OPTION_TYPE_AREA,
+            \Magento\Catalog\Model\Product\Option::OPTION_TYPE_FILE,
+            \Magento\Catalog\Model\Product\Option::OPTION_TYPE_DATE,
+            \Magento\Catalog\Model\Product\Option::OPTION_TYPE_DATE_TIME,
+            \Magento\Catalog\Model\Product\Option::OPTION_TYPE_TIME,
+        ];
     }
 
     /**


### PR DESCRIPTION
This commit allows the price and price_type functionality to be expanded by third party modules with no real change in the logic utilized.

This is one of many options - but I feel like it's the one that requires the least thought.  Utilizing this methodology anyone can write an interceptor to obtain this functionality for a third-party custom option.

Additional options, such as through XML or other means exist but require more thought and change the underlying behavior - while simply pulling these out into their own function does not.

This PR is intended to be the smallest possible change that improves the extensibility of core.  As it is not an [@]API class it can be removed, changed, etc in the future without "bc breaks".
