### PR TITLE
Add missing product_id key into $inventoryData

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -162,7 +162,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                         $this->attributeHelper->getStoreWebsiteId($storeId)
                     );
                     if (!$stockItemDo->getProductId()) {
-                        $inventoryData[] = $productId;
+                        $inventoryData['product_id'] = $productId;
                     }
 
                     $stockItemId = $stockItemDo->getId();


### PR DESCRIPTION
When `Update Attributes` for many product with the function `execute` of controller `Magento\Catalog\Controller\Adminhtml\Product\Action\Attribute\Save` and the product has no stock item, the stock item is not created. The behavior of a normal product save is to create a stock item in that case, but the mass update with changed `$inventoryData` is not doing that because of the missing key `product_id` in [line 165](https://github.com/magento/magento2/blob/2adb6e287f53c7a860aa5829733aad1014e11be2/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php#L165).