### PR TITLE
Add de_LU and fr_LU languages for Luxembourg

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -31,6 +31,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'de_AT', /*German (Austria)*/
         'de_CH', /*German (Switzerland)*/
         'de_DE', /*German (Germany)*/
+        'de_LU', /*German (Luxembourg)*/
         'el_GR', /*Greek (Greece)*/
         'en_AU', /*English (Australian)*/
         'en_CA', /*English (Canadian)*/
@@ -53,6 +54,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'fr_BE', /*French (Belgium)*/
         'fr_CA', /*French (Canada)*/
         'fr_FR', /*French (France)*/
+        'fr_LU', /*French (Luxembourg)*/
         'gu_IN', /*Gujarati (India)*/
         'he_IL', /*Hebrew (Israel)*/
         'hi_IN', /*Hindi (India)*/


### PR DESCRIPTION
For our Luxembourgian customers it would be very nice if their languages were also supported.

Although de_LU and fr_LU can be easily added with a plugin - which is my current solution - it's a small change to add it to the Magento code. I think the Luxembourgians would be thankful.
