### PR TITLE
don't hardcode image delimiter in media validator

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Media.php
@@ -16,8 +16,6 @@ class Media extends AbstractImportValidator implements RowValidatorInterface
 
     const ADDITIONAL_IMAGES = 'additional_images';
 
-    const ADDITIONAL_IMAGES_DELIMITER = ',';
-
     /** @var array */
     protected $mediaAttributes = ['image', 'small_image', 'thumbnail'];
 
@@ -83,7 +81,7 @@ class Media extends AbstractImportValidator implements RowValidatorInterface
             }
         }
         if (isset($value[self::ADDITIONAL_IMAGES]) && strlen($value[self::ADDITIONAL_IMAGES])) {
-            foreach (explode(self::ADDITIONAL_IMAGES_DELIMITER, $value[self::ADDITIONAL_IMAGES]) as $image) {
+            foreach (explode($this->context->getMultipleValueSeparator(), $value[self::ADDITIONAL_IMAGES]) as $image) {
                 if (!$this->checkPath($image) && !$this->checkValidUrl($image)) {
                     $this->_addMessages(
                         [


### PR DESCRIPTION
This value is currently hardcoded to a comma, when instead it should be
looking at the multiple value separator from the product entity importer.