### PR TITLE
mage.cookies.set/get fix for value object

### DIFF
--- a/lib/web/mage/cookies.js
+++ b/lib/web/mage/cookies.js
@@ -77,7 +77,7 @@
             domain = options.domain;
             secure = options.secure;
 
-            document.cookie = name + '=' + encodeURIComponent(value) +
+            document.cookie = name + '=' + encodeURIComponent(JSON.stringify(value)) +
                 (expires ? '; expires=' + expires.toGMTString() :  '') +
                 (path ? '; path=' + path : '') +
                 (domain ? '; domain=' + domain : '') +
@@ -137,7 +137,7 @@
                 endstr = document.cookie.length;
             }
 
-            return decodeURIComponent(document.cookie.substring(offset, endstr));
+            return decodeURIComponent(JSON.parse(document.cookie.substring(offset, endstr)));
         };
 
         return this;


### PR DESCRIPTION
When we pass an object as value to `mage.cookies.set`, it incorrectly converts to string and the result is something like: `"[Object object]"`.
This means that when we enable `Cookie Restriction Mode`, the method `CookieHelper::isUserNotAllowSaveCookie` will always return false, breaking other modules such as `Google Analytics` (the monitoring code will never show up!).

This PR fix the problem
