### PR TITLE
add-product-image-label-bug

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php
@@ -157,7 +157,7 @@ class CreateHandler implements ExtensionInterface
                 $product->setData($mediaAttrCode . '_label', $newImages[$attrData]['label']);
             }
 
-            if (in_array($attrData, array_keys($existImages))) {
+            if (in_array($attrData, array_keys($existImages)) && isset($existImages[$attrData]['label'])) {
                 $product->setData($mediaAttrCode . '_label', $existImages[$attrData]['label']);
             }
 


### PR DESCRIPTION
- fixes notice error that prevents saving product in non default store view when image label has not been defined

To reproduce:
1) In a store with multiple store views add product with at least 1 image (do not add image alt tag)
2) After saving the product switch to store view, change the product name and save
3) the save fails with error:
Notice: Undefined index: label in /home/mark/Projects/magento2/app/code/Magento/Catalog/Model/Product/Gallery/CreateHandler.php on line 161
