### PR TITLE
Changed constructor to use interface instead of direct classname

### DIFF
--- a/lib/internal/Magento/Framework/App/FrontController.php
+++ b/lib/internal/Magento/Framework/App/FrontController.php
@@ -24,7 +24,7 @@ class FrontController implements FrontControllerInterface
      * @param \Magento\Framework\App\Response\Http $response
      */
     public function __construct(
-        RouterList $routerList,
+        RouterListInterface $routerList,
         \Magento\Framework\App\Response\Http $response
     ) {
         $this->_routerList = $routerList;


### PR DESCRIPTION
Constructor should use an interface instead of a direct classname so it can be overwritten when necessary. In the di.xml this was already done, but in this constructor it didn't use the interface yet, so this has been changed.
