### PR TITLE
Additional sort order attribute for sorting by position

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -1649,7 +1649,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             // optimize if using cat index
             $filters = $this->_productLimitationFilters;
             if (isset($filters['category_id']) || isset($filters['visibility'])) {
-                $this->getSelect()->order('cat_index.position ' . $dir);
+                $this->getSelect()->order('cat_index.position ' . $dir)->order('e.entity_id ' . $dir);
             } else {
                 $this->getSelect()->order('e.entity_id ' . $dir);
             }


### PR DESCRIPTION
catalog_category_product_index rows has "1" position values for all items by default, so sorting by cat_index.position won't work.
If we get magento 2.1.3 with sample data and try to change position sort direction on catalog - it does'n change anything.