### PR TITLE
Let less continue compilation if file is empty

### DIFF
--- a/lib/internal/Magento/Framework/Css/PreProcessor/Adapter/Less/Processor.php
+++ b/lib/internal/Magento/Framework/Css/PreProcessor/Adapter/Less/Processor.php
@@ -88,10 +88,8 @@ class Processor implements ContentProcessorInterface
             gc_enable();
 
             if (trim($content) === '') {
-                $errorMessage = PHP_EOL . self::ERROR_MESSAGE_PREFIX . PHP_EOL . $path;
-                $this->logger->critical($errorMessage);
-
-                throw new ContentProcessorException(new Phrase($errorMessage));
+                $this->logger->warning('Parsed less file is empty: ' .  $path);
+                return '';
             }
 
             return $content;

--- a/lib/internal/Magento/Framework/Css/PreProcessor/Adapter/Less/Processor.php
+++ b/lib/internal/Magento/Framework/Css/PreProcessor/Adapter/Less/Processor.php
@@ -90,9 +90,9 @@ class Processor implements ContentProcessorInterface
             if (trim($content) === '') {
                 $this->logger->warning('Parsed less file is empty: ' .  $path);
                 return '';
+            } else {
+                return $content;
             }
-
-            return $content;
         } catch (\Exception $e) {
             throw new ContentProcessorException(new Phrase($e->getMessage()));
         }


### PR DESCRIPTION
Hi!

During our deployment, we encountered a problem with less compilation: `magento setup:static-content:deploy` failed, when a less file had content it it (like comments, imports, ...) but the resulting parsed file did not.

I tracked the problem down to the less processor, which throws an Exception. It turns out the behaviour is inconsistent - if the content is empty in the first place, the parser will just return an empty string:

```
if (trim($content) === '') {
    return '';
}
```

But if the parser returns an empty string, the task fails:
```
if (trim($content) === '') {
    $errorMessage = PHP_EOL . self::ERROR_MESSAGE_PREFIX . PHP_EOL . $path;
    $this->logger->critical($errorMessage);
    throw new ContentProcessorException(new Phrase($errorMessage));
}
```

My suggestion replaces the Exception with a warning.

