### PR TITLE
Update Options.php

### DIFF
--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
@@ -163,6 +163,8 @@ class Options extends \Magento\Backend\Block\Widget\Form\Generic
             }
         }
 
+        $data['value'] = html_entity_decode( $data['value'] );
+
         // prepare element dropdown values
         if ($values = $parameter->getValues()) {
             // dropdown options are specified in configuration

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
@@ -163,7 +163,7 @@ class Options extends \Magento\Backend\Block\Widget\Form\Generic
             }
         }
 
-        $data['value'] = html_entity_decode( $data['value'] );
+        $data['value'] = html_entity_decode($data['value']);
 
         // prepare element dropdown values
         if ($values = $parameter->getValues()) {


### PR DESCRIPTION
Prevent special charachters (like ü or ß) from being inserted as HTML encoded entities (like &uuml; or &szlig;) in widget input fields.