### PR TITLE
Fixed Issue #8425

### DIFF
--- a/app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php
+++ b/app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php
@@ -86,7 +86,7 @@ class DevTestsRunCommand extends Command
             list($dir, $options) = $this->commands[$key];
             $dirName = realpath(BP . '/dev/tests/' . $dir);
             chdir($dirName);
-            $command = 'php '. BP . '/' . $vendorDir . '/phpunit/phpunit/phpunit ' . $options;
+            $command = PHP_BINARY . ' ' . BP . '/' . $vendorDir . '/phpunit/phpunit/phpunit ' . $options;
             $message = $dirName . '> ' . $command;
             $output->writeln(['', str_pad("---- {$message} ", 70, '-'), '']);
             passthru($command, $returnVal);


### PR DESCRIPTION
The use of PHP_BINARY instead of 'php' should affect the used PHP Version. With the Constant, the correct php version should be called.