### PR TITLE
Allow X-Forwarded-For to have multiple values

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/PhpEnvironment/RemoteAddress.php
+++ b/lib/internal/Magento/Framework/HTTP/PhpEnvironment/RemoteAddress.php
@@ -64,6 +64,11 @@ class RemoteAddress
             return false;
         }
 
+        if (strpos($this->remoteAddress, ',') !== false) {
+            $ipList = explode(',', $this->remoteAddress);
+            $this->remoteAddress = trim(reset($ipList));
+        }
+
         return $ipToLong ? ip2long($this->remoteAddress) : $this->remoteAddress;
     }
 


### PR DESCRIPTION
PR #1546 was closed because CLA issues, thus I'm resubmitting the changes. 

### Preconditions
1. HAProxy/Nginx offloading SSL and sending traffic to Varnish;
2. Varnish in front of Apache/Nginx.

### Steps to reproduce
1. Place an order according to the preconditions.

### Expected result
1. Current customer IP address stored into quote and order tables.

### Actual result
1. Stored IP is Varnish/HAProxy IP address relative to the webserver (usually 127.0.0.1 or some internal IP, depends on network structure);