### PR TITLE
Fix "each()" function call on potentially invalid data

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/AbstractResource.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/AbstractResource.php
@@ -563,7 +563,7 @@ abstract class AbstractResource extends \Magento\Eav\Model\Entity\AbstractEntity
             }
         }
 
-        if (sizeof($attributesData) == 1) {
+        if (is_array($attributesData) && sizeof($attributesData) == 1) {
             $_data = each($attributesData);
             $attributesData = $_data[1];
         }


### PR DESCRIPTION
In some cases the `$attributesData` variable can be `false` at this point of execution. If this happens `count($attributesData)` returns 1 and then the code inside the `if` is evaluated. But then the call to `each` fails with error `Variable passed to each() is not an array or object in /var/www/html/vendor/magento/module-catalog/Model/ResourceModel/AbstractResource.php`

It is necessary to check that `$attributesData` is actually an array before attempt to `count` its content.