### PR TITLE
Customer account edit form: additional info block visible

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
@@ -77,8 +77,8 @@
                     autocomplete="off" />
             </div>
         </div>
-        <?php echo $block->getChildHtml('form_additional_info'); ?>
     </fieldset>
+    <?php echo $block->getChildHtml('form_additional_info'); ?>
     <div class="actions-toolbar">
         <div class="primary">
             <button type="submit" class="action save primary" title="<?php echo $block->escapeHtmlAttr(__('Save')) ?>"><span><?php echo $block->escapeHtml(__('Save')) ?></span></button>


### PR DESCRIPTION
Moved the additional info block in the customer account edit form outside of the fieldset which hides with the checkboxes options. It is now visible without having to check one of the checkboxes.