### PR TITLE
Fix USPS Priority Mail to Canada

### DIFF
--- a/app/code/Magento/Usps/Model/Carrier.php
+++ b/app/code/Magento/Usps/Model/Carrier.php
@@ -490,7 +490,11 @@ class Carrier extends AbstractCarrierOnline implements \Magento\Shipping\Model\C
             $package->addChild('Length', $length);
             $package->addChild('Height', $height);
             $package->addChild('Girth', $girth);
-
+            
+            $package->addChild('OriginZip', $r->getOrigPostal());
+            $package->addChild('AcceptanceDateTime', date('c'));
+            $package->addChild('DestinationPostalCode', $r->getDestPostal());
+            
             $api = 'IntlRateV2';
         }
         $request = $xml->asXML();


### PR DESCRIPTION
As USPS states in the XML response:
> The Origin ZIP Code and the Destination Postal Code is required for Priority Mail International when mailing to Canada.

This patch adds the three required fields, therefore fixing the issue with shipping USPS Priority Mail International from the US to Canada.

See Also: #3186