### PR TITLE
Use better function for 'Continue Shopping' url

### DIFF
--- a/app/code/Magento/Checkout/Block/Onepage/Success.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Success.php
@@ -122,4 +122,12 @@ class Success extends \Magento\Framework\View\Element\Template
         return $this->httpContext->getValue(Context::CONTEXT_AUTH)
             && $this->isVisible($order);
     }
+    
+    /**
+     * @return string
+     */
+    public function getContinueUrl()
+    {
+        return $this->_storeManager->getStore()->getBaseUrl();
+    }
 }

--- a/app/code/Magento/Checkout/Block/Onepage/Success.php
+++ b/app/code/Magento/Checkout/Block/Onepage/Success.php
@@ -122,7 +122,7 @@ class Success extends \Magento\Framework\View\Element\Template
         return $this->httpContext->getValue(Context::CONTEXT_AUTH)
             && $this->isVisible($order);
     }
-    
+
     /**
      * @return string
      */

--- a/app/code/Magento/Checkout/Test/Unit/Block/Onepage/SuccessTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Onepage/SuccessTest.php
@@ -19,6 +19,11 @@ class SuccessTest extends \PHPUnit_Framework_TestCase
     protected $block;
 
     /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $layout;
+
+    /**
      * @var \Magento\Sales\Model\Order\Config | \PHPUnit_Framework_MockObject_MockObject
      */
     protected $orderConfig;
@@ -27,7 +32,7 @@ class SuccessTest extends \PHPUnit_Framework_TestCase
      * @var \Magento\Checkout\Model\Session | \PHPUnit_Framework_MockObject_MockObject
      */
     protected $checkoutSession;
-    
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -38,17 +43,50 @@ class SuccessTest extends \PHPUnit_Framework_TestCase
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
         $this->orderConfig = $this->getMock(\Magento\Sales\Model\Order\Config::class, [], [], '', false);
-        $this->storeManagerMock = $this->getMock('Magento\Store\Model\StoreManagerInterface', [], [], '', false);
+        $this->storeManagerMock = $this->getMock(\Magento\Store\Model\StoreManagerInterface::class, [], [], '', false);
 
