### PR TITLE
Allow extending config variables

### DIFF
--- a/app/code/Magento/Email/Model/Source/Variables.php
+++ b/app/code/Magento/Email/Model/Source/Variables.php
@@ -61,7 +61,7 @@ class Variables implements \Magento\Framework\Option\ArrayInterface
     public function toOptionArray($withGroup = false)
     {
         $optionArray = [];
-        foreach ($this->_configVariables as $variable) {
+        foreach ($this->getData() as $variable) {
             $optionArray[] = [
                 'value' => '{{config path="' . $variable['value'] . '"}}',
                 'label' => $variable['label'],

--- a/app/code/Magento/Email/Model/Source/Variables.php
+++ b/app/code/Magento/Email/Model/Source/Variables.php
@@ -81,6 +81,6 @@ class Variables implements \Magento\Framework\Option\ArrayInterface
      */
     public function getData()
     {
-        return  $this->_configVariables;
+        return $this->_configVariables;
     }
 }


### PR DESCRIPTION
Currently, you can't elegantly extend the config variables via plugins. A plugin would have to take care of both `toOptionArray()` _and_ `getData()`.

By using a method call, now plugins can inject themselves in two places in one go.
