### PR TITLE
add anonymize ip option for google analytics

### DIFF
--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -80,14 +80,13 @@ class Ga extends \Magento\Framework\View\Element\Template
             $optPageURL = ", '" . $this->escapeHtmlAttr($pageName, false) . "'";
         }
 
-        $anonymizeIp = "false";
+        $anonymizeIp = "";
         if ($this->_googleAnalyticsData->isAnonymizedIpActive()) {
-          $anonymizeIp = "true";
+          $anonymizeIp = ", {'anonymizeIp': true}";
         }
 
-        return "\nga('create', '{$this->escapeJsQuote(
-            $accountId
-        )}', 'auto');\nga('send', 'pageview'{$optPageURL}, {'anonymizeIp' : {$anonymizeIp}});\n";
+        return "\nga('create', '" . $this->escapeHtmlAttr($accountId, false)
+           . ", 'auto');\nga('send', 'pageview'{$optPageURL}{$anonymizeIp});\n";
     }
 
     /**
@@ -111,6 +110,12 @@ class Ga extends \Magento\Framework\View\Element\Template
         $result = [];
 
         $result[] = "ga('require', 'ec', 'ec.js');";
+
+        $anonymizeIp = "";
+        if ($this->_googleAnalyticsData->isAnonymizedIpActive()) {
+          $anonymizeIp = ", {'anonymizeIp': true}";
+        }
+
         foreach ($collection as $order) {
             if ($order->getIsVirtual()) {
                 $address = $order->getBillingAddress();
@@ -148,7 +153,7 @@ class Ga extends \Magento\Framework\View\Element\Template
                 $order->getBaseShippingAmount()
             );
 
-            $result[] = "ga('send', 'pageview');";
+            $result[] = "ga('send', 'pageview'{$anonymizeIp});";
         }
         return implode("\n", $result);
     }

--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -80,8 +80,14 @@ class Ga extends \Magento\Framework\View\Element\Template
             $optPageURL = ", '" . $this->escapeHtmlAttr($pageName, false) . "'";
         }
 
-        return "\nga('create', '" . $this->escapeHtmlAttr($accountId, false)
-            . ", 'auto');\nga('send', 'pageview'{$optPageURL});\n";
+        $anonymizeIp = "false";
+        if ($this->_googleAnalyticsData->isAnonymizedIpActive()) {
+          $anonymizeIp = "true";
+        }
+
+        return "\nga('create', '{$this->escapeJsQuote(
+            $accountId
+        )}', 'auto');\nga('send', 'pageview'{$optPageURL}, {'anonymizeIp' : {$anonymizeIp}});\n";
     }
 
     /**

--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -82,11 +82,11 @@ class Ga extends \Magento\Framework\View\Element\Template
 
         $anonymizeIp = "";
         if ($this->_googleAnalyticsData->isAnonymizedIpActive()) {
-          $anonymizeIp = ", {'anonymizeIp': true}";
+          $anonymizeIp = "\nga('set', 'anonymizeIp', true);";
         }
 
         return "\nga('create', '" . $this->escapeHtmlAttr($accountId, false)
-           . ", 'auto');\nga('send', 'pageview'{$optPageURL}{$anonymizeIp});\n";
+           . ", 'auto');{$anonymizeIp}\nga('send', 'pageview'{$optPageURL});\n";
     }
 
     /**
@@ -110,11 +110,6 @@ class Ga extends \Magento\Framework\View\Element\Template
         $result = [];
 
         $result[] = "ga('require', 'ec', 'ec.js');";
-
-        $anonymizeIp = "";
-        if ($this->_googleAnalyticsData->isAnonymizedIpActive()) {
-          $anonymizeIp = ", {'anonymizeIp': true}";
-        }
 
         foreach ($collection as $order) {
             if ($order->getIsVirtual()) {
@@ -153,7 +148,7 @@ class Ga extends \Magento\Framework\View\Element\Template
                 $order->getBaseShippingAmount()
             );
 
-            $result[] = "ga('send', 'pageview'{$anonymizeIp});";
+            $result[] = "ga('send', 'pageview');";
         }
         return implode("\n", $result);
     }

--- a/app/code/Magento/GoogleAnalytics/Helper/Data.php
+++ b/app/code/Magento/GoogleAnalytics/Helper/Data.php
@@ -23,6 +23,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     const XML_PATH_ACCOUNT = 'google/analytics/account';
 
+    const XML_PATH_ANONYMIZE = 'google/analytics/anonymize';
+
     /**
      * Whether GA is ready to use
      *
@@ -34,4 +36,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $accountId = $this->scopeConfig->getValue(self::XML_PATH_ACCOUNT, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store);
         return $accountId && $this->scopeConfig->isSetFlag(self::XML_PATH_ACTIVE, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store);
     }
+
+    /**
+     * Whether anonymized IPs are active
+     *
+     * @param null|string|bool|int|Store $store
+     * @return bool
+     */
+    public function isAnonymizedIpActive($store = null) {
+        $anonymize = $this->scopeConfig->getValue(self::XML_PATH_ANONYMIZE, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store);
+        return $anonymize;
+    }
+
 }

--- a/app/code/Magento/GoogleAnalytics/etc/adminhtml/system.xml
+++ b/app/code/Magento/GoogleAnalytics/etc/adminhtml/system.xml
@@ -23,6 +23,14 @@
                         <field id="*/*/active">1</field>
                     </depends>
                 </field>
+
+		<field id="anonymize" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Anonymize IP</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+		    <depends>
+                        <field id="*/*/active">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
     </system>


### PR DESCRIPTION
Hi, 

I implemented an option for anonymized ips with google analytics. 
The section "Google Analytics" in the backend (Stores > Configuration, Sales > Google API) has a new field "Anonymize IP".  

According to the value in Anonymize IP, the ga('send' ...)-call in the generated html is either

   ga('send', 'pageview', {'anonymizeIp' : false});

or

   ga('send', 'pageview', {'anonymizeIp' : true});

(see https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization)

this is my first try to extend magento and i'm open to suggestions.

- thomas