-        $this->checkoutSession = $this->getMockBuilder(
-            \Magento\Checkout\Model\Session::class
-        )
+        $this->layout = $this->getMockBuilder(\Magento\Framework\View\LayoutInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods([])
+            ->getMock();
+
+        $this->checkoutSession = $this->getMockBuilder(\Magento\Checkout\Model\Session::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $eventManager = $this->getMockBuilder(\Magento\Framework\Event\ManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods([])
+            ->getMock();
+
+        $urlBuilder = $this->getMockBuilder(\Magento\Framework\UrlInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods([])
+            ->getMock();
+
+        $scopeConfig = $this->getMockBuilder(\Magento\Framework\App\Config\ScopeConfigInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods([])
+            ->getMock();
+        $scopeConfig->expects($this->any())
+            ->method('getValue')
+            ->with($this->stringContains('advanced/modules_disable_output/'), \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->will($this->returnValue(false));
+
+        $context = $this->getMockBuilder(\Magento\Framework\View\Element\Template\Context::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getLayout', 'getEventManager', 'getUrlBuilder', 'getScopeConfig', 'getStoreManager'])
+            ->getMock();
+        $context->expects($this->any())->method('getLayout')->will($this->returnValue($this->layout));
+        $context->expects($this->any())->method('getEventManager')->will($this->returnValue($eventManager));
+        $context->expects($this->any())->method('getUrlBuilder')->will($this->returnValue($urlBuilder));
+        $context->expects($this->any())->method('getScopeConfig')->will($this->returnValue($scopeConfig));
+        $context->expects($this->any())->method('getStoreManager')->will($this->returnValue($this->storeManagerMock));
 
         $this->block = $objectManager->getObject(
             \Magento\Checkout\Block\Onepage\Success::class,
             [
+                'context' => $context,
                 'orderConfig' => $this->orderConfig,
                 'checkoutSession' => $this->checkoutSession
             ]
@@ -116,7 +154,7 @@ class SuccessTest extends \PHPUnit_Framework_TestCase
             [['status1', 'status2'], true]
         ];
     }
-    
+
     public function testGetContinueUrl()
     {
         $storeMock = $this->getMock('Magento\Store\Model\Store', [], [], '', false);

--- a/app/code/Magento/Checkout/Test/Unit/Block/Onepage/SuccessTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Onepage/SuccessTest.php
@@ -10,6 +10,7 @@ use Magento\Sales\Model\Order;
 /**
  * Class SuccessTest
  * @package Magento\Checkout\Block\Onepage
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class SuccessTest extends \PHPUnit_Framework_TestCase
 {

--- a/app/code/Magento/Checkout/Test/Unit/Block/Onepage/SuccessTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Onepage/SuccessTest.php
@@ -72,8 +72,9 @@ class SuccessTest extends \PHPUnit_Framework_TestCase
             ->method('getValue')
             ->with(
                 $this->stringContains(
-                    'advanced/modules_disable_output/'), 
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                    'advanced/modules_disable_output/'
+                ),
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             )
             ->will($this->returnValue(false));
 

--- a/app/code/Magento/Checkout/Test/Unit/Block/Onepage/SuccessTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Onepage/SuccessTest.php
@@ -70,7 +70,11 @@ class SuccessTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $scopeConfig->expects($this->any())
             ->method('getValue')
-            ->with($this->stringContains('advanced/modules_disable_output/'), \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->with(
+                $this->stringContains(
+                    'advanced/modules_disable_output/'), 
+                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            )
             ->will($this->returnValue(false));
 
         $context = $this->getMockBuilder(\Magento\Framework\View\Element\Template\Context::class)
@@ -157,7 +161,7 @@ class SuccessTest extends \PHPUnit_Framework_TestCase
 
     public function testGetContinueUrl()
     {
-        $storeMock = $this->getMock('Magento\Store\Model\Store', [], [], '', false);
+        $storeMock = $this->getMock(\Magento\Store\Model\Store::class, [], [], '', false);
         $this->storeManagerMock->expects($this->once())->method('getStore')->will($this->returnValue($storeMock));
         $storeMock->expects($this->once())->method('getBaseUrl')->will($this->returnValue('Expected Result'));
 

--- a/app/code/Magento/Checkout/Test/Unit/Block/Onepage/SuccessTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Onepage/SuccessTest.php
@@ -27,12 +27,18 @@ class SuccessTest extends \PHPUnit_Framework_TestCase
      * @var \Magento\Checkout\Model\Session | \PHPUnit_Framework_MockObject_MockObject
      */
     protected $checkoutSession;
+    
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $storeManagerMock;
 
     protected function setUp()
     {
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
         $this->orderConfig = $this->getMock(\Magento\Sales\Model\Order\Config::class, [], [], '', false);
+        $this->storeManagerMock = $this->getMock('Magento\Store\Model\StoreManagerInterface', [], [], '', false);
 
         $this->checkoutSession = $this->getMockBuilder(
             \Magento\Checkout\Model\Session::class
@@ -109,5 +115,14 @@ class SuccessTest extends \PHPUnit_Framework_TestCase
             [[Order::STATE_PENDING_PAYMENT, 'status2'],  false],
             [['status1', 'status2'], true]
         ];
+    }
+    
+    public function testGetContinueUrl()
+    {
+        $storeMock = $this->getMock('Magento\Store\Model\Store', [], [], '', false);
+        $this->storeManagerMock->expects($this->once())->method('getStore')->will($this->returnValue($storeMock));
+        $storeMock->expects($this->once())->method('getBaseUrl')->will($this->returnValue('Expected Result'));
+
+        $this->assertEquals('Expected Result', $this->block->getContinueUrl());
     }
 }

--- a/app/code/Magento/Checkout/view/frontend/templates/success.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/success.phtml
@@ -22,7 +22,7 @@
 
     <div class="actions-toolbar">
         <div class="primary">
-            <a class="action primary continue" href="<?php /* @escapeNotVerified */ echo $block->getUrl() ?>"><span><?php /* @escapeNotVerified */ echo __('Continue Shopping') ?></span></a>
+            <a class="action primary continue" href="<?php /* @escapeNotVerified */ echo $block->getContinueUrl() ?>"><span><?php /* @escapeNotVerified */ echo __('Continue Shopping') ?></span></a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
The 'Continue Shopping' url on the checkout success page is basically hard-coded to be the store base url because it just calls Magento\Framework\View\Element\AbstractBlock::getUrl() without any parameters. This means a developer would need to override the module-checkout/view/frontend/templates/success.phtml file completely in order to change the url.

I propose creating a getContinueUrl function in the Magento\Checkout\Block\Onepage\Success class that would allow developers a way to change the url for the 'Continue Shopping' button by using a plugin instead of needing to override a core template, which is bad practice. The Magento_Multishipping module already does this for its success page 'Continue Shopping' url, so I mostly copied that implementation.