### PR TITLE
Only resize images for themes which are being used instead of all installed themes.

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Image/Cache.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/Cache.php
@@ -8,6 +8,7 @@ namespace Magento\Catalog\Model\Product\Image;
 use Magento\Catalog\Helper\Image as ImageHelper;
 use Magento\Catalog\Model\Product;
 use Magento\Theme\Model\ResourceModel\Theme\Collection as ThemeCollection;
+use Magento\Theme\Model\Config\Customization as ThemeCustomizationConfig;
 use Magento\Framework\App\Area;
 use Magento\Framework\View\ConfigInterface;
 
@@ -22,6 +23,11 @@ class Cache
      * @var ThemeCollection
      */
     protected $themeCollection;
+
+    /**
+     * @var ThemeCustomizationConfig
+     */
+    protected $themeCustomizationConfig;
 
     /**
      * @var ImageHelper
@@ -41,10 +47,12 @@ class Cache
     public function __construct(
         ConfigInterface $viewConfig,
         ThemeCollection $themeCollection,
-        ImageHelper $imageHelper
+        ImageHelper $imageHelper,
+        ThemeCustomizationConfig $themeCustomizationConfig
     ) {
         $this->viewConfig = $viewConfig;
         $this->themeCollection = $themeCollection;
+        $this->themeCustomizationConfig = $themeCustomizationConfig;
         $this->imageHelper = $imageHelper;
     }
 
@@ -58,8 +66,10 @@ class Cache
     protected function getData()
     {
         if (!$this->data) {
+            $themes = $this->getThemesInUse();
+
             /** @var \Magento\Theme\Model\Theme $theme */
-            foreach ($this->themeCollection->loadRegisteredThemes() as $theme) {
+            foreach ($themes as $theme) {
                 $config = $this->viewConfig->getViewConfig([
                     'area' => Area::AREA_FRONTEND,
                     'themeModel' => $theme,
@@ -126,5 +136,21 @@ class Cache
         $this->imageHelper->save();
 
         return $this;
+    }
+
+    protected function getThemesInUse()
+    {
+        $themesInUse = [];
+
+        $registeredThemes = $this->themeCollection->loadRegisteredThemes();
+        $storesByThemes   = $this->themeCustomizationConfig->getStoresByThemes();
+
+        foreach ($registeredThemes as $registeredTheme) {
+            if (array_key_exists($registeredTheme->getThemeId(), $storesByThemes)) {
+                $themesInUse[] = $registeredTheme;
+            }
+        }
+
+        return $themesInUse;
     }
 }

--- a/app/code/Magento/Catalog/Model/Product/Image/Cache.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/Cache.php
@@ -43,6 +43,7 @@ class Cache
      * @param ConfigInterface $viewConfig
      * @param ThemeCollection $themeCollection
      * @param ImageHelper $imageHelper
+     * @param ThemeCustomizationConfig $themeCustomizationConfig
      */
     public function __construct(
         ConfigInterface $viewConfig,
@@ -138,6 +139,11 @@ class Cache
         return $this;
     }
 
+    /**
+     * Retrieve themes which are currently active in the frontend
+     *
+     * @return array
+     */
     protected function getThemesInUse()
     {
         $themesInUse = [];

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Image/CacheTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Image/CacheTest.php
@@ -44,6 +44,11 @@ class CacheTest extends \PHPUnit_Framework_TestCase
     protected $themeCollection;
 
     /**
+     * @var \Magento\Theme\Model\Config\Customization|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $themeCustomizationConfig;
+
+    /**
      * @var \Magento\Catalog\Helper\Image|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $imageHelper;
@@ -70,6 +75,10 @@ class CacheTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->themeCustomizationConfig = $this->getMockBuilder(\Magento\Theme\Model\Config\Customization::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->imageHelper = $this->getMockBuilder(\Magento\Catalog\Helper\Image::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -84,6 +93,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
             [
                 'viewConfig' => $this->viewConfig,
                 'themeCollection' => $this->themeCollection,
+                'themeCustomizationConfig' => $this->themeCustomizationConfig,
                 'imageHelper' => $this->imageHelper,
             ]
         );
@@ -125,6 +135,12 @@ class CacheTest extends \PHPUnit_Framework_TestCase
         $this->themeCollection->expects($this->once())
             ->method('loadRegisteredThemes')
             ->willReturn([$themeMock]);
+
+        $this->themeCustomizationConfig->expects($this->once())
+            ->method('getStoresByThemes')
+            ->willReturn([
+                $themeMock->getThemeId() => [1]
+            ]);
 
         $this->viewConfig->expects($this->once())
             ->method('getViewConfig')


### PR DESCRIPTION
Currently Magento resizes catalog images in the frontend for all the installed themes.
So if you have the `Magento/blank`, `Magento/luma` and your own custom theme, it would resize the images for those three themes. Even if you only use your own custom theme in the frontend.

This PR should fix this, it will only resize catalog images for themes which are actually active.

This code is being executed when running the command: `bin/magento catalog:images:resize` and also in the `afterSave` method of the `Magento\Catalog\Model\Product` class.