### PR TITLE
Remove erroneous documentation from addForeignKey

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/AdapterInterface.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/AdapterInterface.php
@@ -370,7 +370,6 @@ interface AdapterInterface
      * @param string $refTableName
      * @param string $refColumnName
      * @param string $onDelete
-     * @param string $onUpdate
      * @param boolean $purge trying remove invalid data
      * @param string $schemaName
      * @param string $refSchemaName


### PR DESCRIPTION
addForeignKey contains an "onUpdate" parameter in the documentation, but not in the function call, causing some IDEs and developers (such as myself) confusion.

Looking at this list, one would think there is an `$onUpdate` parameter that could/should be filled -but there is not!

![](http://i.imgur.com/xe3oD5h.png)