### PR TITLE
Fix incorrect table name during catalog product indexing

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
@@ -281,7 +281,7 @@ class FlatTableBuilder
             if (!empty($columnValueNames)) {
                 $select->joinLeft(
                     $temporaryValueTableName,
-                    sprintf('e.%1$s = %2$s.%1$s', $linkField, $temporaryTableName),
+                    sprintf('e.%1$s = %2$s.%1$s', $linkField, $temporaryValueTableName),
                     $columnValueNames
                 );
                 $allColumns = array_merge($allColumns, $columnValueNames);


### PR DESCRIPTION
The left join used an incorrect table name and it added way more rows for a single entity than it should. The entity id wasn't unique anymore, which failed the insert part of the SQL query.

This bug is not released yet in any version, only exists in the develop branch. I really hope this time you will be faster than the usual and merge it in before you release the bug in a "stable" version.

![](http://66.media.tumblr.com/c69d6a0e4d4ba681ed9045b23a8c5ee2/tumblr_inline_nvd5p9QbfH1raprkq_500.gif)

