### PR TITLE
Make a hardcoded value in Customizable Options interceptable

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Options.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options.php
@@ -208,7 +208,7 @@ class Options extends \Magento\Framework\View\Element\Template
         $config = [];
         foreach ($this->getOptions() as $option) {
             /* @var $option \Magento\Catalog\Model\Product\Option */
-            if ($option->getGroupByType() == \Magento\Catalog\Model\Product\Option::OPTION_GROUP_SELECT) {
+            if ($option->hasValues()) {
                 $tmpPriceValues = [];
                 foreach ($option->getValues() as $valueId => $value) {
                     $tmpPriceValues[$valueId] = $this->_getPriceConfiguration($value);

--- a/app/code/Magento/Catalog/Model/Product/Option.php
+++ b/app/code/Magento/Catalog/Model/Product/Option.php
@@ -219,6 +219,17 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
     }
 
     /**
+     * Whether or not the option type contains sub-values
+     *
+     * @param string $type
+     * @return bool
+     */
+    public function hasValues($type = null)
+    {
+        return $this->getGroupByType($type) == self::OPTION_GROUP_SELECT;
+    }
+
+    /**
      * @return ProductCustomOptionValuesInterface[]|null
      */
     public function getValues()

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/OptionTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/OptionTest.php
@@ -35,6 +35,15 @@ class OptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($productSku, $this->model->getProductSku());
     }
 
+    public function testHasValues()
+    {
+        $this->model->setType('drop_down');
+        $this->assertTrue($this->model->hasValues());
+
+        $this->model->setType('field');
+        $this->assertFalse($this->model->hasValues());
+    }
+
     public function testGetRegularPrice()
     {
         $priceInfoMock = $this->getMockForAbstractClass(


### PR DESCRIPTION
Update the Product Option model and Block to utilize a hasValues() method rather than hardcoded check for SELECT group

This is meant to be a non-breaking stop-gap measure to allow extensions and integrators to create custom customizable options without having to rewrite core Magento classes and without having to replace the Options block.
