### PR TITLE
Unable to save subscription checkbox on Admin customer save

### DIFF
--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
@@ -244,10 +244,10 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
 
                 $isSubscribed = null;
                 if ($this->_authorization->isAllowed(null)) {
-                    $isSubscribed = $this->getRequest()->getPost('subscription');
+                    $isSubscribed = (bool)$this->getRequest()->getPost('subscription');
                 }
                 if ($isSubscribed !== null) {
-                    if ($isSubscribed !== 'false') {
+                    if ($isSubscribed !== false) {
                         $this->_subscriberFactory->create()->subscribeCustomerById($customerId);
                     } else {
                         $this->_subscriberFactory->create()->unsubscribeCustomerById($customerId);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
@@ -247,7 +247,7 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
                     $isSubscribed = (bool)$this->getRequest()->getPost('subscription');
                 }
                 if ($isSubscribed !== null) {
-                    if ($isSubscribed !== false) {
+                    if ($isSubscribed !== '0') {
                         $this->_subscriberFactory->create()->subscribeCustomerById($customerId);
                     } else {
                         $this->_subscriberFactory->create()->unsubscribeCustomerById($customerId);

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
@@ -244,7 +244,7 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index
 
                 $isSubscribed = null;
                 if ($this->_authorization->isAllowed(null)) {
-                    $isSubscribed = (bool)$this->getRequest()->getPost('subscription');
+                    $isSubscribed = $this->getRequest()->getPost('subscription');
                 }
                 if ($isSubscribed !== null) {
                     if ($isSubscribed !== '0') {


### PR DESCRIPTION
**Preconditions**

Default Magento code base with sample data.

**Steps to reproduce**
1. Log in to Admin
2. Select a customer/ create a customer
3. Subscription tab
4. Save

the "Subscribed to Newsletter" will be always 'checked' because the condition of the if is clearly wrong

Actual and Expected result

To make sure that everybody involved in the fix are on the same page, precisely describe the result you expected to get and the result you actually observed after performing the steps.

**Expected result:**
It would be expect to see the "Subscribed to Newsletter" checkbox being saved correctly

**Additional information**

The change is fairy simple, in the if statement before was comparing with false as a string, so when getting the the value from the post, i make sure i cast it with (bool).

Then just check is !== false
