### PR TITLE
Allow comments in widget.xml parameters

### DIFF
--- a/app/code/Magento/Widget/Model/Config/Converter.php
+++ b/app/code/Magento/Widget/Model/Config/Converter.php
@@ -44,7 +44,7 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
                     case 'parameters':
                         /** @var $parameter \DOMNode */
                         foreach ($widgetSubNode->childNodes as $parameter) {
-                            if ($parameter->nodeName === '#text') {
+                            if (in_array($parameter->nodeName, ['#text', '#comment'])) {
                                 continue;
                             }
                             $subNodeAttributes = $parameter->attributes;
@@ -57,7 +57,7 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
                             $widgetArray['supported_containers'] = [];
                         }
                         foreach ($widgetSubNode->childNodes as $container) {
-                            if ($container->nodeName === '#text') {
+                            if (in_array($container->nodeName, ['#text', '#comment'])) {
                                 continue;
                             }
                             $widgetArray['supported_containers'] = array_merge(


### PR DESCRIPTION
## Problem

Magento crashes in case if you have comments inside **parameters** section of **widget.xml**
(issue also reported here [3882](https://github.com/magento/magento2/issues/3882))

## Steps to reproduce
1. Add comment in parameters section of widget.xml (`<parameters><!-- any comment --</parameters>`)
1. Clean cache
1. Reload page
1. you should see this error message on frontpage `PHP Fatal error:  Call to a member function getNamedItem() on null in /vagrant/vendor/magento/module-widget/Model/Config/Converter.php on line 54` 