### PR TITLE
Travis should run the static tests against PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ env:
 cache:
   apt: true
   directories: $HOME/.composer/cache
-matrix:
-  exclude:
-    - php: 7.0
-      env: TEST_SUITE=static
 before_install: ./dev/travis/before_install.sh
 install: composer install --no-interaction --prefer-dist
 before_script: ./dev/travis/before_script.sh


### PR DESCRIPTION
Travis should be changed so that static tests will be runned against PHP 7 as well. 

See for instance this build: https://travis-ci.org/magento/magento2/builds/178637640
Static tests pass against PHP 7 but fail against PHP 5.6. So there is difference between the two versions and we should build en pass static test for both PHP versions.