### PR TITLE
Fixed Doc Block for the dispatch method of the Rest Controller

### DIFF
--- a/app/code/Magento/Webapi/Controller/Rest.php
+++ b/app/code/Magento/Webapi/Controller/Rest.php
@@ -200,6 +200,9 @@ class Rest implements \Magento\Framework\App\FrontControllerInterface
     /**
      * Handle REST request
      *
+     * Based on request decide is it schema request or API request and process accordingly.
+     * Throws Exception in case if cannot be processed properly.
+     *
      * @param \Magento\Framework\App\RequestInterface $request
      * @return \Magento\Framework\App\ResponseInterface
      */


### PR DESCRIPTION
During MageTitans Hackathon in Mexico it was noticed that the dispatch method of the Rest Controller does not provide enough information in the description on how the method is supposed to work. The description was updated to highlight the key points of method execution. This information will help developers to understand the method better. It will be used by automatic documentation generation tools.

The content of the Pull Request:
- updated doc block for the method dispatch in the Rest Controller.