### PR TITLE
Removed unused variable

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Category.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category.php
@@ -744,7 +744,6 @@ class Category extends AbstractResource
      */
     public function getChildren($category, $recursive = true)
     {
-        $linkField = $this->getLinkField();
         $attributeId = $this->getIsActiveAttributeId();
         $backendTable = $this->getTable([$this->getEntityTablePrefix(), 'int']);
         $connection = $this->getConnection();


### PR DESCRIPTION
Currently `$linkfield` is defined twice. The first one is never used since it's overridden by the second. See [this code sample](https://github.com/magento/magento2/blob/develop/app/code/Magento/Catalog/Model/ResourceModel/Category.php#L747-L752).
