### PR TITLE
Fixes issues with url rewrites created on shop with multiple storeviews

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Product/AnchorUrlRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Product/AnchorUrlRewriteGenerator.php
@@ -55,7 +55,7 @@ class AnchorUrlRewriteGenerator
             $anchorCategoryIds = $category->getAnchorsAbove();
             if ($anchorCategoryIds) {
                 foreach ($anchorCategoryIds as $anchorCategoryId) {
-                    $anchorCategory = $this->categoryRepository->get($anchorCategoryId);
+                    $anchorCategory = $this->categoryRepository->get($anchorCategoryId, $storeId);
                     $urls[] = $this->urlRewriteFactory->create()
                         ->setEntityType(ProductUrlRewriteGenerator::ENTITY_TYPE)
                         ->setEntityId($product->getId())

--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
@@ -108,7 +108,7 @@ class ProductScopeRewriteGenerator
 
         foreach ($product->getStoreIds() as $id) {
             if (!$this->isGlobalScope($id)
-                && $this->storeViewService->doesEntityHaveOverriddenUrlKeyForStore($id, $productId, Product::ENTITY)
+                && !$this->storeViewService->doesEntityHaveOverriddenUrlKeyForStore($id, $productId, Product::ENTITY)
             ) {
                 // before loading the category collection by looping it, clone it and set the correct store id,
                 // so we get the correct url_path & url_key for that specific store id

--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
@@ -110,7 +110,12 @@ class ProductScopeRewriteGenerator
             if (!$this->isGlobalScope($id)
                 && !$this->storeViewService->doesEntityHaveOverriddenUrlKeyForStore($id, $productId, Product::ENTITY)
             ) {
-                $urls = array_merge($urls, $this->generateForSpecificStoreView($id, $productCategories, $product));
+                // before loading the category collection by looping it, clone it and set the correct store id,
+                // so we get the correct url_path & url_key for that specific store id
+                $storeSpecificproductCategories = clone $productCategories;
+                $storeSpecificproductCategories->setStoreId($id);
+
+                $urls = array_merge($urls, $this->generateForSpecificStoreView($id, $storeSpecificproductCategories, $product));
             }
         }
 

--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
@@ -112,10 +112,10 @@ class ProductScopeRewriteGenerator
             ) {
                 // before loading the category collection by looping it, clone it and set the correct store id,
                 // so we get the correct url_path & url_key for that specific store id
-                $storeSpecificproductCategories = clone $productCategories;
-                $storeSpecificproductCategories->setStoreId($id);
+                $storeSpecificProductCategories = clone $productCategories;
+                $storeSpecificProductCategories->setStoreId($id);
 
-                $urls = array_merge($urls, $this->generateForSpecificStoreView($id, $storeSpecificproductCategories, $product));
+                $urls = array_merge($urls, $this->generateForSpecificStoreView($id, $storeSpecificProductCategories, $product));
             }
         }
 

--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductScopeRewriteGenerator.php
@@ -108,7 +108,7 @@ class ProductScopeRewriteGenerator
 
         foreach ($product->getStoreIds() as $id) {
             if (!$this->isGlobalScope($id)
-                && !$this->storeViewService->doesEntityHaveOverriddenUrlKeyForStore($id, $productId, Product::ENTITY)
+                && $this->storeViewService->doesEntityHaveOverriddenUrlKeyForStore($id, $productId, Product::ENTITY)
             ) {
                 // before loading the category collection by looping it, clone it and set the correct store id,
                 // so we get the correct url_path & url_key for that specific store id

--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlRewriteGenerator.php
@@ -132,8 +132,7 @@ class ProductUrlRewriteGenerator
 
         $productCategories = $product->getCategoryCollection()
             ->addAttributeToSelect('url_key')
-            ->addAttributeToSelect('url_path')
-            ->setStoreId($storeId);
+            ->addAttributeToSelect('url_path');
 
         $urls = $this->isGlobalScope($storeId)
             ? $this->generateForGlobalScope($productCategories)

--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlRewriteGenerator.php
@@ -132,7 +132,8 @@ class ProductUrlRewriteGenerator
 
         $productCategories = $product->getCategoryCollection()
             ->addAttributeToSelect('url_key')
-            ->addAttributeToSelect('url_path');
+            ->addAttributeToSelect('url_path')
+            ->setStoreId($storeId);
 
         $urls = $this->isGlobalScope($storeId)
             ? $this->generateForGlobalScope($productCategories)


### PR DESCRIPTION
We have a project where we import a bunch of categories and products programmatically.
And after that we let the url rewrites being created as this doesn't seem to happen automatically.

In Magento 2.1.2, there are problems in the category urls when we do this, where the url's use the url_key from the category data from store id 0 (admin values) instead of from the specific storeview we try to generate the url rewrites for.

This PR fixes our issues.

Possibly related to https://github.com/magento/magento2/issues/4112 and https://github.com/magento/magento2/issues/2619