### PR TITLE
Changed locator class name for ObjectManager

### DIFF
--- a/lib/internal/Magento/Framework/App/ObjectManagerFactory.php
+++ b/lib/internal/Magento/Framework/App/ObjectManagerFactory.php
@@ -41,7 +41,7 @@ class ObjectManagerFactory
      *
      * @var string
      */
-    protected $_locatorClassName = \Magento\Framework\ObjectManager\ObjectManager::class;
+    protected $_locatorClassName = \Magento\Framework\App\ObjectManager::class;
 
     /**
      * Config class name
@@ -180,7 +180,6 @@ class ObjectManagerFactory
         $objectManager = new $this->_locatorClassName($this->factory, $diConfig, $sharedInstances);
 
         $this->factory->setObjectManager($objectManager);
-        ObjectManager::setInstance($objectManager);
 
         $generatorParams = $diConfig->getArguments(\Magento\Framework\Code\Generator::class);
         /** Arguments are stored in different format when DI config is compiled, thus require custom processing */


### PR DESCRIPTION
Changed the locator class name for the object manager to \Magento\Framework\App\ObjectManager which extends \Magento\Framework\ObjectManager\ObjectManager. In the constructor of \Magento\Framework\App\ObjectManager the object manager is already set as the ObjectManager instance, so there is no need to call it seperately in the ObjectManagerFactory class.

If this pull request is denied, then the constructor function of \Magento\Framework\App\ObjectManager should be removed since it will not be called anywhere in the application.
