### PR TITLE
Fix notice during DI compilation

### DIFF
--- a/lib/internal/Magento/Framework/Code/Reader/ArgumentsReader.php
+++ b/lib/internal/Magento/Framework/Code/Reader/ArgumentsReader.php
@@ -25,7 +25,7 @@ class ArgumentsReader
         /**
          * Skip native PHP types, classes without constructor
          */
-        if (!$class->getFileName() || false == $class->hasMethod(
+        if ($class->isInterface() || !$class->getFileName() || false == $class->hasMethod(
             '__construct'
         ) || !$inherited && $class->getConstructor()->class != $class->getName()
         ) {


### PR DESCRIPTION
If an interface has a constructor on it, `getConstructor()` for a ReflectionClass object of it will be null and cause this:

```
 [Exception]
  Notice: Trying to get property of non-object in /Users/cristianquiroz/src/magento2/vendor/magento/framework/Code/Reader/ArgumentsReader.php on line 30
```

Magento shouldn't pull any dependencies from interface constructors anyway, they will need to be properly implemented before they can be used.

# Steps to reproduce
1. Add any interface to a Magento2 module or library with a contructor on it.
2. run `php bin/magento setup:di:compile`

# Expected results
Success

# Actual results
```
 [Exception]
  Notice: Trying to get property of non-object in /Users/cristianquiroz/src/magento2/vendor/magento/framework/Code/Reader/ArgumentsReader.php on line 30
```