### PR TITLE
Remove zend json from email

### DIFF
--- a/app/code/Magento/Email/Block/Adminhtml/Template/Edit/Form.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template/Edit/Form.php
@@ -22,12 +22,19 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     protected $_variableFactory;
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Data\FormFactory $formFactory
      * @param \Magento\Variable\Model\VariableFactory $variableFactory
      * @param \Magento\Email\Model\Source\Variables $variables
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
@@ -35,10 +42,13 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         \Magento\Framework\Data\FormFactory $formFactory,
         \Magento\Variable\Model\VariableFactory $variableFactory,
         \Magento\Email\Model\Source\Variables $variables,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->_variableFactory = $variableFactory;
         $this->_variables = $variables;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         parent::__construct($context, $registry, $formFactory, $data);
     }
 
@@ -60,6 +70,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
      * @return \Magento\Backend\Block\Widget\Form
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     protected function _prepareForm()
     {
@@ -100,7 +111,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         $fieldset->addField(
             'variables',
             'hidden',
-            ['name' => 'variables', 'value' => \Zend_Json::encode($this->getVariables())]
+            ['name' => 'variables', 'value' => $this->serializer->serialize($this->getVariables())]
         );
         $fieldset->addField('template_variables', 'hidden', ['name' => 'template_variables']);
 

--- a/app/code/Magento/Email/Controller/Adminhtml/Email/Template/DefaultTemplate.php
+++ b/app/code/Magento/Email/Controller/Adminhtml/Email/Template/DefaultTemplate.php
@@ -14,16 +14,26 @@ class DefaultTemplate extends \Magento\Email\Controller\Adminhtml\Email\Template
     private $emailConfig;
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Framework\Registry $coreRegistry
      * @param \Magento\Email\Model\Template\Config $emailConfig
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         \Magento\Framework\Registry $coreRegistry,
-        \Magento\Email\Model\Template\Config $emailConfig
+        \Magento\Email\Model\Template\Config $emailConfig,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->emailConfig = $emailConfig;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         parent::__construct($context, $coreRegistry);
     }
 
@@ -31,6 +41,7 @@ class DefaultTemplate extends \Magento\Email\Controller\Adminhtml\Email\Template
      * Set template data to retrieve it in template info form
      *
      * @return void
