### PR TITLE
MAGETWO-61828: Text swatch "zero" not shown

### DIFF
--- a/app/code/Magento/Swatches/Helper/Data.php
+++ b/app/code/Magento/Swatches/Helper/Data.php
@@ -419,7 +419,7 @@ class Data
         foreach ($swatchCollection as $item) {
             if ($item['type'] != Swatch::SWATCH_TYPE_TEXTUAL) {
                 $swatches[$item['option_id']] = $item->getData();
-            } elseif ($item['store_id'] == $currentStoreId && $item['value']) {
+            } elseif ($item['store_id'] == $currentStoreId && $item['value'] != '') {
                 $fallbackValues[$item['option_id']][$currentStoreId] = $item->getData();
             } elseif ($item['store_id'] == self::DEFAULT_STORE_ID) {
                 $fallbackValues[$item['option_id']][self::DEFAULT_STORE_ID] = $item->getData();


### PR DESCRIPTION
When you create text swatch with value "0" (zero) it won't render cause comparison in /module-swatches/Helper/Data.php was wrong. Right way to check value there should be:

elseif ($item['store_id'] == $currentStoreId && $item['value'] != '')

instead of:

elseif ($item['store_id'] == $currentStoreId && $item['value'])

