### PR TITLE
change getId() to getPaymentId()

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Transactions/Fetch.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Transactions/Fetch.php
@@ -33,7 +33,7 @@ class Fetch extends \Magento\Sales\Controller\Adminhtml\Transactions
             return $resultRedirect->setPath('sales/*/');
         }
         try {
-            $this->orderPaymentRepository->get($txn->getId())->setOrder($txn->getOrder())->importTransactionInfo($txn);
+            $this->orderPaymentRepository->get($txn->getPaymentId())->setOrder($txn->getOrder())->importTransactionInfo($txn);
             $txn->save();
             $this->messageManager->addSuccess(__('The transaction details have been updated.'));
         } catch (\Magento\Framework\Exception\LocalizedException $e) {


### PR DESCRIPTION
Both 2.1.2 and latest develop version cannot fetch payment transaction info via admin panel.

## Environment:
- Magento version: 2.1.2 and later.
- Client OS: Windows, Mac, Linux
- Browser: IE, FireFox, Chrome, Safari
- MySQL: 5.6/5.7

## How to reproduce:
1. Implement payment integration module with fetch transaction information.
2. Create order without transaction data (like check money, cod).
3. Create order with transaction data (like credit card or others).
4. Execute fetch transaction data from admin panel.
5. Cannot load transaction info.

## Issue reason:
Magento\Sales\Controller\Adminhtml\Transactions\Fetch tries to get Order Payment object on line 36 with $txn->getId(), but there is no assurance that transaction id is always same as payment id.

## How to fix:
Change $txn->getId() to $txn->getPaymentId().