### PR TITLE
Remove distinction in http/https for requirejs-config.js

### DIFF
--- a/lib/internal/Magento/Framework/View/Asset/File/FallbackContext.php
+++ b/lib/internal/Magento/Framework/View/Asset/File/FallbackContext.php
@@ -14,11 +14,6 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 class FallbackContext extends Context
 {
     /**
-     * Secure path
-     */
-    const SECURE_PATH = 'secure';
-
-    /**
      * @var string
      */
     private $area;
@@ -43,14 +38,12 @@ class FallbackContext extends Context
      * @param string $areaType
      * @param string $themePath
      * @param string $localeCode
-     * @param bool $isSecure
      */
-    public function __construct($baseUrl, $areaType, $themePath, $localeCode, $isSecure = false)
+    public function __construct($baseUrl, $areaType, $themePath, $localeCode)
     {
         $this->area = $areaType;
         $this->theme = $themePath;
         $this->locale = $localeCode;
-        $this->isSecure = $isSecure;
         parent::__construct($baseUrl, DirectoryList::STATIC_VIEW, $this->generatePath());
     }
 
@@ -103,6 +96,6 @@ class FallbackContext extends Context
      */
     public function getConfigPath()
     {
-        return $this->getPath() . ($this->isSecure ? '/' . self::SECURE_PATH : '');
+        return $this->getPath();
     }
 }

--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -269,8 +269,7 @@ class Repository
                     'baseUrl' => $url,
                     'areaType' => $area,
                     'themePath' => $themePath,
-                    'localeCode' => $locale,
-                    'isSecure' => $isSecure
+                    'localeCode' => $locale
                 ]
             );
         }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/File/FallbackContextTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/File/FallbackContextTest.php
@@ -31,7 +31,6 @@ class FallbackContextTest extends \PHPUnit_Framework_TestCase
      * @param string $areaType
      * @param string $themePath
      * @param string $localeCode
-     * @param bool $isSecure
      * @param string $expectedResult
      * @dataProvider getConfigPathDataProvider
      */
@@ -40,7 +39,6 @@ class FallbackContextTest extends \PHPUnit_Framework_TestCase
         $areaType,
         $themePath,
         $localeCode,
-        $isSecure,
         $expectedResult
     ) {
         $this->fallbackContext = $this->objectManager->getObject(
@@ -49,8 +47,7 @@ class FallbackContextTest extends \PHPUnit_Framework_TestCase
                 'baseUrl' => $baseUrl,
                 'areaType' => $areaType,
                 'themePath' => $themePath,
-                'localeCode' => $localeCode,
-                'isSecure' => $isSecure
+                'localeCode' => $localeCode
             ]
         );
         $this->assertEquals($expectedResult, $this->fallbackContext->getConfigPath());
@@ -64,7 +61,6 @@ class FallbackContextTest extends \PHPUnit_Framework_TestCase
                 'areaType' => 'frontend',
                 'themePath' => 'Magento/blank',
                 'localeCode' => 'en_US',
-                'isSecure' => false,
                 'expectedResult' => 'frontend/Magento/blank/en_US'
             ],
             'https' => [
@@ -72,8 +68,7 @@ class FallbackContextTest extends \PHPUnit_Framework_TestCase
                 'areaType' => 'frontend',
                 'themePath' => 'Magento/blank',
                 'localeCode' => 'en_US',
-                'isSecure' => true,
-                'expectedResult' => 'frontend/Magento/blank/en_US/secure'
+                'expectedResult' => 'frontend/Magento/blank/en_US'
             ]
         ];
     }


### PR DESCRIPTION
This code is only used for the generation of requirejs-config.js so removing the http/https distinction has no effect on other files.

The contents of requirejs-config.js are exactly equal when requested over http as https and only the http variant is generated by running `magento setup:static-content:deploy`

After this fix the generated file is also available for https requests.

Fixes #5977
