### PR TITLE
Fix Product import does incorrectly insert attribute values per store for products with numeric skus

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1232,12 +1232,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
         foreach ($attributesData as $tableName => $skuData) {
             $tableData = [];
             foreach ($skuData as $sku => $attributes) {
-                $linkId = $this->_connection->fetchOne(
-                    $this->_connection->select()
-                        ->from($this->getResource()->getTable('catalog_product_entity'))
-                        ->where('sku = ?', $sku)
-                        ->columns($this->getProductEntityLinkField())
-                );
+                $linkId = $this->skuProcessor->getNewSku($sku)[$this->getProductEntityLinkField()];
 
                 foreach ($attributes as $attributeId => $storeValues) {
                     foreach ($storeValues as $storeId => $storeValue) {


### PR DESCRIPTION
### Preconditions:
- have latest M2.1 installed
- install demo data (using bin/magento demodata installation options)
### Issue:

Product import does incorrectly insert attribute values per store for products with numeric skus.
### How to replicate:
- Import a product file with this content:

```
sku,store_view_code,attribute_set_code,product_type,name,tax_class_name,visibility,price
1000000-Red,,Default,simple,Name 1000000-Red,Taxable Goods,Not Visible Individually,200
1000000,,Default,simple,Name 1000000,Taxable Goods,Not Visible Individually,100
```
- Note that the first product has sku 1000000-Red and the 2nd product has sku 1000000.
#### Expected:
- Product with sku 1000000-Red is imported with name = "Name 1000000-Red".
- Product with sku 1000000 is imported with name = "Name 1000000".
#### Actual:
- Product with sku 1000000-Red is imported with name = "Name 1000000".
- Product with sku 1000000 is imported with no name.
### Cause:
- The query to get the link id was:
  `SELECT`catalog_product_entity`.*,`catalog_product_entity`.`row_id`FROM`catalog_product_entity`WHERE (sku = 1000000) AND (catalog_product_entity.created_in <= 1) AND (catalog_product_entity.updated_in > 1);`
- The row id is not correctly taken for the 2nd product with sku 1000000. Because the sku is compared to the number 1000000, MySql matches '1000000-Red' for sku = 1000000, therefore when the row id for sku 1000000 is requested, the row id for sku 1000000-Red is returned.
### Solution 1:
- This issue would be fixed by converting the sku to a string so the query will use the condition `WHERE (sku = '1000000')` instead of `WHERE (sku = 1000000)`.
### Solution 2:
- However, I see no reason why we can't take the link id using the new sku collected data, like it's done in \Magento\CatalogImportExport\Model\Import\Product::_saveProductWebsites.
### Notes:

This PR implements Solution 2. If you have a good reason to always query the database for the link id, you can implement Solution 1 by changing code:

```
                $linkId = $this->_connection->fetchOne(
                    $this->_connection->select()        
                        ->from($this->getResource()->getTable('catalog_product_entity'))        
                        ->where('sku = ?',  $sku)       
                        ->columns($this->getProductEntityLinkField())       
                );
```

to:

```
                 $linkId = $this->_connection->fetchOne(
                    $this->_connection->select()        
                        ->from($this->getResource()->getTable('catalog_product_entity'))        
                        ->where('sku = ?', (string)$sku)        
                        ->columns($this->getProductEntityLinkField())       
                );
```
