### PR TITLE
Fix: various problems with minimum order amount enabled

### DIFF
--- a/app/code/Magento/Quote/Model/ShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingAddressManagement.php
@@ -117,9 +117,13 @@ class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressM
         $address->setSaveInAddressBook($saveInAddressBook);
         $address->setCollectShippingRates(true);
 
+        
+        /*
+        // Fix for https://github.com/magento/magento2/issues/6151
         if (!$quote->validateMinimumAmount($quote->getIsMultiShipping())) {
             throw new InputException(__($this->getMinimumAmountErrorMessage()->getMessage()));
         }
+        */
 
         try {
             $address->save();


### PR DESCRIPTION
See https://github.com/magento/magento2/issues/6151 for the basics.

When minimum order amount is enabled:
1. add 1 product to the cart; total is below min order amount -> no error.
2. Try to remove that product -> error about minimum amount.
3. Try to add more to the cart with total still below min order -> error about minimum amount
4. Add a product that will bring the total cart amount **over** the min order amount and no errors!

I will request the Magento team takes a look at this line. I don't understand why the minimum amount is being validated here but perhaps it has something to do with multi-shipping checkouts. However, it botches the min order amount logic badly in it's current form.