### PR TITLE
Update DataProvider.php

### DIFF
--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © 2016 Magento. All rights reserved.
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 

--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -103,9 +103,12 @@ class DataProvider implements DataProviderInterface
             $read = $this->fileReadFactory->create($filePath[0], \Magento\Framework\Filesystem\DriverPool::FILE);
             $content = $read->readAll();
             foreach ($this->getPhrases($content) as $phrase) {
-                $translatedPhrase = $this->translate->render([$phrase], []);
-                if ($phrase != $translatedPhrase) {
-                    $dictionary[$phrase] = $translatedPhrase;
+                try {
+                    $translatedPhrase = $this->translate->render([$phrase], []);
+                    if ($phrase != $translatedPhrase) {
+                        $dictionary[$phrase] = $translatedPhrase;
+                    }
+                } catch (\Exception $e) {
                 }
             }
         }

--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -109,7 +109,7 @@ class DataProvider implements DataProviderInterface
                         $dictionary[$phrase] = $translatedPhrase;
                     }
                 } catch (\Exception $e) {
-                    throw new \Exception(sprintf('Error while generating translating phrase "%s" in file %s.',
+                    throw new \Exception(sprintf('Error while translating phrase "%s" in file %s.',
                         $phrase, $filePath[0]));
                 }
             }

--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Translation\Model\Js;
 
+use Magento\Framework\LocalizedException;
+
 /**
  * DataProvider for js translation
  */
@@ -109,7 +111,7 @@ class DataProvider implements DataProviderInterface
                         $dictionary[$phrase] = $translatedPhrase;
                     }
                 } catch (\Exception $e) {
-                    throw new \Exception(sprintf('Error while translating phrase "%s" in file %s.',
+                    throw new LocalizedException(sprintf(__('Error while translating phrase "%s" in file %s.'),
                         $phrase, $filePath[0]));
                 }
             }

--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
 
@@ -111,8 +111,9 @@ class DataProvider implements DataProviderInterface
                         $dictionary[$phrase] = $translatedPhrase;
                     }
                 } catch (\Exception $e) {
-                    throw new LocalizedException(sprintf(__('Error while translating phrase "%s" in file %s.'),
-                        $phrase, $filePath[0]));
+                    throw new LocalizedException(
+                        sprintf(__('Error while translating phrase "%s" in file %s.'), $phrase, $filePath[0])
+                    );
                 }
             }
         }

--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -141,8 +141,8 @@ class DataProvider implements DataProviderInterface
                 }
             }
             if (false === $result) {
-                throw new \Exception(
-                    sprintf('Error while generating js translation dictionary: "%s"', error_get_last())
+                throw new LocalizedException(
+                    sprintf(__('Error while generating js translation dictionary: "%s"'), error_get_last())
                 );
             }
         }

--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -109,6 +109,8 @@ class DataProvider implements DataProviderInterface
                         $dictionary[$phrase] = $translatedPhrase;
                     }
                 } catch (\Exception $e) {
+                    throw new \Exception(sprintf('Error while generating translating phrase "%s" in file %s.',
+                        $phrase, $filePath[0]));
                 }
             }
         }


### PR DESCRIPTION
Some template files from extensions cause the js-translation.json file to contain an empty array. The try-catch block prevents this and will just exclude that specific file from the loaded language strings, since it's almost impossible to debug which file is causing this.