### PR TITLE
Replace boolean cast to be able to disable frame, aspect ratio, trans…

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Image.php
+++ b/app/code/Magento/Catalog/Model/Product/Image.php
@@ -278,7 +278,7 @@ class Image extends \Magento\Framework\Model\AbstractModel
      */
     public function setKeepAspectRatio($keep)
     {
-        $this->_keepAspectRatio = filter_var($keep, FILTER_VALIDATE_BOOLEAN);
+        $this->_keepAspectRatio = $keep && $keep !== 'false';
         return $this;
     }
 
@@ -288,7 +288,7 @@ class Image extends \Magento\Framework\Model\AbstractModel
      */
     public function setKeepFrame($keep)
     {
-        $this->_keepFrame = filter_var($keep, FILTER_VALIDATE_BOOLEAN);
+        $this->_keepFrame = $keep && $keep !== 'false';
         return $this;
     }
 
@@ -298,7 +298,7 @@ class Image extends \Magento\Framework\Model\AbstractModel
      */
     public function setKeepTransparency($keep)
     {
-        $this->_keepTransparency = filter_var($keep, FILTER_VALIDATE_BOOLEAN);
+        $this->_keepTransparency = $keep && $keep !== 'false';
         return $this;
     }
 
@@ -308,7 +308,7 @@ class Image extends \Magento\Framework\Model\AbstractModel
      */
     public function setConstrainOnly($flag)
     {
-        $this->_constrainOnly = filter_var($flag, FILTER_VALIDATE_BOOLEAN);
+        $this->_constrainOnly = $flag && $flag !== 'false';
         return $this;
     }
 

--- a/app/code/Magento/Catalog/Model/Product/Image.php
+++ b/app/code/Magento/Catalog/Model/Product/Image.php
@@ -278,7 +278,7 @@ class Image extends \Magento\Framework\Model\AbstractModel
      */
     public function setKeepAspectRatio($keep)
     {
-        $this->_keepAspectRatio = (bool)$keep;
+        $this->_keepAspectRatio = filter_var($keep, FILTER_VALIDATE_BOOLEAN);
         return $this;
     }
 
@@ -288,7 +288,7 @@ class Image extends \Magento\Framework\Model\AbstractModel
      */
     public function setKeepFrame($keep)
     {
-        $this->_keepFrame = (bool)$keep;
+        $this->_keepFrame = filter_var($keep, FILTER_VALIDATE_BOOLEAN);
         return $this;
     }
 
@@ -298,7 +298,7 @@ class Image extends \Magento\Framework\Model\AbstractModel
      */
     public function setKeepTransparency($keep)
     {
-        $this->_keepTransparency = (bool)$keep;
+        $this->_keepTransparency = filter_var($keep, FILTER_VALIDATE_BOOLEAN);
         return $this;
     }
 
@@ -308,7 +308,7 @@ class Image extends \Magento\Framework\Model\AbstractModel
      */
     public function setConstrainOnly($flag)
     {
-        $this->_constrainOnly = (bool)$flag;
+        $this->_constrainOnly = filter_var($flag, FILTER_VALIDATE_BOOLEAN);
         return $this;
     }
 


### PR DESCRIPTION
…parency or constrain only in view.xml

If you set frame to false in view.xml the code would cast it to true because `(bool)'false'` is equal to `true`. By using the `filter_var` function the cast to boolean is done correctly.