### PR TITLE
Move cache to instance of price box widget

### DIFF
--- a/app/code/Magento/Catalog/view/base/web/js/price-box.js
+++ b/app/code/Magento/Catalog/view/base/web/js/price-box.js
@@ -21,7 +21,6 @@ define([
 
     $.widget('mage.priceBox', {
         options: globalOptions,
-        cache: {},
 
         /**
          * Widget initialisation.
@@ -39,6 +38,7 @@ define([
          * Widget creating.
          */
         _create: function createPriceBox() {
+            this.cache = {};
             var box = this.element;
 
             this._setDefaultsFromPriceConfig();


### PR DESCRIPTION
When caches are shared on the class of the price box widget, there can
be a case where price boxes are displayed on the page which do not share
the same values that should be stored in that cache. For instance,
upsells and related products can have price boxes in them, and they will
overwrite the cache of the price box on the product page. This change
moves the cache off of the class itself and onto the instance so
instances of price box widgets don't interfere with one another.
