### PR TITLE
Remove _required class from ZIP field

### DIFF
--- a/app/code/Magento/Directory/view/adminhtml/templates/js/optional_zip_countries.phtml
+++ b/app/code/Magento/Directory/view/adminhtml/templates/js/optional_zip_countries.phtml
@@ -40,6 +40,7 @@ function setPostcodeOptional(zipElement, country) {
             zipElement.removeClassName('required-entry');
         }
         zipElement.up('div.field').removeClassName('required');
+        zipElement.up('div.field').removeClassName('_required');
     } else {
         zipElement.addClassName('required-entry');
         zipElement.up('div.field').addClassName('required');


### PR DESCRIPTION
This patch fixes issue when Postalcode/Zip field stays required even a country from exception list is is chosen. 