### PR TITLE
Fix for "Stock Status" field not disappearing in admin when "Manage Stock" = No

### DIFF
--- a/app/code/Magento/CatalogInventory/Ui/DataProvider/Product/Form/Modifier/AdvancedInventory.php
+++ b/app/code/Magento/CatalogInventory/Ui/DataProvider/Product/Form/Modifier/AdvancedInventory.php
@@ -174,6 +174,9 @@ class AdvancedInventory extends AbstractModifier
                     'value' => '1',
                     'dataScope' => $fieldCode . '.is_in_stock',
                     'scopeLabel' => '[GLOBAL]',
+                    'imports' => [
+                        'visible' => '${$.provider}:data.product.stock_data.manage_stock',
+                    ],
                 ]
             );
             $this->meta = $this->arrayManager->merge(


### PR DESCRIPTION
In Admin, on Product edit page, "Stock Status" field is not disappearing when "Manage Stock" = No.
The same field is disappearing on "Advanced Inventory" pop-up (click on  "Advanced Inventory" link).
There is no point to leave this field active and visible, when "Manage Stock" = No.

