### PR TITLE
Fix #8315: test setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Writer/Csv/StdoTest.php crashes in debug mode

### DIFF
--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Writer/Csv/StdoTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Writer/Csv/StdoTest.php
@@ -5,25 +5,15 @@
  */
 namespace Magento\Setup\Test\Unit\Module\I18n\Dictionary\Writer\Csv;
 
+use Magento\Setup\Module\I18n\Dictionary\Writer\Csv\Stdo;
+
 class StdoTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var resource
-     */
-    protected $_handler;
-
-    protected function setUp()
-    {
-        $this->_handler = STDOUT;
-    }
-
     public function testThatHandlerIsRight()
     {
-        $this->markTestSkipped('This is skiped as we should not close the STDO!');
-        $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
-        /** @var \Magento\Setup\Module\I18n\Dictionary\Writer\Csv $writer */
-        $writer = $objectManagerHelper->getObject(\Magento\Setup\Module\I18n\Dictionary\Writer\Csv\Stdo::class);
-
-        $this->assertAttributeEquals($this->_handler, '_fileHandler', $writer);
+        $handler = STDOUT;
+        // Mocking object's under test destructor here is perfectly valid as there is no way to reopen STDOUT
+        $writer = $this->getMock(Stdo::class, ['__destruct']);
+        $this->assertAttributeEquals($handler, '_fileHandler', $writer);
     }
 }


### PR DESCRIPTION
It was crashing when running PHPUnit with `--debug` flag due to `STDOUT` closing in destructor of object under test.

I don't think this test is enforcing any useful behavior thus it would be better to simply remove it.