### PR TITLE
Fix for https://github.com/magento/magento2/issues/8287

### DIFF
--- a/app/code/Magento/Quote/Model/ShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingAddressManagement.php
@@ -118,7 +118,7 @@ class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressM
         $address->setCollectShippingRates(true);
 
         if (!$quote->validateMinimumAmount($quote->getIsMultiShipping())) {
-            throw new InputException($this->getMinimumAmountErrorMessage()->getMessage());
+            throw new InputException(__($this->getMinimumAmountErrorMessage()->getMessage()));
         }
 
         try {


### PR DESCRIPTION
Added missing __() wrap on execption. Without it a new exception is thrown: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\Framework\Exception\InputException::__construct() must be an instance of Magento\Framework\Phrase, string given

Fix for https://github.com/magento/magento2/issues/8287