### PR TITLE
Change order of parameters passed to LogicException in AbstractTemplate.php

### DIFF
--- a/app/code/Magento/Email/Model/AbstractTemplate.php
+++ b/app/code/Magento/Email/Model/AbstractTemplate.php
@@ -352,7 +352,7 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
             $result = $processor->filter($this->getTemplateText());
         } catch (\Exception $e) {
             $this->cancelDesignConfig();
-            throw new \LogicException(__($e->getMessage()), $e);
+            throw new \LogicException(__($e->getMessage()), $e->getCode(), $e);
         }
         if ($isDesignApplied) {
             $this->cancelDesignConfig();


### PR DESCRIPTION
Parameters are passed in an incorrect order and trigger a fatal error