### PR TITLE
CatalogSearch indexer.xml references wrong class

### DIFF
--- a/app/code/Magento/CatalogSearch/etc/indexer.xml
+++ b/app/code/Magento/CatalogSearch/etc/indexer.xml
@@ -10,7 +10,7 @@
         <title translate="true">Catalog Search</title>
         <description translate="true">Rebuild Catalog product fulltext search index</description>
 
-        <saveHandler class="Magento\CatalogSearch\Model\Indexer\IndexHandler" />
+        <saveHandler class="Magento\CatalogSearch\Model\Indexer\IndexerHandler" />
         <structure class="Magento\CatalogSearch\Model\Indexer\IndexStructure" />
     </indexer>
 </config>


### PR DESCRIPTION
I believe there to be a typo on the changed line. There is no file in the "Magento/CatalogSearch/Model/Indexer/" directory named "IndexHandler" but there is a "IndexerHandler".