### PR TITLE
Fix check for boolean product attributes

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Attributes.php
@@ -12,6 +12,7 @@
 namespace Magento\Catalog\Block\Product\View;
 
 use Magento\Catalog\Model\Product;
+use Magento\Framework\Phrase;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 
 class Attributes extends \Magento\Framework\View\Element\Template
@@ -85,8 +86,8 @@ class Attributes extends \Magento\Framework\View\Element\Template
                 } elseif ($attribute->getFrontendInput() == 'price' && is_string($value)) {
                     $value = $this->priceCurrency->convertAndFormat($value);
                 }
-
-                if (is_string($value) && strlen($value)) {
+    
+                if ($value instanceof Phrase || (is_string($value) && strlen($value))) {
                     $data[$attribute->getAttributeCode()] = [
                         'label' => __($attribute->getStoreLabel()),
                         'value' => $value,


### PR DESCRIPTION
Based on that Issue [#6634](https://github.com/magento/magento2/issues/6634) here is a fix to add also boolean product attributes to display in frontend.

Magento2 handles translations with the Phrase instance. A product attribut with type boolean uses Phrase instance but the validation verify for strings.
This fix also includes the instance Phrase for the verification.