### PR TITLE
Do not try to parse comments from cross-domain iframes

### DIFF
--- a/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
+++ b/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
@@ -24,6 +24,15 @@ define([
          * @param {jQuery} element - Comment holder
          */
         (function lookup(element) {
+            if ($.nodeName(element, "iframe")) {
+                var a = document.createElement('a');
+                a.href = $(element).prop('src');
+
+                if (a.hostname != window.location.hostname) {
+                    return;
+                }
+            }
+
             $(element).contents().each(function (index, el) {
                 switch (el.nodeType) {
                     case 1: // ELEMENT_NODE


### PR DESCRIPTION
In the page-cache.js module the comments jQuery function tries to parse
comments from each element in the DOM. This fails when it tries to parse any
iframe elements that have a src attribute from a different domain.

This change skips any iframe element that does not belong to the current
domain.