### PR TITLE
Add bin/magento commands to list store/website data

### DIFF
--- a/app/code/Magento/Store/Console/Command/StoreListCommand.php
+++ b/app/code/Magento/Store/Console/Command/StoreListCommand.php
@@ -1,0 +1,69 @@
+<?php
+namespace Magento\Store\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Class StoreListCommand
+ *
+ * Command for listing the configured stores
+ */
+class StoreListCommand extends Command
+{
+    /** @var \Magento\Store\Model\StoreManagerInterface $storeManager */
+    private $storeManager;
+
+    public function __construct(
+        \Magento\Store\Model\StoreManagerInterface $storeManager
+    ) {
+        $this->storeManager = $storeManager;
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('store:list')
+            ->setDescription('Displays the list of stores');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $table = $this->getHelperSet()->get('table');
+            $table->setHeaders(['ID', 'Website ID', 'Group ID', 'Name', 'Code', 'Sort Order', 'Is Active']);
+
+            foreach ($this->storeManager->getStores(true, true) as $store) {
+                $table->addRow([
+                    $store->getId(),
+                    $store->getWebsiteId(),
+                    $store->getStoreGroupId(),
+                    $store->getName(),
+                    $store->getCode(),
+                    $store->getData('sort_order'),
+                    $store->getData('is_active'),
+                ]);
+            }
+
+            $table->render($output);
+
+            return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+        } catch (\Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+                $output->writeln($e->getTraceAsString());
+            }
+
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+        }
+    }
+}

--- a/app/code/Magento/Store/Console/Command/WebsiteListCommand.php
+++ b/app/code/Magento/Store/Console/Command/WebsiteListCommand.php
@@ -1,0 +1,68 @@
+<?php
+namespace Magento\Store\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Class WebsiteListCommand
+ *
+ * Command for listing the configured websites
+ */
+class WebsiteListCommand extends Command
+{
+    /** @var \Magento\Store\Api\WebsiteManagementInterface $storeManager */
+    private $manager;
+
+    public function __construct(
+        \Magento\Store\Api\WebsiteRepositoryInterface $websiteManagement
+    ) {
+        $this->manager = $websiteManagement;
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('store:website:list')
+            ->setDescription('Displays the list of websites');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $table = $this->getHelperSet()->get('table');
+            $table->setHeaders(['ID', 'Default Group Id', 'Name', 'Code', 'Sort Order', 'Is Default']);
+
+            foreach ($this->manager->getList() as $website) {
+                $table->addRow([
+                    $website->getId(),
+                    $website->getDefaultGroupId(),
+                    $website->getName(),
+                    $website->getCode(),
+                    $website->getData('sort_order'),
+                    $website->getData('is_default'),
+                ]);
+            }
+
+            $table->render($output);
+
+            return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+        } catch (\Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+                $output->writeln($e->getTraceAsString());
+            }
+
+            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+        }
+    }
+}

--- a/app/code/Magento/Store/Test/Unit/Console/Command/StoreListCommandTest.php
+++ b/app/code/Magento/Store/Test/Unit/Console/Command/StoreListCommandTest.php
@@ -1,0 +1,113 @@
+<?php
+namespace Magento\Store\Test\Unit\Console\Command;
+
+use Magento\Store\Console\Command\StoreListCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\TableHelper;
+use Magento\Store\Model\Store;
+use Magento\Framework\Console\Cli;
+
+/**
+ * @package Magento\Store\Test\Unit\Console\Command
+ */
+class StoreListCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var StoreListCommand
+     */
+    private $command;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManagerMock;
+
+    /**
+     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    private $objectManager;
+
+    protected function setUp()
+    {
+        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+
+        $this->storeManagerMock = $this->getMockForAbstractClass(\Magento\Store\Model\StoreManagerInterface::class);
+
+        $this->command = $this->objectManager->getObject(
+            StoreListCommand::class,
+            ['storeManager' => $this->storeManagerMock]
+        );
+
+        /** @var HelperSet $helperSet */
+        $helperSet = $this->objectManager->getObject(
+            HelperSet::class,
+            ['helpers' => [$this->objectManager->getObject(TableHelper::class)]]
+        );
+
+        //Inject table helper for output
+        $this->command->setHelperSet($helperSet);
+    }
+
+    public function testExecuteExceptionNoVerbosity()
+    {
+        $this->storeManagerMock->expects($this->any())
+            ->method('getStores')
+            ->willThrowException(new \Exception("Dummy test exception"));
+
+        $tester = new CommandTester($this->command);
+        $this->assertEquals(Cli::RETURN_FAILURE, $tester->execute([]));
+
+        $linesOutput = array_filter(explode(PHP_EOL, $tester->getDisplay()));
+        $this->assertEquals('Dummy test exception', $linesOutput[0]);
+    }
+
+    public function testExecute()
+    {
+        $storeData = [
+            'store_id' => '999',
+            'group_id' => '777',
+            'website_id' => '888',
+            'name' => 'unit test store',
+            'code' => 'unit_test_store',
+            'is_active' => '1',
+            'sort_order' => '123',
+        ];
+
+        $stores = [
+            $this->objectManager->getObject(Store::class)->setData($storeData),
+        ];
+
+        $this->storeManagerMock->expects($this->any())
+            ->method('getStores')
+            ->willReturn($stores);
+
+        $tester = new CommandTester($this->command);
+        $this->assertEquals(Cli::RETURN_SUCCESS, $tester->execute([]));
+
+        $linesOutput = array_filter(explode(PHP_EOL, $tester->getDisplay()));
+        $this->assertCount(5, $linesOutput, 'There should be 5 lines output. 3 Spacers, 1 header, 1 content.');
+
+        $this->assertEquals($linesOutput[0], $linesOutput[2], "Lines 0, 2, 4 should be spacer lines");
+        $this->assertEquals($linesOutput[2], $linesOutput[4], "Lines 0, 2, 4 should be spacer lines");
+
+        $headerValues = array_values(array_filter(explode('|', $linesOutput[1])));
+        //trim to remove the whitespace left from the exploding pipe separation
+        $this->assertEquals('ID', trim($headerValues[0]));
+        $this->assertEquals('Website ID', trim($headerValues[1]));
+        $this->assertEquals('Group ID', trim($headerValues[2]));
+        $this->assertEquals('Name', trim($headerValues[3]));
+        $this->assertEquals('Code', trim($headerValues[4]));
+        $this->assertEquals('Sort Order', trim($headerValues[5]));
+        $this->assertEquals('Is Active', trim($headerValues[6]));
+
+        $storeValues = array_values(array_filter(explode('|', $linesOutput[3])));
+        $this->assertEquals('999', trim($storeValues[0]));
+        $this->assertEquals('888', trim($storeValues[1]));
+        $this->assertEquals('777', trim($storeValues[2]));
+        $this->assertEquals('unit test store', trim($storeValues[3]));
+        $this->assertEquals('unit_test_store', trim($storeValues[4]));
+        $this->assertEquals('123', trim($storeValues[5]));
+        $this->assertEquals('1', trim($storeValues[6]));
+    }
+}

