### PR TITLE
Set store id on block only when empty

### DIFF
--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -110,8 +110,10 @@ class BlockRepository implements BlockRepositoryInterface
      */
     public function save(Data\BlockInterface $block)
     {
-        $storeId = $this->storeManager->getStore()->getId();
-        $block->setStoreId($storeId);
+        if (empty($block->getStoreId())) {
+            $block->setStoreId($this->storeManager->getStore()->getId());
+        }
+        
         try {
             $this->resource->save($block);
         } catch (\Exception $exception) {


### PR DESCRIPTION
Prevents store id from being overwritten by current store id when creating cms blocks in a setup script.
