### PR TITLE
Fix quote's outdated shipping address overwriting PayPal Express shipping address

### DIFF
--- a/app/code/Magento/Braintree/Model/Paypal/Helper/QuoteUpdater.php
+++ b/app/code/Magento/Braintree/Model/Paypal/Helper/QuoteUpdater.php
@@ -84,6 +84,14 @@ class QuoteUpdater extends AbstractHelper
 
         $quote->collectTotals();
 
+        /**
+         * Unset shipping assignment to prevent from saving / applying outdated data
+         * @see \Magento\Quote\Model\QuoteRepository\SaveHandler::processShippingAssignment
+         */
+        if ($quote->getExtensionAttributes()) {
+            $quote->getExtensionAttributes()->setShippingAssignments(null);
+        }
+
         $this->quoteRepository->save($quote);
     }
 

--- a/app/code/Magento/Braintree/Model/Paypal/Helper/QuoteUpdater.php
+++ b/app/code/Magento/Braintree/Model/Paypal/Helper/QuoteUpdater.php
@@ -130,11 +130,6 @@ class QuoteUpdater extends AbstractHelper
         $shippingAddress->setCollectShippingRates(true);
 
         $this->updateAddressData($shippingAddress, $details['shippingAddress']);
-
-        // PayPal's address supposes not saving against customer account
-        $shippingAddress->setSaveInAddressBook(false);
-        $shippingAddress->setSameAsBilling(false);
-        $shippingAddress->unsCustomerAddressId();
     }
 
     /**
@@ -157,11 +152,6 @@ class QuoteUpdater extends AbstractHelper
         $billingAddress->setFirstname($details['firstName']);
         $billingAddress->setLastname($details['lastName']);
         $billingAddress->setEmail($details['email']);
-
-        // PayPal's address supposes not saving against customer account
-        $billingAddress->setSaveInAddressBook(false);
-        $billingAddress->setSameAsBilling(false);
-        $billingAddress->unsCustomerAddressId();
     }
 
     /**
@@ -182,5 +172,10 @@ class QuoteUpdater extends AbstractHelper
         $address->setRegionCode($addressData['region']);
         $address->setCountryId($addressData['countryCodeAlpha2']);
         $address->setPostcode($addressData['postalCode']);
+
+        // PayPal's address supposes not saving against customer account
+        $address->setSaveInAddressBook(false);
+        $address->setSameAsBilling(false);
+        $address->unsCustomerAddressId();
     }
 }

--- a/app/code/Magento/Braintree/Model/Paypal/Helper/QuoteUpdater.php
+++ b/app/code/Magento/Braintree/Model/Paypal/Helper/QuoteUpdater.php
@@ -176,6 +176,6 @@ class QuoteUpdater extends AbstractHelper
         // PayPal's address supposes not saving against customer account
         $address->setSaveInAddressBook(false);
         $address->setSameAsBilling(false);
-        $address->unsCustomerAddressId();
+        $address->setCustomerAddressId(null);
     }
 }

--- a/app/code/Magento/Braintree/Model/Paypal/Helper/QuoteUpdater.php
+++ b/app/code/Magento/Braintree/Model/Paypal/Helper/QuoteUpdater.php
@@ -130,6 +130,11 @@ class QuoteUpdater extends AbstractHelper
         $shippingAddress->setCollectShippingRates(true);
 
         $this->updateAddressData($shippingAddress, $details['shippingAddress']);
+
+        // PayPal's address supposes not saving against customer account
+        $shippingAddress->setSaveInAddressBook(false);
+        $shippingAddress->setSameAsBilling(false);
+        $shippingAddress->unsCustomerAddressId();
     }
 
     /**
@@ -152,6 +157,11 @@ class QuoteUpdater extends AbstractHelper
         $billingAddress->setFirstname($details['firstName']);
         $billingAddress->setLastname($details['lastName']);
         $billingAddress->setEmail($details['email']);
+
+        // PayPal's address supposes not saving against customer account
+        $billingAddress->setSaveInAddressBook(false);
+        $billingAddress->setSameAsBilling(false);
+        $billingAddress->unsCustomerAddressId();
     }
 
     /**


### PR DESCRIPTION
# Issue

PayPal responded shipping address fail to save against quote on Braintree PayPal Express checkout

# Preconditions
Magento EE 2.1.3

# Steps to reproduce

1. Log in to an account
2. Add product to the basket
3. Go to *One Page Checkout*
4. Enter every shipping address details; select a shipping method; and continue to the payment step
5. Don't proceed to payment; Go back to the basket and click PayPal Express checkout
6. Enter paypal credential (or proceed with sandbox default address data); proceed

![paypal-one-click-outdated-shipping-address](https://cloud.githubusercontent.com/assets/945819/22983718/ea502ad8-f39a-11e6-9697-70fb23de3f3e.gif)

# Expected Result

On `braintree/paypal/review/`, delivery address should show the PayPal's shipping address.

For sandbox, it should be:

```
Mr John Doe
123 Division Street
Apt. #1
Chicago, Greater Manchester, 60618
United States
```

![paypal-one-click-expected-address](https://cloud.githubusercontent.com/assets/945819/22984237/a32df5c0-f39c-11e6-8ba5-80e22d5f2c89.png)


# Actual Result

The delivery address shows the outdated shipping address which entered from One Page Checkout