--- a/app/code/Magento/Store/Test/Unit/Console/Command/WebsiteListCommandTest.php
+++ b/app/code/Magento/Store/Test/Unit/Console/Command/WebsiteListCommandTest.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\TableHelper;
 use Magento\Store\Model\Website;
 use Magento\Framework\Console\Cli;
+use Magento\Store\Api\WebsiteRepositoryInterface;
 
 /**
  * @package Magento\Store\Test\Unit\Console\Command
@@ -32,7 +33,7 @@ class WebsiteListCommandTest extends \PHPUnit_Framework_TestCase
     {
         $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
-        $this->websiteRepositoryMock = $this->getMockForAbstractClass(\Magento\Store\Api\WebsiteRepositoryInterface::class);
+        $this->websiteRepositoryMock = $this->getMockForAbstractClass(WebsiteRepositoryInterface::class);
 
         $this->command = $this->objectManager->getObject(
             WebsiteListCommand::class,

--- a/app/code/Magento/Store/Test/Unit/Console/Command/WebsiteListCommandTest.php
+++ b/app/code/Magento/Store/Test/Unit/Console/Command/WebsiteListCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace Magento\Store\Test\Unit\Console\Command;
+
+use Magento\Store\Console\Command\WebsiteListCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\TableHelper;
+use Magento\Store\Model\Website;
+use Magento\Framework\Console\Cli;
+
+/**
+ * @package Magento\Store\Test\Unit\Console\Command
+ */
+class WebsiteListCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var WebsiteListCommand
+     */
+    private $command;
+
+    /**
+     * @var \Magento\Store\Api\WebsiteRepositoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $websiteRepositoryMock;
+
+    /**
+     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    private $objectManager;
+
+    protected function setUp()
+    {
+        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+
+        $this->websiteRepositoryMock = $this->getMockForAbstractClass(\Magento\Store\Api\WebsiteRepositoryInterface::class);
+
+        $this->command = $this->objectManager->getObject(
+            WebsiteListCommand::class,
+            ['websiteManagement' => $this->websiteRepositoryMock]
+        );
+
+        /** @var HelperSet $helperSet */
+        $helperSet = $this->objectManager->getObject(
+            HelperSet::class,
+            ['helpers' => [$this->objectManager->getObject(TableHelper::class)]]
+        );
+
+        //Inject table helper for output
+        $this->command->setHelperSet($helperSet);
+    }
+
+    public function testExecuteExceptionNoVerbosity()
+    {
+        $this->websiteRepositoryMock->expects($this->any())
+            ->method('getList')
+            ->willThrowException(new \Exception("Dummy test exception"));
+
+        $tester = new CommandTester($this->command);
+        $this->assertEquals(Cli::RETURN_FAILURE, $tester->execute([]));
+
+        $linesOutput = array_filter(explode(PHP_EOL, $tester->getDisplay()));
+        $this->assertEquals('Dummy test exception', $linesOutput[0]);
+    }
+
+    public function testExecute()
+    {
+        $websiteData = [
+            'id' => '444',
+            'default_group_id' => '555',
+            'name' => 'unit test website',
+            'code' => 'unit_test_website',
+            'is_default' => '0',
+            'sort_order' => '987',
+        ];
+
+        $websites = [
+            $this->objectManager->getObject(Website::class)->setData($websiteData),
+        ];
+
+        $this->websiteRepositoryMock->expects($this->any())
+            ->method('getList')
+            ->willReturn($websites);
+
+        $tester = new CommandTester($this->command);
+        $this->assertEquals(Cli::RETURN_SUCCESS, $tester->execute([]));
+
+        $linesOutput = array_filter(explode(PHP_EOL, $tester->getDisplay()));
+        $this->assertCount(5, $linesOutput, 'There should be 5 lines output. 3 Spacers, 1 header, 1 content.');
+
+        $this->assertEquals($linesOutput[0], $linesOutput[2], "Lines 0, 2, 4 should be spacer lines");
+        $this->assertEquals($linesOutput[2], $linesOutput[4], "Lines 0, 2, 4 should be spacer lines");
+
+        $headerValues = array_values(array_filter(explode('|', $linesOutput[1])));
+        //trim to remove the whitespace left from the exploding pipe separation
+        $this->assertEquals('ID', trim($headerValues[0]));
+        $this->assertEquals('Default Group Id', trim($headerValues[1]));
+        $this->assertEquals('Name', trim($headerValues[2]));
+        $this->assertEquals('Code', trim($headerValues[3]));
+        $this->assertEquals('Sort Order', trim($headerValues[4]));
+        $this->assertEquals('Is Default', trim($headerValues[5]));
+
+        $websiteValues = array_values(array_filter(explode('|', $linesOutput[3])));
+        $this->assertEquals('444', trim($websiteValues[0]));
+        $this->assertEquals('555', trim($websiteValues[1]));
+        $this->assertEquals('unit test website', trim($websiteValues[2]));
+        $this->assertEquals('unit_test_website', trim($websiteValues[3]));
+        $this->assertEquals('987', trim($websiteValues[4]));
+        $this->assertEquals('0', trim($websiteValues[5]));
+    }
+}

