### PR TITLE
Remove breadcrumbs for multistore homepage

### DIFF
--- a/app/code/Magento/Cms/Block/Page.php
+++ b/app/code/Magento/Cms/Block/Page.php
@@ -124,16 +124,26 @@ class Page extends \Magento\Framework\View\Element\AbstractBlock implements
      */
     protected function _addBreadcrumbs(\Magento\Cms\Model\Page $page)
     {
+        $homePageIdentifier = $this->_scopeConfig->getValue(
+            'web/default/cms_home_page',
+            ScopeInterface::SCOPE_STORE
+        );
+        $homePageDelimiterPosition = strrpos($homePageIdentifier, '|');
+        if ($homePageDelimiterPosition) {
+            $homePageIdentifier = substr($homePageIdentifier, 0, $homePageDelimiterPosition);
+        }
+        $noRouteIdentifier = $this->_scopeConfig->getValue(
+            'web/default/cms_no_route',
+            ScopeInterface::SCOPE_STORE
+        );
+        $noRouteDelimiterPosition = strrpos($noRouteIdentifier, '|');
+        if ($noRouteDelimiterPosition) {
+            $noRouteIdentifier = substr($noRouteIdentifier, 0, $noRouteDelimiterPosition);
+        }
         if ($this->_scopeConfig->getValue('web/default/show_cms_breadcrumbs', ScopeInterface::SCOPE_STORE)
             && ($breadcrumbsBlock = $this->getLayout()->getBlock('breadcrumbs'))
-            && $page->getIdentifier() !== $this->_scopeConfig->getValue(
-                'web/default/cms_home_page',
-                ScopeInterface::SCOPE_STORE
-            )
-            && $page->getIdentifier() !== $this->_scopeConfig->getValue(
-                'web/default/cms_no_route',
-                ScopeInterface::SCOPE_STORE
-            )
+            && $page->getIdentifier() !== $homePageIdentifier
+            && $page->getIdentifier() !== $noRouteIdentifier
         ) {
             $breadcrumbsBlock->addCrumb(
                 'home',


### PR DESCRIPTION
When there are multiple different cms home pages with same identifier but for different store views, breadcrumbs are shown in all of them except the first.
The same applies for 404 pages.
Fixes #6504 
