### PR TITLE
Set static html fragments as cacheable

### DIFF
--- a/pub/static/.htaccess
+++ b/pub/static/.htaccess
@@ -89,11 +89,12 @@ AddType application/xml xml
     ExpiresByType application/x-gzip "access plus 0 seconds"
     ExpiresByType application/x-bzip2 "access plus 0 seconds"
 
-    # CSS, JavaScript
-    <FilesMatch \.(css|js)$>
+    # CSS, JavaScript, html
+    <FilesMatch \.(css|js|html)$>
         ExpiresDefault "access plus 1 year"
     </FilesMatch>
     ExpiresByType text/css "access plus 1 year"
+    ExpiresByType text/html "access plus 1 year"
     ExpiresByType application/javascript "access plus 1 year"
 
     # Favicon, images, flash


### PR DESCRIPTION
Fixes issue where static content knockout templates are retrieved again for every request from the server, depending on apache configuration. With this patch, we no longer depend on specifics of environment apache configuration.