### PR TITLE
Remove zend json checkout

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -86,4 +86,12 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
     {
         return $this->_storeManager->getStore()->getBaseUrl();
     }
+
+    /**
+     * @return bool|string
+     */
+    public function getSerializedCheckoutConfig()
+    {
+        return $this->serializer->serialize($this->getCheckoutConfig());
+    }
 }

--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -21,13 +21,19 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
     protected $layoutProcessors;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
+     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
      * @param array $data
-     * @codeCoverageIgnore
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
@@ -35,12 +41,15 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
         array $data = []
     ) {
         $this->configProvider = $configProvider;
         $this->layoutProcessors = $layoutProcessors;
         parent::__construct($context, $customerSession, $checkoutSession, $data);
         $this->_isScopePrivate = true;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
     }
 
     /**
@@ -64,7 +73,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         foreach ($this->layoutProcessors as $processor) {
             $this->jsLayout = $processor->process($this->jsLayout);
         }
-        return \Zend_Json::encode($this->jsLayout);
+        return $this->serializer->serialize($this->jsLayout);
     }
 
     /**

--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -21,7 +21,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
     protected $layoutProcessors;
 
     /**
-     * @var \Magento\Framework\Serialize\SerializerInterface
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
     private $serializer;
 
@@ -31,7 +31,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
-     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @param array $data
      * @throws \RuntimeException
      */
