### PR TITLE
Fix #7371

### DIFF
--- a/app/code/Magento/CatalogRule/Pricing/Price/CatalogRulePrice.php
+++ b/app/code/Magento/CatalogRule/Pricing/Price/CatalogRulePrice.php
@@ -99,9 +99,9 @@ class CatalogRulePrice extends AbstractPrice implements BasePriceProviderInterfa
                         $this->product->getId()
                     );
                 $this->value = $this->value ? floatval($this->value) : false;
-                if ($this->value) {
-                    $this->value = $this->priceCurrency->convertAndRound($this->value);
-                }
+            }
+            if ($this->value) {
+                $this->value = $this->priceCurrency->convertAndRound($this->value);
             }
         }
 

--- a/app/code/Magento/CatalogRule/Test/Unit/Pricing/Price/CatalogRulePriceTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Pricing/Price/CatalogRulePriceTest.php
@@ -208,12 +208,20 @@ class CatalogRulePriceTest extends \PHPUnit_Framework_TestCase
 
     public function testGetValueFromData()
     {
+        $catalogRulePrice = 7.1;
+        $convertedPrice = 5.84;
+        
+        $this->priceCurrencyMock->expects($this->any())
+            ->method('convertAndRound')
+            ->with($catalogRulePrice)
+            ->will($this->returnValue($convertedPrice));
+        
         $this->saleableItemMock->expects($this->once())->method('hasData')
             ->with('catalog_rule_price')->willReturn(true);
         $this->saleableItemMock->expects($this->once())->method('getData')
-            ->with('catalog_rule_price')->willReturn('7.1');
+            ->with('catalog_rule_price')->willReturn($catalogRulePrice);
 
-        $this->assertEquals(7.1, $this->object->getValue());
+        $this->assertEquals($convertedPrice, $this->object->getValue());
     }
 
     public function testGetAmountNoBaseAmount()

--- a/app/code/Magento/CatalogRule/Test/Unit/Pricing/Price/CatalogRulePriceTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Pricing/Price/CatalogRulePriceTest.php
@@ -210,12 +210,12 @@ class CatalogRulePriceTest extends \PHPUnit_Framework_TestCase
     {
         $catalogRulePrice = 7.1;
         $convertedPrice = 5.84;
-        
+
         $this->priceCurrencyMock->expects($this->any())
             ->method('convertAndRound')
             ->with($catalogRulePrice)
             ->will($this->returnValue($convertedPrice));
-        
+
         $this->saleableItemMock->expects($this->once())->method('hasData')
             ->with('catalog_rule_price')->willReturn(true);
         $this->saleableItemMock->expects($this->once())->method('getData')


### PR DESCRIPTION
 'catalog_rule_price' is added to products only before load of the Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Product\Collection and it is used only for detecting the minimal price here - Magento\Catalog\Pricing\Price\BasePrice. Due to it the price has never converted to the site currency.