### PR TITLE
Allow digits in communication class type definition

### DIFF
--- a/lib/internal/Magento/Framework/Communication/etc/communication.xsd
+++ b/lib/internal/Magento/Framework/Communication/etc/communication.xsd
@@ -65,7 +65,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z\\]+" />
+            <xs:pattern value="[a-zA-Z]+[a-zA-Z0-9\\]+" />
             <xs:minLength value="4" />
         </xs:restriction>
     </xs:simpleType>


### PR DESCRIPTION
Our company vendor prefix "N98" is not allowed. The XSD prohibits the usage of digits.