### PR TITLE
Start to replace the usage of Zend Framework1 Json Encoder and Decoder

### DIFF
--- a/app/code/Magento/Cms/Block/Adminhtml/Wysiwyg/Images/Tree.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Wysiwyg/Images/Tree.php
@@ -65,7 +65,7 @@ class Tree extends \Magento\Backend\Block\Template
                 'cls' => 'folder',
             ];
         }
-        return \Zend_Json::encode($jsonArray);
+        return \Zend\Json\Encoder::encode($jsonArray);
     }
 
     /**

--- a/app/code/Magento/Email/Block/Adminhtml/Template/Edit/Form.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template/Edit/Form.php
@@ -100,7 +100,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         $fieldset->addField(
             'variables',
             'hidden',
-            ['name' => 'variables', 'value' => \Zend_Json::encode($this->getVariables())]
+            ['name' => 'variables', 'value' => \Zend\Json\Encoder::encode($this->getVariables())]
         );
         $fieldset->addField('template_variables', 'hidden', ['name' => 'template_variables']);
 

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template/DefaultTemplate.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template/DefaultTemplate.php
@@ -49,7 +49,7 @@ class DefaultTemplate extends \Magento\Email\Controller\Adminhtml\Email\Template
 
             $template->loadDefault($templateId);
             $template->setData('orig_template_code', $templateId);
-            $template->setData('template_variables', \Zend_Json::encode($template->getVariablesOptionArray(true)));
+            $template->setData('template_variables', \Zend\Json\Encoder::encode($template->getVariablesOptionArray(true)));
 
             $templateBlock = $this->_view->getLayout()->createBlock(
                 \Magento\Email\Block\Adminhtml\Template\Edit::class

--- a/app/code/Magento/Email/Model/Template.php
+++ b/app/code/Magento/Email/Model/Template.php
@@ -289,7 +289,7 @@ class Template extends AbstractTemplate implements \Magento\Framework\Mail\Templ
         $variables = [];
         if ($variablesString && is_string($variablesString)) {
             $variablesString = str_replace("\n", '', $variablesString);
-            $variables = \Zend_Json::decode($variablesString);
+            $variables = \Zend\Json\Decoder::decode($variablesString, \Zend\Json\Json::TYPE_ARRAY);
         }
         return $variables;
     }

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
@@ -269,13 +269,14 @@ abstract class AbstractController extends \PHPUnit_Framework_TestCase
         /** @var $cookieManager CookieManagerInterface */
         $cookieManager = $this->_objectManager->get(CookieManagerInterface::class);
         try {
-            $messages = \Zend_Json::decode(
-                $cookieManager->getCookie(MessagePlugin::MESSAGES_COOKIES_NAME, \Zend_Json::encode([]))
+            $messages = \Zend\Json\Decoder::decode(
+                $cookieManager->getCookie(MessagePlugin::MESSAGES_COOKIES_NAME, \Zend\Json\Encoder::encode([])),
+                \Zend\Json\Json::TYPE_ARRAY
             );
             if (!is_array($messages)) {
                 $messages = [];
             }
-        } catch (\Zend_Json_Exception $e) {
+        } catch (\RuntimeException $e) {
             $messages = [];
         }
 

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/TestCase/ControllerAbstractTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/TestCase/ControllerAbstractTest.php
@@ -244,6 +244,6 @@ class ControllerAbstractTest extends \Magento\TestFramework\TestCase\AbstractCon
 
         $this->cookieManagerMock->expects($this->any())
             ->method('getCookie')
-            ->willReturn(\Zend_Json::encode($cookieMessages));
+            ->willReturn(\Zend\Json\Encoder::encode($cookieMessages));
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
@@ -108,7 +108,10 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($this->model->getTemplateText());
         $this->assertNotEmpty($this->model->getTemplateSubject());
         $this->assertNotEmpty($this->model->getOrigTemplateVariables());
-        $this->assertInternalType('array', \Zend_Json::decode($this->model->getOrigTemplateVariables()));
+        $this->assertInternalType('array', \Zend\Json\Decoder::decode(
+            $this->model->getOrigTemplateVariables(),
+            \Zend\Json\Json::TYPE_ARRAY)
+        );
     }
 
     /**

--- a/lib/internal/Magento/Framework/Controller/Result/Json.php
+++ b/lib/internal/Magento/Framework/Controller/Result/Json.php
@@ -44,7 +44,7 @@ class Json extends AbstractResult
      */
     public function setData($data, $cycleCheck = false, $options = [])
     {
-        $this->json = \Zend_Json::encode($data, $cycleCheck, $options);
+        $this->json = \Zend\Json\Encoder::encode($data, $cycleCheck, $options);
         return $this;
     }
 

