### PR TITLE
issues 6849: Invoice Id is not stored into credit memo DB record

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo.php
@@ -50,6 +50,10 @@ class Creditmemo extends SalesResource implements CreditmemoResourceInterface
             $object->setBillingAddressId($object->getOrder()->getBillingAddress()->getId());
         }
 
+        if (!$object->getInvoiceId() && $object->getInvoice()) {
+            $object->setInvoiceId($object->getInvoice()->getId());
+        }
+
         return parent::_beforeSave($object);
     }
 }


### PR DESCRIPTION
Fix for issue: https://github.com/magento/magento2/issues/6849, https://github.com/magento/magento2/issues/6848
