### PR TITLE
Added spacingTop feature to sticky plugin.

### DIFF
--- a/lib/web/mage/sticky.js
+++ b/lib/web/mage/sticky.js
@@ -12,7 +12,7 @@ define([
     $.widget('mage.sticky', {
         options: {
             container: '',
-            offsetTop: 0
+            spacingTop: 0
         },
 
         /**
@@ -43,10 +43,10 @@ define([
             if( !isStatic && this.element.is(':visible') ) {
                 offset = $(document).scrollTop() - this.parentOffset;
 
-                if (typeof this.options.offsetTop === 'function') {
-                    offset += this.options.offsetTop();
+                if (typeof this.options.spacingTop === 'function') {
+                    offset += this.options.spacingTop();
                 } else {
-                    offset += this.options.offsetTop;
+                    offset += this.options.spacingTop;
                 }
 
                 offset = Math.max( 0, Math.min( offset, this.maxOffset) );

--- a/lib/web/mage/sticky.js
+++ b/lib/web/mage/sticky.js
@@ -43,7 +43,11 @@ define([
             if( !isStatic && this.element.is(':visible') ) {
                 offset = $(document).scrollTop() - this.parentOffset;
 
-                offset += this.options.offsetTop;
+                if (typeof this.options.offsetTop === 'function') {
+                    offset += this.options.offsetTop();
+                } else {
+                    offset += this.options.offsetTop;
+                }
 
                 offset = Math.max( 0, Math.min( offset, this.maxOffset) );
                 

--- a/lib/web/mage/sticky.js
+++ b/lib/web/mage/sticky.js
@@ -11,7 +11,8 @@ define([
     
     $.widget('mage.sticky', {
         options: {
-            container: ''
+            container: '',
+            offsetTop: 0
         },
 
         /**
@@ -41,6 +42,8 @@ define([
 
             if( !isStatic && this.element.is(':visible') ) {
                 offset = $(document).scrollTop() - this.parentOffset;
+
+                offset += this.options.offsetTop;
 
                 offset = Math.max( 0, Math.min( offset, this.maxOffset) );
                 


### PR DESCRIPTION
By default sticky element get sticked at the top of the screen
without any gap. This commit allows to add it in options object:

``` js
$('#element').sticky({
    container: '#container',
    spacingTop: 25
});
```
