### PR TITLE
Replace class-like name in catalog-search/./di.xml

### DIFF
--- a/app/code/Magento/CatalogSearch/etc/di.xml
+++ b/app/code/Magento/CatalogSearch/etc/di.xml
@@ -132,14 +132,14 @@
             </argument>
         </arguments>
     </virtualType>
-    <virtualType name="virtualFulltextCollectionFactory" type="Magento\Catalog\Model\ResourceModel\Product\CollectionFactory">
+    <virtualType name="fulltextCollectionFactoryVirtual" type="Magento\Catalog\Model\ResourceModel\Product\CollectionFactory">
         <arguments>
             <argument name="instanceName" xsi:type="string">Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection</argument>
         </arguments>
     </virtualType>
     <type name="Magento\CatalogSearch\Model\Layer\Category\ItemCollectionProvider">
         <arguments>
-            <argument name="collectionFactory" xsi:type="object">virtualFulltextCollectionFactory</argument>
+            <argument name="collectionFactory" xsi:type="object">fulltextCollectionFactoryVirtual</argument>
         </arguments>
     </type>
 

--- a/app/code/Magento/CatalogSearch/etc/di.xml
+++ b/app/code/Magento/CatalogSearch/etc/di.xml
@@ -132,14 +132,14 @@
             </argument>
         </arguments>
     </virtualType>
-    <virtualType name="Magento\CatalogSearch\Model\ResourceModel\Fulltext\CollectionFactory" type="Magento\Catalog\Model\ResourceModel\Product\CollectionFactory">
+    <virtualType name="virtualFulltextCollectionFactory" type="Magento\Catalog\Model\ResourceModel\Product\CollectionFactory">
         <arguments>
             <argument name="instanceName" xsi:type="string">Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection</argument>
         </arguments>
     </virtualType>
     <type name="Magento\CatalogSearch\Model\Layer\Category\ItemCollectionProvider">
         <arguments>
-            <argument name="collectionFactory" xsi:type="object">Magento\CatalogSearch\Model\ResourceModel\Fulltext\CollectionFactory</argument>
+            <argument name="collectionFactory" xsi:type="object">virtualFulltextCollectionFactory</argument>
         </arguments>
     </type>
 


### PR DESCRIPTION
There is an error in compilation process:

	$ ./bin/magento deploy:mode:set production
	Enabled maintenance mode
	Starting compilation
	Something went wrong while compiling generated code. See the error log for details.
	Command returned non-zero exit code:
	`/usr/bin/php7.0 -f /.../bin/magento setup:di:compile`

if some module's `di.xml` contains decorator (interceptor) for virtual type `Magento\Catalog\Model\ResourceModel\Product\CollectionFactory`

	<!-- Interceptor to get error with full-text search -->
	<type name="Magento\Catalog\Model\ResourceModel\Product\CollectionFactory">
		<plugin name="flancer32_sample_plugin"
				type="Flancer32\Sample\Plugin\Catalog\Model\ResourceModel\Product\CollectionFactory"
				sortOrder="100"
				disabled="false"/>
	</type>

This is an error from log:

	[RuntimeException]                                                                                                                                                                               
	Source class "\Magento\CatalogSearch\Model\ResourceModel\Fulltext\SearchCollection" for "Magento\CatalogSearch\Model\ResourceModel\Fulltext\SearchCollectionFactory" generation does not exist. 

We should rename original virtual type `Magento\Catalog\Model\ResourceModel\Product\CollectionFactory` to smth like `virtualFulltextCollectionFactory` to enable production mode compilation.