### PR TITLE
Fix checking active carrier against store

### DIFF
--- a/app/code/Magento/Shipping/Model/CarrierFactory.php
+++ b/app/code/Magento/Shipping/Model/CarrierFactory.php
@@ -106,7 +106,8 @@ class CarrierFactory implements CarrierFactoryInterface
     {
         return $this->_scopeConfig->isSetFlag(
             'carriers/' . $carrierCode . '/active',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $storeId
         ) ? $this->create(
             $carrierCode,
             $storeId


### PR DESCRIPTION
# Issue

Scope specifically enabled carrier does not work

![screen shot 2016-11-07 at 15 46 24](https://cloud.githubusercontent.com/assets/945819/20068671/64e34808-a511-11e6-8a8a-d1f02c975c26.png)


# Bug Reproduction

### Prerequisite

There are two websites.

`Flatrate` is disabled in `default` scope and the first website, and enabled in the second website.

NOTE: We need two websites in this test case to make sure the MAGE_RUN_CODE will only be set against the first website when visiting Admin Panel

### Steps

1. Go to Admin > Order > New Order > New Customer > select a store in the second website.
2. Add a product to basket
3. Fill in the addresses
4. Chose any payment method
5. Click `Get shipping methods and rates`

### Expected Result

`Flatrate` shows up as avaliable shipping method

### Actual Result

`Flatrate` does not show up

### Cause of issue

`\Magento\Shipping\Model\CarrierFactory::createIfActive` only check if a carrier is active against a scope resolved by scope-resolver which takes the MAGE_RUN_CODE to resolve. If a carrier is disabled by default and by the the website of MAGE_RUN_CODE and only enabled for specific websites, the method will return `false` which is wrong
