### PR TITLE
Remove Zend_Json from the persistent module remember me status observer

### DIFF
--- a/app/code/Magento/Persistent/Observer/SetRememberMeStatusForAjaxLoginObserver.php
+++ b/app/code/Magento/Persistent/Observer/SetRememberMeStatusForAjaxLoginObserver.php
@@ -29,17 +29,27 @@ class SetRememberMeStatusForAjaxLoginObserver implements ObserverInterface
     protected $_persistentData = null;
 
     /**
-     * Constructor
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
+     * SetRememberMeStatusForAjaxLoginObserver constructor.
      *
      * @param \Magento\Persistent\Helper\Data $persistentData
      * @param \Magento\Persistent\Helper\Session $persistentSession
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Persistent\Helper\Data $persistentData,
-        \Magento\Persistent\Helper\Session $persistentSession
+        \Magento\Persistent\Helper\Session $persistentSession,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->_persistentData = $persistentData;
         $this->_persistentSession = $persistentSession;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
@@ -63,7 +73,7 @@ class SetRememberMeStatusForAjaxLoginObserver implements ObserverInterface
             $requestData = [];
             $content = $request->getContent();
             if ($content) {
-                $requestData = \Zend_Json::decode($content);
+                $requestData = $this->serializer->unserialize($content);
             }
             $isRememberMeChecked = empty($requestData['persistent_remember_me']) ? false : true;
             $this->_persistentSession->setRememberMeChecked((bool)$isRememberMeChecked);


### PR DESCRIPTION
Since Zend Framework1 is EOF then we should start to move away from it.

This PR removes the usage of Zend_Json in the persistent module.