### PR TITLE
Convert MageBraintree to use the serializer rather than Zend_Json

### DIFF
--- a/app/code/Magento/Braintree/Gateway/Response/VaultDetailsHandler.php
+++ b/app/code/Magento/Braintree/Gateway/Response/VaultDetailsHandler.php
@@ -42,23 +42,31 @@ class VaultDetailsHandler implements HandlerInterface
     protected $config;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+
+    /**
      * Constructor
      *
      * @param PaymentTokenInterfaceFactory $paymentTokenFactory
      * @param OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory
      * @param Config $config
      * @param SubjectReader $subjectReader
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      */
     public function __construct(
         PaymentTokenInterfaceFactory $paymentTokenFactory,
         OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory,
         Config $config,
-        SubjectReader $subjectReader
+        SubjectReader $subjectReader,
+        \Magento\Framework\Serialize\SerializerInterface $serializer
     ) {
         $this->paymentTokenFactory = $paymentTokenFactory;
         $this->paymentExtensionFactory = $paymentExtensionFactory;
         $this->config = $config;
         $this->subjectReader = $subjectReader;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -133,7 +141,7 @@ class VaultDetailsHandler implements HandlerInterface
      */
     private function convertDetailsToJSON($details)
     {
-        $json = \Zend_Json::encode($details);
+        $json = $this->serializer->serialize($details);
         return $json ? $json : '{}';
     }
 

--- a/app/code/Magento/Braintree/Gateway/Response/VaultDetailsHandler.php
+++ b/app/code/Magento/Braintree/Gateway/Response/VaultDetailsHandler.php
@@ -60,13 +60,14 @@ class VaultDetailsHandler implements HandlerInterface
         OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory,
         Config $config,
         SubjectReader $subjectReader,
-        \Magento\Framework\Serialize\SerializerInterface $serializer
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null
     ) {
         $this->paymentTokenFactory = $paymentTokenFactory;
         $this->paymentExtensionFactory = $paymentExtensionFactory;
         $this->config = $config;
         $this->subjectReader = $subjectReader;
-        $this->serializer = $serializer;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
     }
 
     /**

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Response/VaultDetailsHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Response/VaultDetailsHandlerTest.php
@@ -122,11 +122,20 @@ class VaultDetailsHandlerTest extends \PHPUnit_Framework_TestCase
             ->method('getCctypesMapper')
             ->willReturn($mapperArray);
 
+        $this->serializer = $this->getMock(
+            \Magento\Framework\Serialize\SerializerInterface::class,
+            [],
+            [],
+            '',
+            false
+        );
+
         $this->paymentHandler = new VaultDetailsHandler(
             $this->paymentTokenFactory,
             $this->paymentExtensionFactory,
             $this->config,
-            $this->subjectReader
+            $this->subjectReader,
+            $this->serializer
         );
     }
 


### PR DESCRIPTION
As Zend1 is end of life usage of Zend_Json should be converted to the internal serializer in Magento2