### PR TITLE
Remove unused argument

### DIFF
--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -135,7 +135,7 @@ class Bootstrap
     {
         $dirList = self::createFilesystemDirectoryList($rootDir, $initParams);
         $autoloadWrapper = AutoloaderRegistry::getAutoloader();
-        Populator::populateMappings($autoloadWrapper, $dirList, new ComponentRegistrar());
+        Populator::populateMappings($autoloadWrapper, $dirList);
     }
 
     /**


### PR DESCRIPTION
[Populator::populateMappings(…)](https://github.com/magento/magento2/blob/4a2ceadbb40a758487c09d6c403c02620bf384cd/lib/internal/Magento/Framework/Autoload/Populator.php#L23-L41) method signature declares two parameters but is passed three arguments in `App/Bootstrap::populateAutoloader`

The third parameter was removed from signature and body at: https://github.com/magento/magento2/commit/39abd590500a825e79cc8bece246f7143937aaad this PR suggests remove the third argument at the call site.