### PR TITLE
Fix order clause sql syntax, fix join conditions with same issue

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -2037,7 +2037,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             $this->getSelect()->join(
                 ['cat_pro' => $this->getTable('catalog_category_product')],
                 $joinCond,
-                ['cat_index.position' => 'position']
+                ['cat_pro.position' => 'position']
             );
         }
         $this->_joinFields['position'] = ['table' => 'cat_pro', 'field' => 'position'];

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -1643,9 +1643,6 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
                 $this->getSelect()->order($this->_getAttributeFieldName($attribute) . ' ' . $dir);
                 return $this;
             }
-            if ($this->isEnabledFlat()) {
-                $this->getSelect()->order("cat_index.position {$dir}");
-            }
             // optimize if using cat index
             $filters = $this->_productLimitationFilters;
             if (isset($filters['category_id']) || isset($filters['visibility'])) {

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -1644,7 +1644,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
                 return $this;
             }
             if ($this->isEnabledFlat()) {
-                $this->getSelect()->order("cat_index_position {$dir}");
+                $this->getSelect()->order("cat_index.position {$dir}");
             }
             // optimize if using cat index
             $filters = $this->_productLimitationFilters;
@@ -1997,7 +1997,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             $this->getSelect()->join(
                 ['cat_index' => $this->getTable('catalog_category_product_index')],
                 $joinCond,
-                ['cat_index_position' => 'position']
+                ['cat_index.position' => 'position']
             );
         }
 
@@ -2037,7 +2037,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             $this->getSelect()->join(
                 ['cat_pro' => $this->getTable('catalog_category_product')],
                 $joinCond,
-                ['cat_index_position' => 'position']
+                ['cat_index.position' => 'position']
             );
         }
         $this->_joinFields['position'] = ['table' => 'cat_pro', 'field' => 'position'];


### PR DESCRIPTION
Should fix [issue #5504](https://github.com/magento/magento2/issues/5504) - Currently throwing column not found exceptions when calling `addAttributeToSort()` if flat product is enabled. Also potentially whenever `_applyZeroStoreProductLimitations()` or `_applyProductLimitations()` is called.

***Solution***
`cat_index_position` should be `cat_index.position`