### PR TITLE
Mark the STDO test as skipped

### DIFF
--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Writer/Csv/StdoTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Writer/Csv/StdoTest.php
@@ -19,6 +19,7 @@ class StdoTest extends \PHPUnit_Framework_TestCase
 
     public function testThatHandlerIsRight()
     {
+        $this->markTestSkipped('This is skiped as we should not close the STDO!');
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         /** @var \Magento\Setup\Module\I18n\Dictionary\Writer\Csv $writer */
         $writer = $objectManagerHelper->getObject(\Magento\Setup\Module\I18n\Dictionary\Writer\Csv\Stdo::class);


### PR DESCRIPTION
This is related to https://github.com/magento/magento2/issues/8315.

Basically phpunit uses the STDO and so we should not close this. Either remove the test or skip the test, I dont mint either.