### PR TITLE
Throw exception for invalid (missing) template in dev mode

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/View/Element/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Element/TemplateTest.php
@@ -14,11 +14,21 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
      */
     protected $_block;
 
+    /**
+     * @var \Magento\TestFramework\ObjectManager
+     */
+    protected $objectManager;
+
+    /**
+     * @var string
+     */
+    private $origMode;
+
     protected function setUp()
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $params = ['layout' => $objectManager->create(\Magento\Framework\View\Layout::class, [])];
-        $context = $objectManager->create(\Magento\Framework\View\Element\Template\Context::class, $params);
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $params = ['layout' => $this->objectManager->create(\Magento\Framework\View\Layout::class, [])];
+        $context = $this->objectManager->create(\Magento\Framework\View\Element\Template\Context::class, $params);
         $this->_block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
             \Magento\Framework\View\LayoutInterface::class
         )->createBlock(
@@ -26,6 +36,21 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
             '',
             ['context' => $context]
         );
+
+        /** @var \Magento\TestFramework\App\State $appState */
+        $appState = $this->objectManager->get(\Magento\TestFramework\App\State::class);
+        $this->origMode = $appState->getMode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function tearDown()
+    {
+        /** @var \Magento\TestFramework\App\State $appState */
+        $appState = $this->objectManager->get(\Magento\TestFramework\App\State::class);
+        $appState->setMode($this->origMode);
+        parent::tearDown();
     }
 
     public function testConstruct()
@@ -70,6 +95,9 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
     {
         \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\App\State::class)
             ->setAreaCode(Area::AREA_GLOBAL);
+        /** @var \Magento\TestFramework\App\State $appState */
+        $appState = $this->objectManager->get(\Magento\TestFramework\App\State::class);
+        $appState->setMode(\Magento\TestFramework\App\State::MODE_DEFAULT);
         $this->assertEmpty($this->_block->toHtml());
         $this->_block->setTemplate(uniqid('invalid_filename.phtml'));
         $this->assertEmpty($this->_block->toHtml());

--- a/lib/internal/Magento/Framework/View/Element/Template.php
+++ b/lib/internal/Magento/Framework/View/Element/Template.php
@@ -256,10 +256,12 @@ class Template extends AbstractBlock
         } else {
             $html = '';
             $templatePath = $fileName ?: $this->getTemplate();
-            $this->_logger->critical(
-                "Invalid template file: '{$templatePath}' in module: '{$this->getModuleName()}'"
-                . " block's name: '{$this->getNameInLayout()}'"
-            );
+            $errorMessage = "Invalid template file: '{$templatePath}' in module: '{$this->getModuleName()}'"
+                . " block's name: '{$this->getNameInLayout()}'";
+            if ($this->_appState->getMode() === \Magento\Framework\App\State::MODE_DEVELOPER) {
+                throw new \InvalidArgumentException($errorMessage);
+            }
+            $this->_logger->critical($errorMessage);
         }
 
         \Magento\Framework\Profiler::stop('TEMPLATE:' . $fileName);

--- a/lib/internal/Magento/Framework/View/Element/Template.php
+++ b/lib/internal/Magento/Framework/View/Element/Template.php
@@ -259,7 +259,11 @@ class Template extends AbstractBlock
             $errorMessage = "Invalid template file: '{$templatePath}' in module: '{$this->getModuleName()}'"
                 . " block's name: '{$this->getNameInLayout()}'";
             if ($this->_appState->getMode() === \Magento\Framework\App\State::MODE_DEVELOPER) {
-                throw new \InvalidArgumentException($errorMessage);
+                throw new \Magento\Framework\Exception\ValidatorException(
+                    new \Magento\Framework\Phrase(
+                        $errorMessage
+                    )
+                );
             }
             $this->_logger->critical($errorMessage);
         }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/TemplateTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/TemplateTest.php
@@ -51,6 +51,11 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
      */
     protected $loggerMock;
 
