### PR TITLE
Fix swatch-renderer.js 843:866

### DIFF
--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -840,27 +840,29 @@ define([
                 }
             );
 
-            if (result.oldPrice.amount !== result.finalPrice.amount) {
-                $(this.options.slyOldPriceSelector).show();
-            } else {
-                $(this.options.slyOldPriceSelector).hide();
-            }
-
-            if (result.tierPrices.length) {
-                if (this.options.tierPriceTemplate) {
-                    tierPriceHtml = mageTemplate(
-                        this.options.tierPriceTemplate,
-                        {
-                            'tierPrices': result.tierPrices,
-                            '$t': $t,
-                            'currencyFormat': this.options.jsonConfig.currencyFormat,
-                            'priceUtils': priceUtils
-                        }
-                    );
-                    $(this.options.tierPriceBlockSelector).html(tierPriceHtml).show();
+            if (typeof(result) != "undefined") {
+                if (result.oldPrice.amount !== result.finalPrice.amount) {
+                    $(this.options.slyOldPriceSelector).show();
+                } else {
+                    $(this.options.slyOldPriceSelector).hide();
                 }
-            } else {
-                $(this.options.tierPriceBlockSelector).hide();
+
+                if (result.tierPrices.length) {
+                    if (this.options.tierPriceTemplate) {
+                        tierPriceHtml = mageTemplate(
+                            this.options.tierPriceTemplate,
+                            {
+                                'tierPrices': result.tierPrices,
+                                '$t': $t,
+                                'currencyFormat': this.options.jsonConfig.currencyFormat,
+                                'priceUtils': priceUtils
+                            }
+                        );
+                        $(this.options.tierPriceBlockSelector).html(tierPriceHtml).show();
+                    }
+                } else {
+                    $(this.options.tierPriceBlockSelector).hide();
+                }
             }
         },
 


### PR DESCRIPTION
Hello,
There is an error in console when product has more than one kind of swatches: 
Uncaught TypeError: Cannot read property 'oldPrice' of undefined - swatch-renderer.js:843

Step to reproduce:
1) Install Sample Data
2) Set Special Price for some Simple of the Configurable product which has more than one kind of swatches, for example SKU: WJ03
3) Go to PDP (../augusta-pullover-jacket.html)
4) Select some Color and look to the console - there You will be able to see the error. This is because 'result' is null before all of the swatches are selected.

Some fixes have been added. Please, test.
Thanks.