### PR TITLE
Fix saving of empty multi select input

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/multiselect.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/multiselect.js
@@ -31,7 +31,7 @@ define([
          * @inheritdoc
          */
         normalizeData: function (value) {
-            if (utils.isEmpty(value) || this.value().length == 0) {
+            if (utils.isEmpty(value) || (typeof value != 'undefined' && value.length == 0)) {
                 value = '';
             }
 

--- a/app/code/Magento/Ui/view/base/web/js/form/element/multiselect.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/multiselect.js
@@ -31,8 +31,8 @@ define([
          * @inheritdoc
          */
         normalizeData: function (value) {
-            if (utils.isEmpty(value)) {
-                value = [];
+            if (utils.isEmpty(value) || this.value().length == 0) {
+                value = '';
             }
 
             return _.isString(value) ? value.split(',') : value;
@@ -83,6 +83,17 @@ define([
             this.error(false);
 
             return this;
+        },
+
+        /**
+         * @inheritdoc
+         */
+        onUpdate: function () {
+            if (this.value().length == 0) {
+                this.value('');
+            }
+
+            this._super();
         }
     });
 });


### PR DESCRIPTION
The original issue is described here: https://github.com/magento/magento2/issues/6281

When you save an empty multi select input originally it sent an empty array, which was filtered out
by the magento2-base/lib/web/mage/utils/objects.js::flatten() method and it was not sent to the
backend for save. This fix changes the empty array to an empty string, which will be passed to
the backend and it saves it as empty value properly

![](http://66.media.tumblr.com/c2b03e242ea5cd2b7b3f92de9a60b32a/tumblr_inline_odd3a4Zm4S1raprkq_500.gif)
