### PR TITLE
Update PurgeCache.php

### DIFF
--- a/app/code/Magento/CacheInvalidate/Model/PurgeCache.php
+++ b/app/code/Magento/CacheInvalidate/Model/PurgeCache.php
@@ -58,6 +58,7 @@ class PurgeCache
         $headers = [self::HEADER_X_MAGENTO_TAGS_PATTERN => $tagsPattern];
         $socketAdapter->setOptions(['timeout' => 10]);
         foreach ($servers as $server) {
+            $headers['Host'] = $server->getHost();
             try {
                 $socketAdapter->connect($server->getHost(), $server->getPort());
                 $socketAdapter->write(
@@ -66,6 +67,7 @@ class PurgeCache
                     '1.1',
                     $headers
                 );
+                $socketAdapter->read();
                 $socketAdapter->close();
             } catch (\Exception $e) {
                 $this->logger->critical($e->getMessage(), compact('server', 'tagsPattern'));


### PR DESCRIPTION
Additionally to PR https://github.com/magento/magento2/pull/7650, when Varnish cache sits behind an NGINX proxy, HTTP code 499 is returned unless socket stream waits for response (which should not have much of a performance impact due to nature of PURGE request)