@@ -41,7 +41,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
-        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
         array $data = []
     ) {
         $this->configProvider = $configProvider;
@@ -49,7 +49,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         parent::__construct($context, $customerSession, $checkoutSession, $data);
         $this->_isScopePrivate = true;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**

--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -31,8 +31,8 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
-     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @throws \RuntimeException
      */
     public function __construct(
@@ -41,8 +41,8 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->configProvider = $configProvider;
         $this->layoutProcessors = $layoutProcessors;

--- a/app/code/Magento/Checkout/Block/Cart/Sidebar.php
+++ b/app/code/Magento/Checkout/Block/Cart/Sidebar.php
@@ -28,6 +28,11 @@ class Sidebar extends AbstractCart
     protected $imageHelper;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Checkout\Model\Session $checkoutSession
@@ -42,6 +47,7 @@ class Sidebar extends AbstractCart
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Catalog\Helper\Image $imageHelper,
         \Magento\Customer\CustomerData\JsLayoutDataProviderPoolInterface $jsLayoutDataProvider,
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
         array $data = []
     ) {
         if (isset($data['jsLayout'])) {
@@ -53,6 +59,8 @@ class Sidebar extends AbstractCart
         parent::__construct($context, $customerSession, $checkoutSession, $data);
         $this->_isScopePrivate = false;
         $this->imageHelper = $imageHelper;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
     }
 
     /**
@@ -72,6 +80,14 @@ class Sidebar extends AbstractCart
             'minicartMaxItemsVisible' => $this->getMiniCartMaxItemsCount(),
             'websiteId' => $this->_storeManager->getStore()->getWebsiteId()
         ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getSerializedConfig()
+    {
+        return $this->serializer->serialize($this->getConfig());
     }
 
     /**

--- a/app/code/Magento/Checkout/Block/Cart/Sidebar.php
+++ b/app/code/Magento/Checkout/Block/Cart/Sidebar.php
@@ -38,8 +38,8 @@ class Sidebar extends AbstractCart
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Catalog\Helper\Image $imageHelper
      * @param \Magento\Customer\CustomerData\JsLayoutDataProviderPoolInterface $jsLayoutDataProvider
-     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @throws \RuntimeException
      */
     public function __construct(
@@ -48,8 +48,8 @@ class Sidebar extends AbstractCart
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Catalog\Helper\Image $imageHelper,
         \Magento\Customer\CustomerData\JsLayoutDataProviderPoolInterface $jsLayoutDataProvider,
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         if (isset($data['jsLayout'])) {
             $this->jsLayout = array_merge_recursive($jsLayoutDataProvider->getData(), $data['jsLayout']);

--- a/app/code/Magento/Checkout/Block/Cart/Sidebar.php
+++ b/app/code/Magento/Checkout/Block/Cart/Sidebar.php
@@ -28,7 +28,7 @@ class Sidebar extends AbstractCart
     protected $imageHelper;
 
     /**
-     * @var \Magento\Framework\Serialize\SerializerInterface
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
     private $serializer;
 
@@ -38,8 +38,9 @@ class Sidebar extends AbstractCart
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Catalog\Helper\Image $imageHelper
      * @param \Magento\Customer\CustomerData\JsLayoutDataProviderPoolInterface $jsLayoutDataProvider
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @param array $data
-     * @codeCoverageIgnore
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
@@ -47,7 +48,7 @@ class Sidebar extends AbstractCart
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Catalog\Helper\Image $imageHelper,
         \Magento\Customer\CustomerData\JsLayoutDataProviderPoolInterface $jsLayoutDataProvider,
-        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
         array $data = []
     ) {
         if (isset($data['jsLayout'])) {
@@ -60,7 +61,7 @@ class Sidebar extends AbstractCart
         $this->_isScopePrivate = false;
         $this->imageHelper = $imageHelper;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**

--- a/app/code/Magento/Checkout/Block/Onepage.php
+++ b/app/code/Magento/Checkout/Block/Onepage.php
@@ -111,4 +111,12 @@ class Onepage extends \Magento\Framework\View\Element\Template
     {
         return $this->_storeManager->getStore()->getBaseUrl();
     }
+
+    /**
+     * @return bool|string
+     */
+    public function getSerializedCheckoutConfig()
+    {
+        return $this->serializer->serialize($this->getCheckoutConfig());
+    }
 }

--- a/app/code/Magento/Checkout/Block/Onepage.php
+++ b/app/code/Magento/Checkout/Block/Onepage.php
@@ -46,8 +46,8 @@ class Onepage extends \Magento\Framework\View\Element\Template
      * @param \Magento\Framework\Data\Form\FormKey $formKey
      * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
-     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @throws \RuntimeException
      */
     public function __construct(
@@ -55,8 +55,8 @@ class Onepage extends \Magento\Framework\View\Element\Template
         \Magento\Framework\Data\Form\FormKey $formKey,
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         parent::__construct($context, $data);
         $this->formKey = $formKey;

--- a/app/code/Magento/Checkout/Block/Onepage.php
+++ b/app/code/Magento/Checkout/Block/Onepage.php
@@ -37,7 +37,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
     protected $layoutProcessors;
 
     /**
-     * @var \Magento\Framework\Serialize\SerializerInterface
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
     private $serializer;
 
@@ -46,7 +46,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
      * @param \Magento\Framework\Data\Form\FormKey $formKey
      * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
-     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      * @param array $data
      * @throws \RuntimeException
      */
@@ -55,7 +55,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
         \Magento\Framework\Data\Form\FormKey $formKey,
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
-        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -65,7 +65,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
         $this->configProvider = $configProvider;
         $this->layoutProcessors = $layoutProcessors;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**

--- a/app/code/Magento/Checkout/Block/Onepage.php
+++ b/app/code/Magento/Checkout/Block/Onepage.php
@@ -37,18 +37,25 @@ class Onepage extends \Magento\Framework\View\Element\Template
     protected $layoutProcessors;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Framework\Data\Form\FormKey $formKey
      * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
      * @param array $data
+     * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
         \Magento\Framework\Data\Form\FormKey $formKey,
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null
     ) {
         parent::__construct($context, $data);
         $this->formKey = $formKey;
@@ -56,6 +63,8 @@ class Onepage extends \Magento\Framework\View\Element\Template
         $this->jsLayout = isset($data['jsLayout']) && is_array($data['jsLayout']) ? $data['jsLayout'] : [];
         $this->configProvider = $configProvider;
         $this->layoutProcessors = $layoutProcessors;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\SerializerInterface::class);
     }
 
     /**
@@ -66,7 +75,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
         foreach ($this->layoutProcessors as $processor) {
             $this->jsLayout = $processor->process($this->jsLayout);
         }
-        return \Zend_Json::encode($this->jsLayout);
+        return $this->serializer->serialize($this->jsLayout);
     }
 
     /**

--- a/app/code/Magento/Checkout/Block/Onepage.php
+++ b/app/code/Magento/Checkout/Block/Onepage.php
@@ -46,16 +46,17 @@ class Onepage extends \Magento\Framework\View\Element\Template
      * @param \Magento\Framework\Data\Form\FormKey $formKey
      * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
-     * @param array $data
      * @param \Magento\Framework\Serialize\SerializerInterface|null $serializer
+     * @param array $data
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
         \Magento\Framework\Data\Form\FormKey $formKey,
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
-        array $data = [],
-        \Magento\Framework\Serialize\SerializerInterface $serializer = null
+        \Magento\Framework\Serialize\SerializerInterface $serializer = null,
+        array $data = []
     ) {
         parent::__construct($context, $data);
         $this->formKey = $formKey;

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
@@ -122,4 +122,15 @@ class ShippingTest extends \PHPUnit_Framework_TestCase
         $this->storeManager->expects($this->once())->method('getStore')->willReturn($storeMock);
         $this->assertEquals($baseUrl, $this->model->getBaseUrl());
     }
+
+    public function testGetSerializedCheckoutConfig()
+    {
+        $checkoutConfig = ['checkout', 'config'];
+        $this->configProvider->expects($this->once())->method('getConfig')->willReturn($checkoutConfig);
+        $this->serializer->expects($this->once())->method('serialize')->will(
+            $this->returnValue(json_encode($checkoutConfig))
+        );
+
+        $this->assertEquals(json_encode($checkoutConfig), $this->model->getSerializedCheckoutConfig());
+    }
 }

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
@@ -82,8 +82,8 @@ class ShippingTest extends \PHPUnit_Framework_TestCase
             $this->checkoutSession,
             $this->configProvider,
             [$this->layoutProcessor],
-            $this->serializer,
-            ['jsLayout' => $this->layout]
+            ['jsLayout' => $this->layout],
+            $this->serializer
         );
     }
 

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
@@ -47,6 +47,11 @@ class ShippingTest extends \PHPUnit_Framework_TestCase
      */
     protected $layout;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $serializer;
+
     protected function setUp()
     {
         $this->context = $this->getMock(\Magento\Framework\View\Element\Template\Context::class, [], [], '', false);
@@ -69,6 +74,7 @@ class ShippingTest extends \PHPUnit_Framework_TestCase
 
         $this->storeManager = $this->getMock(\Magento\Store\Model\StoreManagerInterface::class);
         $this->context->expects($this->once())->method('getStoreManager')->willReturn($this->storeManager);
+        $this->serializer = $this->getMock(\Magento\Framework\Serialize\SerializerInterface::class,[],[],'',false);
 
         $this->model = new \Magento\Checkout\Block\Cart\Shipping(
             $this->context,
@@ -76,6 +82,7 @@ class ShippingTest extends \PHPUnit_Framework_TestCase
             $this->checkoutSession,
             $this->configProvider,
             [$this->layoutProcessor],
+            $this->serializer,
             ['jsLayout' => $this->layout]
         );
     }
@@ -91,13 +98,18 @@ class ShippingTest extends \PHPUnit_Framework_TestCase
     {
         $layoutProcessed = $this->layout;
         $layoutProcessed['components']['thirdComponent'] = ['param' => 'value'];
+        $jsonLayoutProcessed = json_encode($layoutProcessed);
 
         $this->layoutProcessor->expects($this->once())
             ->method('process')
             ->with($this->layout)
             ->willReturn($layoutProcessed);
+
+        $this->serializer->expects($this->once())->method('serialize')->will(
+            $this->returnValue($jsonLayoutProcessed)
+        );
         $this->assertEquals(
-            \Zend_Json::encode($layoutProcessed),
+            $jsonLayoutProcessed,
             $this->model->getJsLayout()
         );
     }

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
@@ -74,7 +74,7 @@ class ShippingTest extends \PHPUnit_Framework_TestCase
 
         $this->storeManager = $this->getMock(\Magento\Store\Model\StoreManagerInterface::class);
         $this->context->expects($this->once())->method('getStoreManager')->willReturn($this->storeManager);
-        $this->serializer = $this->getMock(\Magento\Framework\Serialize\SerializerInterface::class,[],[],'',false);
+        $this->serializer = $this->getMock(\Magento\Framework\Serialize\Serializer\Json::class,[],[],'',false);
 
         $this->model = new \Magento\Checkout\Block\Cart\Shipping(
             $this->context,

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
@@ -74,7 +74,7 @@ class ShippingTest extends \PHPUnit_Framework_TestCase
 
         $this->storeManager = $this->getMock(\Magento\Store\Model\StoreManagerInterface::class);
         $this->context->expects($this->once())->method('getStoreManager')->willReturn($this->storeManager);
-        $this->serializer = $this->getMock(\Magento\Framework\Serialize\Serializer\Json::class,[],[],'',false);
+        $this->serializer = $this->getMock(\Magento\Framework\Serialize\Serializer\Json::class, [], [], '', false);
 
         $this->model = new \Magento\Checkout\Block\Cart\Shipping(
             $this->context,

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/SidebarTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/SidebarTest.php
@@ -99,7 +99,7 @@ class SidebarTest extends \PHPUnit_Framework_TestCase
             ->method('getRequest')
             ->will($this->returnValue($this->requestMock));
 
-        $this->serializer = $this->getMock(\Magento\Framework\Serialize\Serializer\Json::class,[],[],'',false);
+        $this->serializer = $this->getMock(\Magento\Framework\Serialize\Serializer\Json::class, [], [], '', false);
 
         $this->model = $this->_objectManager->getObject(
             \Magento\Checkout\Block\Cart\Sidebar::class,

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/SidebarTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/SidebarTest.php
@@ -99,7 +99,7 @@ class SidebarTest extends \PHPUnit_Framework_TestCase
             ->method('getRequest')
             ->will($this->returnValue($this->requestMock));
 
-        $this->serializer = $this->getMock(\Magento\Framework\Serialize\SerializerInterface::class,[],[],'',false);
+        $this->serializer = $this->getMock(\Magento\Framework\Serialize\Serializer\Json::class,[],[],'',false);
 
         $this->model = $this->_objectManager->getObject(
             \Magento\Checkout\Block\Cart\Sidebar::class,

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/SidebarTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/SidebarTest.php
@@ -53,6 +53,11 @@ class SidebarTest extends \PHPUnit_Framework_TestCase
      */
     protected $requestMock;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $serializer;
+
     protected function setUp()
     {
         $this->_objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -94,12 +99,15 @@ class SidebarTest extends \PHPUnit_Framework_TestCase
             ->method('getRequest')
             ->will($this->returnValue($this->requestMock));
 
+        $this->serializer = $this->getMock(\Magento\Framework\Serialize\SerializerInterface::class,[],[],'',false);
+
         $this->model = $this->_objectManager->getObject(
             \Magento\Checkout\Block\Cart\Sidebar::class,
             [
                 'context' => $contextMock,
                 'imageHelper' => $this->imageHelper,
-                'checkoutSession' => $this->checkoutSessionMock
+                'checkoutSession' => $this->checkoutSessionMock,
+                'serializer' => $this->serializer
             ]
         );
     }

--- a/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
@@ -59,7 +59,7 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
             false
         );
 
-        $this->serializer = $this->getMock(\Magento\Framework\Serialize\Serializer\Json::class,[],[],'',false);
+        $this->serializer = $this->getMock(\Magento\Framework\Serialize\Serializer\Json::class, [], [], '', false);
 
         $this->model = new \Magento\Checkout\Block\Onepage(
             $contextMock,

--- a/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
@@ -109,4 +109,15 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($jsonLayout, $this->model->getJsLayout());
     }
+
+    public function testGetSerializedCheckoutConfig()
+    {
+        $checkoutConfig = ['checkout', 'config'];
+        $this->configProviderMock->expects($this->once())->method('getConfig')->willReturn($checkoutConfig);
+        $this->serializer->expects($this->once())->method('serialize')->will(
+            $this->returnValue(json_encode($checkoutConfig))
+        );
+
+        $this->assertEquals(json_encode($checkoutConfig), $this->model->getSerializedCheckoutConfig());
+    }
 }

--- a/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
@@ -59,7 +59,7 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
             false
         );
 
-        $this->serializer = new \Magento\Framework\Serialize\Serializer\Json();
+        $this->serializer = $this->getMock(\Magento\Framework\Serialize\SerializerInterface::class,[],[],'',false);
 
         $this->model = new \Magento\Checkout\Block\Onepage(
             $contextMock,
@@ -103,6 +103,9 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
         $processedLayout = ['layout' => ['processed' => true]];
         $jsonLayout = '{"layout":{"processed":true}}';
         $this->layoutProcessorMock->expects($this->once())->method('process')->with([])->willReturn($processedLayout);
+        $this->serializer->expects($this->once())->method('serialize')->will(
+            $this->returnValue(json_encode($processedLayout))
+        );
 
         $this->assertEquals($jsonLayout, $this->model->getJsLayout());
     }

--- a/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
@@ -32,6 +32,11 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
      */
     protected $layoutProcessorMock;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $serializer;
+
     protected function setUp()
     {
         $contextMock = $this->getMock(\Magento\Framework\View\Element\Template\Context::class, [], [], '', false);
@@ -54,11 +59,15 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
             false
         );
 
+        $this->serializer = new \Magento\Framework\Serialize\Serializer\Json();
+
         $this->model = new \Magento\Checkout\Block\Onepage(
             $contextMock,
             $this->formKeyMock,
             $this->configProviderMock,
-            [$this->layoutProcessorMock]
+            [$this->layoutProcessorMock],
+            [],
+            $this->serializer
         );
     }
 

--- a/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
@@ -66,8 +66,8 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
             $this->formKeyMock,
             $this->configProviderMock,
             [$this->layoutProcessorMock],
-            $this->serializer,
-            []
+            [],
+            $this->serializer
         );
     }
 