--- a/lib/internal/Magento/Framework/Data/Form/Element/Editablemultiselect.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editablemultiselect.php
@@ -41,7 +41,7 @@ class Editablemultiselect extends \Magento\Framework\Data\Form\Element\Multisele
             $elementJsClass = $this->getData('element_js_class');
         }
 
-        $selectConfigJson = \Zend_Json::encode($selectConfig);
+        $selectConfigJson = \Zend\Json\Encoder::encode($selectConfig);
         $jsObjectName = $this->getJsObjectName();
 
         // TODO: TaxRateEditableMultiselect should be moved to a static .js module.

--- a/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
@@ -174,7 +174,7 @@ class Editor extends Textarea
                     //<![CDATA[
                     require(["jquery", "mage/translate", "mage/adminhtml/wysiwyg/widget"], function(jQuery){
                         (function($) {
-                            $.mage.translate.add(' . \Zend\Json\Encoder::encode($this->getButtonTranslations()) . ')
+                            $.mage.translate.add(' . \Zend_Json::encode($this->getButtonTranslations()) . ')
                         })(jQuery);
                     });
                     //]]>

--- a/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
@@ -126,7 +126,7 @@ class Editor extends Textarea
                 window.tinyMCE_GZ = window.tinyMCE_GZ || {}; window.tinyMCE_GZ.loaded = true;require(["jquery", "mage/translate", "mage/adminhtml/events", "mage/adminhtml/wysiwyg/tiny_mce/setup", "mage/adminhtml/wysiwyg/widget"], function(jQuery){' .
                 "\n" .
                 '  (function($) {$.mage.translate.add(' .
-                \Zend_Json::encode(
+                \Zend\Json\Encoder::encode(
                     $this->getButtonTranslations()
                 ) .
                 ')})(jQuery);' .
@@ -135,7 +135,7 @@ class Editor extends Textarea
                 ' = new tinyMceWysiwygSetup("' .
                 $this->getHtmlId() .
                 '", ' .
-                \Zend_Json::encode(
+                \Zend\Json\Encoder::encode(
                     $this->getConfig()
                 ) .
                 ');' .
@@ -174,7 +174,7 @@ class Editor extends Textarea
                     //<![CDATA[
                     require(["jquery", "mage/translate", "mage/adminhtml/wysiwyg/widget"], function(jQuery){
                         (function($) {
-                            $.mage.translate.add(' . \Zend_Json::encode($this->getButtonTranslations()) . ')
+                            $.mage.translate.add(' . \Zend\Json\Encoder::encode($this->getButtonTranslations()) . ')
                         })(jQuery);
                     });
                     //]]>

--- a/lib/internal/Magento/Framework/DataObject.php
+++ b/lib/internal/Magento/Framework/DataObject.php
@@ -331,7 +331,7 @@ class DataObject implements \ArrayAccess
     public function toJson(array $keys = [])
     {
         $data = $this->toArray($keys);
-        return \Zend_Json::encode($data);
+        return \Zend\Json\Encoder::encode($data);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Json/Decoder.php
+++ b/lib/internal/Magento/Framework/Json/Decoder.php
@@ -13,10 +13,11 @@ class Decoder implements DecoderInterface
      * Decodes the given $data string which is encoded in the JSON format.
      *
      * @param string $data
+     * @param int $decodeType
      * @return mixed
      */
-    public function decode($data)
+    public function decode($data, $decodeType = \Zend\Json\Json::TYPE_ARRAY)
     {
-        return \Zend\Json\Decoder::decode($data);
+        return \Zend\Json\Decoder::decode($data, $decodeType);
     }
 }

--- a/lib/internal/Magento/Framework/Json/Decoder.php
+++ b/lib/internal/Magento/Framework/Json/Decoder.php
@@ -17,6 +17,6 @@ class Decoder implements DecoderInterface
      */
     public function decode($data)
     {
-        return \Zend_Json::decode($data);
+        return \Zend\Json\Decoder::decode($data);
     }
 }

--- a/lib/internal/Magento/Framework/Json/DecoderInterface.php
+++ b/lib/internal/Magento/Framework/Json/DecoderInterface.php
@@ -16,8 +16,7 @@ interface DecoderInterface
      * Decodes the given $data string which is encoded in the JSON format into a PHP type (array, string literal, etc.)
      *
      * @param $data
-     * @param int $decodeType
      * @return mixed
      */
-    public function decode($data, $decodeType = \Zend\Json\Json::TYPE_ARRAY);
+    public function decode($data);
 }

--- a/lib/internal/Magento/Framework/Json/DecoderInterface.php
+++ b/lib/internal/Magento/Framework/Json/DecoderInterface.php
@@ -15,8 +15,9 @@ interface DecoderInterface
     /**
      * Decodes the given $data string which is encoded in the JSON format into a PHP type (array, string literal, etc.)
      *
-     * @param string $data
+     * @param $data
+     * @param int $decodeType
      * @return mixed
      */
-    public function decode($data);
+    public function decode($data, $decodeType = \Zend\Json\Json::TYPE_ARRAY);
 }

--- a/lib/internal/Magento/Framework/Json/Encoder.php
+++ b/lib/internal/Magento/Framework/Json/Encoder.php
@@ -31,6 +31,6 @@ class Encoder implements EncoderInterface
     public function encode($data)
     {
         $this->translateInline->processResponseBody($data);
-        return \Zend_Json::encode($data);
+        return \Zend\Json\Encoder::encode($data);
     }
 }

