### PR TITLE
Variable $address is not used

### DIFF
--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -106,12 +106,6 @@ class Ga extends \Magento\Framework\View\Element\Template
 
         $result[] = "ga('require', 'ec', 'ec.js');";
         foreach ($collection as $order) {
-            if ($order->getIsVirtual()) {
-                $address = $order->getBillingAddress();
-            } else {
-                $address = $order->getShippingAddress();
-            }
-
             foreach ($order->getAllVisibleItems() as $item) {
                 $result[] = sprintf(
                     "ga('ec:addProduct', {


### PR DESCRIPTION
The Variable $address is not used anywhere else in this method. Due to that, the conditional statement has no effect on the code and can be removed.