### PR TITLE
AddressRepository save method causes large memory consumption, eventually leading to out of memory crash

### DIFF
--- a/app/code/Magento/Customer/Model/Address.php
+++ b/app/code/Magento/Customer/Model/Address.php
@@ -171,13 +171,14 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress
     public function getDataModel($defaultBillingAddressId = null, $defaultShippingAddressId = null)
     {
         if ($this->getCustomerId() || $this->getParentId()) {
-            if ($this->getCustomer()->getDefaultBillingAddress()) {
+            if ((intval($defaultBillingAddressId) == 0) && $this->getCustomer()->getDefaultBillingAddress()) {
                 $defaultBillingAddressId = $this->getCustomer()->getDefaultBillingAddress()->getId();
             }
-            if ($this->getCustomer()->getDefaultShippingAddress()) {
+            if ((intval($defaultShippingAddressId) == 0) && $this->getCustomer()->getDefaultShippingAddress()) {
                 $defaultShippingAddressId = $this->getCustomer()->getDefaultShippingAddress()->getId();
             }
         }
+        
         return parent::getDataModel($defaultBillingAddressId, $defaultShippingAddressId);
     }
 

--- a/app/code/Magento/Customer/Model/Address.php
+++ b/app/code/Magento/Customer/Model/Address.php
@@ -171,10 +171,10 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress
     public function getDataModel($defaultBillingAddressId = null, $defaultShippingAddressId = null)
     {
         if ($this->getCustomerId() || $this->getParentId()) {
-            if ((intval($defaultBillingAddressId) == 0) && $this->getCustomer()->getDefaultBillingAddress()) {
+            if (($defaultBillingAddressId === null) && $this->getCustomer()->getDefaultBillingAddress()) {
                 $defaultBillingAddressId = $this->getCustomer()->getDefaultBillingAddress()->getId();
             }
-            if ((intval($defaultShippingAddressId) == 0) && $this->getCustomer()->getDefaultShippingAddress()) {
+            if (($defaultShippingAddressId === null) && $this->getCustomer()->getDefaultShippingAddress()) {
                 $defaultShippingAddressId = $this->getCustomer()->getDefaultShippingAddress()->getId();
             }
         }

--- a/app/code/Magento/Customer/Model/ResourceModel/AddressRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/AddressRepository.php
@@ -139,7 +139,17 @@ class AddressRepository implements \Magento\Customer\Api\AddressRepositoryInterf
         $this->addressRegistry->push($addressModel);
         $this->updateAddressCollection($customerModel, $addressModel);
 
-        return $addressModel->getDataModel();
+        $defaultBillingAddressId = null;
+        if (!is_null($customerModel->getDefaultBillingAddress())) {
+            $defaultBillingAddressId = $customerModel->getDefaultBillingAddress()->getId();
+        }
+
+        $defaultShippingAddressId = null;
+        if (!is_null($customerModel->getDefaultShippingAddress())) {
+            $defaultShippingAddressId = $customerModel->getDefaultShippingAddress()->getId();
+        }
+
+        return $addressModel->getDataModel($defaultBillingAddressId, $defaultShippingAddressId);
     }
 
     /**

--- a/app/code/Magento/Customer/Model/ResourceModel/AddressRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/AddressRepository.php
@@ -140,12 +140,12 @@ class AddressRepository implements \Magento\Customer\Api\AddressRepositoryInterf
         $this->updateAddressCollection($customerModel, $addressModel);
 
         $defaultBillingAddressId = null;
-        if ($customerModel->getDefaultBillingAddress() is CustomerAddressModel) {
+        if ($customerModel->getDefaultBillingAddress() instanceof CustomerAddressModel) {
             $defaultBillingAddressId = $customerModel->getDefaultBillingAddress()->getId();
         }
 
         $defaultShippingAddressId = null;
-        if ($customerModel->getDefaultShippingAddress() is CustomerAddressModel) {
+        if ($customerModel->getDefaultShippingAddress() instanceof CustomerAddressModel) {
             $defaultShippingAddressId = $customerModel->getDefaultShippingAddress()->getId();
         }
 

--- a/app/code/Magento/Customer/Model/ResourceModel/AddressRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/AddressRepository.php
@@ -140,12 +140,12 @@ class AddressRepository implements \Magento\Customer\Api\AddressRepositoryInterf
         $this->updateAddressCollection($customerModel, $addressModel);
 
         $defaultBillingAddressId = null;
-        if (!is_null($customerModel->getDefaultBillingAddress())) {
+        if ($customerModel->getDefaultBillingAddress() is CustomerAddressModel) {
             $defaultBillingAddressId = $customerModel->getDefaultBillingAddress()->getId();
         }
 
         $defaultShippingAddressId = null;
-        if (!is_null($customerModel->getDefaultShippingAddress())) {
+        if ($customerModel->getDefaultShippingAddress() is CustomerAddressModel) {
             $defaultShippingAddressId = $customerModel->getDefaultShippingAddress()->getId();
         }
 

--- a/app/code/Magento/Customer/Model/ResourceModel/AddressRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/AddressRepository.php
@@ -140,12 +140,12 @@ class AddressRepository implements \Magento\Customer\Api\AddressRepositoryInterf
         $this->updateAddressCollection($customerModel, $addressModel);
 
         $defaultBillingAddressId = null;
-        if ($customerModel->getDefaultBillingAddress() instanceof CustomerAddressModel) {
+        if ($customerModel->getDefaultBillingAddress()) {
             $defaultBillingAddressId = $customerModel->getDefaultBillingAddress()->getId();
         }
 
         $defaultShippingAddressId = null;
-        if ($customerModel->getDefaultShippingAddress() instanceof CustomerAddressModel) {
+        if ($customerModel->getDefaultShippingAddress()) {
             $defaultShippingAddressId = $customerModel->getDefaultShippingAddress()->getId();
         }
 


### PR DESCRIPTION
### Preconditions
<!--- Provide a more detailed information of environment you use -->
<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->
1. Magento version: 2.1.2
2. PHP 7.0.15

### Steps to reproduce
1. Create a customer with a lot of addresses. In our case, we have 250+ shipping addresses.
2. Loop through all the addresses and save the data models via the address repository.

### Expected result
<!--- Tell us what should happen -->
1. Addresses are saved. No memory side effects.

### Actual result
<!--- Tell us what happens instead -->
1. With each address that is saved, the memory usage increases. In our case it is around 2mb per address.

Fix:
The fix needs to happen in two places:

The getDataModel() method in Magento\Customer\Model\Address does not take into account the default billing and shipping address that are passed. This causes the customer to be loaded, which most likely causes the memory issue.

The Magento\Customer\Model\ResourceModel\AddressRepository save() method returns the data model of the address object. When calling address->getDataModel() is does not pass in the default billing and shipping address id.