### PR TITLE
Prevent LogicException for not extending \Magento\Framework\App\Helper\AbstractHelper

### DIFF
--- a/app/code/Magento/Swatches/Helper/Data.php
+++ b/app/code/Magento/Swatches/Helper/Data.php
@@ -24,7 +24,7 @@ use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Data
+class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
     /**
      * When we init media gallery empty image types contain this value.


### PR DESCRIPTION
Prevent LogicException for not extending \Magento\Framework\App\Helper\AbstractHelper

Step-by-step description:

In any .phtml try following code:

`$_helper = $this->helper('Magento\Swatches\Helper\Data');`