### PR TITLE
Update Save.php

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -162,7 +162,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
                         $this->attributeHelper->getStoreWebsiteId($storeId)
                     );
                     if (!$stockItemDo->getProductId()) {
-                        $inventoryData[] = $productId;
+                        $inventoryData['product_id'] = $productId;
                     }
 
                     $stockItemId = $stockItemDo->getId();


### PR DESCRIPTION
If quantity is changed using mass action for attribute changes, but no stock item exists for the product, saving the newly created stockItem in StockItemRepository->save($stockItem) returns without saving the stockItem, since $stockItem->getProductId() is null, due to it being added to the array with key '0' (see line 165). To fix this, the array key has been changed to "product_id", such that StockItemRepository successfully creates the stockItem.
Also, in my opinion, StockItemRepository->save() should not just return without notice, especially as it already encapsulates the functionality in a try/catch block. Throwing an exception would actually tell the user that something went wrong.