### PR TITLE
Fixed overly bold icons in Firefox Mac

### DIFF
--- a/lib/web/css/source/lib/_icons.less
+++ b/lib/web/css/source/lib/_icons.less
@@ -344,6 +344,7 @@
     @_icon-font-vertical-align
 ) {
     -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     ._lib-icon-font-size(@_icon-font-size, @_icon-font-line-height);
     .lib-css(color, @_icon-font-color);
     .lib-css(content, @_icon-font-content);


### PR DESCRIPTION
Firefox on the Mac renders the icons in an overly bold style '-webkit-font-smoothing: antialiased;' is included in this file to address the issue on most webkit browsers but it doesn't help with firefox on the Mac. adding -moz-osx-font-smoothing: grayscale; performs the equivalent function for firefox.