### PR TITLE
Product name not shown in message when trying to add more products to cart then there are in stock

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/StockStateProvider.php
+++ b/app/code/Magento/CatalogInventory/Model/StockStateProvider.php
@@ -106,6 +106,10 @@ class StockStateProvider implements StockStateProviderInterface
     {
         $result = $this->objectFactory->create();
         $result->setHasError(false);
+        
+        $product = $this->productFactory->create();
+        $product->load($stockItem->getProductId());
+        $stockItem->setProduct($product);
 
         $qty = $this->getNumber($qty);
 


### PR DESCRIPTION
Preconditions
Magento 2.1.x
Steps to reproduce

Set the stock of a product to 20.
Add the same product to the cart with qty greater then 20.
Expected result

A message saying 'We don't have as many "<product_name>" as you requested'.
Actual result

![5cefdb6a-f369-11e6-92bb-6debb34ff2aa](https://cloud.githubusercontent.com/assets/5745279/23254584/d5aaf88c-f9b8-11e6-8b1c-034d9c1dd552.png)

Fixes #8560
