### PR TITLE
Removed preference from di.xml

### DIFF
--- a/app/code/Magento/NewRelicReporting/etc/di.xml
+++ b/app/code/Magento/NewRelicReporting/etc/di.xml
@@ -6,7 +6,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="Magento\Framework\Module\ModuleListInterface" type="Magento\Framework\Module\ModuleList" />
     <type name="Magento\NewRelicReporting\Model\Module\Collect">
         <arguments>
             <argument name="fullModuleList" xsi:type="object">Magento\Framework\Module\FullModuleList</argument>


### PR DESCRIPTION
Removed preference from di.xml in the NewRelicReporting module. This preference is already in the di.xml file in the app/etc/di.xml file so it's declared twice. Removed the one from this module for cleaner code.
