### PR TITLE
Add PHP 7.1 to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1 # Experimental, forward compatible (allowed to fail, see matrix: allow_failures: below)
 env:
   global:
     - COMPOSER_BIN_DIR=~/bin
@@ -25,11 +26,13 @@ cache:
   apt: true
   directories: $HOME/.composer/cache
 matrix:
+  allow_failures:
+    - php: 7.1
   exclude:
     - php: 7.0
       env: TEST_SUITE=static
 before_install: ./dev/travis/before_install.sh
-install: composer install --no-interaction --prefer-dist
+install: test ${TRAVIS_PHP_VERSION:0:3} = "7.1" && composer install --no-interaction --prefer-dist --ignore-platform-reqs || composer install --no-interaction --prefer-dist
 before_script: ./dev/travis/before_script.sh
 script: 
   - cd dev/tests/$TEST_SUITE


### PR DESCRIPTION
This change is for forward compatibility with PHP 7.1.

Add PHP 7.1 (currently PHP 7.1-RC6 on Travis) to the Travis build. Allow
failures with it as failures are expected.

To get it to work, for PHP 7.1 composer ignores platform requirements.

Refs:

- https://github.com/magento/magento2/issues/5701