### PR TITLE
Don't skip attribute options with a value of 0 from the layered navigation

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Layer/Filter/Attribute.php
+++ b/app/code/Magento/CatalogSearch/Model/Layer/Filter/Attribute.php
@@ -53,7 +53,7 @@ class Attribute extends AbstractFilter
     public function apply(\Magento\Framework\App\RequestInterface $request)
     {
         $attributeValue = $request->getParam($this->_requestVar);
-        if (empty($attributeValue)) {
+        if (empty($attributeValue) && !is_numeric($attributeValue)) {
             return $this;
         }
         $attribute = $this->getAttributeModel();
@@ -95,7 +95,7 @@ class Attribute extends AbstractFilter
         $options = $attribute->getFrontend()
             ->getSelectOptions();
         foreach ($options as $option) {
-            if (empty($option['value'])) {
+            if (empty($option['value']) && !is_numeric($option['value'])) {
                 continue;
             }
 


### PR DESCRIPTION
## Bug Fix

Steps to replicate : 
1. Create an attribute to be used in the Layered Navigation using the source_model `Magento\Eav\Model\Entity\Attribute\Source\Boolean`.

2. When you are on a category page, on the layered navigation you are not given the option to filter by 'No' even though there are products in the category which have this value, you can only filter by 'Yes' because all the attribute options with a falsy value won't be available. 'No' has a falsy value of 0;

<img width="336" alt="screen shot 2016-11-26 at 15 36 37" src="https://cloud.githubusercontent.com/assets/8201815/20641470/4367b84c-b3f0-11e6-9cc3-33f46ec90a11.png">

## Code Explanation

Make sure that attribute options with a numeric value are not skipped. Empty strings will still be skipped.
