### PR TITLE
makes $layerResolver protected in Category view

### DIFF
--- a/app/code/Magento/Catalog/Controller/Category/View.php
+++ b/app/code/Magento/Catalog/Controller/Category/View.php
@@ -62,7 +62,7 @@ class View extends \Magento\Framework\App\Action\Action
      *
      * @var Resolver
      */
-    private $layerResolver;
+    protected $layerResolver;
 
     /**
      * @var CategoryRepositoryInterface


### PR DESCRIPTION
When you *need* to overwrite this View controller but want to inherit
since most of the functionality is exactly the same you have access to
everything but the $layerResolver which is kind of annoying. Its also
pointless to need to copy the constructor to your child class just
because of this. So make $layerResolver protected.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>