### PR TITLE
Replace ext name spaces with dashes (as composer does when storing)

### DIFF
--- a/setup/src/Magento/Setup/Model/PhpInformation.php
+++ b/setup/src/Magento/Setup/Model/PhpInformation.php
@@ -45,7 +45,9 @@ class PhpInformation
     public function getCurrent()
     {
         if (!$this->current) {
-            $this->current = array_map('strtolower', get_loaded_extensions());
+            $this->current = array_map(function ($ext) {
+                return str_replace(' ', '-', strtolower($ext));
+            }, get_loaded_extensions());
         }
         return $this->current;
     }


### PR DESCRIPTION
When trying to run `setup:install` with the PHP extension `opcache` set as a composer requirement, magento will fail with (even if it is installed):

```
Missing following extensions: 'zend-opcache'

Exception trace:
 () at /var/www/setup/src/Magento/Setup/Model/Installer.php:484
 Magento\Setup\Model\Installer->checkExtensions() at n/a:n/a
 call_user_func_array() at /var/www/setup/src/Magento/Setup/Model/Installer.php:344
 Magento\Setup\Model\Installer->install() at /var/www/setup/src/Magento/Setup/Console/Command/InstallCommand.php:125
 Magento\Setup\Console\Command\InstallCommand->execute() at /var/www/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:257
 Symfony\Component\Console\Command\Command->run() at /var/www/vendor/symfony/console/Symfony/Component/Console/Application.php:874
 Symfony\Component\Console\Application->doRunCommand() at /var/www/vendor/symfony/console/Symfony/Component/Console/Application.php:195
 Symfony\Component\Console\Application->doRun() at /var/www/vendor/magento/framework/Console/Cli.php:96
 Magento\Framework\Console\Cli->doRun() at /var/www/vendor/symfony/console/Symfony/Component/Console/Application.php:126
 Symfony\Component\Console\Application->run() at /var/www/bin/magento:23
```

This is because spaces are not being replaced with dashes as composer does for extensions: https://github.com/composer/composer/blob/master/src/Composer/Repository/PlatformRepository.php#L296

Note that the opcache extension does have spaces in it's name `Zend OPcache`:

```
www-data@8e57bf8de2d5:~$ php -a
Interactive shell

php > var_dump(get_loaded_extensions());
php shell code:1:
array(45) {
  [0] =>
  string(4) "Core"
  [1] =>
  string(4) "date"
  [2] =>
  string(6) "libxml"
  [3] =>
  string(7) "openssl"
  [4] =>
  string(4) "pcre"
  [5] =>
  string(7) "sqlite3"
  [6] =>
  string(4) "zlib"
  [7] =>
  string(5) "ctype"
  [8] =>
  string(4) "curl"
  [9] =>
  string(3) "dom"
  [10] =>
  string(8) "fileinfo"
  [11] =>
  string(6) "filter"
  [12] =>
  string(3) "ftp"
  [13] =>
  string(4) "hash"
  [14] =>
  string(5) "iconv"
  [15] =>
  string(4) "json"
  [16] =>
  string(8) "mbstring"
  [17] =>
  string(3) "SPL"
  [18] =>
  string(3) "PDO"
  [19] =>
  string(7) "session"
  [20] =>
  string(5) "posix"
  [21] =>
  string(8) "readline"
  [22] =>
  string(10) "Reflection"
  [23] =>
  string(8) "standard"
  [24] =>
  string(9) "SimpleXML"
  [25] =>
  string(10) "pdo_sqlite"
  [26] =>
  string(4) "Phar"
  [27] =>
  string(9) "tokenizer"
  [28] =>
  string(3) "xml"
  [29] =>
  string(9) "xmlreader"
  [30] =>
  string(9) "xmlwriter"
  [31] =>
  string(7) "mysqlnd"
  [32] =>
  string(9) "blackfire"
  [33] =>
  string(6) "bcmath"
  [34] =>
  string(2) "gd"
  [35] =>
  string(4) "intl"
  [36] =>
  string(6) "mcrypt"
  [37] =>
  string(6) "mysqli"
  [38] =>
  string(5) "pcntl"
  [39] =>
  string(9) "pdo_mysql"
  [40] =>
  string(4) "soap"
  [41] =>
  string(3) "xsl"
  [42] =>
  string(3) "zip"
  [43] =>
  string(12) "Zend OPcache"
  [44] =>
  string(6) "xdebug"
}
```

I'm not sure how to test this as it's not possible to mock `get_loaded_extensions()` without dodgy namespace hacks. Any suggestions? 