### PR TITLE
Return focus to search input after closing autocomplete dropdown

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -86,6 +86,8 @@ define([
                 setTimeout($.proxy(function () {
                     if (this.autoComplete.is(':hidden')) {
                         this.setActiveState(false);
+                    } else {
+                        this.element.trigger('focus');
                     }
                     this.autoComplete.hide();
                     this._updateAriaHasPopup(false);


### PR DESCRIPTION
After closing the autocomplete dropdown by clicking away from it, return focus to the search input element.

Otherwise the searchbox that was opened will not close when clicking away from it. You need to return the focus to it by clicking it again, and only then you can close it by clicking away from it.

Steps to reproduce: Search something that gets some search result so that the autocomplete gets populated. Start searching for it again so that the dropdown opens. Click away (dropdown should close). Click away again (the search bar will not close, against user expectation).