### PR TITLE
magento/magento2 #2370: A PHPDoc comment typo fix

### DIFF
--- a/app/code/Magento/Config/Model/Config/SourceFactory.php
+++ b/app/code/Magento/Config/Model/Config/SourceFactory.php
@@ -26,7 +26,7 @@ class SourceFactory
      * Create backend model by name
      *
      * @param string $modelName
-     * @return mixed
+     * @return \Magento\Framework\Option\ArrayInterface|object
      */
     public function create($modelName)
     {

--- a/app/code/Magento/Config/Model/Config/SourceFactory.php
+++ b/app/code/Magento/Config/Model/Config/SourceFactory.php
@@ -26,7 +26,7 @@ class SourceFactory
      * Create backend model by name
      *
      * @param string $modelName
-     * @return \Magento\Framework\Option\ArrayInterface|object
+     * @return \Magento\Framework\Option\ArrayInterface
      */
     public function create($modelName)
     {


### PR DESCRIPTION
Fixed typo in 
app/code/Magento/Config/Model/Config/SourceFactory.php on line 26

wrong typo was 

@return mixed 

fixed in 

@return \Magento\Framework\Option\ArrayInterface|object