### PR TITLE
Removed uncommon Comment-Syntax

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
+++ b/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
@@ -21,7 +21,7 @@ use Magento\Framework\Phrase;
  */
 class PhpCookieManager implements CookieManagerInterface
 {
-    /**#@+
+    /**
      * Constants for Cookie manager.
      * RFC 2109 - Page 15
      * http://www.ietf.org/rfc/rfc6265.txt
@@ -30,13 +30,11 @@ class PhpCookieManager implements CookieManagerInterface
     const MAX_COOKIE_SIZE = 4096;
     const EXPIRE_NOW_TIME = 1;
     const EXPIRE_AT_END_OF_SESSION_TIME = 0;
-    /**#@-*/
 
-    /**#@+
+    /**
      * Constant for metadata array key
      */
     const KEY_EXPIRE_TIME = 'expiry';
-    /**#@-*/
 
     /**
      * @var CookieScopeInterface


### PR DESCRIPTION
The Syntax of /**#@+ isn't used usually. Maybe it's a remnant of an old merge conflict?