### PR TITLE
Fix incorrect schema definition for price

### DIFF
--- a/app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml
+++ b/app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml
@@ -19,14 +19,14 @@
         <?php echo($block->getPriceDisplayLabel()) ? 'data-label="' . $block->getPriceDisplayLabel() . $block->getPriceDisplayInclExclTaxes() . '"' : '' ?>
         data-price-amount="<?php /* @escapeNotVerified */ echo $block->getDisplayValue(); ?>"
         data-price-type="<?php /* @escapeNotVerified */ echo $block->getPriceType(); ?>"
-        class="price-wrapper <?php /* @escapeNotVerified */ echo $block->getPriceWrapperCss(); ?>"
-        <?php echo $block->getSchema() ? ' itemprop="price"' : '' ?>>
+        class="price-wrapper <?php /* @escapeNotVerified */ echo $block->getPriceWrapperCss(); ?>">
         <?php /* @escapeNotVerified */ echo $block->formatCurrency($block->getDisplayValue(), (bool)$block->getIncludeContainer()) ?>
     </span>
     <?php if ($block->hasAdjustmentsHtml()): ?>
         <?php echo $block->getAdjustmentsHtml() ?>
     <?php endif; ?>
     <?php if ($block->getSchema()): ?>
+        <meta itemprop="price" content="<?php /* @escapeNotVerified */ echo $block->getDisplayValue(); ?>" />
         <meta itemprop="priceCurrency" content="<?php /* @escapeNotVerified */ echo $block->getDisplayCurrencyCode()?>" />
     <?php endif; ?>
 </span>


### PR DESCRIPTION
Fixes an incorrect schema definition for pricing, before this change
the structured data testing tool provided by Google flags the price
as a warning since it contains the currency symbol, a separate
itemprop exists for the priceCurrency, I have added a separate meta
tag for the price without the currenccy symbol.