### PR TITLE
Remove "default" code from schema URL

### DIFF
--- a/app/code/Magento/Swagger/view/frontend/templates/swagger-ui/index.phtml
+++ b/app/code/Magento/Swagger/view/frontend/templates/swagger-ui/index.phtml
@@ -14,7 +14,7 @@
 
 /** @var \Magento\Framework\View\Element\Template $block */
 
-$schemaUrl = rtrim($block->getBaseUrl(), '/') . '/rest/default/schema?services=all';
+$schemaUrl = rtrim($block->getBaseUrl(), '/') . '/rest/schema?services=all';
 ?>
 
 <div id='header'>


### PR DESCRIPTION
There is an error `Can't read swagger JSON from http://shop.com/rest/default/schema?services=all` on "http://shop.com/swagger/" page if default storeview code is changed.