### PR TITLE
Fix UK mobile number validation

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -214,7 +214,7 @@ define([
         ],
         "mobileUK": [
             function(value) {
-                return value.length > 9 && value.match(/^((0|\+44)7(5|6|7|8|9){1}\d{2}\s?\d{6})$/);
+                return value.length > 9 && value.match(/^((0|\+44)7\d{3}\s?\d{6})$/);
             },
             $.mage.__('Please specify a valid mobile number')
         ],

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -320,7 +320,7 @@
         "mobileUK": [
             function (phone_number, element) {
                 return this.optional(element) || phone_number.length > 9 &&
-                    phone_number.match(/^((0|\+44)7(5|6|7|8|9){1}\d{2}\s?\d{6})$/);
+                    phone_number.match(/^((0|\+44)7\d{3}\s?\d{6})$/);
             },
             $.mage.__('Please specify a valid mobile number')
         ],


### PR DESCRIPTION
The validation for UK mobile numbers is too restrictive on the third digit, my own phone number begins 074 and the current validator does not return a valid match, this loosens the restriction.