### PR TITLE
Update ViewAction.php

### DIFF
--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/ViewAction.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/ViewAction.php
@@ -53,12 +53,13 @@ class ViewAction extends Column
                 if (isset($item['entity_id'])) {
                     $viewUrlPath = $this->getData('config/viewUrlPath') ?: '#';
                     $urlEntityParamName = $this->getData('config/urlEntityParamName') ?: 'entity_id';
+                    $indexField = $this->getData('config/indexField') ?: 'entity_id';
                     $item[$this->getData('name')] = [
                         'view' => [
                             'href' => $this->urlBuilder->getUrl(
                                 $viewUrlPath,
                                 [
-                                    $urlEntityParamName => $item['entity_id']
+                                    $urlEntityParamName => $item[$indexField]
                                 ]
                             ),
                             'label' => __('View')

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/ViewAction.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/ViewAction.php
@@ -50,10 +50,10 @@ class ViewAction extends Column
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
-                if (isset($item['entity_id'])) {
+                $indexField = $this->getData('config/indexField') ?: 'entity_id';
+                if (isset($item[$indexField])) {
                     $viewUrlPath = $this->getData('config/viewUrlPath') ?: '#';
                     $urlEntityParamName = $this->getData('config/urlEntityParamName') ?: 'entity_id';
-                    $indexField = $this->getData('config/indexField') ?: 'entity_id';
                     $item[$this->getData('name')] = [
                         'view' => [
                             'href' => $this->urlBuilder->getUrl(


### PR DESCRIPTION
In flles 
magento/module-sales/view/adminhtml/ui_component/sales_order_view_creditmemo_grid.xml
magento/module-sales/view/adminhtml/ui_component/sales_order_view_invoice_grid.xml
magento/module-sales/view/adminhtml/ui_component/sales_order_view_shipment_grid.xml

the following snippet is used:

`````` XML
<actionsColumn name="actions" class="Magento\Sales\Ui\Component\Listing\Column\ViewAction">
     <argument name="data" xsi:type="array">
         <item name="config" xsi:type="array">
             <item name="indexField" xsi:type="string">entity_id</item>
             <item name="viewUrlPath" xsi:type="string">sales/order_creditmemo/view</item>
             <item name="urlEntityParamName" xsi:type="string">creditmemo_id</item>
         </item>
     </argument>
 </actionsColumn>```


however, unlike "viewUrlPath" and  "urlEntityParamName"  the item named "indexField" is not implemented in the code of Magento\Sales\Ui\Component\Listing\Column\ViewAction

It is needed when adding a custom table the same way as credmemo, invoice and shipment grids with a an index field other than "entity_id"
``````
