### PR TITLE
Fixed return type of OrderRepository::getList

### DIFF
--- a/app/code/Magento/Sales/Model/OrderRepository.php
+++ b/app/code/Magento/Sales/Model/OrderRepository.php
@@ -99,7 +99,7 @@ class OrderRepository implements \Magento\Sales\Api\OrderRepositoryInterface
      * Find entities by criteria
      *
      * @param \Magento\Framework\Api\SearchCriteria $searchCriteria
-     * @return OrderInterface[]
+     * @return \Magento\Sales\Api\Data\OrderSearchResultInterface
      */
     public function getList(\Magento\Framework\Api\SearchCriteria $searchCriteria)
     {


### PR DESCRIPTION
as it is the $searchResult variable that is returned, we do not retrieve an array of OrderInterface.
You cannot iterate on what is returning the getList method, you need to ->getItems first.