### PR TITLE
Remove warning from setup/src/Magento/Setup/Module/I18n/Dictionary/Writer/Csv.php

### DIFF
--- a/setup/src/Magento/Setup/Module/I18n/Dictionary/Writer/Csv.php
+++ b/setup/src/Magento/Setup/Module/I18n/Dictionary/Writer/Csv.php
@@ -59,7 +59,9 @@ class Csv implements WriterInterface
      */
     public function __destructor()
     {
-        fclose($this->_fileHandler);
+        if (is_resource($this->_fileHandler)) {
+            fclose($this->_fileHandler);
+        }
     }
 
     /**
@@ -67,6 +69,8 @@ class Csv implements WriterInterface
      */
     public function __destruct()
     {
-        fclose($this->_fileHandler);
+        if (is_resource($this->_fileHandler)) {
+            fclose($this->_fileHandler);
+        }
     }
 }


### PR DESCRIPTION
During the running of the unit test suite you will see the following error cause be a warning being thrown in the class `setup/src/Magento/Setup/Module/I18n/Dictionary/Writer/Csv.php`.

```
vagrant@vagrant /v/w/h/mage2-github> ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Writer/CsvTest.php
PHPUnit 4.1.0 by Sebastian Bergmann.

Configuration read from /var/www/html/mage2-github/dev/tests/unit/phpunit.xml.dist

E..

Time: 80 ms, Memory: 4.00MB

There was 1 error:

1) Magento\Setup\Test\Unit\Module\I18n\Dictionary\Writer\CsvTest::testWrongOutputFile
PHPUnit_Framework_Exception: Warning: fclose() expects parameter 1 to be resource, null given in /var/www/html/mage2-github/setup/src/Magento/Setup/Module/I18n/Dictionary/Writer/Csv.php:70.

/var/www/html/mage2-github/dev/tests/unit/framework/bootstrap.php:51
/var/www/html/mage2-github/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php:165
/var/www/html/mage2-github/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Writer/CsvTest.php:61

Caused by
InvalidArgumentException: Cannot open file for write dictionary: "wrong/path"

/var/www/html/mage2-github/setup/src/Magento/Setup/Module/I18n/Dictionary/Writer/Csv.php:32
/var/www/html/mage2-github/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php:165
/var/www/html/mage2-github/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Writer/CsvTest.php:61

FAILURES!
Tests: 3, Assertions: 6, Errors: 1.
```

The fix I have put in place is to check for the handle is actually a resource before passing it to fclose. Now the tests run without the error.

```
vagrant@vagrant /v/w/h/mage2-github> ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Writer/CsvTest.php
PHPUnit 4.1.0 by Sebastian Bergmann.

Configuration read from /var/www/html/mage2-github/dev/tests/unit/phpunit.xml.dist

...

Time: 54 ms, Memory: 4.00MB

OK (3 tests, 8 assertions)
```