### PR TITLE
Fix invalid asset resolution with numeric theme_id

### DIFF
--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -146,8 +146,13 @@ class Repository
         }
 
         if ($theme) {
-            $params['themeModel'] = $this->getThemeProvider()->getThemeByFullPath($area . '/' . $theme);
-            if (!$params['themeModel']) {
+            if (is_numeric($theme)) {
+                $params['themeModel'] = $this->getThemeProvider()->getThemeById($theme);
+            } else {
+                $params['themeModel'] = $this->getThemeProvider()->getThemeByFullPath($area . '/' . $theme);
+            }
+            
+            if (!$params['themeModel']->getId()) {
                 throw new \UnexpectedValueException("Could not find theme '$theme' for area '$area'");
             }
         } elseif (empty($params['themeModel'])) {


### PR DESCRIPTION
There are cases in which the theme *ID* is passed to the asset resolution, but the processing in this case doesn't handle numbers correctly. This has the direct effect of the system not finding valid template files, for example.

One case of a passed numeric theme ID is [saving a widget instance, to create the layout update XML](https://github.com/magento/magento2/blob/010156ffeeb1319c6e3e266e43617af51f05b32a/app/code/Magento/Widget/Model/Widget/Instance.php#L557). Because the theme model is invalid, M2 will always resolve the template relative to `vendor/` (M2), never for third parties/themes.

So the call would be equivalent to - say - `$this->getThemeProvider()->getThemeByFullPath('frontend/5')`, which, as much as I tried to think that there's some magic coversion happening somewhere, it wasn't the case, and the theme model was never found.

This bug was hidden this much time because the validation of the theme model is done incorrectly, assuming it can sometimes be falsy, which is not the case, as the model is a result of `$themeCollection->getFirstItem()`, which will always be an object (so truthy). The ID needs to be checked instead.

I'm possibly very wrong in my PR, or this is a pretty serious bug.