### PR TITLE
Added returned error message to transparent payment response

### DIFF
--- a/app/code/Magento/Payment/view/frontend/templates/transparent/iframe.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/transparent/iframe.phtml
@@ -39,7 +39,7 @@ $params = $block->getParams();
                     var parent = window.top;
                     $(parent).trigger('clearTimeout');
                     globalMessageList.addErrorMessage({
-                        message: $t('An error occurred on the server. Please try to place the order again.')
+                        message: $t("<?php echo $params['error_msg']; ?>.")
                     });
                 }
             );


### PR DESCRIPTION
I noticed that all unsuccessful transaction had the same error message, which was

module_payment/view/frontend/transparent/iframe.phtml line 41 to 43
```
globalMessageList.addErrorMessage({
    message: $t('An error occurred on the server. Please try to place the order again.')
});
```

To receive a more meaningful message I change the code above to 

```
globalMessageList.addErrorMessage({
    message: $t('<?php echo $params['error_msg'] ?>.')
});
```

Now instead of getting for every error the same message:
   `An error occurred on the server. Please try to place the order again`

I get something like this:
   `Transaction has been declined`