### PR TITLE
Removed argument from di.xml

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -313,11 +313,6 @@
             <argument name="cacheFrontend" xsi:type="object">Magento\Framework\App\Cache\Type\Config</argument>
         </arguments>
     </type>
-    <type name="Magento\Framework\Cache\Config\Reader">
-        <arguments>
-            <argument name="fileName" xsi:type="string">cache.xml</argument>
-        </arguments>
-    </type>
     <type name="Magento\Framework\Cache\Config\Data">
         <arguments>
             <argument name="cacheId" xsi:type="string">config_cache</argument>


### PR DESCRIPTION
Removed argument from di.xml for the Magento\Framework\Cache\Config\Reader class. This argument already has a default given in the code so it should not be present in di.xml. Removed it from di.xml for cleaner code.
