### PR TITLE
setup:di:compile returns exit code 0 if errors are found

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/Compiler/Log/Log.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Log/Log.php
@@ -81,11 +81,15 @@ class Log
      * Write entries
      *
      * @return void
+     * @throws \Magento\Framework\Validator\Exception
      */
     public function report()
     {
         $this->_successWriter->write($this->_successEntries);
         $this->_errorWriter->write($this->_errorEntries);
+        if (count($this->_errorEntries) > 0) {
+            throw new \Magento\Framework\Validator\Exception(__('Error during compilation'));
+        }
     }
 
     /**

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Log/Writer/Console.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Log/Writer/Console.php
@@ -70,6 +70,7 @@ class Console
 
         if ($errorsCount) {
             $this->console->writeln('<error>' . 'Total Errors Count: ' . $errorsCount . '</error>');
+            throw new \Magento\Framework\Validator\Exception(__('Error durring compilation'));
         }
     }
 

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Log/Writer/Console.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Log/Writer/Console.php
@@ -70,7 +70,6 @@ class Console
 
         if ($errorsCount) {
             $this->console->writeln('<error>' . 'Total Errors Count: ' . $errorsCount . '</error>');
-            throw new \Magento\Framework\Validator\Exception(__('Error durring compilation'));
         }
     }
 


### PR DESCRIPTION
## The problem
As a follow up to https://github.com/magento/magento2/issues/3060 and https://github.com/magento/magento2/pull/3189, running `bin/magento setup:di:compile` doesn't **always** return a non-zero exit code.

## Steps to reproduce
1. Cause an `Incorrect dependency` error.
1. Run `setup:di:compile`
1. Check exit code `echo $?`

## Expected result
Since there are `Errors during compilation`, the exit code should not be `0`

## Actual result - before this PR
Exit code was `0`, since we never entered the `catch (OperationException $e)` in [Magento\Setup\Console\Command\DiCompileCommand::execute()](https://github.com/magento/magento2/pull/3189/files#diff-13455dec36ebb2aa5a7c79e73d874a7dR201)

See screenshot: http://www.vaimo.com/snaps/pablo.ivulic/exit-code-0-not-ok.png

## Actual result - after this PR
Exit code is now `1`.
![exit-code-1](https://cloud.githubusercontent.com/assets/7068697/21144862/81f1ebfa-c14c-11e6-93b4-e0d0ba750f17.png)