### PR TITLE
Fix: The title tag on the contact us page is now translatable

### DIFF
--- a/app/code/Magento/Contact/Block/ContactForm.php
+++ b/app/code/Magento/Contact/Block/ContactForm.php
@@ -31,4 +31,10 @@ class ContactForm extends Template
     {
         return $this->getUrl('contact/index/post', ['_secure' => true]);
     }
+
+	protected function _prepareLayout()
+	{
+		$this->pageConfig->getTitle()->set(__('Contact Us'));
+		return parent::_prepareLayout();
+	}
 }

--- a/app/code/Magento/Contact/Block/ContactForm.php
+++ b/app/code/Magento/Contact/Block/ContactForm.php
@@ -32,6 +32,9 @@ class ContactForm extends Template
         return $this->getUrl('contact/index/post', ['_secure' => true]);
     }
 
+	/**
+	 * @return $this
+	 */
 	protected function _prepareLayout()
 	{
 		$this->pageConfig->getTitle()->set(__('Contact Us'));

--- a/app/code/Magento/Contact/Block/ContactForm.php
+++ b/app/code/Magento/Contact/Block/ContactForm.php
@@ -32,12 +32,12 @@ class ContactForm extends Template
         return $this->getUrl('contact/index/post', ['_secure' => true]);
     }
 
-	/**
-	 * @return $this
-	 */
-	protected function _prepareLayout()
-	{
-		$this->pageConfig->getTitle()->set(__('Contact Us'));
-		return parent::_prepareLayout();
-	}
+    /**
+     * @return $this
+     */
+    protected function _prepareLayout()
+    {
+        $this->pageConfig->getTitle()->set(__('Contact Us'));
+        return parent::_prepareLayout();
+    }
 }


### PR DESCRIPTION
The title tag on the Contact form page was not translatable (hardcoded in conact_index_index.xml), it now is translatable