### PR TITLE
Make "is_required" and "is_visible" properties of telephone, company and fax attributes of addresses configurable

### DIFF
--- a/app/code/Magento/Customer/Block/Widget/Company.php
+++ b/app/code/Magento/Customer/Block/Widget/Company.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Customer\Block\Widget;
+
+use Magento\Customer\Api\AddressMetadataInterface;
+use Magento\Customer\Api\CustomerMetadataInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Helper\Address as AddressHelper;
+use Magento\Customer\Model\Options;
+use Magento\Framework\View\Element\Template\Context;
+
+/**
+ * Widget for showing customer company.
+ *
+ * @method CustomerInterface getObject()
+ * @method Name setObject(CustomerInterface $customer)
+ *
+ * @SuppressWarnings(PHPMD.DepthOfInheritance)
+ */
+class Company extends AbstractWidget
+{
+
+    /**
+     * the attribute code
+     */
+    const ATTRIBUTE_CODE = 'company';
+
+    /**
+     * @var AddressMetadataInterface
+     */
+    protected $addressMetadata;
+
+    /**
+     * @var Options
+     */
+    protected $options;
+
+    /**
+     * @param Context                   $context
+     * @param AddressHelper             $addressHelper
+     * @param CustomerMetadataInterface $customerMetadata
+     * @param Options                   $options
+     * @param AddressMetadataInterface  $addressMetadata
+     * @param array                     $data
+     */
+    public function __construct(
+        Context $context,
+        AddressHelper $addressHelper,
+        CustomerMetadataInterface $customerMetadata,
+        Options $options,
+        AddressMetadataInterface $addressMetadata,
+        array $data = []
+    )
+    {
+        $this->options = $options;
+        parent::__construct($context, $addressHelper, $customerMetadata, $data);
+        $this->addressMetadata = $addressMetadata;
+        $this->_isScopePrivate = true;
+    }
+
+    /**
+     * @return void
+     */
+    public function _construct()
+    {
+        parent::_construct();
+
+        // default template location
+        $this->setTemplate('widget/company.phtml');
+    }
+
+    /**
+     * Can show config value
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    protected function _showConfig($key)
+    {
+        return (bool)$this->getConfig($key);
+    }
+
+    /**
+     * Can show prefix
+     *
+     * @return bool
+     */
+    public function showCompany()
+    {
+        return $this->_isAttributeVisible(self::ATTRIBUTE_CODE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function _getAttribute($attributeCode)
+    {
+        if ($this->getForceUseCustomerAttributes() || $this->getObject() instanceof CustomerInterface) {
+            return parent::_getAttribute($attributeCode);
+        }
+
+        try {
+            $attribute = $this->addressMetadata->getAttributeMetadata($attributeCode);
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            return null;
+        }
+
+        if ($this->getForceUseCustomerRequiredAttributes() && $attribute && !$attribute->isRequired()) {
+            $customerAttribute = parent::_getAttribute($attributeCode);
+            if ($customerAttribute && $customerAttribute->isRequired()) {
+                $attribute = $customerAttribute;
+            }
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * Retrieve store attribute label
+     *
+     * @param string $attributeCode
+     *
+     * @return string
+     */
+    public function getStoreLabel($attributeCode)
+    {
+        $attribute = $this->_getAttribute($attributeCode);
+        return $attribute ? __($attribute->getStoreLabel()) : '';
+    }
+
+    /**
+     * Get string with frontend validation classes for attribute
+     *
+     * @param string $attributeCode
+     *
+     * @return string
+     */
+    public function getAttributeValidationClass($attributeCode)
+    {
+        return $this->_addressHelper->getAttributeValidationClass($attributeCode);
+    }
+
+    /**
+     * @param string $attributeCode
+     *
+     * @return bool
+     */
+    private function _isAttributeVisible($attributeCode)
+    {
+        $attributeMetadata = $this->_getAttribute($attributeCode);
+        return $attributeMetadata ? (bool)$attributeMetadata->isVisible() : false;
+    }
+
+    /**
+     * Check if company attribute enabled in system
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->_getAttribute(self::ATTRIBUTE_CODE) ? (bool)$this->_getAttribute(self::ATTRIBUTE_CODE)->isVisible(
+        ) : false;
+    }
+
+    /**
+     * Check if company attribute marked as required
+     *
+     * @return bool
+     */
+    public function isRequired()
+    {
+        return $this->_getAttribute(self::ATTRIBUTE_CODE) ? (bool)$this->_getAttribute(self::ATTRIBUTE_CODE)
+            ->isRequired() : false;
+    }
+}

--- a/app/code/Magento/Customer/Block/Widget/Fax.php
+++ b/app/code/Magento/Customer/Block/Widget/Fax.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Customer\Block\Widget;
+
+use Magento\Customer\Api\AddressMetadataInterface;
+use Magento\Customer\Api\CustomerMetadataInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Helper\Address as AddressHelper;
+use Magento\Customer\Model\Options;
+use Magento\Framework\View\Element\Template\Context;
+
+/**
+ * Widget for showing customer company.
+ *
+ * @method CustomerInterface getObject()
+ * @method Name setObject(CustomerInterface $customer)
+ *
+ * @SuppressWarnings(PHPMD.DepthOfInheritance)
+ */
+class Fax extends AbstractWidget
+{
+
+    /**
+     * the attribute code
+     */
+    const ATTRIBUTE_CODE = 'fax';
+
+    /**
+     * @var AddressMetadataInterface
+     */
+    protected $addressMetadata;
+
+    /**
+     * @var Options
+     */
+    protected $options;
+
+    /**
+     * @param Context                   $context
+     * @param AddressHelper             $addressHelper
+     * @param CustomerMetadataInterface $customerMetadata
+     * @param Options                   $options
+     * @param AddressMetadataInterface  $addressMetadata
+     * @param array                     $data
+     */
+    public function __construct(
+        Context $context,
+        AddressHelper $addressHelper,
+        CustomerMetadataInterface $customerMetadata,
+        Options $options,
+        AddressMetadataInterface $addressMetadata,
+        array $data = []
+    )
+    {
+        $this->options = $options;
+        parent::__construct($context, $addressHelper, $customerMetadata, $data);
+        $this->addressMetadata = $addressMetadata;
+        $this->_isScopePrivate = true;
+    }
+
+    /**
+     * @return void
+     */
+    public function _construct()
+    {
+        parent::_construct();
+
+        // default template location
+        $this->setTemplate('widget/fax.phtml');
+    }
+
+    /**
+     * Can show config value
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    protected function _showConfig($key)
+    {
+        return (bool)$this->getConfig($key);
+    }
+
+    /**
+     * Can show prefix
+     *
+     * @return bool
+     */
+    public function showFax()
+    {
+        return $this->_isAttributeVisible(self::ATTRIBUTE_CODE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function _getAttribute($attributeCode)
+    {
+        if ($this->getForceUseCustomerAttributes() || $this->getObject() instanceof CustomerInterface) {
+            return parent::_getAttribute($attributeCode);
+        }
+
+        try {
+            $attribute = $this->addressMetadata->getAttributeMetadata($attributeCode);
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            return null;
+        }
+
+        if ($this->getForceUseCustomerRequiredAttributes() && $attribute && !$attribute->isRequired()) {
+            $customerAttribute = parent::_getAttribute($attributeCode);
+            if ($customerAttribute && $customerAttribute->isRequired()) {
+                $attribute = $customerAttribute;
+            }
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * Retrieve store attribute label
+     *
+     * @param string $attributeCode
+     *
+     * @return string
+     */
+    public function getStoreLabel($attributeCode)
+    {
+        $attribute = $this->_getAttribute($attributeCode);
+        return $attribute ? __($attribute->getStoreLabel()) : '';
+    }
+
+    /**
+     * Get string with frontend validation classes for attribute
+     *
+     * @param string $attributeCode
+     *
+     * @return string
+     */
+    public function getAttributeValidationClass($attributeCode)
+    {
+        return $this->_addressHelper->getAttributeValidationClass($attributeCode);
+    }
+
+    /**
+     * @param string $attributeCode
+     *
+     * @return bool
+     */
+    private function _isAttributeVisible($attributeCode)
+    {
+        $attributeMetadata = $this->_getAttribute($attributeCode);
+        return $attributeMetadata ? (bool)$attributeMetadata->isVisible() : false;
+    }
+
+    /**
+     * Check if company attribute enabled in system
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->_getAttribute(self::ATTRIBUTE_CODE) ? (bool)$this->_getAttribute(self::ATTRIBUTE_CODE)->isVisible(
+        ) : false;
+    }
+
+    /**
+     * Check if company attribute marked as required
+     *
+     * @return bool
+     */
+    public function isRequired()
+    {
+        return $this->_getAttribute(self::ATTRIBUTE_CODE) ? (bool)$this->_getAttribute(self::ATTRIBUTE_CODE)
+            ->isRequired() : false;
+    }
+}

--- a/app/code/Magento/Customer/Block/Widget/Telephone.php
+++ b/app/code/Magento/Customer/Block/Widget/Telephone.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Customer\Block\Widget;
+
+use Magento\Customer\Api\AddressMetadataInterface;
+use Magento\Customer\Api\CustomerMetadataInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Helper\Address as AddressHelper;
+use Magento\Customer\Model\Options;
+use Magento\Framework\View\Element\Template\Context;
+
+/**
+ * Widget for showing customer telephone.
+ *
+ * @method CustomerInterface getObject()
+ * @method Name setObject(CustomerInterface $customer)
+ *
+ * @SuppressWarnings(PHPMD.DepthOfInheritance)
+ */
+class Telephone extends AbstractWidget
+{
+
+    /**
+     * the attribute code
+     */
+    const ATTRIBUTE_CODE = 'telephone';
+
+    /**
+     * @var AddressMetadataInterface
+     */
+    protected $addressMetadata;
+
+    /**
+     * @var Options
+     */
+    protected $options;
+
+    /**
+     * @param Context                   $context
+     * @param AddressHelper             $addressHelper
+     * @param CustomerMetadataInterface $customerMetadata
+     * @param Options                   $options
+     * @param AddressMetadataInterface  $addressMetadata
+     * @param array                     $data
+     */
+    public function __construct(
+        Context $context,
+        AddressHelper $addressHelper,
+        CustomerMetadataInterface $customerMetadata,
+        Options $options,
+        AddressMetadataInterface $addressMetadata,
+        array $data = []
+    )
+    {
+        $this->options = $options;
+        parent::__construct($context, $addressHelper, $customerMetadata, $data);
+        $this->addressMetadata = $addressMetadata;
+        $this->_isScopePrivate = true;
+    }
+
+    /**
+     * @return void
+     */
+    public function _construct()
+    {
+        parent::_construct();
+
+        // default template location
+        $this->setTemplate('widget/telephone.phtml');
+    }
+
+    /**
+     * Can show config value
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    protected function _showConfig($key)
+    {
+        return (bool)$this->getConfig($key);
+    }
+
+    /**
+     * Can show prefix
+     *
+     * @return bool
+     */
+    public function showTelephone()
+    {
+        return $this->_isAttributeVisible(self::ATTRIBUTE_CODE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function _getAttribute($attributeCode)
+    {
+        if ($this->getForceUseCustomerAttributes() || $this->getObject() instanceof CustomerInterface) {
+            return parent::_getAttribute($attributeCode);
+        }
+
+        try {
+            $attribute = $this->addressMetadata->getAttributeMetadata($attributeCode);
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            return null;
+        }
+
+        if ($this->getForceUseCustomerRequiredAttributes() && $attribute && !$attribute->isRequired()) {
+            $customerAttribute = parent::_getAttribute($attributeCode);
+            if ($customerAttribute && $customerAttribute->isRequired()) {
+                $attribute = $customerAttribute;
+            }
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * Retrieve store attribute label
+     *
+     * @param string $attributeCode
+     *
+     * @return string
+     */
+    public function getStoreLabel($attributeCode)
+    {
+        $attribute = $this->_getAttribute($attributeCode);
+        return $attribute ? __($attribute->getStoreLabel()) : '';
+    }
+
+    /**
+     * Get string with frontend validation classes for attribute
+     *
+     * @param string $attributeCode
+     *
+     * @return string
+     */
+    public function getAttributeValidationClass($attributeCode)
+    {
+        return $this->_addressHelper->getAttributeValidationClass($attributeCode);
+    }
+
+    /**
+     * @param string $attributeCode
+     *
+     * @return bool
+     */
+    private function _isAttributeRequired($attributeCode)
+    {
+        $attributeMetadata = $this->_getAttribute($attributeCode);
+        return $attributeMetadata ? (bool)$attributeMetadata->isRequired() : false;
+    }
+
+    /**
+     * @param string $attributeCode
+     *
+     * @return bool
+     */
+    private function _isAttributeVisible($attributeCode)
+    {
+        $attributeMetadata = $this->_getAttribute($attributeCode);
+        return $attributeMetadata ? (bool)$attributeMetadata->isVisible() : false;
+    }
+
+    /**
+     * Check if telephone attribute enabled in system
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->_getAttribute(self::ATTRIBUTE_CODE) ? (bool)$this->_getAttribute(self::ATTRIBUTE_CODE)->isVisible(
+        ) : false;
+    }
+
+    /**
+     * Check if telephone attribute marked as required
+     *
+     * @return bool
+     */
+    public function isRequired()
+    {
+        return $this->_getAttribute(self::ATTRIBUTE_CODE) ? (bool)$this->_getAttribute(self::ATTRIBUTE_CODE)
+            ->isRequired() : false;
+    }
+}

--- a/app/code/Magento/Customer/Block/Widget/Telephone.php
+++ b/app/code/Magento/Customer/Block/Widget/Telephone.php
@@ -150,17 +150,6 @@ class Telephone extends AbstractWidget
      *
      * @return bool
      */
-    private function _isAttributeRequired($attributeCode)
-    {
-        $attributeMetadata = $this->_getAttribute($attributeCode);
-        return $attributeMetadata ? (bool)$attributeMetadata->isRequired() : false;
-    }
-
-    /**
-     * @param string $attributeCode
-     *
-     * @return bool
-     */
     private function _isAttributeVisible($attributeCode)
     {
         $attributeMetadata = $this->_getAttribute($attributeCode);

--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -579,9 +579,11 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
             $errors[] = __('%fieldName is a required field.', ['fieldName' => 'city']);
         }
 
-        if (!\Zend_Validate::is($this->getTelephone(), 'NotEmpty')) {
-            $errors[] = __('%fieldName is a required field.', ['fieldName' => 'telephone']);
+        if ($this->isTelephoneFieldRequired()) {
+            if (!\Zend_Validate::is($this->getTelephone(), 'NotEmpty')) {
+                $errors[] = __('%fieldName is a required field.', ['fieldName' => 'telephone']);
 
+            }
         }
 
         $_havingOptionalZip = $this->_directoryData->getCountriesWithOptionalZip();
@@ -639,5 +641,13 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
     public function unsRegion()
     {
         return $this->unsetData("region");
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isTelephoneFieldRequired()
+    {
+        return ($this->_eavConfig->getAttribute('customer_address', 'telephone')->getIsRequired());
     }
 }

--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -579,7 +579,7 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
             $errors[] = __('%fieldName is a required field.', ['fieldName' => 'city']);
         }
 
-        if ($this->isTelephoneFieldRequired()) {
+        if ($this->isTelephoneRequired()) {
             if (!\Zend_Validate::is($this->getTelephone(), 'NotEmpty')) {
                 $errors[] = __('%fieldName is a required field.', ['fieldName' => 'telephone']);
 
@@ -646,7 +646,7 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
     /**
      * @return bool
      */
-    protected function isTelephoneFieldRequired()
+    protected function isTelephoneRequired()
     {
         return ($this->_eavConfig->getAttribute('customer_address', 'telephone')->getIsRequired());
     }

--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -25,6 +25,8 @@ use Magento\Framework\Model\AbstractExtensibleModel;
  * @method int getCountryId()
  * @method string getCity()
  * @method string getTelephone()
+ * @method string getCompany()
+ * @method string getFax()
  * @method string getPostcode()
  * @method bool getShouldIgnoreValidation()
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -586,6 +588,20 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
             }
         }
 
+        if ($this->isFaxRequired()) {
+            if (!\Zend_Validate::is($this->getFax(), 'NotEmpty')) {
+                $errors[] = __('%fieldName is a required field.', ['fieldName' => 'fax']);
+
+            }
+        }
+
+        if ($this->isCompanyRequired()) {
+            if (!\Zend_Validate::is($this->getCompany(), 'NotEmpty')) {
+                $errors[] = __('%fieldName is a required field.', ['fieldName' => 'company']);
+
+            }
+        }
+
         $_havingOptionalZip = $this->_directoryData->getCountriesWithOptionalZip();
         if (!in_array(
             $this->getCountryId(),
@@ -646,8 +662,24 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
     /**
      * @return bool
      */
+    protected function isCompanyRequired()
+    {
+        return ($this->_eavConfig->getAttribute('customer_address', 'company')->getIsRequired());
+    }
+
+    /**
+     * @return bool
+     */
     protected function isTelephoneRequired()
     {
         return ($this->_eavConfig->getAttribute('customer_address', 'telephone')->getIsRequired());
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isFaxRequired()
+    {
+        return ($this->_eavConfig->getAttribute('customer_address', 'fax')->getIsRequired());
     }
 }

--- a/app/code/Magento/Customer/Model/Config/Backend/Show/AddressOnly.php
+++ b/app/code/Magento/Customer/Model/Config/Backend/Show/AddressOnly.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Model\Config\Backend\Show;
+
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
+
+/**
+ * Customer Show Address Model
+ *
+ * @author     Magento Core Team <core@magentocommerce.com>
+ */
+class AddressOnly extends Customer
+{
+    /**
+     * Retrieve attribute objects
+     *
+     * @return AbstractAttribute[]
+     */
+    protected function _getAttributeObjects()
+    {
+        return [$this->_eavConfig->getAttribute('customer_address', $this->_getAttributeCode())];
+    }
+}

--- a/app/code/Magento/Customer/etc/adminhtml/system.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/system.xml
@@ -232,6 +232,11 @@
                     <source_model>Magento\Config\Model\Config\Source\Nooptreq</source_model>
                     <backend_model>Magento\Customer\Model\Config\Backend\Show\Customer</backend_model>
                 </field>
+                <field id="telephone_show" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Show Telephone</label>
+                    <source_model>Magento\Config\Model\Config\Source\Nooptreq</source_model>
+                    <backend_model>Magento\Customer\Model\Config\Backend\Show\Customer</backend_model>
+                </field>
             </group>
             <group id="startup" translate="label" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Login Options</label>

--- a/app/code/Magento/Customer/etc/adminhtml/system.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/system.xml
@@ -235,7 +235,7 @@
                 <field id="telephone_show" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Show Telephone</label>
                     <source_model>Magento\Config\Model\Config\Source\Nooptreq</source_model>
-                    <backend_model>Magento\Customer\Model\Config\Backend\Show\Customer</backend_model>
+                    <backend_model>Magento\Customer\Model\Config\Backend\Show\AddressOnly</backend_model>
                 </field>
             </group>
             <group id="startup" translate="label" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/app/code/Magento/Customer/etc/adminhtml/system.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/system.xml
@@ -237,6 +237,16 @@
                     <source_model>Magento\Config\Model\Config\Source\Nooptreq</source_model>
                     <backend_model>Magento\Customer\Model\Config\Backend\Show\AddressOnly</backend_model>
                 </field>
+                <field id="company_show" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Show Company</label>
+                    <source_model>Magento\Config\Model\Config\Source\Nooptreq</source_model>
+                    <backend_model>Magento\Customer\Model\Config\Backend\Show\AddressOnly</backend_model>
+                </field>
+                <field id="fax_show" translate="label" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Show Fax</label>
+                    <source_model>Magento\Config\Model\Config\Source\Nooptreq</source_model>
+                    <backend_model>Magento\Customer\Model\Config\Backend\Show\AddressOnly</backend_model>
+                </field>
             </group>
             <group id="startup" translate="label" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Login Options</label>

--- a/app/code/Magento/Customer/etc/config.xml
+++ b/app/code/Magento/Customer/etc/config.xml
@@ -52,6 +52,8 @@
                 <dob_show />
                 <gender_show />
                 <telephone_show>req</telephone_show>
+                <company_show>opt</company_show>
+                <fax_show/>
             </address>
             <startup>
                 <redirect_dashboard>1</redirect_dashboard>

--- a/app/code/Magento/Customer/etc/config.xml
+++ b/app/code/Magento/Customer/etc/config.xml
@@ -51,6 +51,7 @@
                 <suffix_options />
                 <dob_show />
                 <gender_show />
+                <telephone_show>req</telephone_show>
             </address>
             <startup>
                 <redirect_dashboard>1</redirect_dashboard>

--- a/app/code/Magento/Customer/etc/config.xml
+++ b/app/code/Magento/Customer/etc/config.xml
@@ -65,7 +65,7 @@
 {{depend street4}}{{var street4}}{{/depend}}
 {{if city}}{{var city}},  {{/if}}{{if region}}{{var region}}, {{/if}}{{if postcode}}{{var postcode}}{{/if}}
 {{var country}}
-T: {{var telephone}}
+{{depend telephone}}T: {{var telephone}}{{/depend}}
 {{depend fax}}F: {{var fax}}{{/depend}}
 {{depend vat_id}}VAT: {{var vat_id}}{{/depend}}</text>
                 <oneline>{{depend prefix}}{{var prefix}} {{/depend}}{{var firstname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var lastname}}{{depend suffix}} {{var suffix}}{{/depend}}, {{var street}}, {{var city}}, {{var region}} {{var postcode}}, {{var country}}</oneline>

--- a/app/code/Magento/Customer/i18n/en_US.csv
+++ b/app/code/Magento/Customer/i18n/en_US.csv
@@ -192,6 +192,8 @@ Customers,Customers
 "Please enter the street.","Please enter the street."
 "Please enter the city.","Please enter the city."
 "Please enter the phone number.","Please enter the phone number."
+"Please enter the fax number.","Please enter the fax number."
+"Please enter the company.","Please enter the company."
 "Please enter the zip/postal code.","Please enter the zip/postal code."
 "Please enter the country.","Please enter the country."
 "Please enter the state/province.","Please enter the state/province."

--- a/app/code/Magento/Customer/i18n/en_US.csv
+++ b/app/code/Magento/Customer/i18n/en_US.csv
@@ -475,6 +475,8 @@ Password:,Password:
 "Show Tax/VAT Number","Show Tax/VAT Number"
 "Show Gender","Show Gender"
 "Show Telephone","Show Telephone"
+"Show Company","Show Company"
+"Show Fax","Show Fax"
 "Login Options","Login Options"
 "Redirect Customer to Account Dashboard after Logging in","Redirect Customer to Account Dashboard after Logging in"
 "Customer will stay on the current page if ""No"" is selected.","Customer will stay on the current page if ""No"" is selected."

--- a/app/code/Magento/Customer/i18n/en_US.csv
+++ b/app/code/Magento/Customer/i18n/en_US.csv
@@ -474,6 +474,7 @@ Password:,Password:
 "Show Date of Birth","Show Date of Birth"
 "Show Tax/VAT Number","Show Tax/VAT Number"
 "Show Gender","Show Gender"
+"Show Telephone","Show Telephone"
 "Login Options","Login Options"
 "Redirect Customer to Account Dashboard after Logging in","Redirect Customer to Account Dashboard after Logging in"
 "Customer will stay on the current page if ""No"" is selected.","Customer will stay on the current page if ""No"" is selected."

--- a/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
@@ -8,6 +8,7 @@
 
 /** @var \Magento\Customer\Block\Address\Edit $block */
 ?>
+<?php $_telephone = $block->getLayout()->createBlock('Magento\Customer\Block\Widget\Telephone') ?>
 <form class="form-address-edit"
       action="<?php echo $block->escapeUrl($block->getSaveUrl()) ?>"
       method="post"
@@ -31,19 +32,11 @@
                        class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('company')) ?>">
             </div>
         </div>
-        <div class="field telephone required">
-            <label class="label" for="telephone">
-                <span><?php echo $block->escapeHtml(__('Phone Number')) ?></span>
-            </label>
-            <div class="control">
-                <input type="text"
-                       name="telephone"
-                       value="<?php echo $block->escapeHtmlAttr($block->getAddress()->getTelephone()) ?>"
-                       title="<?php echo $block->escapeHtmlAttr(__('Phone Number')) ?>"
-                       class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('telephone')) ?>"
-                       id="telephone">
-            </div>
-        </div>
+
+        <?php if ($_telephone->isEnabled()): ?>
+            <?php echo $_telephone->setTelephone($block->getAddress()->getTelephone())->toHtml() ?>
+        <?php endif ?>
+
         <div class="field fax">
             <label class="label" for="fax"><span><?php echo $block->escapeHtml(__('Fax')) ?></span></label>
             <div class="control">

--- a/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
@@ -8,7 +8,9 @@
 
 /** @var \Magento\Customer\Block\Address\Edit $block */
 ?>
+<?php $_company = $block->getLayout()->createBlock('Magento\Customer\Block\Widget\Company') ?>
 <?php $_telephone = $block->getLayout()->createBlock('Magento\Customer\Block\Widget\Telephone') ?>
+<?php $_fax = $block->getLayout()->createBlock('Magento\Customer\Block\Widget\Fax') ?>
 <form class="form-address-edit"
       action="<?php echo $block->escapeUrl($block->getSaveUrl()) ?>"
       method="post"
@@ -21,33 +23,19 @@
         <input type="hidden" name="success_url" value="<?php echo $block->escapeUrl($block->getSuccessUrl()) ?>">
         <input type="hidden" name="error_url" value="<?php echo $block->escapeUrl($block->getErrorUrl()) ?>">
         <?php echo $block->getNameBlockHtml() ?>
-        <div class="field company">
-            <label class="label" for="company"><span><?php echo $block->escapeHtml(__('Company')) ?></span></label>
-            <div class="control">
-                <input type="text"
-                       name="company"
-                       id="company"
-                       title="<?php echo $block->escapeHtmlAttr(__('Company')) ?>"
-                       value="<?php echo $block->escapeHtmlAttr($block->getAddress()->getCompany()) ?>"
-                       class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('company')) ?>">
-            </div>
-        </div>
+
+        <?php if ($_company->isEnabled()): ?>
+            <?php echo $_company->setCompany($block->getAddress()->getCompany())->toHtml() ?>
+        <?php endif ?>
 
         <?php if ($_telephone->isEnabled()): ?>
             <?php echo $_telephone->setTelephone($block->getAddress()->getTelephone())->toHtml() ?>
         <?php endif ?>
 
-        <div class="field fax">
-            <label class="label" for="fax"><span><?php echo $block->escapeHtml(__('Fax')) ?></span></label>
-            <div class="control">
-                <input type="text"
-                       name="fax"
-                       id="fax"
-                       title="<?php echo $block->escapeHtmlAttr(__('Fax')) ?>"
-                       value="<?php echo $block->escapeHtmlAttr($block->getAddress()->getFax()) ?>"
-                       class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('fax')) ?>">
-            </div>
-        </div>
+        <?php if ($_fax->isEnabled()): ?>
+            <?php echo $_fax->setFax($block->getAddress()->getFax())->toHtml() ?>
+        <?php endif ?>
+
     </fieldset>
     <fieldset class="fieldset">
         <legend class="legend"><span><?php echo $block->escapeHtml(__('Address')) ?></span></legend><br>

--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -45,16 +45,20 @@
         <fieldset class="fieldset address">
             <legend class="legend"><span><?php echo $block->escapeHtml(__('Address Information')) ?></span></legend><br>
             <input type="hidden" name="create_address" value="1" />
-            <div class="field company">
-                <label for="company" class="label"><span><?php echo $block->escapeHtml(__('Company')) ?></span></label>
-                <div class="control">
-                    <input type="text" name="company" id="company" value="<?php echo $block->escapeHtmlAttr($block->getFormData()->getCompany()) ?>" title="<?php echo $block->escapeHtmlAttr(__('Company')) ?>" class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('company')) ?>">
-                </div>
-            </div>
+
+            <?php $_company = $block->getLayout()->createBlock('Magento\Customer\Block\Widget\Company') ?>
+            <?php if ($_company->isEnabled()): ?>
+                <?php echo $_company->setCompany($block->getFormData()->getCompany())->toHtml() ?>
+            <?php endif ?>
 
             <?php $_telephone = $block->getLayout()->createBlock('Magento\Customer\Block\Widget\Telephone') ?>
             <?php if ($_telephone->isEnabled()): ?>
                 <?php echo $_telephone->setTelephone($block->getFormData()->getTelephone())->toHtml() ?>
+            <?php endif ?>
+
+            <?php $_fax = $block->getLayout()->createBlock('Magento\Customer\Block\Widget\Fax') ?>
+            <?php if ($_fax->isEnabled()): ?>
+                <?php echo $_fax->setFax($block->getFormData()->getFax())->toHtml() ?>
             <?php endif ?>
 
             <?php $_streetValidationClass = $this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('street'); ?>

--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -51,12 +51,11 @@
                     <input type="text" name="company" id="company" value="<?php echo $block->escapeHtmlAttr($block->getFormData()->getCompany()) ?>" title="<?php echo $block->escapeHtmlAttr(__('Company')) ?>" class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('company')) ?>">
                 </div>
             </div>
-            <div class="field telephone">
-                <label for="telephone" class="label"><span><?php echo $block->escapeHtml(__('Phone Number')) ?></span></label>
-                <div class="control">
-                    <input type="text" name="telephone" id="telephone" value="<?php echo $block->escapeHtmlAttr($block->getFormData()->getTelephone()) ?>" title="<?php echo $block->escapeHtmlAttr(__('Phone Number')) ?>" class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('telephone')) ?>">
-                </div>
-            </div>
+
+            <?php $_telephone = $block->getLayout()->createBlock('Magento\Customer\Block\Widget\Telephone') ?>
+            <?php if ($_telephone->isEnabled()): ?>
+                <?php echo $_telephone->setTelephone($block->getFormData()->getTelephone())->toHtml() ?>
+            <?php endif ?>
 
             <?php $_streetValidationClass = $this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('street'); ?>
 
@@ -176,7 +175,7 @@ require([
 
     var dataForm = $('#form-validate');
     var ignore = <?php /* @noEscape */ echo $_dob->isEnabled() ? '\'input[id$="full"]\'' : 'null'; ?>;
-    
+
     dataForm.mage('validation', {
     <?php if ($_dob->isEnabled()): ?>
         errorPlacement: function(error, element) {

--- a/app/code/Magento/Customer/view/frontend/templates/widget/company.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/company.phtml
@@ -8,10 +8,25 @@
 
 /** @var \Magento\Customer\Block\Widget\Company $block */
 ?>
-
-<div class="field company<?php if ($block->isRequired()) echo ' required' ?>">
-    <label for="company" class="label"><span><?php echo $block->escapeHtml(__('Company')) ?></span></label>
+<div class="field company <?php echo $block->isRequired() ? 'required' : '' ?>">
+    <label for="company" class="label">
+        <span>
+            <?php echo $block->escapeHtml(__('Company')) ?>
+        </span>
+    </label>
     <div class="control">
-        <input type="text" name="company" id="company" value="<?php echo $block->escapeHtmlAttr($block->getCompany()) ?>" title="<?php echo $block->escapeHtmlAttr(__('Company')) ?>" class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('company')) ?>">
+        <?php
+            $_validationClass = $block->escapeHtmlAttr(
+                $this->helper('Magento\Customer\Helper\Address')
+                     ->getAttributeValidationClass('company')
+            );
+        ?>
+        <input type="text"
+               name="company"
+               id="company"
+               value="<?php echo $block->escapeHtmlAttr($block->getCompany()) ?>"
+               title="<?php echo $block->escapeHtmlAttr(__('Company')) ?>"
+               class="input-text <?php echo $_validationClass ?: '' ?>"
+         >
     </div>
 </div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/company.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/company.phtml
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// @codingStandardsIgnoreFile
+
+/** @var \Magento\Customer\Block\Widget\Company $block */
+?>
+
+<div class="field company<?php if ($block->isRequired()) echo ' required' ?>">
+    <label for="company" class="label"><span><?php echo $block->escapeHtml(__('Company')) ?></span></label>
+    <div class="control">
+        <input type="text" name="company" id="company" value="<?php echo $block->escapeHtmlAttr($block->getCompany()) ?>" title="<?php echo $block->escapeHtmlAttr(__('Company')) ?>" class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('company')) ?>">
+    </div>
+</div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/fax.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/fax.phtml
@@ -9,9 +9,25 @@
 /** @var \Magento\Customer\Block\Widget\Fax $block */
 ?>
 
-<div class="field fax<?php if ($block->isRequired()) echo ' required' ?>">
-    <label for="fax" class="label"><span><?php echo $block->escapeHtml(__('Fax')) ?></span></label>
+<div class="field fax <?php echo $block->isRequired() ? 'required' : '' ?>">
+    <label for="fax" class="label">
+        <span>
+            <?php echo $block->escapeHtml(__('Fax')) ?>
+        </span>
+    </label>
     <div class="control">
-        <input type="text" name="fax" id="fax" value="<?php echo $block->escapeHtmlAttr($block->getFax()) ?>" title="<?php echo $block->escapeHtmlAttr(__('Fax')) ?>" class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('fax')) ?>">
+        <?php
+            $_validationClass = $block->escapeHtmlAttr(
+                $this->helper('Magento\Customer\Helper\Address')
+                     ->getAttributeValidationClass('fax')
+            );
+        ?>
+        <input type="text"
+               name="fax"
+               id="fax"
+               value="<?php echo $block->escapeHtmlAttr($block->getFax()) ?>"
+               title="<?php echo $block->escapeHtmlAttr(__('Fax')) ?>"
+               class="input-text <?php echo $_validationClass ?: '' ?>"
+        >
     </div>
 </div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/fax.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/fax.phtml
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// @codingStandardsIgnoreFile
+
+/** @var \Magento\Customer\Block\Widget\Fax $block */
+?>
+
+<div class="field fax<?php if ($block->isRequired()) echo ' required' ?>">
+    <label for="fax" class="label"><span><?php echo $block->escapeHtml(__('Fax')) ?></span></label>
+    <div class="control">
+        <input type="text" name="fax" id="fax" value="<?php echo $block->escapeHtmlAttr($block->getFax()) ?>" title="<?php echo $block->escapeHtmlAttr(__('Fax')) ?>" class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('fax')) ?>">
+    </div>
+</div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/telephone.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/telephone.phtml
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// @codingStandardsIgnoreFile
+
+/** @var \Magento\Customer\Block\Widget\Telephone $block */
+?>
+
+<div class="field telephone<?php if ($block->isRequired()) echo ' required' ?>">
+    <label for="telephone" class="label"><span><?php echo $block->escapeHtml(__('Phone Number')) ?></span></label>
+    <div class="control">
+        <input type="text" name="telephone" id="telephone" value="<?php echo $block->escapeHtmlAttr($block->getTelephone()) ?>" title="<?php echo $block->escapeHtmlAttr(__('Phone Number')) ?>" class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('telephone')) ?>">
+    </div>
+</div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/telephone.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/telephone.phtml
@@ -9,9 +9,25 @@
 /** @var \Magento\Customer\Block\Widget\Telephone $block */
 ?>
 
-<div class="field telephone<?php if ($block->isRequired()) echo ' required' ?>">
-    <label for="telephone" class="label"><span><?php echo $block->escapeHtml(__('Phone Number')) ?></span></label>
+<div class="field telephone <?php echo $block->isRequired() ? 'required' : '' ?>">
+    <label for="telephone" class="label">
+        <span>
+            <?php echo $block->escapeHtml(__('Phone Number')) ?>
+        </span>
+    </label>
     <div class="control">
-        <input type="text" name="telephone" id="telephone" value="<?php echo $block->escapeHtmlAttr($block->getTelephone()) ?>" title="<?php echo $block->escapeHtmlAttr(__('Phone Number')) ?>" class="input-text <?php echo $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('telephone')) ?>">
+        <?php
+            $_validationClass = $block->escapeHtmlAttr(
+                $this->helper('Magento\Customer\Helper\Address')
+                     ->getAttributeValidationClass('fax')
+            );
+        ?>
+        <input type="text"
+               name="telephone"
+               id="telephone"
+               value="<?php echo $block->escapeHtmlAttr($block->getTelephone()) ?>"
+               title="<?php echo $block->escapeHtmlAttr(__('Phone Number')) ?>"
+               class="input-text <?php echo $_validationClass ?: '' ?>"
+        >
     </div>
 </div>

--- a/app/code/Magento/Sales/Model/Order/Address/Validator.php
+++ b/app/code/Magento/Sales/Model/Order/Address/Validator.php
@@ -61,6 +61,14 @@ class Validator
         if ($this->isTelephoneRequired()) {
             $this->required['telephone'] = 'Phone Number';
         }
+
+        if ($this->isCompanyRequired()) {
+            $this->required['company'] = 'Company';
+        }
+
+        if ($this->isFaxRequired()) {
+            $this->required['fax'] = 'Fax';
+        }
     }
 
     /**
@@ -121,6 +129,18 @@ class Validator
             }
         }
 
+        if ($this->isCompanyRequired()) {
+            if ($this->isEmpty($address->getCompany())) {
+                $errors[] = __('Please enter the company.');
+            }
+        }
+
+        if ($this->isFaxRequired()) {
+            if ($this->isEmpty($address->getFax())) {
+                $errors[] = __('Please enter the fax number.');
+            }
+        }
+
         $countryId = $address->getCountryId();
 
         if ($this->isZipRequired($countryId) && $this->isEmpty($address->getPostcode())) {
@@ -176,5 +196,21 @@ class Validator
     protected function isTelephoneRequired()
     {
         return ($this->eavConfig->getAttribute('customer_address', 'telephone')->getIsRequired());
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isCompanyRequired()
+    {
+        return ($this->eavConfig->getAttribute('customer_address', 'company')->getIsRequired());
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isFaxRequired()
+    {
+        return ($this->eavConfig->getAttribute('customer_address', 'fax')->getIsRequired());
     }
 }

--- a/app/code/Magento/Sales/Model/Order/Address/Validator.php
+++ b/app/code/Magento/Sales/Model/Order/Address/Validator.php
@@ -47,7 +47,8 @@ class Validator
 
     /**
      * @param DirectoryHelper $directoryHelper
-     * @param CountryFactory $countryFactory
+     * @param CountryFactory  $countryFactory
+     * @param EavConfig       $eavConfig
      */
     public function __construct(
         DirectoryHelper $directoryHelper,

--- a/app/code/Magento/Sales/Model/Order/Address/Validator.php
+++ b/app/code/Magento/Sales/Model/Order/Address/Validator.php
@@ -6,6 +6,7 @@
 namespace Magento\Sales\Model\Order\Address;
 
 use Magento\Eav\Model\Config as EavConfig;
+use Magento\Framework\App\ObjectManager;
 use Magento\Sales\Model\Order\Address;
 use Magento\Directory\Helper\Data as DirectoryHelper;
 use Magento\Directory\Model\CountryFactory;
@@ -53,11 +54,12 @@ class Validator
     public function __construct(
         DirectoryHelper $directoryHelper,
         CountryFactory $countryFactory,
-        EavConfig $eavConfig
+        EavConfig $eavConfig = null
     ) {
         $this->directoryHelper = $directoryHelper;
         $this->countryFactory = $countryFactory;
-        $this->eavConfig = $eavConfig;
+        $this->eavConfig = $eavConfig ?: ObjectManager::getInstance()
+            ->get(EavConfig::class);
 
         if ($this->isTelephoneRequired()) {
             $this->required['telephone'] = 'Phone Number';

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Form/RegisterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Form/RegisterTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Block\Form;
+
+/**
+ * Test class for \Magento\Customer\Block\Form\Register
+ *
+ * @magentoAppArea frontend
+ */
+class RegisterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     */
+    public function testCompanyDefault()
+    {
+        /** @var \Magento\Customer\Block\Widget\Company $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Form\Register::class
+        )->setTemplate('Magento_Customer::form/register.phtml')
+        ->setShowAddressFields(true);
+
+        $this->assertContains('title="Company"', $block->toHtml());
+    }
+
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     */
+    public function testTelephoneDefault()
+    {
+        /** @var \Magento\Customer\Block\Widget\Company $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Form\Register::class
+        )->setTemplate('Magento_Customer::form/register.phtml')
+        ->setShowAddressFields(true);
+
+        $this->assertContains('title="Phone&#x20;Number"', $block->toHtml());
+    }
+
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     */
+    public function testFaxDefault()
+    {
+        /** @var \Magento\Customer\Block\Widget\Company $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Form\Register::class
+        )->setTemplate('Magento_Customer::form/register.phtml')
+        ->setShowAddressFields(true);
+
+        $this->assertNotContains('title="Fax"', $block->toHtml());
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     */
+    public function testCompanyDisabled()
+    {
+        /** @var \Magento\Customer\Model\Attribute $model */
+        $model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Model\Attribute::class
+        );
+        $model->loadByCode('customer_address', 'company')->setIsVisible('0');
+        $model->save();
+
+        /** @var \Magento\Customer\Block\Widget\Company $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Form\Register::class
+        )->setTemplate('Magento_Customer::form/register.phtml')
+        ->setShowAddressFields(true);
+
+        $this->assertNotContains('title="Company"', $block->toHtml());
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     */
+    public function testTelephoneDisabled()
+    {
+        /** @var \Magento\Customer\Model\Attribute $model */
+        $model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Model\Attribute::class
+        );
+        $model->loadByCode('customer_address', 'telephone')->setIsVisible('0');
+        $model->save();
+
+        /** @var \Magento\Customer\Block\Widget\Company $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Form\Register::class
+        )->setTemplate('Magento_Customer::form/register.phtml')
+        ->setShowAddressFields(true);
+
+        $this->assertNotContains('title="Phone&#x20;Number"', $block->toHtml());
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     */
+    public function testFaxEnabled()
+    {
+        /** @var \Magento\Customer\Model\Attribute $model */
+        $model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Model\Attribute::class
+        );
+        $model->loadByCode('customer_address', 'fax')->setIsVisible('1');
+        $model->save();
+
+        /** @var \Magento\Customer\Block\Widget\Company $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Form\Register::class
+        )->setTemplate('Magento_Customer::form/register.phtml')
+        ->setShowAddressFields(true);
+
+        $this->assertContains('title="Fax"', $block->toHtml());
+    }
+
+    protected function tearDown()
+    {
+        /** @var \Magento\Eav\Model\Config $eavConfig */
+        $eavConfig = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Eav\Model\Config::class);
+        $eavConfig->clear();
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/CompanyTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/CompanyTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Block\Widget;
+
+/**
+ * Test class for \Magento\Customer\Block\Widget\Taxvat
+ *
+ * @magentoAppArea frontend
+ */
+class CompanyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @magentoAppIsolation enabled
+     */
+    public function testToHtml()
+    {
+        /** @var \Magento\Customer\Block\Widget\Company $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Widget\Company::class
+        );
+
+        $this->assertContains('title="Company"', $block->toHtml());
+        $this->assertNotContains('required', $block->toHtml());
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     */
+    public function testToHtmlRequired()
+    {
+        /** @var \Magento\Customer\Model\Attribute $model */
+        $model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Model\Attribute::class
+        );
+        $model->loadByCode('customer_address', 'company')->setIsRequired(true);
+        $model->save();
+
+        /** @var \Magento\Customer\Block\Widget\Company $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Widget\Company::class
+        );
+
+        $this->assertContains('title="Company"', $block->toHtml());
+        $this->assertContains('required', $block->toHtml());
+    }
+
+    protected function tearDown()
+    {
+        /** @var \Magento\Eav\Model\Config $eavConfig */
+        $eavConfig = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Eav\Model\Config::class);
+        $eavConfig->clear();
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/FaxTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/FaxTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Block\Widget;
+
+/**
+ * Test class for \Magento\Customer\Block\Widget\Taxvat
+ *
+ * @magentoAppArea frontend
+ */
+class FaxTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @magentoAppIsolation enabled
+     */
+    public function testToHtml()
+    {
+        /** @var \Magento\Customer\Block\Widget\Fax $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Widget\Fax::class
+        );
+
+        $this->assertContains('title="Fax"', $block->toHtml());
+        $this->assertNotContains('required', $block->toHtml());
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     */
+    public function testToHtmlRequired()
+    {
+        /** @var \Magento\Customer\Model\Attribute $model */
+        $model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Model\Attribute::class
+        );
+        $model->loadByCode('customer_address', 'fax')->setIsRequired(true);
+        $model->save();
+
+        /** @var \Magento\Customer\Block\Widget\Fax $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Widget\Fax::class
+        );
+
+        $this->assertContains('title="Fax"', $block->toHtml());
+        $this->assertContains('required', $block->toHtml());
+    }
+
+    protected function tearDown()
+    {
+        /** @var \Magento\Eav\Model\Config $eavConfig */
+        $eavConfig = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Eav\Model\Config::class);
+        $eavConfig->clear();
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/TelephoneTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Widget/TelephoneTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Block\Widget;
+
+/**
+ * Test class for \Magento\Customer\Block\Widget\Taxvat
+ *
+ * @magentoAppArea frontend
+ */
+class TelephoneTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @magentoAppIsolation enabled
+     */
+    public function testToHtml()
+    {
+        /** @var \Magento\Customer\Block\Widget\Telephone $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Widget\Telephone::class
+        );
+
+        $this->assertContains('title="Phone&#x20;Number"', $block->toHtml());
+        $this->assertContains('required', $block->toHtml());
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     */
+    public function testToHtmlRequired()
+    {
+        /** @var \Magento\Customer\Model\Attribute $model */
+        $model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Model\Attribute::class
+        );
+        $model->loadByCode('customer_address', 'telephone')->setIsRequired(false);
+        $model->save();
+
+        /** @var \Magento\Customer\Block\Widget\Telephone $block */
+        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Customer\Block\Widget\Telephone::class
+        );
+
+        $this->assertContains('title="Phone&#x20;Number"', $block->toHtml());
+        $this->assertNotContains('required', $block->toHtml());
+    }
+
+    protected function tearDown()
+    {
+        /** @var \Magento\Eav\Model\Config $eavConfig */
+        $eavConfig = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Eav\Model\Config::class);
+        $eavConfig->clear();
+    }
+}

--- a/lib/internal/Magento/Framework/Filter/Test/Unit/TemplateTest.php
+++ b/lib/internal/Magento/Framework/Filter/Test/Unit/TemplateTest.php
@@ -43,7 +43,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
 {{depend street4}}{{var street4}}{{/depend}}
 {{if city}}{{var city}},  {{/if}}{{if region}}{{var region}}, {{/if}}{{if postcode}}{{var postcode}}{{/if}}
 {{var country}}
-T: {{var telephone}}
+{{depend telephone}}T: {{var telephone}}{{/depend}}
 {{depend fax}}F: {{var fax}}{{/depend}}
 {{depend vat_id}}VAT: {{var vat_id}}{{/depend}}
 TEMPLATE;


### PR DESCRIPTION
Fixes #1691.
We added configuration for telephone, fax and company fields in configuration:
![grafik](https://cloud.githubusercontent.com/assets/662059/22855420/a57cb556-f080-11e6-8f1b-770695ee88ba.png)
You can set them to be optional, required, or not shown at all. All necessary forms have been adjusted.