### PR TITLE
Check return value for getItems() in getIdentities().

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ProductList/Related.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Related.php
@@ -126,8 +126,11 @@ class Related extends \Magento\Catalog\Block\Product\AbstractProduct implements 
     public function getIdentities()
     {
         $identities = [];
-        foreach ($this->getItems() as $item) {
-            $identities = array_merge($identities, $item->getIdentities());
+        $items = $this->getItems();
+        if ( !empty( $items ) ) {
+            foreach ($items as $item) {
+                $identities = array_merge($identities, $item->getIdentities());
+            }
         }
         return $identities;
     }


### PR DESCRIPTION
If getItems() returns an empty array then this code will generate a PHP warning and potentially crash the page; let's not do that, and check our return values before we try to loop over them.