### PR TITLE
Remove unused entity_id foreign key

### DIFF
--- a/app/code/Magento/Catalog/Setup/InstallSchema.php
+++ b/app/code/Magento/Catalog/Setup/InstallSchema.php
@@ -2022,18 +2022,6 @@ class InstallSchema implements InstallSchemaInterface
                 'attribute_id',
                 \Magento\Framework\DB\Ddl\Table::ACTION_CASCADE
             )
-            ->addForeignKey(
-                $installer->getFkName(
-                    'catalog_product_entity_media_gallery',
-                    'entity_id',
-                    'catalog_product_entity',
-                    'entity_id'
-                ),
-                'entity_id',
-                $installer->getTable('catalog_product_entity'),
-                'entity_id',
-                \Magento\Framework\DB\Ddl\Table::ACTION_CASCADE
-            )
             ->setComment(
                 'Catalog Product Media Gallery Attribute Backend Table'
             );


### PR DESCRIPTION
This PR fixes a bug that prevents Magento 2 from working with Amazon Aurora.

Steps To Reproduce
===============
1. Obtain the Magento code:
`composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition`
2. Build an AWS Aurora RDS instance.
3. Configure `app/etc/env.php` to use the AWS Aurora RDS instance.
4. Run the following command:
`php bin/magento setup:db-schema:upgrade`

Expected Result
===============
Success

Actual Result
===============
```
  [PDOException]                                                         
  SQLSTATE[HY000]: General error: 1030 Got error 38 from storage engine 
```

InnoDB Logs
===============
```
------------------------
LATEST FOREIGN KEY ERROR
------------------------
2016-11-14 23:22:42 2adea2388700 Error in foreign key constraint of table magento/catalog_product_entity_media_gallery:
there is no index in the table which would contain
the columns as the first columns, or the data types in the
table do not match the ones in the referenced table
or one of the ON ... SET NULL columns is declared NOT NULL. Constraint:
,
  CONSTRAINT "CAT_PRD_ENTT_MDA_GLR_ENTT_ID_CAT_PRD_ENTT_ENTT_ID" FOREIGN KEY ("entity_id") REFERENCES "catalog_product_entity" ("entity_id") ON DELETE CASCADE
```

Explanation
==============
When [catalog_product_entity_media_gallery](https://github.com/magento/magento2/blob/089f7596602946d89aa472aa7548c3c862cbd0a1/app/code/Magento/Catalog/Setup/InstallSchema.php#L1970-L2036) is created, a foreign key is created on the column `entity_id`.

However, the `entity_id` column is dropped [in the upgrade script here](https://github.com/magento/magento2/blob/089f7596602946d89aa472aa7548c3c862cbd0a1/app/code/Magento/Catalog/Setup/UpgradeSchema.php#L275)

On MariaDB 5.6, the `php bin/magento setup:db-schema:upgrade` completes successfully, but no foreign key is ever created.

However, on Amazon Aurora, as of their update last Friday, the same command results in `error 38` as referenced above.

Since, either way, the foreign key does not appear to ever be created, I removed it from the InstallSchema.php file.