### PR TITLE
Remove Zend_Json from the unit test in the CustomerImportExport module

### DIFF
--- a/app/code/Magento/CustomerImportExport/Test/Unit/Model/ResourceModel/Import/CustomerComposite/DataTest.php
+++ b/app/code/Magento/CustomerImportExport/Test/Unit/Model/ResourceModel/Import/CustomerComposite/DataTest.php
@@ -105,7 +105,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $jsonDecoderMock->expects($this->once())
             ->method('decode')
-            ->willReturn(\Zend_Json::decode($bunchData));
+            ->willReturn(json_decode($bunchData, true));
         $jsonHelper = $helper->getObject(
             \Magento\Framework\Json\Helper\Data::class,
             [
@@ -140,7 +140,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
         return [
             'address entity' => [
                 '$entityType' => CustomerComposite::COMPONENT_ENTITY_ADDRESS,
-                '$bunchData' => \Zend_Json::encode(
+                '$bunchData' => json_encode(
                     [
                         [
                             '_scope' => CustomerComposite::SCOPE_DEFAULT,
@@ -170,7 +170,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
             ],
             'customer entity default scope' => [
                 '$entityType' => CustomerComposite::COMPONENT_ENTITY_CUSTOMER,
-                '$bunchData' => \Zend_Json::encode(
+                '$bunchData' => json_encode(
                     [
                         [
                             '_scope' => CustomerComposite::SCOPE_DEFAULT,
@@ -202,7 +202,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
             ],
             'customer entity address scope' => [
                 '$entityType' => CustomerComposite::COMPONENT_ENTITY_CUSTOMER,
-                '$bunchData' => \Zend_Json::encode(
+                '$bunchData' => json_encode(
                     [
                         [
                             '_scope' => CustomerComposite::SCOPE_ADDRESS,


### PR DESCRIPTION
Since Zend Framework1 is EOF then we should start to move away from it.

This PR removes the usage of Zend_Json in the CustomerImportExport module.