### PR TITLE
Setting proper resource name

### DIFF
--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -33,7 +33,7 @@
             <class>separator-top</class>
             <label>Store Email Addresses</label>
             <tab>general</tab>
-            <resource>Magento_Backend::trans_email</resource>
+            <resource>Magento_Config::trans_email</resource>
             <group id="ident_custom1" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Custom Email 1</label>
                 <field id="email" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">

--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -182,8 +182,8 @@ class Translate implements \Magento\Framework\TranslateInterface
         $this->_data = [];
 
         $this->_loadModuleTranslation();
-        $this->_loadPackTranslation();
         $this->_loadThemeTranslation();
+        $this->_loadPackTranslation();
         $this->_loadDbTranslation();
 
         if (!$forceReload) {

--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -182,8 +182,8 @@ class Translate implements \Magento\Framework\TranslateInterface
         $this->_data = [];
 
         $this->_loadModuleTranslation();
-        $this->_loadThemeTranslation();
         $this->_loadPackTranslation();
+        $this->_loadThemeTranslation();
         $this->_loadDbTranslation();
 
         if (!$forceReload) {


### PR DESCRIPTION
The resource name declared for 'trans_email' is inconsistent with the resource declared in config module.
Therefore enabling the resource 'trans_email' for a role does not allow the role to modify the resource.