### PR TITLE
Remove Zend_Json from Customer module

### DIFF
--- a/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
+++ b/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
@@ -16,15 +16,25 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
     protected $jsLayout;
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         parent::__construct($context, $data);
         $this->jsLayout = isset($data['jsLayout']) && is_array($data['jsLayout']) ? $data['jsLayout'] : [];
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
@@ -32,7 +42,7 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
      */
     public function getJsLayout()
     {
-        return \Zend_Json::encode($this->jsLayout);
+        return $this->serializer->serialize($this->jsLayout);
     }
 
     /**
@@ -48,6 +58,14 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
             'customerForgotPasswordUrl' => $this->escapeUrl($this->getCustomerForgotPasswordUrl()),
             'baseUrl' => $this->escapeUrl($this->getBaseUrl())
         ];
+    }
+
+    /**
+     * @return bool|string
+     */
+    public function getSerializedConfig()
+    {
+        return $this->serializer->serialize($this->getConfig());
     }
 
     /**

--- a/app/code/Magento/Customer/view/frontend/templates/account/authentication-popup.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/authentication-popup.phtml
@@ -10,7 +10,7 @@
 ?>
 <div id="authenticationPopup" data-bind="scope:'authenticationPopup'" style="display: none;">
     <script>
-        window.authenticationPopup = <?php /* @noEscape */ echo \Zend_Json::encode($block->getConfig()); ?>;
+        window.authenticationPopup = <?php /* @noEscape */ echo $block->getSerializedConfig(); ?>;
     </script>
     <!-- ko template: getTemplate() --><!-- /ko -->
     <script type="text/x-magento-init">


### PR DESCRIPTION
In this PR I have updated the Customer module's auth pop-up to use the core Magento Json serilizer lib rather than Zend1' json class.

I have also added a new method to be used in the template and a new test to cover this new method.