### PR TITLE
Issues 5762 and 6799 and probably 5948

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/LinkedProductSelectBuilderByIndexPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/LinkedProductSelectBuilderByIndexPrice.php
@@ -86,7 +86,7 @@ class LinkedProductSelectBuilderByIndexPrice implements LinkedProductSelectBuild
             ->where('t.website_id = ?', $this->storeManager->getStore()->getWebsiteId())
             ->where('t.customer_group_id = ?', $this->customerSession->getCustomerGroupId())
             ->order('t.min_price ' . Select::SQL_ASC)
-            ->limit($limit)];
+            ->limit($limit);
         $priceSelect = $this->baseSelectProcessor->process($priceSelect);
 
         return [$priceSelect];

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/LinkedProductSelectBuilderByIndexPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/LinkedProductSelectBuilderByIndexPrice.php
@@ -63,7 +63,7 @@ class LinkedProductSelectBuilderByIndexPrice implements LinkedProductSelectBuild
     /**
      * {@inheritdoc}
      */
-    public function build($productId)
+    public function build($productId, $limit = 1)
     {
         $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
         $productTable = $this->resource->getTableName('catalog_product_entity');
@@ -86,7 +86,7 @@ class LinkedProductSelectBuilderByIndexPrice implements LinkedProductSelectBuild
             ->where('t.website_id = ?', $this->storeManager->getStore()->getWebsiteId())
             ->where('t.customer_group_id = ?', $this->customerSession->getCustomerGroupId())
             ->order('t.min_price ' . Select::SQL_ASC)
-            ->limit(1);
+            ->limit($limit)];
         $priceSelect = $this->baseSelectProcessor->process($priceSelect);
 
         return [$priceSelect];

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderByBasePrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderByBasePrice.php
@@ -71,7 +71,7 @@ class LinkedProductSelectBuilderByBasePrice implements LinkedProductSelectBuilde
     /**
      * {@inheritdoc}
      */
