### PR TITLE
Add exception error message to fileDeploy method to help debug if got error

### DIFF
--- a/app/code/Magento/Deploy/Model/Deploy/LocaleDeploy.php
+++ b/app/code/Magento/Deploy/Model/Deploy/LocaleDeploy.php
@@ -409,6 +409,9 @@ class LocaleDeploy implements DeployInterface
 
             $this->logger->critical($errorMessage);
         } catch (\Exception $exception) {
+            $pathInfo = $fullPath ?: $filePath;
+            $errorMessage =  __('Compilation from source: ') . $pathInfo . PHP_EOL . $exception->getMessage();
+            $this->output->write(PHP_EOL . PHP_EOL . $errorMessage . PHP_EOL, true);
             $this->output->write('.');
             if ($this->output->isVerbose()) {
                 $this->output->writeln($exception->getTraceAsString());


### PR DESCRIPTION
For example have executed command setup:static-content:deploy
If not add this fix you just get count of errors. If you execute setup:static-content:deploy -v then you do not get error msg only back trace. I think it will be useful to see error message.

