### PR TITLE
Fix trailing slash used a product URL suffix

### DIFF
--- a/app/code/Magento/UrlRewrite/Controller/Router.php
+++ b/app/code/Magento/UrlRewrite/Controller/Router.php
@@ -129,7 +129,7 @@ class Router implements \Magento\Framework\App\RouterInterface
     protected function getRewrite($requestPath, $storeId)
     {
         return $this->urlFinder->findOneByData([
-            UrlRewrite::REQUEST_PATH => trim($requestPath, '/'),
+            UrlRewrite::REQUEST_PATH => ltrim($requestPath, '/'),
             UrlRewrite::STORE_ID => $storeId,
         ]);
     }


### PR DESCRIPTION
In reference to issue #7040 
Seems a couple of other people are complaining too  e.g. http://magento.stackexchange.com/questions/107477/slash-as-category-url-suffix-gives-404-error-on-all-category-pages
