### PR TITLE
Add php value for setting auto_detect_line_endings on.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -54,6 +54,12 @@
 ## disable user agent verification to not break multiple image upload
 
     php_flag suhosin.session.cryptua off
+
+###########################################
+## Allow line endings to be automatically detected to allow imports to work as expected
+
+    php_value auto_detect_line_endings on
+
 </IfModule>
 <IfModule mod_php7.c>
 ############################################
@@ -77,6 +83,12 @@
 ## disable user agent verification to not break multiple image upload
 
     php_flag suhosin.session.cryptua off
+
+###########################################
+## Allow line endings to be automatically detected to allow imports to work as expected
+
+    php_value auto_detect_line_endings on
+
 </IfModule>
 <IfModule mod_security.c>
 ###########################################


### PR DESCRIPTION
This PR is to fix issue #6393 

The default for auto_detect_line_endings when PHP is installed is off therefore to stop other users of magento falling into this issue the htaccess file can cover this off.

Thanks for considering.