+    /**
+     * @var \Magento\Framework\App\State|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $appState;
+
     protected function setUp()
     {
         $this->resolver = $this->getMock(
@@ -90,8 +95,8 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         $this->loggerMock = $this->getMock(\Psr\Log\LoggerInterface::class);
         $this->templateEngine->expects($this->any())->method('get')->willReturn($this->templateEngine);
 
-        $appState = $this->getMock(\Magento\Framework\App\State::class, ['getAreaCode'], [], '', false);
-        $appState->expects($this->any())->method('getAreaCode')->willReturn('frontend');
+        $this->appState = $this->getMock(\Magento\Framework\App\State::class, ['getAreaCode', 'getMode'], [], '', false);
+        $this->appState->expects($this->any())->method('getAreaCode')->willReturn('frontend');
         $storeManagerMock = $this->getMock(StoreManager::class, [], [], '', false);
         $storeMock = $this->getMock(Store::class, [], [], '', false);
         $storeManagerMock->expects($this->any())
@@ -112,7 +117,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
                 'enginePool' => $this->templateEngine,
                 'resolver' => $this->resolver,
                 'validator' => $this->validator,
-                'appState' => $appState,
+                'appState' => $this->appState,
                 'logger' => $this->loggerMock,
                 'storeManager' => $storeManagerMock,
                 'urlBuilder' => $urlBuilderMock,
@@ -163,6 +168,30 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
             ->with($exception)
             ->willReturn(null);
         $this->assertEquals($output, $this->block->fetchView($template));
+    }
+
+    public function testFetchViewWithNoFileNameDeveloperMode()
+    {
+        $template = false;
+        $templatePath = 'wrong_template_path.pthml';
+        $moduleName = 'Acme';
+        $blockName = 'acme_test_module_test_block';
+        $exception = "Invalid template file: '{$templatePath}' in module: '{$moduleName}' block's name: '{$blockName}'";
+        $this->block->setTemplate($templatePath);
+        $this->block->setData('module_name', $moduleName);
+        $this->block->setNameInLayout($blockName);
+        $this->validator->expects($this->once())
+            ->method('isValid')
+            ->with($template)
+            ->willReturn(false);
+        $this->loggerMock->expects($this->never())
+            ->method('critical');
+        $this->appState->expects($this->once())
+            ->method('getMode')
+            ->willReturn(\Magento\Framework\App\State::MODE_DEVELOPER);
+
+        $this->setExpectedException('\InvalidArgumentException', $exception);
+        $this->block->fetchView($template);
     }
 
     public function testSetTemplateContext()

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/TemplateTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/TemplateTest.php
@@ -95,7 +95,13 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         $this->loggerMock = $this->getMock(\Psr\Log\LoggerInterface::class);
         $this->templateEngine->expects($this->any())->method('get')->willReturn($this->templateEngine);
 
-        $this->appState = $this->getMock(\Magento\Framework\App\State::class, ['getAreaCode', 'getMode'], [], '', false);
+        $this->appState = $this->getMock(
+            \Magento\Framework\App\State::class,
+            ['getAreaCode', 'getMode'],
+            [],
+            '',
+            false
+        );
         $this->appState->expects($this->any())->method('getAreaCode')->willReturn('frontend');
         $storeManagerMock = $this->getMock(StoreManager::class, [], [], '', false);
         $storeMock = $this->getMock(Store::class, [], [], '', false);

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/TemplateTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/TemplateTest.php
@@ -196,7 +196,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
             ->method('getMode')
             ->willReturn(\Magento\Framework\App\State::MODE_DEVELOPER);
 
-        $this->setExpectedException('\InvalidArgumentException', $exception);
+        $this->setExpectedException('\Magento\Framework\Exception\ValidatorException', $exception);
         $this->block->fetchView($template);
     }
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/TemplateTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/TemplateTest.php
@@ -196,7 +196,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
             ->method('getMode')
             ->willReturn(\Magento\Framework\App\State::MODE_DEVELOPER);
 
-        $this->setExpectedException('\Magento\Framework\Exception\ValidatorException', $exception);
+        $this->setExpectedException(\Magento\Framework\Exception\ValidatorException::class, $exception);
         $this->block->fetchView($template);
     }
 


### PR DESCRIPTION
In developer mode php notices/warnings etc are promoted to being exceptions. This means the developer is a bit more diligent with cleaning up any messes as they occur. This does not seem to apply to layout declarations with invalid templates.

I noticed this error on a Magento 1 client which is filled with "Not valid template file", I checked in M2 and this error seems to persist. Developer mode does not promote invalid template errors to being an exception.

This change should make sure developers do not leave any dead templates in their layout.xml. It seems like an easy win to me. 

Don't we all want clean log files? :)