### PR TITLE
Fix nav not working in mobile

### DIFF
--- a/app/design/frontend/Magento/blank/etc/view.xml
+++ b/app/design/frontend/Magento/blank/etc/view.xml
@@ -227,7 +227,7 @@
                 </var>
                 <var name="options">
                     <var name="options">
-                        <var name="navigation">dots</var>
+                        <var name="nav">dots</var>
                     </var>
                 </var>
             </var>


### PR DESCRIPTION
In mobile thumbs don't disappear and dots are not present.
In Luma theme the var name is "nav" instead of "navigation" and it works as expected.
