### PR TITLE
Fix for issue when Product Import imports attributes for wrong SKU

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1249,7 +1249,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 $linkId = $this->_connection->fetchOne(
                     $this->_connection->select()
                         ->from($this->getResource()->getTable('catalog_product_entity'))
-                        ->where('sku = ?', $sku)
+                        ->where('sku = ?', (string)$sku)
                         ->columns($this->getProductEntityLinkField())
                 );
 


### PR DESCRIPTION
In case of importing numeric SKUs, Magento can update wrong product. 
See examples on a screenshots. 
![1](https://cloud.githubusercontent.com/assets/1975805/19516152/f669fb44-95fa-11e6-8cfb-9e2e0c3aee72.png)
![2](https://cloud.githubusercontent.com/assets/1975805/19516156/f9570522-95fa-11e6-9bde-10e11c84d736.png)
![3](https://cloud.githubusercontent.com/assets/1975805/19516157/fcc84aea-95fa-11e6-8529-c48060364efe.png)
