### PR TITLE
Fixed phpseclib\Net\SFTP constants used in write() method

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Io/Sftp.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/Sftp.php
@@ -20,7 +20,7 @@ class Sftp extends AbstractIo
     const SSH2_PORT = 22;
 
     /**
-     * @var \Net_SFTP $_connection
+     * @var \phpseclib\Net\SFTP $_connection
      */
     protected $_connection = null;
 
@@ -184,7 +184,7 @@ class Sftp extends AbstractIo
      */
     public function write($filename, $source, $mode = null)
     {
-        $mode = is_readable($source) ? NET_SFTP_LOCAL_FILE : NET_SFTP_STRING;
+        $mode = is_readable($source) ? \phpseclib\Net\SFTP::SOURCE_LOCAL_FILE : \phpseclib\Net\SFTP::SOURCE_STRING;
         return $this->_connection->put($filename, $source, $mode);
     }
 


### PR DESCRIPTION
I noticed the `\Magento\Framework\Filesystem\Io\Sftp` class was modified to use an updated phpseclib library in commit 1383a49e742a811a40ead99c515df6fc4ce60e28 

The write method uses the constants `NET_SFTP_LOCAL_FILE` and `NET_SFTP_STRING` that worked just fine prior the library update. Since the library has changed, these constants are outdated and the write method throws this:  
`Notice: Use of undefined constant NET_SFTP_LOCAL_FILE - assumed 'NET_SFTP_LOCAL_FILE' in /var/www/releases/release-0/vendor/magento/framework/Filesystem/Io/Sftp.php on line 187`

when trying to use it.

I modified the constants according the actual library used in Magento. Please refer to https://github.com/phpseclib/phpseclib/blob/master/phpseclib/Net/SFTP.php to verify correctness.

Regards.
