### PR TITLE
Remove "<2.7" constraint on symfony/console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "tubalmartin/cssmin": "2.4.8-p4",
         "magento/magento-composer-installer": ">=0.1.11",
         "braintree/braintree_php": "3.7.0",
-        "symfony/console": "~2.3 <2.7",
+        "symfony/console": "~2.3",
         "symfony/event-dispatcher": "~2.1",
         "symfony/process": "~2.1",
         "phpseclib/phpseclib": "2.0.*",


### PR DESCRIPTION
Sibling to https://github.com/magento/composer/pull/3:

> I guess this constraints was added before Symfony silenced its deprecation notices.
> But now that it does, there should be no reason to exclude 2.7 & 2.8,
> unless you've found a BC break blocker. In which case we'd be happy to know which one!