### PR TITLE
Fatal error on cms block grid delete.

### DIFF
--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
@@ -78,4 +78,24 @@ class Collection extends AbstractCollection
         $entityMetadata = $this->metadataPool->getMetadata(BlockInterface::class);
         $this->joinStoreRelationTable('cms_block_store', $entityMetadata->getLinkField());
     }
+
+    /**
+     * Create all ids retrieving select with limitation
+     * Backward compatibility with EAV collection
+     *
+     * @param int $limit
+     * @param int $offset
+     * @return \Magento\Eav\Model\Entity\Collection\AbstractCollection
+     */
+    protected function _getAllIdsSelect($limit = null, $offset = null)
+    {
+        $idsSelect = clone $this->getSelect();
+        $idsSelect->reset(\Magento\Framework\DB\Select::ORDER);
+        $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_COUNT);
+        $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_OFFSET);
+        $idsSelect->reset(\Magento\Framework\DB\Select::COLUMNS);
+        $idsSelect->columns($this->getResource()->getIdFieldName(), 'main_table');
+        $idsSelect->limit($limit, $offset);
+        return $idsSelect;
+    }
 }

--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Collection.php
@@ -78,24 +78,4 @@ class Collection extends AbstractCollection
         $entityMetadata = $this->metadataPool->getMetadata(BlockInterface::class);
         $this->joinStoreRelationTable('cms_block_store', $entityMetadata->getLinkField());
     }
-
-    /**
-     * Create all ids retrieving select with limitation
-     * Backward compatibility with EAV collection
-     *
-     * @param int $limit
-     * @param int $offset
-     * @return \Magento\Eav\Model\Entity\Collection\AbstractCollection
-     */
-    protected function _getAllIdsSelect($limit = null, $offset = null)
-    {
-        $idsSelect = clone $this->getSelect();
-        $idsSelect->reset(\Magento\Framework\DB\Select::ORDER);
-        $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_COUNT);
-        $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_OFFSET);
-        $idsSelect->reset(\Magento\Framework\DB\Select::COLUMNS);
-        $idsSelect->columns($this->getResource()->getIdFieldName(), 'main_table');
-        $idsSelect->limit($limit, $offset);
-        return $idsSelect;
-    }
 }

--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Grid/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Grid/Collection.php
@@ -91,10 +91,31 @@ class Collection extends BlockCollection implements SearchResultInterface
      * @param int $limit
      * @param int $offset
      * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getAllIds($limit = null, $offset = null)
     {
         return $this->getConnection()->fetchCol($this->_getAllIdsSelect($limit, $offset), $this->_bindParams);
+    }
+
+    /**
+     * Create all ids retrieving select with limitation
+     *
+     * @param int $limit
+     * @param int $offset
+     * @return \Magento\Framework\DB\Select
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    protected function _getAllIdsSelect($limit = null, $offset = null)
+    {
+        $idsSelect = clone $this->getSelect();
+        $idsSelect->reset(\Magento\Framework\DB\Select::ORDER);
+        $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_COUNT);
+        $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_OFFSET);
+        $idsSelect->reset(\Magento\Framework\DB\Select::COLUMNS);
+        $idsSelect->columns($this->getResource()->getIdFieldName(), 'main_table');
+        $idsSelect->limit($limit, $offset);
+        return $idsSelect;
     }
 
     /**

--- a/app/code/Magento/Cms/Model/ResourceModel/Block/Grid/Collection.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block/Grid/Collection.php
@@ -85,40 +85,6 @@ class Collection extends BlockCollection implements SearchResultInterface
     }
 
     /**
-     * Retrieve all ids for collection
-     * Backward compatibility with EAV collection
-     *
-     * @param int $limit
-     * @param int $offset
-     * @return array
-     * @throws \Magento\Framework\Exception\LocalizedException
-     */
-    public function getAllIds($limit = null, $offset = null)
-    {
-        return $this->getConnection()->fetchCol($this->_getAllIdsSelect($limit, $offset), $this->_bindParams);
-    }
-
-    /**
-     * Create all ids retrieving select with limitation
-     *
-     * @param int $limit
-     * @param int $offset
-     * @return \Magento\Framework\DB\Select
-     * @throws \Magento\Framework\Exception\LocalizedException
-     */
-    protected function _getAllIdsSelect($limit = null, $offset = null)
-    {
-        $idsSelect = clone $this->getSelect();
-        $idsSelect->reset(\Magento\Framework\DB\Select::ORDER);
-        $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_COUNT);
-        $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_OFFSET);
-        $idsSelect->reset(\Magento\Framework\DB\Select::COLUMNS);
-        $idsSelect->columns($this->getResource()->getIdFieldName(), 'main_table');
-        $idsSelect->limit($limit, $offset);
-        return $idsSelect;
-    }
-
-    /**
      * Get search criteria.
      *
      * @return \Magento\Framework\Api\SearchCriteriaInterface|null


### PR DESCRIPTION
See https://github.com/magento/magento2/issues/8415 for more information on how to reproduce.

On the develop branch when using the Cms Block grid in the admin section the delete option throws a fatal error.

```
Fatal error: Uncaught Error: Call to undefined method Magento\Cms\Model\ResourceModel\Block\Grid\Collection::_getAllIdsSelect()
```