### PR TITLE
FPC JS - Fix for CORS issue

### DIFF
--- a/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
+++ b/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
@@ -26,7 +26,8 @@ define([
         (function lookup(element) {
             if ($.nodeName(element, "iframe") && $(element).prop('src').indexOf(window.location.hostname) === -1) { 
                 return []; 
-            }             
+            }
+            
             $(element).contents().each(function (index, el) {
                 switch (el.nodeType) {
                     case 1: // ELEMENT_NODE

--- a/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
+++ b/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
@@ -24,6 +24,9 @@ define([
          * @param {jQuery} element - Comment holder
          */
         (function lookup(element) {
+            if ($.nodeName(element, "iframe") && $(element).prop('src').indexOf(window.location.hostname) === -1) { 
+                return []; 
+            }             
             $(element).contents().each(function (index, el) {
                 switch (el.nodeType) {
                     case 1: // ELEMENT_NODE

--- a/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
+++ b/app/code/Magento/PageCache/view/frontend/web/js/page-cache.js
@@ -27,7 +27,6 @@ define([
             if ($.nodeName(element, "iframe") && $(element).prop('src').indexOf(window.location.hostname) === -1) { 
                 return []; 
             }
-            
             $(element).contents().each(function (index, el) {
                 switch (el.nodeType) {
                     case 1: // ELEMENT_NODE


### PR DESCRIPTION
Page cache JS cannot modify dom of a external iframed page.

How to test (this is a fix for below):
Insert an iframe into your magento page with an external source for example (assuming you aren't google):
<iframe src="https://google.com/"></iframe>

Expected result:
No JS errors in console

Actual result (from chrome):
Uncaught DOMException: Failed to read the 'contentDocument' property from 'HTMLIFrameElement': Blocked a frame with origin "https://google.com/" from accessing a cross-origin frame.