### PR TITLE
Fix theme source model used in widget grid

### DIFF
--- a/app/code/Magento/Widget/Model/ResourceModel/Widget/Instance/Options/ThemeId.php
+++ b/app/code/Magento/Widget/Model/ResourceModel/Widget/Instance/Options/ThemeId.php
@@ -22,11 +22,11 @@ class ThemeId implements \Magento\Framework\Option\ArrayInterface
     protected $_resourceModel;
 
     /**
-     * @param \Magento\Theme\Model\ResourceModel\Theme\Collection $widgetResourceModel
+     * @param \Magento\Theme\Model\ResourceModel\Theme\CollectionFactory $widgetResourceModel
      */
-    public function __construct(\Magento\Theme\Model\ResourceModel\Theme\Collection $widgetResourceModel)
+    public function __construct(\Magento\Theme\Model\ResourceModel\Theme\CollectionFactory $widgetResourceModel)
     {
-        $this->_resourceModel = $widgetResourceModel;
+        $this->_resourceModel = $widgetResourceModel->create();
     }
 
     /**


### PR DESCRIPTION
It may happen that source model for Theme field in Widget grid will not show all installed themes due to injecting theme Collection class and not the factory. This fix injects the factory class and create new collection instance for the source model to use making sure it will always select all available themes from the database (this is the way Magento\Widget\Model\ResourceModel\Widget\Instance\Options\Themes class behaves)