### PR TITLE
CMS Page and Block - Load by identifier and store id - fix issue 6570

### DIFF
--- a/app/code/Magento/Cms/Api/BlockRepositoryInterface.php
+++ b/app/code/Magento/Cms/Api/BlockRepositoryInterface.php
@@ -26,10 +26,11 @@ interface BlockRepositoryInterface
      * Retrieve block.
      *
      * @param int $blockId
+     * @param int|null $storeId
      * @return \Magento\Cms\Api\Data\BlockInterface
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function getById($blockId);
+    public function getById($blockId, $storeId = null);
 
     /**
      * Retrieve blocks matching the specified criteria.
@@ -53,9 +54,10 @@ interface BlockRepositoryInterface
      * Delete block by ID.
      *
      * @param int $blockId
+     * @param int|null $storeId
      * @return bool true on success
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function deleteById($blockId);
+    public function deleteById($blockId, $storeId = null);
 }

--- a/app/code/Magento/Cms/Api/PageRepositoryInterface.php
+++ b/app/code/Magento/Cms/Api/PageRepositoryInterface.php
@@ -26,10 +26,11 @@ interface PageRepositoryInterface
      * Retrieve page.
      *
      * @param int $pageId
+     * @param null|int $storeId
      * @return \Magento\Cms\Api\Data\PageInterface
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function getById($pageId);
+    public function getById($pageId, $storeId = null);
 
     /**
      * Retrieve pages matching the specified criteria.
@@ -53,9 +54,10 @@ interface PageRepositoryInterface
      * Delete page by ID.
      *
      * @param int $pageId
+     * @param int|null $storeId
      * @return bool true on success
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function deleteById($pageId);
+    public function deleteById($pageId, $storeId = null);
 }

--- a/app/code/Magento/Cms/Api/PageRepositoryInterface.php
+++ b/app/code/Magento/Cms/Api/PageRepositoryInterface.php
@@ -26,7 +26,7 @@ interface PageRepositoryInterface
      * Retrieve page.
      *
      * @param int $pageId
-     * @param null|int $storeId
+     * @param int|null $storeId
      * @return \Magento\Cms\Api\Data\PageInterface
      * @throws \Magento\Framework\Exception\LocalizedException
      */

--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -124,12 +124,18 @@ class BlockRepository implements BlockRepositoryInterface
      * Load Block data by given Block Identity
      *
      * @param string $blockId
+     * @param int|null $storeId
      * @return Block
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getById($blockId)
+    public function getById($blockId, $storeId = null)
     {
         $block = $this->blockFactory->create();
+
+        if (!is_null($storeId)) {
+            $block->setStoreId($storeId);
+        }
+
         $this->resource->load($block, $blockId);
         if (!$block->getId()) {
             throw new NoSuchEntityException(__('CMS Block with id "%1" does not exist.', $blockId));
@@ -196,13 +202,14 @@ class BlockRepository implements BlockRepositoryInterface
      * Delete Block by given Block Identity
      *
      * @param string $blockId
+     * @param int|null $storeId
      * @return bool
      * @throws CouldNotDeleteException
      * @throws NoSuchEntityException
      */
-    public function deleteById($blockId)
+    public function deleteById($blockId, $storeId = null)
     {
-        return $this->delete($this->getById($blockId));
+        return $this->delete($this->getById($blockId, $storeId));
     }
 
     /**

--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -132,7 +132,7 @@ class BlockRepository implements BlockRepositoryInterface
     {
         $block = $this->blockFactory->create();
 
-        if (!is_null($storeId)) {
+        if ($storeId === null) {
             $block->setStoreId($storeId);
         }
 

--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -132,7 +132,7 @@ class BlockRepository implements BlockRepositoryInterface
     {
         $block = $this->blockFactory->create();
 
-        if ($storeId === null) {
+        if ($storeId !== null) {
             $block->setStoreId($storeId);
         }
 

--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -138,7 +138,7 @@ class PageRepository implements PageRepositoryInterface
     {
         $page = $this->pageFactory->create();
 
-        if (!is_null($storeId)) {
+        if ($storeId === null) {
             $page->setStoreId($storeId);
         }
 

--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -130,12 +130,18 @@ class PageRepository implements PageRepositoryInterface
      * Load Page data by given Page Identity
      *
      * @param string $pageId
+     * @param int|null $storeId
      * @return Page
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getById($pageId)
+    public function getById($pageId, $storeId = null)
     {
         $page = $this->pageFactory->create();
+
+        if (!is_null($storeId)) {
+            $page->setStoreId($storeId);
+        }
+
         $page->load($pageId);
         if (!$page->getId()) {
             throw new NoSuchEntityException(__('CMS Page with id "%1" does not exist.', $pageId));
@@ -205,13 +211,14 @@ class PageRepository implements PageRepositoryInterface
      * Delete Page by given Page Identity
      *
      * @param string $pageId
+     * @param int|null $storeId
      * @return bool
      * @throws CouldNotDeleteException
      * @throws NoSuchEntityException
      */
-    public function deleteById($pageId)
+    public function deleteById($pageId, $storeId = null)
     {
-        return $this->delete($this->getById($pageId));
+        return $this->delete($this->getById($pageId, $storeId));
     }
 
     /**

--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -138,7 +138,7 @@ class PageRepository implements PageRepositoryInterface
     {
         $page = $this->pageFactory->create();
 
-        if ($storeId === null) {
+        if ($storeId !== null) {
             $page->setStoreId($storeId);
         }
 

--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -110,7 +110,8 @@ class PageRepository implements PageRepositoryInterface
      */
     public function save(\Magento\Cms\Api\Data\PageInterface $page)
     {
-        if (empty($page->getStoreId())) {
+        $pageStoreId = $page->getStoreId();
+        if (empty($pageStoreId)) {
             $storeId = $this->storeManager->getStore()->getId();
             $page->setStoreId($storeId);
         }

--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -110,8 +110,7 @@ class PageRepository implements PageRepositoryInterface
      */
     public function save(\Magento\Cms\Api\Data\PageInterface $page)
     {
-        $pageStoreId = $page->getStoreId();
-        if (empty($pageStoreId)) {
+        if (empty($page->getStoreId())) {
             $storeId = $this->storeManager->getStore()->getId();
             $page->setStoreId($storeId);
         }


### PR DESCRIPTION
The following should fix issue https://github.com/magento/magento2/issues/6570

This should allow developers to access a cms block or a cms page by identifier and store ID.

This change should be backwards compatible, if no `storeId` is passed in then the functionality will work as it previously did.

If a `storeId` is passed in then it should get picked up by the logic in `Magento\Cms\Model\ResourceModel\Page::_getLoadSelect` and `Magento\Cms\Model\ResourceModel\Block::_getLoadSelect`.

A bit unrelated, but PHPStorm notified me of a bug which I fixed in commit 594871f648c50dadd92adbf92627e36da6cd41e9