### PR TITLE
Allow USPS Shipping Methods Without ExtraServices

### DIFF
--- a/app/code/Magento/Usps/Model/Carrier.php
+++ b/app/code/Magento/Usps/Model/Carrier.php
@@ -2060,6 +2060,11 @@ class Carrier extends AbstractCarrierOnline implements \Magento\Shipping\Model\C
      */
     private function isServiceAvailable(\SimpleXMLElement $service)
     {
+        // Allow services which which don't provide any ExtraServices
+        if(empty($service->ExtraServices->children()->count())) {
+            return true;
+        }
+
         foreach ($service->ExtraServices->children() as $child) {
             if (filter_var($child->Available, FILTER_VALIDATE_BOOLEAN)) {
                 return true;


### PR DESCRIPTION
According to the USPS API `<ExtraServices>` can show up as an empty element, like so: `<ExtraServices/>`. In fact, this is causing an issue with "Priority Mail International" shipments to the UK, because USPS doesn't offer any extra services for that shipping method to that country. They do however add extra services to Priority Mail International packages sent to Australia.

![https___www_usps_com_business_web-tools-apis_rate-calculator-api_htm](https://cloud.githubusercontent.com/assets/3330/21019495/450eb836-bd36-11e6-8bc3-5a0b52cd31fa.png)
API Docs: https://www.usps.com/business/web-tools-apis/rate-calculator-api.htm