### PR TITLE
Combined testCodeStylePsr2() with the testCodeStyle() function.

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
@@ -115,37 +115,6 @@ class LiveCodeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Run the PSR2 code sniffs on the code
-     *
-     * @TODO: combine with testCodeStyle
-     * @return void
-     */
-    public function testCodeStylePsr2()
-    {
-        $reportFile = self::$reportDir . '/phpcs_psr2_report.txt';
-        $wrapper = new Wrapper();
-        $codeSniffer = new CodeSniffer('PSR2', $reportFile, $wrapper);
-        if (!$codeSniffer->canRun()) {
-            $this->markTestSkipped('PHP Code Sniffer is not installed.');
-        }
-        if (version_compare($wrapper->version(), '1.4.7') === -1) {
-            $this->markTestSkipped('PHP Code Sniffer Build Too Old.');
-        }
-
-        $result = $codeSniffer->run(self::getWhitelist());
-
-        $output = "";
-        if (file_exists($reportFile)) {
-            $output = file_get_contents($reportFile);
-        }
-        $this->assertEquals(
-            0,
-            $result,
-            "PHP Code Sniffer has found {$result} error(s): " . PHP_EOL . $output
-        );
-    }
-
-    /**
      * Run the magento specific coding standards on the code
      *
      * @return void
@@ -155,9 +124,15 @@ class LiveCodeTest extends PHPUnit_Framework_TestCase
         $reportFile = self::$reportDir . '/phpcs_report.txt';
         $wrapper = new Wrapper();
         $codeSniffer = new CodeSniffer(realpath(__DIR__ . '/_files/phpcs'), $reportFile, $wrapper);
+
         if (!$codeSniffer->canRun()) {
             $this->markTestSkipped('PHP Code Sniffer is not installed.');
         }
+
+        if (version_compare($wrapper->version(), '1.4.7') === -1) {
+            $this->markTestSkipped('PHP Code Sniffer Build Too Old.');
+        }
+
         $codeSniffer->setExtensions(['php', 'phtml']);
         $result = $codeSniffer->run(self::getWhitelist(['php', 'phtml']));
 

--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcs/ruleset.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcs/ruleset.xml
@@ -7,9 +7,9 @@
 -->
 <ruleset name="Magento">
     <description>Magento coding standard.</description>
-    <rule ref="PSR2">
-        <exclude-pattern>*/_files/*</exclude-pattern>
-    </rule>
+    <!-- We don't want to test stub file for unit testing -->
+    <exclude-pattern>*/_files/*</exclude-pattern>
+    <rule ref="PSR2"/>
     <rule ref="Zend.Files.ClosingTag"/>
     <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
     <rule ref="Generic.WhiteSpace.ScopeIndent"/>

--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcs/ruleset.xml
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpcs/ruleset.xml
@@ -7,6 +7,9 @@
 -->
 <ruleset name="Magento">
     <description>Magento coding standard.</description>
+    <rule ref="PSR2">
+        <exclude-pattern>*/_files/*</exclude-pattern>
+    </rule>
     <rule ref="Zend.Files.ClosingTag"/>
     <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
     <rule ref="Generic.WhiteSpace.ScopeIndent"/>


### PR DESCRIPTION
- Core Magento team mentioned to combine these 2 functions in the comments.
- Excluded _files/* from the PSR2 standards because these are stub files for tests and multiple classes per file throws PSR2 errors for these files.