### PR TITLE
Strict checking types during di compilation

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/BackslashTrim.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/BackslashTrim.php
@@ -57,7 +57,7 @@ class BackslashTrim implements ModificationInterface
         }
 
         foreach ($argument as $key => &$value) {
-            if (in_array($key, ['_i_', '_ins_'])) {
+            if (in_array($key, ['_i_', '_ins_'], true)) {
                 $value = ltrim($value, '\\');
                 continue;
             }

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/PreferencesResolving.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/PreferencesResolving.php
@@ -41,7 +41,7 @@ class PreferencesResolving implements ModificationInterface
         }
 
         foreach ($argument as $key => &$value) {
-            if (in_array($key, ['_i_', '_ins_'])) {
+            if (in_array($key, ['_i_', '_ins_'], true)) {
                 $value = $this->resolvePreferenceRecursive($value, $preferences);
                 continue;
             }


### PR DESCRIPTION
setup:di:compile fails when any of argument's item has a name "0"

eg:
`<item name="0" xsi:type="object">AnyClass</item>`

To prevent such situation strict types checking must be implemented.