### PR TITLE
Update Stock.php

### DIFF
--- a/app/code/Magento/CatalogInventory/Helper/Stock.php
+++ b/app/code/Magento/CatalogInventory/Helper/Stock.php
@@ -156,7 +156,7 @@ class Stock
             $resource = $this->getStockStatusResource();
             $resource->addStockDataToCollection(
                 $collection,
-                !$isShowOutOfStock && $collection->getFlag('require_stock_items')
+                !$isShowOutOfStock || $collection->getFlag('require_stock_items')
             );
             $collection->setFlag($stockFlag, true);
         }


### PR DESCRIPTION
Relates to issue: https://github.com/magento/magento2/issues/8566

A flag set to null will always overwrite the isShowOutOfStock variable. So you can't set the default value from the admin configuration.