### PR TITLE
Solves #6068: StoreManager::getStore(null) returns default store after calling StoreManager::setCurrentStore(0)

### DIFF
--- a/app/code/Magento/Store/Model/StoreManager.php
+++ b/app/code/Magento/Store/Model/StoreManager.php
@@ -150,7 +150,7 @@ class StoreManager implements
     public function getStore($storeId = null)
     {
         if (!isset($storeId) || '' === $storeId || $storeId === true) {
-            if (!$this->currentStoreId) {
+            if (!isset($this->currentStoreId)) {
                 \Magento\Framework\Profiler::start('store.resolve');
                 $this->currentStoreId = $this->storeResolver->getCurrentStoreId();
                 \Magento\Framework\Profiler::stop('store.resolve');


### PR DESCRIPTION
Add support for admin store (ID: 0) to Magento\Store\Model\StoreManager::getStore(). Solves: https://github.com/magento/magento2/issues/6068#issuecomment-244410935