+     * @throws \RuntimeException
      */
     public function execute()
     {
@@ -49,7 +60,10 @@ class DefaultTemplate extends \Magento\Email\Controller\Adminhtml\Email\Template
 
             $template->loadDefault($templateId);
             $template->setData('orig_template_code', $templateId);
-            $template->setData('template_variables', \Zend_Json::encode($template->getVariablesOptionArray(true)));
+            $template->setData(
+                'template_variables',
+                $this->serializer->serialize($template->getVariablesOptionArray(true))
+            );
 
             $templateBlock = $this->_view->getLayout()->createBlock(
                 \Magento\Email\Block\Adminhtml\Template\Edit::class
@@ -57,7 +71,7 @@ class DefaultTemplate extends \Magento\Email\Controller\Adminhtml\Email\Template
             $template->setData('orig_template_currently_used_for', $templateBlock->getCurrentlyUsedForPaths(false));
 
             $this->getResponse()->representJson(
-                $this->_objectManager->get(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($template->getData())
+                $this->serializer->serialize($template->getData())
             );
         } catch (\Exception $e) {
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);

--- a/app/code/Magento/Email/Model/BackendTemplate.php
+++ b/app/code/Magento/Email/Model/BackendTemplate.php
@@ -53,7 +53,8 @@ class BackendTemplate extends Template
         \Magento\Framework\UrlInterface $urlModel,
         \Magento\Email\Model\Template\FilterFactory $filterFactory,
         \Magento\Config\Model\Config\Structure $structure,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->structure = $structure;
         parent::__construct(
@@ -70,7 +71,8 @@ class BackendTemplate extends Template
             $filterManager,
             $urlModel,
             $filterFactory,
-            $data
+            $data,
+            $serializer
         );
     }
 

--- a/app/code/Magento/Email/Model/Template.php
+++ b/app/code/Magento/Email/Model/Template.php
@@ -92,7 +92,12 @@ class Template extends AbstractTemplate implements \Magento\Framework\Mail\Templ
     private $filterFactory;
 
     /**
-     * Initialize dependencies.
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
+     * Template constructor.
      *
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\View\DesignInterface $design
@@ -108,6 +113,8 @@ class Template extends AbstractTemplate implements \Magento\Framework\Mail\Templ
      * @param \Magento\Framework\UrlInterface $urlModel
      * @param Template\FilterFactory $filterFactory
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -125,9 +132,12 @@ class Template extends AbstractTemplate implements \Magento\Framework\Mail\Templ
         \Magento\Framework\Filter\FilterManager $filterManager,
         \Magento\Framework\UrlInterface $urlModel,
         \Magento\Email\Model\Template\FilterFactory $filterFactory,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->filterFactory = $filterFactory;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         parent::__construct(
             $context,
             $design,
@@ -289,7 +299,7 @@ class Template extends AbstractTemplate implements \Magento\Framework\Mail\Templ
         $variables = [];
         if ($variablesString && is_string($variablesString)) {
             $variablesString = str_replace("\n", '', $variablesString);
-            $variables = \Zend_Json::decode($variablesString);
+            $variables = $this->serializer->unserialize($variablesString);
         }
         return $variables;
     }

--- a/app/code/Magento/Email/Test/Unit/Block/Adminhtml/Template/EditTest.php
+++ b/app/code/Magento/Email/Test/Unit/Block/Adminhtml/Template/EditTest.php
@@ -56,7 +56,10 @@ class EditTest extends \PHPUnit_Framework_TestCase
         $menuMock = $this->getMock(
             \Magento\Backend\Model\Menu::class,
             [],
-            [$this->getMock(\Psr\Log\LoggerInterface::class)]
+            [$this->getMock(\Psr\Log\LoggerInterface::class)],
+            '',
+            false,
+            false
         );
         $menuItemMock = $this->getMock(\Magento\Backend\Model\Menu\Item::class, [], [], '', false, false);
         $urlBuilder = $this->getMock(\Magento\Backend\Model\Url::class, [], [], '', false, false);

--- a/app/code/Magento/Email/Test/Unit/Model/BackendTemplateTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/BackendTemplateTest.php
@@ -43,7 +43,9 @@ class BackendTemplateTest extends \PHPUnit_Framework_TestCase
      */
     protected $objectManagerBackup;
 
-    /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject
+     */
     private $serilizerMock;
 
     protected function setUp()

--- a/app/code/Magento/Email/Test/Unit/Model/BackendTemplateTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/BackendTemplateTest.php
@@ -43,6 +43,9 @@ class BackendTemplateTest extends \PHPUnit_Framework_TestCase
      */
     protected $objectManagerBackup;
 
+    /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject */
+    private $serilizerMock;
+
     protected function setUp()
     {
         $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -70,9 +73,15 @@ class BackendTemplateTest extends \PHPUnit_Framework_TestCase
 
         \Magento\Framework\App\ObjectManager::setInstance($objectManagerMock);
 
+        $this->serilizerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
+
         $this->model = $helper->getObject(
             \Magento\Email\Model\BackendTemplate::class,
-            ['scopeConfig' => $this->scopeConfigMock, 'structure' => $this->structureMock]
+            [
+                'scopeConfig' => $this->scopeConfigMock,
+                'structure' => $this->structureMock,
+                'serializer' => $this->serilizerMock
+            ]
         );
     }
 

--- a/app/code/Magento/Email/Test/Unit/Model/BackendTemplateTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/BackendTemplateTest.php
@@ -46,7 +46,7 @@ class BackendTemplateTest extends \PHPUnit_Framework_TestCase
     /**
      * @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $serilizerMock;
+    private $serializerMock;
 
     protected function setUp()
     {
@@ -75,14 +75,14 @@ class BackendTemplateTest extends \PHPUnit_Framework_TestCase
 
         \Magento\Framework\App\ObjectManager::setInstance($objectManagerMock);
 
-        $this->serilizerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
 
         $this->model = $helper->getObject(
             \Magento\Email\Model\BackendTemplate::class,
             [
                 'scopeConfig' => $this->scopeConfigMock,
                 'structure' => $this->structureMock,
-                'serializer' => $this->serilizerMock
+                'serializer' => $this->serializerMock
             ]
         );
     }

--- a/app/code/Magento/Email/Test/Unit/Model/TemplateTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/TemplateTest.php
@@ -84,6 +84,11 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
      */
     private $templateFactory;
 
+    /**
+     * @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $serilizerMock;
+
     protected function setUp()
     {
         $this->context = $this->getMockBuilder(\Magento\Framework\Model\Context::class)
@@ -138,6 +143,8 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
             ->setMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->serilizerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
     }
 
     /**
@@ -164,6 +171,8 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
                 $this->filterManager,
                 $this->urlModel,
                 $this->filterFactory,
+                [],
+                $this->serilizerMock
             ])
             ->getMock();
     }
@@ -532,6 +541,11 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
     {
         $model = $this->getModelMock();
         $model->setData('orig_template_variables', $templateVariables);
+
+        $this->serilizerMock->expects($this->any())->method('unserialize')
+            ->willReturn(
+                json_decode($templateVariables, true)
+            );
         $this->assertEquals($expectedResult, $model->getVariablesOptionArray($withGroup));
     }
 

--- a/app/code/Magento/Email/Test/Unit/Model/TemplateTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/TemplateTest.php
@@ -87,7 +87,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
     /**
      * @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $serilizerMock;
+    private $serializerMock;
 
     protected function setUp()
     {
@@ -144,7 +144,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->serilizerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
     }
 
     /**
@@ -172,7 +172,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
                 $this->urlModel,
                 $this->filterFactory,
                 [],
-                $this->serilizerMock
+                $this->serializerMock
             ])
             ->getMock();
     }
@@ -542,7 +542,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         $model = $this->getModelMock();
         $model->setData('orig_template_variables', $templateVariables);
 
-        $this->serilizerMock->expects($this->any())->method('unserialize')
+        $this->serializerMock->expects($this->any())->method('unserialize')
             ->willReturn(
                 json_decode($templateVariables, true)
             );


### PR DESCRIPTION
Since Zend Framework1 is EOF then we should start to move away from it.

This PR removes the usage of Zend_Json in the Email module.