### PR TITLE
Fix #7912 emulateAreaCode does not emulate config scope

### DIFF
--- a/lib/internal/Magento/Framework/App/State.php
+++ b/lib/internal/Magento/Framework/App/State.php
@@ -175,15 +175,18 @@ class State
 
         $currentArea = $this->_areaCode;
         $this->_areaCode = $areaCode;
+        $this->_configScope->setCurrentScope($areaCode);
         $this->_isAreaCodeEmulated = true;
         try {
             $result = call_user_func_array($callback, $params);
         } catch (\Exception $e) {
             $this->_areaCode = $currentArea;
+            $this->_configScope->setCurrentScope($currentArea);
             $this->_isAreaCodeEmulated = false;
             throw $e;
         }
         $this->_areaCode = $currentArea;
+        $this->_configScope->setCurrentScope($currentArea);
         $this->_isAreaCodeEmulated = false;
         return $result;
     }

--- a/lib/internal/Magento/Framework/App/Test/Unit/StateTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/StateTest.php
@@ -80,7 +80,6 @@ class StateTest extends \PHPUnit_Framework_TestCase
     {
         $areaCode = Area::AREA_FRONTEND;
         $emulatedCode = Area::AREA_ADMINHTML;
-        $this->scopeMock->expects($this->once())->method('setCurrentScope')->with($areaCode);
         $this->model->setAreaCode($areaCode);
         $this->assertEquals(
             $emulatedCode,
@@ -98,7 +97,6 @@ class StateTest extends \PHPUnit_Framework_TestCase
     {
         $areaCode = Area::AREA_ADMINHTML;
         $emulatedCode = Area::AREA_FRONTEND;
-        $this->scopeMock->expects($this->once())->method('setCurrentScope')->with($areaCode);
         $this->model->setAreaCode($areaCode);
         $this->assertFalse(
             $this->model->isAreaCodeEmulated(),
@@ -132,7 +130,6 @@ class StateTest extends \PHPUnit_Framework_TestCase
     {
         $areaCode = Area::AREA_FRONTEND;
         $emulatedCode = Area::AREA_ADMINHTML;
-        $this->scopeMock->expects($this->once())->method('setCurrentScope')->with($areaCode);
         $this->model->setAreaCode($areaCode);
         $this->model->emulateAreaCode($emulatedCode, [$this, 'emulateAreaCodeCallbackException']);
         $this->assertEquals($this->model->getAreaCode(), $areaCode);


### PR DESCRIPTION
When emulateAreaCode is used in console command to emulate frontend
it will not use the frontend config. This causes frontend observers are not triggered.