### PR TITLE
Allows you to have 0 as a option

### DIFF
--- a/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
+++ b/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
@@ -434,7 +434,7 @@ class EavAttribute
             if ($this->isOptionForDelete($attribute, $optionId)) {
                 continue;
             }
-            if ($option[0] === '') {
+            if (!isset($option[0]) || $option[0] === '') {
                 return false;
             }
         }

--- a/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
+++ b/app/code/Magento/Swatches/Model/Plugin/EavAttribute.php
@@ -434,7 +434,7 @@ class EavAttribute
             if ($this->isOptionForDelete($attribute, $optionId)) {
                 continue;
             }
-            if (empty($option[0])) {
+            if ($option[0] === '') {
                 return false;
             }
         }


### PR DESCRIPTION
Corrects validation of options, to allow you to have 0 as a value.

If you have for example sizes and you have a size 0 which some brands are using, right now this wont validate if you try and save it in the admin since empty also validates 0 as both interger, float and string as being empty.