-    public function build($productId)
+    public function build($productId, $limit = 1)
     {
         $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
         $priceAttribute = $this->eavConfig->getAttribute(Product::ENTITY, 'price');
@@ -95,9 +95,8 @@ class LinkedProductSelectBuilderByBasePrice implements LinkedProductSelectBuilde
             ->where('t.attribute_id = ?', $priceAttribute->getAttributeId())
             ->where('t.value IS NOT NULL')
             ->order('t.value ' . Select::SQL_ASC)
-            ->limit(1);
+            ->limit($limit);
         $priceSelect = $this->baseSelectProcessor->process($priceSelect);
-
         $priceSelectDefault = clone $priceSelect;
         $priceSelectDefault->where('t.store_id = ?', Store::DEFAULT_STORE_ID);
         $select[] = $priceSelectDefault;

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderBySpecialPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderBySpecialPrice.php
@@ -90,7 +90,7 @@ class LinkedProductSelectBuilderBySpecialPrice implements LinkedProductSelectBui
     /**
      * {@inheritdoc}
      */
-    public function build($productId)
+    public function build($productId, $limit = 1)
     {
         $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
         $connection = $this->resource->getConnection();
@@ -139,9 +139,8 @@ class LinkedProductSelectBuilderBySpecialPrice implements LinkedProductSelectBui
                 'special_to.value IS NULL OR ' . $connection->getDatePartSql('special_to.value') .' >= ?',
                 $currentDate
             )->order('t.value ' . Select::SQL_ASC)
-            ->limit(1);
+            ->limit($limit);
         $specialPrice = $this->baseSelectProcessor->process($specialPrice);
-
         $specialPriceDefault = clone $specialPrice;
         $specialPriceDefault->where('t.store_id = ?', Store::DEFAULT_STORE_ID);
         $select[] = $specialPriceDefault;

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderByTierPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderByTierPrice.php
@@ -74,7 +74,7 @@ class LinkedProductSelectBuilderByTierPrice implements LinkedProductSelectBuilde
     /**
      * {@inheritdoc}
      */
-    public function build($productId)
+    public function build($productId, $limit = 1)
     {
         $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
         $productTable = $this->resource->getTableName('catalog_product_entity');
@@ -97,9 +97,8 @@ class LinkedProductSelectBuilderByTierPrice implements LinkedProductSelectBuilde
             ->where('t.all_groups = 1 OR customer_group_id = ?', $this->customerSession->getCustomerGroupId())
             ->where('t.qty = ?', 1)
             ->order('t.value ' . Select::SQL_ASC)
-            ->limit(1);
+            ->limit($limit);
         $priceSelect = $this->baseSelectProcessor->process($priceSelect);
-
         $priceSelectDefault = clone $priceSelect;
         $priceSelectDefault->where('t.website_id = ?', self::DEFAULT_WEBSITE_ID);
         $select[] = $priceSelectDefault;

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderComposite.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderComposite.php
@@ -24,11 +24,11 @@ class LinkedProductSelectBuilderComposite implements LinkedProductSelectBuilderI
     /**
      * {@inheritdoc}
      */
-    public function build($productId)
+    public function build($productId, $limit = 1)
     {
         $select = [];
         foreach ($this->linkedProductSelectBuilder as $productSelectBuilder) {
-            $select = array_merge($select, $productSelectBuilder->build($productId));
+            $select = array_merge($select, $productSelectBuilder->build($productId, $limit));
         }
 
         return $select;

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderInterface.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderInterface.php
@@ -12,7 +12,8 @@ interface LinkedProductSelectBuilderInterface
 {
     /**
      * @param int $productId
+     * @param int $limit
      * @return \Magento\Framework\DB\Select[]
      */
-    public function build($productId);
+    public function build($productId, $limit = 1);
 }

--- a/app/code/Magento/CatalogRule/Model/ResourceModel/Product/LinkedProductSelectBuilderByCatalogRulePrice.php
+++ b/app/code/Magento/CatalogRule/Model/ResourceModel/Product/LinkedProductSelectBuilderByCatalogRulePrice.php
@@ -105,7 +105,7 @@ class LinkedProductSelectBuilderByCatalogRulePrice implements LinkedProductSelec
             ->where('t.customer_group_id = ?', $this->customerSession->getCustomerGroupId())
             ->where('t.rule_date = ?', $currentDate)
             ->order('t.rule_price ' . Select::SQL_ASC)
-            ->limit($limit)];
+            ->limit($limit);
         $priceSelect = $this->baseSelectProcessor->process($priceSelect);
 
         return [$priceSelect];

--- a/app/code/Magento/CatalogRule/Model/ResourceModel/Product/LinkedProductSelectBuilderByCatalogRulePrice.php
+++ b/app/code/Magento/CatalogRule/Model/ResourceModel/Product/LinkedProductSelectBuilderByCatalogRulePrice.php
@@ -79,7 +79,7 @@ class LinkedProductSelectBuilderByCatalogRulePrice implements LinkedProductSelec
     /**
      * {@inheritdoc}
      */
-    public function build($productId)
+    public function build($productId, $limit = 1)
     {
         $timestamp = $this->localeDate->scopeTimeStamp($this->storeManager->getStore());
         $currentDate = $this->dateTime->formatDate($timestamp, false);
@@ -105,7 +105,7 @@ class LinkedProductSelectBuilderByCatalogRulePrice implements LinkedProductSelec
             ->where('t.customer_group_id = ?', $this->customerSession->getCustomerGroupId())
             ->where('t.rule_date = ?', $currentDate)
             ->order('t.rule_price ' . Select::SQL_ASC)
-            ->limit(1);
+            ->limit($limit)];
         $priceSelect = $this->baseSelectProcessor->process($priceSelect);
 
         return [$priceSelect];


### PR DESCRIPTION
Small summary:

The array of subproducts retrieved by ConfigurableOptionsProvider()->getProducts($product) is incorrectly being limited to the first enabled product by the SQL generated in the LinkedProductSelectBuilders.  If the first subproduct is out of stock, entire catalog crashes.  This fix adds an optional argument to the LinkedProductSelectBuilders to allow them to retrieve more than 1 subproduct, fixing the crash.

This crash was acknowledged in #6799 but hasn't yet been assigned.
