### PR TITLE
Fix a bug resulting in incorrect offsets with dynamic row drag-n-drop functionality

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dnd.js
+++ b/app/code/Magento/Ui/view/base/web/js/dynamic-rows/dnd.js
@@ -136,8 +136,8 @@ define([
             drEl.instanceCtx = this.getRecord(originRecord[0]);
             drEl.eventMousedownY = isTouchDevice ? event.originalEvent.touches[0].pageY : event.pageY;
             drEl.minYpos =
-                $table.offset().top - originRecord.offset().top + $table.find('thead').outerHeight();
-            drEl.maxYpos = drEl.minYpos + $table.find('tbody').outerHeight() - originRecord.outerHeight();
+                $table.offset().top - originRecord.offset().top + $table.children('thead').outerHeight();
+            drEl.maxYpos = drEl.minYpos + $table.children('tbody').outerHeight() - originRecord.outerHeight();
             $tableWrapper.append(recordNode);
 
             if (isTouchDevice) {


### PR DESCRIPTION
### Preconditions
1. Chrome 54.0.2840.71 (Official Build) m (32-bit) on Windows 10
2. Magento 2.1.2 Install
3. Have a Simple Product with multiple Customizable Options

### Steps to reproduce
1. Attempt to drag the second item in the customizable options list to the first position

### Expected Result
1. The first position obtains a blue overline indicating that the option will be placed above it.  The user is able to drag it up and over. ([Video](https://gfycat.com/PleasantSmoggyElephantbeetle))

### Actual Result
1. The expected overline does not appear, and the object is unable to be moved above.  ([Video](https://gfycat.com/SpicyCavernousAmericantoad))
