### PR TITLE
Fixed missing echo statement in checkout cart coupon template

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/coupon.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/coupon.phtml
@@ -19,7 +19,7 @@
                                                "removeCouponSelector": "#remove-coupon",
                                                "applyButton": "button.action.apply",
                                                "cancelButton": "button.action.cancel"}}'>
-            <div class="fieldset coupon<?php strlen($block->getCouponCode()) ? ' applied' : ''?>">
+            <div class="fieldset coupon<?php echo strlen($block->getCouponCode()) ? ' applied' : ''?>">
                 <input type="hidden" name="remove" id="remove-coupon" value="0" />
                 <div class="field">
                     <label for="coupon_code" class="label"><span><?php /* @escapeNotVerified */ echo __('Enter discount code') ?></span></label>


### PR DESCRIPTION
Due to a missing echo statement the 'applied' class would not be added to the coupon fieldset after applying a coupon code.