### PR TITLE
Fixes duplicate messages shown when adding items to cart

### DIFF
--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -1619,10 +1619,11 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
 
             // collect errors instead of throwing first one
             if ($item->getHasError()) {
-                $message = $item->getMessage();
-                if (!in_array($message, $errors)) {
-                    // filter duplicate messages
-                    $errors[] = $message;
+                foreach ($item->getMessage(false) as $message) {
+                    if (!in_array($message, $errors)) {
+                        // filter duplicate messages
+                        $errors[] = $message;
+                    }
                 }
             }
         }


### PR DESCRIPTION
The duplicate error messages can be shown when adding products to cart.
This fix changes the filtering logic to make only unique messages shown.

Error use case preconditions:
1. Configurable product
2. Adding configurable to cart
3. Two errors occurred
4. "Error message 1" added to configurable product
5. "Error message 1" added to simple product
6. "Error message 2" added to simple product only (let's imagine such validator that validates simples)

Result:
$item->getMessage() for configurable product will return "Error message 1"
$item->getMessage() for configurable product will return "Error message 1\nError message 2"
"Error message 1" will be shown two times, because of "not perfect" unique errors filtering.