### PR TITLE
stringify cookievalue to fix #5596

### DIFF
--- a/app/code/Magento/Cookie/view/frontend/web/js/notices.js
+++ b/app/code/Magento/Cookie/view/frontend/web/js/notices.js
@@ -20,7 +20,7 @@ define([
             $(this.options.cookieAllowButtonSelector).on('click', $.proxy(function() {
                 var cookieExpires = new Date(new Date().getTime() + this.options.cookieLifetime * 1000);
 
-                $.mage.cookies.set(this.options.cookieName, this.options.cookieValue, {expires: cookieExpires});
+                $.mage.cookies.set(this.options.cookieName, JSON.stringify(this.options.cookieValue), {expires: cookieExpires});
                 if ($.mage.cookies.get(this.options.cookieName)) {
                     window.location.reload();
                 } else {


### PR DESCRIPTION
cookieValue should be converted using JSON.stringify, otherwise you'll have a string "[object Object]" as value. Detailed description in #5596 
