### PR TITLE
Fix outlining invoice item price with the header label 'price'

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
@@ -81,8 +81,8 @@ class DefaultInvoice extends \Magento\Sales\Model\Order\Pdf\Items\AbstractItems
         // draw item Prices
         $i = 0;
         $prices = $this->getItemPricesForDisplay();
-        $feedPrice = 395;
-        $feedSubtotal = $feedPrice + 170;
+        $feedPrice = 360;
+        $feedSubtotal = $feedPrice + 205;
         foreach ($prices as $priceData) {
             if (isset($priceData['label'])) {
                 // draw Price label


### PR DESCRIPTION
Fix the outlining of the invoice item price with the header label 'price' by having the same feed distance as used in the header.

In the header the label 'price' has a feed distance of 360:
https://github.com/magento/magento2/blob/develop/app/code/Magento/Sales/Model/Order/Pdf/Invoice.php#L99

This fixes issue https://github.com/magento/magento2/issues/8453