### PR TITLE
Remove Zend1 Json from Magento Captcha module

### DIFF
--- a/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
+++ b/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
@@ -22,16 +22,18 @@ class Refresh extends \Magento\Backend\App\Action
 
     /**
      * @param \Magento\Backend\App\Action\Context $context
-     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
      * @param \Magento\Captcha\Helper\Data $captchaHelper
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Serialize\SerializerInterface $serializer,
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
         \Magento\Captcha\Helper\Data $captchaHelper
     ) {
         parent::__construct($context);
-        $this->serializer = $serializer;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
         $this->captchaHelper = $captchaHelper;
     }
 

--- a/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
+++ b/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
@@ -11,7 +11,7 @@ namespace Magento\Captcha\Controller\Adminhtml\Refresh;
 class Refresh extends \Magento\Backend\App\Action
 {
     /**
-     * @var \Magento\Framework\Serialize\SerializerInterface
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
     protected $serializer;
 
@@ -24,17 +24,15 @@ class Refresh extends \Magento\Backend\App\Action
      * Refresh constructor.
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Captcha\Helper\Data $captchaHelper
-     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
-     * @throws \RuntimeException
+     * @param \Magento\Framework\Serialize\Serializer\Json $serializer
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         \Magento\Captcha\Helper\Data $captchaHelper,
-        \Magento\Framework\Serialize\SerializerInterface $serializer = null
+        \Magento\Framework\Serialize\Serializer\Json $serializer
     ) {
         parent::__construct($context);
-        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
+        $this->serializer = $serializer;
         $this->captchaHelper = $captchaHelper;
     }
 

--- a/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
+++ b/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
@@ -23,6 +23,7 @@ class Refresh extends \Magento\Backend\App\Action
     /**
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     * @param \Magento\Captcha\Helper\Data $captchaHelper
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,

--- a/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
+++ b/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
@@ -21,15 +21,16 @@ class Refresh extends \Magento\Backend\App\Action
     protected $captchaHelper;
 
     /**
+     * Refresh constructor.
      * @param \Magento\Backend\App\Action\Context $context
-     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
      * @param \Magento\Captcha\Helper\Data $captchaHelper
+     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
      * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
-        \Magento\Captcha\Helper\Data $captchaHelper
+        \Magento\Captcha\Helper\Data $captchaHelper,
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null
     ) {
         parent::__construct($context);
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()

--- a/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
+++ b/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
@@ -11,12 +11,36 @@ namespace Magento\Captcha\Controller\Adminhtml\Refresh;
 class Refresh extends \Magento\Backend\App\Action
 {
     /**
+     * @var \Magento\Framework\View\Result\PageFactory
+     */
+    protected $serializer;
+
+    /**
+     * @var \Magento\Captcha\Helper\Data
+     */
+    protected $captchaHelper;
+
+    /**
+     * @param \Magento\Backend\App\Action\Context $context
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     */
+    public function __construct(
+        \Magento\Backend\App\Action\Context $context,
+        \Magento\Framework\Serialize\SerializerInterface $serializer,
+        \Magento\Captcha\Helper\Data $captchaHelper
+    ) {
+        parent::__construct($context);
+        $this->serializer = $serializer;
+        $this->captchaHelper = $captchaHelper;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function execute()
     {
         $formId = $this->getRequest()->getPost('formId');
-        $captchaModel = $this->_objectManager->get(\Magento\Captcha\Helper\Data::class)->getCaptcha($formId);
+        $captchaModel = $this->captchaHelper->getCaptcha($formId);
         $this->_view->getLayout()->createBlock(
             $captchaModel->getBlockName()
         )->setFormId(
@@ -24,7 +48,7 @@ class Refresh extends \Magento\Backend\App\Action
         )->setIsAjax(
             true
         )->toHtml();
-        $this->getResponse()->representJson(json_encode(['imgSrc' => $captchaModel->getImgSrc()]));
+        $this->getResponse()->representJson($this->serializer->serialize(['imgSrc' => $captchaModel->getImgSrc()]));
         $this->_actionFlag->set('', self::FLAG_NO_POST_DISPATCH, true);
     }
 

--- a/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
+++ b/app/code/Magento/Captcha/Controller/Adminhtml/Refresh/Refresh.php
@@ -11,7 +11,7 @@ namespace Magento\Captcha\Controller\Adminhtml\Refresh;
 class Refresh extends \Magento\Backend\App\Action
 {
     /**
-     * @var \Magento\Framework\View\Result\PageFactory
+     * @var \Magento\Framework\Serialize\SerializerInterface
      */
     protected $serializer;
 

--- a/app/code/Magento/Captcha/Controller/Refresh/Index.php
+++ b/app/code/Magento/Captcha/Controller/Refresh/Index.php
@@ -25,6 +25,7 @@ class Index extends \Magento\Framework\App\Action\Action
     /**
      * @param Context $context
      * @param \Magento\Captcha\Helper\Data $captchaHelper
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      */
     public function __construct(
         Context $context,

--- a/app/code/Magento/Captcha/Controller/Refresh/Index.php
+++ b/app/code/Magento/Captcha/Controller/Refresh/Index.php
@@ -18,24 +18,24 @@ class Index extends \Magento\Framework\App\Action\Action
     protected $captchaHelper;
 
     /**
-     * @var \Magento\Framework\Serialize\SerializerInterface
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
     protected $serializer;
 
     /**
      * @param Context $context
      * @param \Magento\Captcha\Helper\Data $captchaHelper
-     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @throws \RuntimeException
      */
     public function __construct(
         Context $context,
         \Magento\Captcha\Helper\Data $captchaHelper,
-        \Magento\Framework\Serialize\SerializerInterface $serializer = null
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->captchaHelper = $captchaHelper;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         parent::__construct($context);
     }
 

--- a/app/code/Magento/Captcha/Controller/Refresh/Index.php
+++ b/app/code/Magento/Captcha/Controller/Refresh/Index.php
@@ -55,7 +55,7 @@ class Index extends \Magento\Framework\App\Action\Action
 
         $block = $this->_view->getLayout()->createBlock($captchaModel->getBlockName());
         $block->setFormId($formId)->setIsAjax(true)->toHtml();
-        $this->_response->representJson(json_encode(['imgSrc' => $captchaModel->getImgSrc()]));
+        $this->_response->representJson($this->serializer->serialize(['imgSrc' => $captchaModel->getImgSrc()]));
         $this->_actionFlag->set('', self::FLAG_NO_POST_DISPATCH, true);
     }
 }

--- a/app/code/Magento/Captcha/Controller/Refresh/Index.php
+++ b/app/code/Magento/Captcha/Controller/Refresh/Index.php
@@ -18,12 +18,21 @@ class Index extends \Magento\Framework\App\Action\Action
     protected $captchaHelper;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    protected $serializer;
+
+    /**
      * @param Context $context
      * @param \Magento\Captcha\Helper\Data $captchaHelper
      */
-    public function __construct(Context $context, \Magento\Captcha\Helper\Data $captchaHelper)
-    {
+    public function __construct(
+        Context $context,
+        \Magento\Captcha\Helper\Data $captchaHelper,
+        \Magento\Framework\Serialize\SerializerInterface $serializer
+    ) {
         $this->captchaHelper = $captchaHelper;
+        $this->serializer = $serializer;
         parent::__construct($context);
     }
 
@@ -34,16 +43,12 @@ class Index extends \Magento\Framework\App\Action\Action
     {
         $formId = $this->_request->getPost('formId');
         if (null === $formId) {
-            try {
-                $params = [];
-                $content = $this->_request->getContent();
-                if ($content) {
-                    $params = \Zend_Json::decode($content);
-                }
-                $formId = isset($params['formId']) ? $params['formId'] : null;
-            } catch (\Zend_Json_Exception $exception) {
-                $formId = null;
+            $params = [];
+            $content = $this->_request->getContent();
+            if ($content) {
+                $params = $this->serializer->unserialize($content);
             }
+            $formId = isset($params['formId']) ? $params['formId'] : null;
         }
         $captchaModel = $this->captchaHelper->getCaptcha($formId);
         $captchaModel->generate();

--- a/app/code/Magento/Captcha/Controller/Refresh/Index.php
+++ b/app/code/Magento/Captcha/Controller/Refresh/Index.php
@@ -25,15 +25,17 @@ class Index extends \Magento\Framework\App\Action\Action
     /**
      * @param Context $context
      * @param \Magento\Captcha\Helper\Data $captchaHelper
-     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         Context $context,
         \Magento\Captcha\Helper\Data $captchaHelper,
-        \Magento\Framework\Serialize\SerializerInterface $serializer
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null
     ) {
         $this->captchaHelper = $captchaHelper;
-        $this->serializer = $serializer;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
         parent::__construct($context);
     }
 

--- a/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
+++ b/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
@@ -40,6 +40,7 @@ class AjaxLogin
      * @param CaptchaHelper $helper
      * @param SessionManagerInterface $sessionManager
      * @param JsonFactory $resultJsonFactory
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      * @param array $formIds
      */
     public function __construct(

--- a/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
+++ b/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
@@ -27,7 +27,7 @@ class AjaxLogin
     protected $resultJsonFactory;
 
     /**
-     * @var \Magento\Framework\Serialize\SerializerInterface
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
     protected $serializer;
 
@@ -40,8 +40,8 @@ class AjaxLogin
      * @param CaptchaHelper $helper
      * @param SessionManagerInterface $sessionManager
      * @param JsonFactory $resultJsonFactory
-     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
      * @param array $formIds
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @throws \RuntimeException
      */
     public function __construct(
@@ -49,13 +49,13 @@ class AjaxLogin
         SessionManagerInterface $sessionManager,
         JsonFactory $resultJsonFactory,
         array $formIds,
-        \Magento\Framework\Serialize\SerializerInterface $serializer = null
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->helper = $helper;
         $this->sessionManager = $sessionManager;
         $this->resultJsonFactory = $resultJsonFactory;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         $this->formIds = $formIds;
     }
 

--- a/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
+++ b/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
@@ -27,6 +27,11 @@ class AjaxLogin
     protected $resultJsonFactory;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    protected $serializer;
+
+    /**
      * @var array
      */
     protected $formIds;
@@ -41,11 +46,13 @@ class AjaxLogin
         CaptchaHelper $helper,
         SessionManagerInterface $sessionManager,
         JsonFactory $resultJsonFactory,
+        \Magento\Framework\Serialize\SerializerInterface $serializer,
         array $formIds
     ) {
         $this->helper = $helper;
         $this->sessionManager = $sessionManager;
         $this->resultJsonFactory = $resultJsonFactory;
+        $this->serializer = $serializer;
         $this->formIds = $formIds;
     }
 
@@ -53,7 +60,6 @@ class AjaxLogin
      * @param \Magento\Customer\Controller\Ajax\Login $subject
      * @param \Closure $proceed
      * @return $this
-     * @throws \Zend_Json_Exception
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
@@ -70,7 +76,7 @@ class AjaxLogin
         $loginParams = [];
         $content = $request->getContent();
         if ($content) {
-            $loginParams = \Zend_Json::decode($content);
+            $loginParams = $this->serializer->unserialize($content);
         }
         $username = isset($loginParams['username']) ? $loginParams['username'] : null;
         $captchaString = isset($loginParams[$captchaInputName]) ? $loginParams[$captchaInputName] : null;

--- a/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
+++ b/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
@@ -40,20 +40,22 @@ class AjaxLogin
      * @param CaptchaHelper $helper
      * @param SessionManagerInterface $sessionManager
      * @param JsonFactory $resultJsonFactory
-     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
      * @param array $formIds
+     * @throws \RuntimeException
      */
     public function __construct(
         CaptchaHelper $helper,
         SessionManagerInterface $sessionManager,
         JsonFactory $resultJsonFactory,
-        \Magento\Framework\Serialize\SerializerInterface $serializer,
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
         array $formIds
     ) {
         $this->helper = $helper;
         $this->sessionManager = $sessionManager;
         $this->resultJsonFactory = $resultJsonFactory;
-        $this->serializer = $serializer;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
         $this->formIds = $formIds;
     }
 

--- a/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
+++ b/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
@@ -48,8 +48,8 @@ class AjaxLogin
         CaptchaHelper $helper,
         SessionManagerInterface $sessionManager,
         JsonFactory $resultJsonFactory,
-        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
-        array $formIds
+        array $formIds,
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null
     ) {
         $this->helper = $helper;
         $this->sessionManager = $sessionManager;

--- a/app/code/Magento/Captcha/Test/Unit/Controller/Refresh/IndexTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Controller/Refresh/IndexTest.php
@@ -97,6 +97,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase
     public function testExecute($formId, $callsNumber)
     {
         $content = ['formId' => $formId];
+        $imgSource = ['imgSrc' => 'source'];
 
         $blockMethods = ['setFormId', 'setIsAjax', 'toHtml'];
         $blockMock = $this->getMock(\Magento\Captcha\Block\Captcha::class, $blockMethods, [], '', false);
@@ -114,10 +115,12 @@ class IndexTest extends \PHPUnit_Framework_TestCase
         $blockMock->expects($this->any())->method('setFormId')->with($formId)->will($this->returnValue($blockMock));
         $blockMock->expects($this->any())->method('setIsAjax')->with(true)->will($this->returnValue($blockMock));
         $blockMock->expects($this->once())->method('toHtml');
-        $this->responseMock->expects($this->once())->method('representJson')->with(json_encode(['imgSrc' => 'source']));
+        $this->responseMock->expects($this->once())->method('representJson')->with(json_encode($imgSource));
         $this->flagMock->expects($this->once())->method('set')->with('', 'no-postDispatch', true);
         $this->serializerMock->expects($this->exactly($callsNumber))
             ->method('unserialize')->will($this->returnValue($content));
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')->will($this->returnValue(json_encode($imgSource)));
 
         $this->model->execute();
     }

--- a/app/code/Magento/Captcha/Test/Unit/Controller/Refresh/IndexTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Controller/Refresh/IndexTest.php
@@ -68,7 +68,7 @@ class IndexTest extends \PHPUnit_Framework_TestCase
         $this->layoutMock = $this->getMock(\Magento\Framework\View\LayoutInterface::class);
         $this->flagMock = $this->getMock(\Magento\Framework\App\ActionFlag::class, [], [], '', false);
         $this->serializerMock = $this->getMock(
-            \Magento\Framework\Serialize\SerializerInterface::class,
+            \Magento\Framework\Serialize\Serializer\Json::class,
             [],
             [],
             '',

--- a/app/code/Magento/Captcha/Test/Unit/Controller/Refresh/IndexTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Controller/Refresh/IndexTest.php
@@ -48,6 +48,11 @@ class IndexTest extends \PHPUnit_Framework_TestCase
     protected $flagMock;
 
     /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $serializerMock;
+
+    /**
      * @var \Magento\Captcha\Controller\Refresh\Index
      */
     protected $model;
@@ -62,6 +67,13 @@ class IndexTest extends \PHPUnit_Framework_TestCase
         $this->viewMock = $this->getMock(\Magento\Framework\App\ViewInterface::class);
         $this->layoutMock = $this->getMock(\Magento\Framework\View\LayoutInterface::class);
         $this->flagMock = $this->getMock(\Magento\Framework\App\ActionFlag::class, [], [], '', false);
+        $this->serializerMock = $this->getMock(
+            \Magento\Framework\Serialize\SerializerInterface::class,
+            [],
+            [],
+            '',
+            false
+        );
 
         $this->contextMock->expects($this->any())->method('getRequest')->will($this->returnValue($this->requestMock));
         $this->contextMock->expects($this->any())->method('getView')->will($this->returnValue($this->viewMock));
@@ -69,13 +81,18 @@ class IndexTest extends \PHPUnit_Framework_TestCase
         $this->contextMock->expects($this->any())->method('getActionFlag')->will($this->returnValue($this->flagMock));
         $this->viewMock->expects($this->any())->method('getLayout')->will($this->returnValue($this->layoutMock));
 
-        $this->model = new \Magento\Captcha\Controller\Refresh\Index($this->contextMock, $this->captchaHelperMock);
+        $this->model = new \Magento\Captcha\Controller\Refresh\Index(
+            $this->contextMock,
+            $this->captchaHelperMock,
+            $this->serializerMock
+        );
     }
 
     /**
      * @dataProvider executeDataProvider
      * @param int $formId
      * @param int $callsNumber
+     * @throws \PHPUnit_Framework_Exception
      */
     public function testExecute($formId, $callsNumber)
     {
@@ -99,6 +116,8 @@ class IndexTest extends \PHPUnit_Framework_TestCase
         $blockMock->expects($this->once())->method('toHtml');
         $this->responseMock->expects($this->once())->method('representJson')->with(json_encode(['imgSrc' => 'source']));
         $this->flagMock->expects($this->once())->method('set')->with('', 'no-postDispatch', true);
+        $this->serializerMock->expects($this->exactly($callsNumber))
+            ->method('unserialize')->will($this->returnValue($content));
 
         $this->model->execute();
     }

--- a/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
@@ -164,8 +164,10 @@ class AjaxLoginTest extends \PHPUnit_Framework_TestCase
      */
     public function testAroundExecuteCaptchaIsNotRequired($username, $requestContent)
     {
-        $this->requestMock->expects($this->once())->method('getContent')->will($this->returnValue(json_encode($requestContent)));
-        $this->serializerMock->expects(($this->once()))->method('unserialize')->will($this->returnValue($requestContent));
+        $this->requestMock->expects($this->once())->method('getContent')
+            ->will($this->returnValue(json_encode($requestContent)));
+        $this->serializerMock->expects(($this->once()))->method('unserialize')
+            ->will($this->returnValue($requestContent));
 
         $this->captchaMock->expects($this->once())->method('isRequired')->with($username)
             ->will($this->returnValue(false));

--- a/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
@@ -96,8 +96,8 @@ class AjaxLoginTest extends \PHPUnit_Framework_TestCase
             $this->captchaHelperMock,
             $this->sessionManagerMock,
             $this->jsonFactoryMock,
-            $this->serializerMock,
-            $this->formIds
+            $this->formIds,
+            $this->serializerMock
         );
     }
 

--- a/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
@@ -85,7 +85,7 @@ class AjaxLoginTest extends \PHPUnit_Framework_TestCase
             ->with('user_login')->will($this->returnValue($this->captchaMock));
         $this->formIds = ['user_login'];
         $this->serializerMock = $this->getMock(
-            \Magento\Framework\Serialize\SerializerInterface::class,
+            \Magento\Framework\Serialize\Serializer\Json::class,
             [],
             [],
             '',


### PR DESCRIPTION
Zend Framework 1 has been at end of life since middle of 2016. Zend Framework 2 comes with a json module that works in the same way as the Zend Framework 1 version.

In this pull request I have updated the captcha module to use the zend framework 2 versions of Zend_Json. I have also updated the code to use json decode via object since that is the new default in Zend Framework 2.