### PR TITLE
Fixed invalid method formatDeliveryDate in order tracking popup

### DIFF
--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/details.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/details.phtml
@@ -6,7 +6,7 @@
 
 // @codingStandardsIgnoreFile
 
-/** @var $block \Magento\Framework\View\Element\Template */
+/** @var $block \Magento\Shipping\Block\Tracking\Popup */
 
 $track = $block->getData('track');
 $email = $block->getData('storeSupportEmail');

--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/popup.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/popup.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-use Magento\Framework\View\Element\Template;
+use Magento\Shipping\Block\Tracking\Popup;
 
 // @codingStandardsIgnoreFile
 
@@ -22,7 +22,7 @@ $results = $block->getTrackingInfo();
                 <?php foreach ($result as $counter => $track): ?>
                     <div class="table-wrapper">
                         <?php
-                            $block->addChild('shipping.tracking.details.' . $counter, Template::class, [
+                            $block->addChild('shipping.tracking.details.' . $counter, Popup::class, [
                                 'track' => $track,
                                 'template' => 'Magento_Shipping::tracking/details.phtml',
                                 'storeSupportEmail' => $block->getStoreSupportEmail()
@@ -33,7 +33,7 @@ $results = $block->getTrackingInfo();
                     </div>
                     <?php if (!empty($track->getProgressdetail())): ?>
                         <?php
-                            $block->addChild('shipping.tracking.progress.'. $counter, Template::class, [
+                            $block->addChild('shipping.tracking.progress.'. $counter, Popup::class, [
                                 'track' => $track,
                                 'template' => 'Magento_Shipping::tracking/progress.phtml'
                             ]);

--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/progress.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/progress.phtml
@@ -6,7 +6,7 @@
 
 // @codingStandardsIgnoreFile
 
-/** @var $block \Magento\Framework\View\Element\Template */
+/** @var $block \Magento\Shipping\Block\Tracking\Popup */
 $track = $block->getData('track');
 ?>
 <div class="table-wrapper">


### PR DESCRIPTION
Track my Order was throwing exception:

`Exception #0 (Magento\Framework\Exception\LocalizedException): Invalid method Magento\Framework\View\Element\Template::formatDeliveryDate`

because details and progress templates had wrong class. formatDeliveryTime() and formatDeliveryDate() methods are from Magento\Shipping\Block\Tracking\Popup class not parent Magento\Framework\View\Element\Template class.
