### PR TITLE
Product->save() shouldn't be called directly

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductWebsiteLinkRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductWebsiteLinkRepository.php
@@ -37,7 +37,7 @@ class ProductWebsiteLinkRepository implements \Magento\Catalog\Api\ProductWebsit
         $product = $this->productRepository->get($productWebsiteLink->getSku());
         $product->setWebsiteIds(array_merge($product->getWebsiteIds(), [$productWebsiteLink->getWebsiteId()]));
         try {
-            $product->save();
+            $this->productRepository->save($product);
         } catch (\Exception $e) {
             throw new CouldNotSaveException(
                 __(
@@ -68,7 +68,7 @@ class ProductWebsiteLinkRepository implements \Magento\Catalog\Api\ProductWebsit
         $product->setWebsiteIds(array_diff($product->getWebsiteIds(), [$websiteId]));
 
         try {
-            $product->save();
+            $this->productRepository->save($product);
         } catch (\Exception $e) {
             throw new CouldNotSaveException(
                 __(


### PR DESCRIPTION
Here is a problem with calling Product->save() directly in ProductWebsiteLinkRepository:

When product has custom options it should have 'has_options' and possibly 'required_options' set to true but calling Product->save() without $product->setCanSaveCustomOptions(true); will result in both 'has_options' and 'required_options' to be set to false.

Also calling $product->save() won't invalidate internal ProductRepository's cache (instances , instancesById) and this would produces other unexpected issues.