--- a/app/code/Magento/Store/etc/di.xml
+++ b/app/code/Magento/Store/etc/di.xml
@@ -373,4 +373,12 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\Console\CommandListInterface">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="commandStoreList" xsi:type="object">Magento\Store\Console\Command\StoreListCommand</item>
+                <item name="commandWebsiteList" xsi:type="object">Magento\Store\Console\Command\WebsiteListCommand</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
### Proposal

I used commands in n98-magerun to output a list of store data and website data, nothing that can't be achieved by connecting to the database and doing a few `SELECT` statements but the magerun wrapper was very helpful in Magento 1.

I'd like to have these commands back in use for Magento 2

| magerun command  | proposed magento2 command  |
|---|---|
| magerun sys:store:list  |  bin/magento store:list |
| magerun sys:website:list  |  bin/magento store:website:list |

### Naming things

>There are only two hard things in Computer Science: cache invalidation and naming things.
> -- Phil Karlton
> http://martinfowler.com/bliki/TwoHardThings.html 

I think the code for the `website:list` command should live in the same directory as the `store:list` command because both entities are part of the `Mage/Store` module.  Also any commands in the `Mage/Store` module should be prefixed with `store`. However, this gives us the odd naming hierarchical structure in the command names listed, listing a website has to include the word `store` or break convention.

If anyone has any suggestions I'm all ears, I've gone for option 1 by default and option 3 breaks convention.

 | option  | list stores  | list websites|
|---|---|---|
| Option 1  |  bin/magento store:list | bin/magento store:website:list |
| Option 2 |  bin/magento store:list:store | bin/magento store:list:website |
| Option 3 |  bin/magento store:list | bin/magento website:list |

### A comment on my code

I'm not sure if this is the correct standard for creating new CLI commands. I copied the approach from the sample data module. If this method is outdated shout out.

### Example usage and output

```
$ bin/magento store:website:list
+----+------------------+--------------+-------+------------+------------+
| ID | Default Group Id | Name         | Code  | Sort Order | Is Default |
+----+------------------+--------------+-------+------------+------------+
| 0  | 0                | Admin        | admin | 0          | 0          |
| 1  | 1                | Main Website | base  | 0          | 1          |
| 2  | 2                | Other Site   | other | 0          | 0          |
+----+------------------+--------------+-------+------------+------------+

$ bin/magento store:list
+----+------------+----------+--------------------+---------+------------+-----------+
| ID | Website ID | Group ID | Name               | Code    | Sort Order | Is Active |
+----+------------+----------+--------------------+---------+------------+-----------+
| 0  | 0          | 0        | Admin              | admin   | 0          | 1         |
| 1  | 1          | 1        | Default Store View | default | 0          | 1         |
| 2  | 2          | 2        | Other Store View   | other   | 0          | 1         |
+----+------------+----------+--------------------+---------+------------+-----------+
```