### PR TITLE
Remove the unused Ajax/Serializer.php class

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Ajax/Serializer.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Ajax/Serializer.php
@@ -5,8 +5,30 @@
  */
 namespace Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Ajax;
 
+use Magento\Framework\View\Element\Template;
+
 class Serializer extends \Magento\Framework\View\Element\Template
 {
+    /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @param Template\Context $context
+     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
+     * @param array $data
+     */
+    public function __construct(
+        Template\Context $context,
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
+    }
+
     /**
      * @return $this
      */
@@ -19,6 +41,7 @@ class Serializer extends \Magento\Framework\View\Element\Template
 
     /**
      * @return string
+     * @deprecated
      */
     public function getProductsJSON()
     {
@@ -30,6 +53,6 @@ class Serializer extends \Magento\Framework\View\Element\Template
                 $result[$id] = $product->toArray(['qty', 'position']);
             }
         }
-        return $result ? \Zend_Json::encode($result) : '{}';
+        return $result ? $this->serializer->serialize($result) : '{}';
     }
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Ajax/Serializer.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Ajax/Serializer.php
@@ -7,6 +7,11 @@ namespace Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Ajax;
 
 use Magento\Framework\View\Element\Template;
 
+/**
+ * Class Serializer
+ * @package Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Ajax
+ * @deprecated
+ */
 class Serializer extends \Magento\Framework\View\Element\Template
 {
     /**
@@ -18,6 +23,7 @@ class Serializer extends \Magento\Framework\View\Element\Template
      * @param Template\Context $context
      * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
      * @param array $data
+     * @throws \RuntimeException
      */
     public function __construct(
         Template\Context $context,

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Ajax/Serializer.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Ajax/Serializer.php
@@ -15,24 +15,24 @@ use Magento\Framework\View\Element\Template;
 class Serializer extends \Magento\Framework\View\Element\Template
 {
     /**
-     * @var \Magento\Framework\Serialize\SerializerInterface
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
     private $serializer;
 
     /**
      * @param Template\Context $context
-     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @param array $data
      * @throws \RuntimeException
      */
     public function __construct(
         Template\Context $context,
-        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**


### PR DESCRIPTION
Since this class is not used anywhere can we remove it as it is using Zend1 Json which is at end of life.