--- a/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
@@ -66,8 +66,8 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
             $this->formKeyMock,
             $this->configProviderMock,
             [$this->layoutProcessorMock],
-            [],
-            $this->serializer
+            $this->serializer,
+            []
         );
     }
 

--- a/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
@@ -59,7 +59,7 @@ class OnepageTest extends \PHPUnit_Framework_TestCase
             false
         );
 
-        $this->serializer = $this->getMock(\Magento\Framework\Serialize\SerializerInterface::class,[],[],'',false);
+        $this->serializer = $this->getMock(\Magento\Framework\Serialize\Serializer\Json::class,[],[],'',false);
 
         $this->model = new \Magento\Checkout\Block\Onepage(
             $contextMock,

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
@@ -43,7 +43,7 @@
         </div>
     <?php endif ?>
     <script>
-        window.checkout = <?php /* @escapeNotVerified */ echo \Zend_Json::encode($block->getConfig()); ?>;
+        window.checkout = <?php /* @escapeNotVerified */ echo $block->getSerializedConfig(); ?>;
     </script>
     <script type="text/x-magento-init">
     {

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/shipping.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/shipping.phtml
@@ -25,7 +25,7 @@
             }
         </script>
         <script>
-            window.checkoutConfig = <?php /* @escapeNotVerified */ echo \Zend_Json::encode($block->getCheckoutConfig()); ?>;
+            window.checkoutConfig = <?php /* @escapeNotVerified */ echo $block->getSerializedCheckoutConfig(); ?>;
             window.customerData = window.checkoutConfig.customerData;
             window.isCustomerLoggedIn = window.checkoutConfig.isCustomerLoggedIn;
             require([

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage.phtml
@@ -23,7 +23,7 @@
         }
     </script>
     <script>
-        window.checkoutConfig = <?php /* @escapeNotVerified */ echo \Zend_Json::encode($block->getCheckoutConfig()); ?>;
+        window.checkoutConfig = <?php /* @escapeNotVerified */ echo $block->getSerializedCheckoutConfig(); ?>;
         // Create aliases for customer.js model from customer module
         window.isCustomerLoggedIn = window.checkoutConfig.isCustomerLoggedIn;
         window.customerData = window.checkoutConfig.customerData;


### PR DESCRIPTION
As Zend1 has been EOL we should consider removing Zend1 components in Magento2. In this pull request I am replacing the usage of Zend_Json with the Magento Framework lib's serializer json object.