### PR TITLE
Storecode in url changed from default to all

### DIFF
--- a/app/code/Magento/Swagger/view/frontend/templates/swagger-ui/index.phtml
+++ b/app/code/Magento/Swagger/view/frontend/templates/swagger-ui/index.phtml
@@ -14,7 +14,7 @@
 
 /** @var \Magento\Framework\View\Element\Template $block */
 
-$schemaUrl = rtrim($block->getBaseUrl(), '/') . '/rest/default/schema?services=all';
+$schemaUrl = rtrim($block->getBaseUrl(), '/') . '/rest/all/schema?services=all';
 ?>
 
 <div id='header'>


### PR DESCRIPTION
Swagger was no longer working after changing the storecode from default to something else, because this file contained a hardcoded code.  Changing it to all which is always availlable no matter which storeviews exist fixes this issue.