### PR TITLE
Changed return type of getAdditionalInformation interfaces

### DIFF
--- a/app/code/Magento/Sales/Api/Data/OrderPaymentInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderPaymentInterface.php
@@ -261,7 +261,7 @@ interface OrderPaymentInterface extends \Magento\Framework\Api\ExtensibleDataInt
     /**
      * Gets the additional information for the order payment.
      *
-     * @return string[] Array of additional information.
+     * @return array|null|mixed Array of additional information.
      */
     public function getAdditionalInformation();
 

--- a/app/code/Magento/Sales/Api/Data/TransactionInterface.php
+++ b/app/code/Magento/Sales/Api/Data/TransactionInterface.php
@@ -154,7 +154,7 @@ interface TransactionInterface extends \Magento\Framework\Api\ExtensibleDataInte
     /**
      * Gets any additional information for the transaction.
      *
-     * @return string[]|null Array of additional information. Otherwise, null.
+     * @return array|null|mixed Array of additional information. Otherwise, null.
      */
     public function getAdditionalInformation();
 


### PR DESCRIPTION
**Pre-requisites :**

1. Make an order using PayPal Express as a payment method and then pay by entering credit card information within Paypal
2. Try to access this particular order via Magento REST api : /rest/V1/orders

**Result :**

API call returns the following error : Notice: Array to string conversion in vendor/magento/framework/Reflection/TypeCaster.php on line 34

**Cause :**

1. When the API tries to get additional_information from the sales_order_payment table, it calls the getAdditionalInformation method. As the function returns an array but the interface return type is defined as a string, an error is generated.

Note that return type of models and interfaces they implement also mismatch.