### PR TITLE
Blank theme: Fix sorter icon changing

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/module/_toolbar.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/module/_toolbar.less
@@ -81,7 +81,7 @@
         );
     }
 
-    .sorter.sort-desc {
+    .sorter .sort-desc {
         &:before {
             content: @icon-arrow-down;
         }


### PR DESCRIPTION
Fix sorter icon not changing when toggling descending/ascending sort in product catalog.

Steps to reproduce: In any store using the Blank theme, go to product grid and click on the sort icon (downwards arrow). It changes the sorting, and the link class changes from sort-desc to sort-asc. The icon does not change as it should, however.