### PR TITLE
Update addCategoriesFilter to return $this

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -852,6 +852,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
      * Filter Product by Categories
      *
      * @param array $categoriesFilter
+     * @return $this
      */
     public function addCategoriesFilter(array $categoriesFilter)
     {
@@ -865,6 +866,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             ];
             $this->getSelect()->where($this->getConnection()->prepareSqlCondition('e.entity_id' , $selectCondition));
         }
+        return $this;
     }
 
     /**


### PR DESCRIPTION
To keep consistency addCategoriesFilter should return $this. All Other methods seems to use fluent API.
