### PR TITLE
Add active class to search form wrapper for more theming flexibility

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/form-mini.js
@@ -122,6 +122,7 @@ define([
          * @param {Boolean} isActive
          */
         setActiveState: function (isActive) {
+            this.searchForm.toggleClass('active', isActive);
             this.searchLabel.toggleClass('active', isActive);
 
             if (this.isExpandable) {


### PR DESCRIPTION
Currently when the search form is focused I can only theme the search label (because it has an active class) and the input element itself (because it is focused). I cannot currently theme the input wrapping .control div as there are no wrapping elements identifying that the form has been focused. 

Adding an active class to the wrapping .minisearch form allows us to theme any children elements when the search form is focused.


 