### PR TITLE
Fix a FATAL ERROR caused by EAV Entities without EAV Attributes

### DIFF
--- a/app/code/Magento/Eav/Model/Config.php
+++ b/app/code/Magento/Eav/Model/Config.php
@@ -390,6 +390,7 @@ class Config
             $entityType
         )->getData();
 
+        $this->_attributeData[$entityTypeCode] = [];
         foreach ($attributes as $attribute) {
             if (empty($attribute['attribute_model'])) {
                 $attribute['attribute_model'] = $entityType->getAttributeModel();


### PR DESCRIPTION
Traditionally we wait for the first attribute of an entity in order to automatically initialize the array.  This is normally fine - however, when an entity supports EAV attributes but has none, this means that the attributeData is never initialized.

This causes issues on Line 512 when array_keys() is called on the array - rendering a PHP FATAL ERROR instead of an empty array.
