### PR TITLE
[PHP 7.1 Compatibility] Void became a reserved word

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/VoidAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/VoidAction.php
@@ -7,7 +7,7 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Creditmemo;
 
 use Magento\Backend\App\Action;
 
-class Void extends \Magento\Backend\App\Action
+class VoidAction extends Action
 {
     /**
      * Authorization level of a basic admin session

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/VoidAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/VoidAction.php
@@ -6,7 +6,7 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Order\Invoice;
 
-class Void extends \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice\View
+class VoidAction extends \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice\View
 {
     /**
      * Void invoice action

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/VoidActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/VoidActionTest.php
@@ -6,11 +6,11 @@
 namespace Magento\Sales\Test\Unit\Controller\Adminhtml\Order\Creditmemo;
 
 /**
- * Class VoidTest
+ * Class VoidActionTest
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class VoidTest extends \PHPUnit_Framework_TestCase
+class VoidActionTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Magento\Sales\Controller\Adminhtml\Order\Creditmemo\AddComment
@@ -179,7 +179,7 @@ class VoidTest extends \PHPUnit_Framework_TestCase
 
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->controller = $objectManager->getObject(
-            \Magento\Sales\Controller\Adminhtml\Order\Creditmemo\Void::class,
+            \Magento\Sales\Controller\Adminhtml\Order\Creditmemo\VoidAction::class,
             [
                 'context' => $this->contextMock,
                 'creditmemoLoader' => $this->loaderMock,

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/VoidActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/VoidActionTest.php
@@ -10,11 +10,11 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Sales\Api\InvoiceRepositoryInterface;
 
 /**
- * Class VoidTest
+ * Class VoidActionTest
  * @package Magento\Sales\Controller\Adminhtml\Order\Invoice
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class VoidTest extends \PHPUnit_Framework_TestCase
+class VoidActionTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -166,7 +166,7 @@ class VoidTest extends \PHPUnit_Framework_TestCase
             ->getMockForAbstractClass();
 
         $this->controller = $objectManager->getObject(
-            \Magento\Sales\Controller\Adminhtml\Order\Invoice\Void::class,
+            \Magento\Sales\Controller\Adminhtml\Order\Invoice\VoidAction::class,
             [
                 'context' => $contextMock,
                 'resultForwardFactory' => $this->resultForwardFactoryMock

--- a/dev/tests/static/framework/Magento/Sniffs/NamingConventions/ReservedWordsSniff.php
+++ b/dev/tests/static/framework/Magento/Sniffs/NamingConventions/ReservedWordsSniff.php
@@ -11,22 +11,27 @@ use PHP_CodeSniffer_Sniff;
 class ReservedWordsSniff implements PHP_CodeSniffer_Sniff
 {
     /**
-     * source: http://php.net/manual/en/reserved.other-reserved-words.php
+     * The following words cannot be used to name a class, interface or trait,
+     * and they are also prohibited from being used in namespaces.
      *
-     * @var array PHP 7 reserved words for name spaces
+     * @link http://php.net/manual/en/reserved.other-reserved-words.php
+     *
+     * @var string[]
      */
     protected $reservedWords = [
-        'int',
-        'float',
-        'bool',
-        'string',
-        'true',
-        'false',
-        'null',
-        'resource',
-        'object',
-        'mixed',
-        'numeric',
+        'int' => '7',
+        'float' => '7',
+        'bool' => '7',
+        'string' => '7',
+        'true' => '7',
+        'false' => '7',
+        'null' => '7',
+        'void' => '7.1',
+        'iterable' => '7.1',
+        'resource' => '7',
+        'object' => '7',
+        'mixed' => '7',
+        'numeric' => '7',
     ];
 
     /**
@@ -34,7 +39,7 @@ class ReservedWordsSniff implements PHP_CodeSniffer_Sniff
      */
     public function register()
     {
-        return [T_NAMESPACE, T_CLASS];
+        return [T_CLASS, T_INTERFACE, T_TRAIT, T_NAMESPACE];
     }
 
     /**
@@ -44,20 +49,23 @@ class ReservedWordsSniff implements PHP_CodeSniffer_Sniff
      * @param int $stackPtr
      * @return void
      */
-    protected function validateNameSpace(PHP_CodeSniffer_File $sourceFile, $stackPtr)
+    protected function validateNamespace(PHP_CodeSniffer_File $sourceFile, $stackPtr)
     {
-        $skippedTokens = ['T_NS_SEPARATOR', 'T_WHITESPACE'];
-        //skip "namespace" and whitespace
         $stackPtr += 2;
         $tokens = $sourceFile->getTokens();
-        while ('T_SEMICOLON' != $tokens[$stackPtr]['type']) {
-            if (in_array($tokens[$stackPtr]['type'], $skippedTokens)) {
-                $stackPtr++;
+        while ($stackPtr < $sourceFile->numTokens && $tokens[$stackPtr]['code'] !== T_SEMICOLON) {
+            if ($tokens[$stackPtr]['code'] === T_WHITESPACE || $tokens[$stackPtr]['code'] === T_NS_SEPARATOR) {
+                $stackPtr++; //skip "namespace" and whitespace
                 continue;
             }
-            $nameSpacePart = strtolower($tokens[$stackPtr]['content']);
-            if (in_array($nameSpacePart, $this->reservedWords)) {
-                $sourceFile->addError('\'' . $nameSpacePart . '\' is a reserved word in PHP 7.', $stackPtr);
+            $namespacePart = $tokens[$stackPtr]['content'];
+            if (isset($this->reservedWords[strtolower($namespacePart)])) {
+                $sourceFile->addError(
+                    'Cannot use "%s" in namespace as it is reserved since PHP %s',
+                    $stackPtr,
+                    'Namespace',
+                    [$namespacePart, $this->reservedWords[$namespacePart]]
+                );
             }
             $stackPtr++;
         }
@@ -73,12 +81,15 @@ class ReservedWordsSniff implements PHP_CodeSniffer_Sniff
     protected function validateClass(PHP_CodeSniffer_File $sourceFile, $stackPtr)
     {
         $tokens = $sourceFile->getTokens();
-        //skipped "class" and whitespace
-        $stackPtr += 2;
+        $stackPtr += 2; //skip "class" and whitespace
         $className = strtolower($tokens[$stackPtr]['content']);
-
-        if (in_array($className, $this->reservedWords)) {
-            $sourceFile->addError('Class name \'' . $className . '\' is a reserved word in PHP 7', $stackPtr);
+        if (isset($this->reservedWords[$className])) {
+            $sourceFile->addError(
+                'Cannot use "%s" as class name as it is reserved since PHP %s',
+                $stackPtr,
+                'Class',
+                [$className, $this->reservedWords[$className]]
+            );
         }
     }
 
@@ -88,12 +99,14 @@ class ReservedWordsSniff implements PHP_CodeSniffer_Sniff
     public function process(PHP_CodeSniffer_File $sourceFile, $stackPtr)
     {
         $tokens = $sourceFile->getTokens();
-        switch ($tokens[$stackPtr]['type']) {
-            case "T_CLASS":
+        switch ($tokens[$stackPtr]['code']) {
+            case T_CLASS:
+            case T_INTERFACE:
+            case T_TRAIT:
                 $this->validateClass($sourceFile, $stackPtr);
                 break;
-            case "T_NAMESPACE":
-                $this->validateNameSpace($sourceFile, $stackPtr);
+            case T_NAMESPACE:
+                $this->validateNamespace($sourceFile, $stackPtr);
                 break;
         }
     }

--- a/lib/internal/Magento/Framework/App/Router/ActionList.php
+++ b/lib/internal/Magento/Framework/App/Router/ActionList.php
@@ -34,7 +34,7 @@ class ActionList
         'for', 'foreach', 'function', 'global', 'goto', 'if', 'implements', 'include', 'instanceof',
         'insteadof','interface', 'isset', 'list', 'namespace', 'new', 'or', 'print', 'private', 'protected',
         'public', 'require', 'return', 'static', 'switch', 'throw', 'trait', 'try', 'unset', 'use', 'var',
-        'while', 'xor',
+        'while', 'xor', 'void',
     ];
 
     /**


### PR DESCRIPTION
Before this change `Creditmemo > Void` and `Invoice > Void` actions in Admin UI had no chance to work under PHP 7.1 as "void" became a reserved word.

Unit and static tests are now able to complete on Travis CI under PHP 7.1: https://travis-ci.org/orlangur/magento2/builds/203260140 (this temporary branch includes #7688 changes).

Corresponding PHPCS sniff is expanded with new reserved words and executed against full codebase.
Before: https://travis-ci.org/orlangur/magento2/jobs/203213045
After: https://travis-ci.org/orlangur/magento2/jobs/203230641