### PR TITLE
Using Dynamic Protocol Concatination

### DIFF
--- a/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
@@ -317,7 +317,7 @@ define(['jquery', 'jquery/ui'], function ($) {
             if (this._loop) {
                 additionalParams += '&loop=1';
             }
-            src = 'http://player.vimeo.com/video/' +
+            src = window.location.protocol + '//player.vimeo.com/video/' +
                 this._code + '?api=1&player_id=vimeo' +
                 this._code +
                 timestamp +


### PR DESCRIPTION
Without this fix, when accessing a product page in https, it produces: Mixed Content: This page ______ was loaded over HTTPS, but requested an insecure resource 'http://player.vimeo.com/video/158730450?api=1&player_id=vimeo1587304501482350824734&autoplay=1'. This request has been blocked; the content must be served over HTTPS.