### PR TITLE
 Fix for Custom quote item attributes are not converting to order item

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -75,6 +75,7 @@ class ToOrderItem
         }
 
         $orderItem = $this->orderItemFactory->create();
+        $this->objectCopyService->copyFieldsetToTarget('quote_convert_item', 'to_order_item', $item, $orderItem);
         $this->dataObjectHelper->populateWithArray(
             $orderItem,
             array_merge($orderItemData, $data),

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -456,6 +456,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
             $order->setShippingAddress($shippingAddress);
             $order->setShippingMethod($quote->getShippingAddress()->getShippingMethod());
         }
+        $order=$this->quoteAddressToOrder->convert($quote->getBillingAddress(), $orderData);
         $billingAddress = $this->quoteAddressToOrderAddress->convert(
             $quote->getBillingAddress(),
             [


### PR DESCRIPTION
When we have custom quote item attributes then after converting quote to order custom quote item attributes are not copying to order item. 
This is fix for that. 
Thanks. 