### PR TITLE
Update Save.php

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
@@ -117,6 +117,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product
                 $productId = $product->getEntityId();
                 $productAttributeSetId = $product->getAttributeSetId();
                 $productTypeId = $product->getTypeId();
+                $this->getRequest()->setParam('type', $productTypeId);
 
                 $this->copyToStores($data, $productId);
 


### PR DESCRIPTION
Problem came when I added new simple product, then I added children product to it. Magento in this case "upgrade" product to configurable but in redirectBack goes to edit form with _current=true so in url 'type=simple' still. This makes problem when I have product attributes for simple type but not for configurable. Attribute is not saved but with type=simple in url it is still visible so js validation throws error.

This fix updates url 'type' param to be current product type.