--- a/lib/internal/Magento/Framework/Module/PackageInfo.php
+++ b/lib/internal/Magento/Framework/Module/PackageInfo.php
@@ -82,7 +82,7 @@ class PackageInfo
             foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
                 $key = $moduleDir . '/composer.json';
                 if (isset($jsonData[$key]) && $jsonData[$key]) {
-                    $packageData = \Zend_Json::decode($jsonData[$key]);
+                    $packageData = \Zend\Json\Decoder::decode($jsonData[$key], \Zend\Json\Json::TYPE_ARRAY);
                     if (isset($packageData['name'])) {
                         $this->packageModuleMap[$packageData['name']] = $moduleName;
                     }

--- a/lib/internal/Magento/Framework/Module/Setup/Migration.php
+++ b/lib/internal/Magento/Framework/Module/Setup/Migration.php
@@ -694,8 +694,8 @@ class Migration
      * @param int $objectDecodeType
      * @return mixed
      */
-    protected function _jsonDecode($encodedValue, $objectDecodeType = \Zend_Json::TYPE_ARRAY)
+    protected function _jsonDecode($encodedValue, $objectDecodeType = \Zend\Json\Json::TYPE_ARRAY)
     {
-        return \Zend_Json::decode($encodedValue, $objectDecodeType);
+        return \Zend\Json\Decoder::decode($encodedValue, $objectDecodeType);
     }
 }

--- a/lib/internal/Magento/Framework/Webapi/Rest/Request/Deserializer/Json.php
+++ b/lib/internal/Magento/Framework/Webapi/Rest/Request/Deserializer/Json.php
@@ -47,7 +47,7 @@ class Json implements \Magento\Framework\Webapi\Rest\Request\DeserializerInterfa
         }
         try {
             $decodedBody = $this->decoder->decode($encodedBody);
-        } catch (\Zend_Json_Exception $e) {
+        } catch (\RuntimeException $e) {
             if ($this->_appState->getMode() !== State::MODE_DEVELOPER) {
                 throw new \Magento\Framework\Webapi\Exception(new Phrase('Decoding error.'));
             } else {

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/Rest/Request/Deserializer/JsonTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/Rest/Request/Deserializer/JsonTest.php
@@ -80,7 +80,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
         /** Prepare mocks for SUT constructor. */
         $this->decoderMock->expects($this->once())
             ->method('decode')
-            ->will($this->throwException(new \Zend_Json_Exception));
+            ->will($this->throwException(new \RuntimeException()));
         $this->_appStateMock->expects($this->once())
             ->method('getMode')
             ->will($this->returnValue('production'));
@@ -109,7 +109,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
             'decode'
         )->will(
             $this->throwException(
-                new \Zend_Json_Exception('Decoding error:' . PHP_EOL . 'Decoding failed: Syntax error')
+                new \RuntimeException('Decoding error:' . PHP_EOL . 'Decoding failed: Syntax error')
             )
         );
         $this->_appStateMock->expects($this->once())


### PR DESCRIPTION
The Zend1 and Zend2 json encoder and decoder classes have the same public interfaces so it should be fairly easy/problem free to exchange them out.

To start with I have replaced the usage in `lib/internal/Magento/Framework/Json/Decoder.php` and `lib/internal/Magento/Framework/Json/Encoder.php`
