### PR TITLE
Fix Reqular Expression so that Unit Tests Complete

### DIFF
--- a/dev/tests/static/framework/Magento/TestFramework/Dependency/PhpRule.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Dependency/PhpRule.php
@@ -88,11 +88,11 @@ class PhpRule implements RuleInterface
         if (!in_array($fileType, ['php', 'template'])) {
             return [];
         }
-
-        $pattern = '~\b(?<class>(?<module>(' . implode(
-            '_|',
+        
+        $pattern = '~\b(?<class>(?<module>((' . implode(
+            '|',
             Files::init()->getNamespaces()
-        ) . '[_\\\\])[a-zA-Z0-9]+)[a-zA-Z0-9_\\\\]*)\b~';
+        ) . ')[_|\\\\]?)[a-zA-Z0-9]+)[a-zA-Z0-9_\\\\]*)\b~';
 
         $dependenciesInfo = [];
         if (preg_match_all($pattern, $contents, $matches)) {


### PR DESCRIPTION
As noted by @srqdeveloper on issue https://github.com/magento/magento2/issues/3901 The regular expression was not matching the following class and module name pattern: ``\Magento\SomeModule\Any\ClassName``

Changing the pattern to the following appears to pass all of the failed tests in this unit:

```
$pattern = '~\b(?<class>(?<module>((' . implode( '|', Files::init()->getNamespaces() ) . ')[_|\\\\]?)[a-zA-Z0-9]+)[a-zA-Z0-9_\\\\]*)\b~';
```