### PR TITLE
Quote values in IN() predicate to avoid cast issues

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1334,7 +1334,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 array_merge($this->getNewSkuFieldsForSelect(), $this->getOldSkuFieldsForSelect())
             )->where(
                 'sku IN (?)',
-                array_keys($entityRowsIn)
+                $this->_connection->quote(array_keys($entityRowsIn))
             );
             $newProducts = $this->_connection->fetchAll($select);
             foreach ($newProducts as $data) {

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1333,8 +1333,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 $entityTable,
                 array_merge($this->getNewSkuFieldsForSelect(), $this->getOldSkuFieldsForSelect())
             )->where(
-                'sku IN (?)',
-                $this->_connection->quote(array_keys($entityRowsIn))
+                $this->_connection->quoteInto('sku IN (?)', array_keys($entityRowsIn))
             );
             $newProducts = $this->_connection->fetchAll($select);
             foreach ($newProducts as $data) {


### PR DESCRIPTION
Values in IN() predicate must be quoted as it may lead to cast issues otherwise.

Experienced: Two SKUs composed of numbers, one with prefix, one without.
- **123456789** (imported)
- **123456789-old** (already in database)

When importing the first one, the query returns both because of MySQL casting:
`SELECT sku FROM catalog_product_entity WHERE sku IN (123456789)` returns
123456789
123456789-old

while `SELECT sku FROM catalog_product_entity WHERE sku IN ("123456789")` returns the correct response
123456789