### PR TITLE
Fix #8308: test setup/src/Magento/Setup/Test/Unit/Model/Cron/JobSetCacheTest.php crashes in debug mode

### DIFF
--- a/setup/src/Magento/Setup/Test/Unit/Model/Cron/JobSetCacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/Cron/JobSetCacheTest.php
@@ -10,17 +10,21 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputArgument;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class JobSetCacheTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider setCacheDataProvider
      * @param string $commandClass
-     * @param string $arrayInput
+     * @param array $arrayInput
      * @param string $jobName
      * @param array $params
      */
     public function testSetCache($commandClass, $arrayInput, $jobName, $params)
     {
+        $arrayInput = new ArrayInput($arrayInput);
         $objectManagerProvider = $this->getMock(\Magento\Setup\Model\ObjectManagerProvider::class, [], [], '', false);
         $objectManager =
             $this->getMockForAbstractClass(\Magento\Framework\ObjectManagerInterface::class, [], '', false);
@@ -62,18 +66,16 @@ class JobSetCacheTest extends \PHPUnit_Framework_TestCase
      */
     public function setCacheDataProvider()
     {
-        $cacheEnable = new ArrayInput(['command' => 'cache:enable', 'types' => ['cache1']]);
-        $cacheDisable = new ArrayInput(['command' => 'cache:disable']);
         return [
             [
                 \Magento\Backend\Console\Command\CacheEnableCommand::class,
-                $cacheEnable,
+                ['command' => 'cache:enable', 'types' => ['cache1']],
                 'setup:cache:enable',
                 ['cache1']
             ],
             [
                 \Magento\Backend\Console\Command\CacheDisableCommand::class,
-                $cacheDisable,
+                ['command' => 'cache:disable'],
                 'setup:cache:disable',
                 []
             ],


### PR DESCRIPTION
It was crashing when running PHPUnit with `--debug` flag due to object passed via data provider (which is never a good idea - there were serious troubles with such data providers littering Bamboo in the past; cannot be solved via implementing listener preventing such kind of data provider AFAIR).