### PR TITLE
Fixed calling non exists order address->getCountry to getCountryId

### DIFF
--- a/app/code/Magento/Authorizenet/Model/Authorizenet.php
+++ b/app/code/Magento/Authorizenet/Model/Authorizenet.php
@@ -332,7 +332,7 @@ abstract class Authorizenet extends \Magento\Payment\Model\Method\Cc
                     ->setXCity($billing->getCity())
                     ->setXState($billing->getRegion())
                     ->setXZip($billing->getPostcode())
-                    ->setXCountry($billing->getCountry())
+                    ->setXCountry($billing->getCountryId())
                     ->setXPhone($billing->getTelephone())
                     ->setXFax($billing->getFax())
                     ->setXCustId($order->getCustomerId())
@@ -352,7 +352,7 @@ abstract class Authorizenet extends \Magento\Payment\Model\Method\Cc
                     ->setXShipToCity($shipping->getCity())
                     ->setXShipToState($shipping->getRegion())
                     ->setXShipToZip($shipping->getPostcode())
-                    ->setXShipToCountry($shipping->getCountry());
+                    ->setXShipToCountry($shipping->getCountryId());
             }
 
             $request->setXPoNum($payment->getPoNumber())

--- a/app/code/Magento/Authorizenet/Model/Directpost/Request.php
+++ b/app/code/Magento/Authorizenet/Model/Directpost/Request.php
@@ -123,7 +123,7 @@ class Request extends AuthorizenetRequest
                 ->setXCity(strval($billing->getCity()))
                 ->setXState(strval($billing->getRegion()))
                 ->setXZip(strval($billing->getPostcode()))
-                ->setXCountry(strval($billing->getCountry()))
+                ->setXCountry(strval($billing->getCountryId()))
                 ->setXPhone(strval($billing->getTelephone()))
                 ->setXFax(strval($billing->getFax()))
                 ->setXCustId(strval($billing->getCustomerId()))
@@ -151,7 +151,7 @@ class Request extends AuthorizenetRequest
             )->setXShipToZip(
                 strval($shipping->getPostcode())
             )->setXShipToCountry(
-                strval($shipping->getCountry())
+                strval($shipping->getCountryId())
             );
         }
 


### PR DESCRIPTION
Problem occurs when Authorize.net AVS is checking card holder against country which is blank.
