### PR TITLE
Fix attributes not added to salesrule_product_attribute after sale rule save

### DIFF
--- a/app/code/Magento/SalesRule/Model/ResourceModel/Rule.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Rule.php
@@ -347,7 +347,7 @@ class Rule extends AbstractResource
     {
         $result = [];
         if (preg_match_all(
-            '~s:46:"Magento\SalesRule\Model\Rule\Condition\Product";s:9:"attribute";s:\d+:"(.*?)"~s',
+            '~s:4[67]:"\\?Magento\\SalesRule\\Model\\Rule\\Condition\\Product";s:9:"attribute";s:\d+:"(.*?)"~s',
             $serializedString,
             $matches
         )

--- a/app/code/Magento/SalesRule/Model/ResourceModel/Rule.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Rule.php
@@ -347,7 +347,7 @@ class Rule extends AbstractResource
     {
         $result = [];
         if (preg_match_all(
-            '~s:32:"salesrule/rule_condition_product";s:9:"attribute";s:\d+:"(.*?)"~s',
+            '~s:46:"Magento\SalesRule\Model\Rule\Condition\Product";s:9:"attribute";s:\d+:"(.*?)"~s',
             $serializedString,
             $matches
         )

--- a/app/code/Magento/SalesRule/Model/ResourceModel/Rule.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Rule.php
@@ -301,7 +301,7 @@ class Rule extends AbstractResource
     public function setActualProductAttributes($rule, $attributes)
     {
         $connection = $this->getConnection();
-        $connection->delete($this->getTable('salesrule_product_attribute'), ['rule_id=?' => $rule->getId()]);
+        $connection->delete($this->getTable('salesrule_product_attribute'), ['row_id=?' => $rule->getId()]);
 
         //Getting attribute IDs for attribute codes
         $attributeIds = [];
@@ -323,7 +323,7 @@ class Rule extends AbstractResource
                 foreach ($rule->getWebsiteIds() as $websiteId) {
                     foreach ($attributeIds as $attribute) {
                         $data[] = [
-                            'rule_id' => $rule->getId(),
+                            'row_id' => $rule->getId(),
                             'website_id' => $websiteId,
                             'customer_group_id' => $customerGroupId,
                             'attribute_id' => $attribute,
@@ -347,7 +347,7 @@ class Rule extends AbstractResource
     {
         $result = [];
         if (preg_match_all(
-            '~s:4[67]:"\\?Magento\\SalesRule\\Model\\Rule\\Condition\\Product";s:9:"attribute";s:\d+:"(.*?)"~s',
+            '~s:4[67]:"\\\\?Magento\\\\SalesRule\\\\Model\\\\Rule\\\\Condition\\\\Product";s:9:"attribute";s:\d+:"(.*?)"~s',
             $serializedString,
             $matches
         )


### PR DESCRIPTION
# Bug Reproduction

1. Create a new product attribute (e.g., promotion)
2. Assign a value of that attribute to a product subject (e.g., promotion = 1)
3. Include that attribute to a cart price rule condition / action condition (e.g., `promotion contains 1`
4. Go to basket page and add the product to cart to test that rule

**Expected result:**

The rule applied

**Actual result:**

The rule is not applied

# Cause of issue

Attribute values failed to include in the select query in use.

Rule object check the product value which gets from `$quoteItem->getProduct()`.

The product instance is fetched through `\Magento\Quote\Model\ResourceModel\Quote\Item\Collection::_assignProducts` which looks up the `\Magento\Quote\Model\Quote\Config::getProductAttributes` to add specific attributes to select.

The sale rule module has a plugin to intercept and append attributes required to the select query.

```xml
<!-- vendor/magento/module-sales-rule/etc/di.xml -->
    <type name="Magento\Quote\Model\Quote\Config">
        <plugin name="append_sales_rule_keys_to_quote" type="Magento\SalesRule\Model\Plugin\QuoteConfigProductAttributes"/>
    </type>
```

The plugin look up a `salesrule_product_attribute` table and get a list of required attributes. However, this table is always null due to this issue.

```php
// \Magento\SalesRule\Model\ResourceModel\Rule::getActiveAttributes
public function getActiveAttributes()
    {
        $connection = $this->getConnection();
        $select = $connection->select()->from(
            ['a' => $this->getTable('salesrule_product_attribute')],
            new \Zend_Db_Expr('DISTINCT ea.attribute_code')
        )->joinInner(
            ['ea' => $this->getTable('eav_attribute')],
            'ea.attribute_id = a.attribute_id',
            []
        );
        return $connection->fetchAll($select);
    }
```

On sale rule save, there is a regex to match all attributes in the rule conditions / rule action conditions.

> salesrule/rule_condition_product

The type is actually `Magento\SalesRule\Model\Rule\Condition\Product`

```diff
// \Magento\SalesRule\Model\ResourceModel\Rule::_afterSave
protected function _afterSave(AbstractModel $object)
    {
        ...
        // Save product attributes used in rule
        $ruleProductAttributes = array_merge(
            $this->getProductAttributes(serialize($object->getConditions()->asArray())),
            $this->getProductAttributes(serialize($object->getActions()->asArray()))
        );
        if (count($ruleProductAttributes)) {
            $this->setActualProductAttributes($object, $ruleProductAttributes);
        }
        ...
    }

// \Magento\SalesRule\Model\ResourceModel\Rule::getProductAttributes
public function getProductAttributes($serializedString)
    {
        $result = [];
        if (preg_match_all(
-            '~s:32:"salesrule/rule_condition_product";s:9:"attribute";s:\d+:"(.*?)"~s',
+            '~s:46:"Magento\SalesRule\Model\Rule\Condition\Product";s:9:"attribute";s:\d+:"(.*?)"~s',
            $serializedString,
            $matches
        )
        ) {
            foreach ($matches[1] as $attributeCode) {
                $result[] = $attributeCode;
            }
        }

        return $result;
    }
```