### PR TITLE
Changed constructor to use an interface

### DIFF
--- a/lib/internal/Magento/Framework/App/FrontController.php
+++ b/lib/internal/Magento/Framework/App/FrontController.php
@@ -10,7 +10,7 @@ namespace Magento\Framework\App;
 class FrontController implements FrontControllerInterface
 {
     /**
-     * @var RouterList
+     * @var RouterListInterface
      */
     protected $_routerList;
 
@@ -24,7 +24,7 @@ class FrontController implements FrontControllerInterface
      * @param \Magento\Framework\App\Response\Http $response
      */
     public function __construct(
-        RouterList $routerList,
+        RouterListInterface $routerList,
         \Magento\Framework\App\Response\Http $response
     ) {
         $this->_routerList = $routerList;


### PR DESCRIPTION
Changed the constructor of the FrontController class to user a RouterListInterface instead of RouterList object. The preference for the RouterListInterface is already in /app/etc/di.xml, but is not being used. Changed to code to use an interface in this constructor.
