### PR TITLE
fix $childrenWrapClass never used

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -187,7 +187,7 @@ class Topmenu extends Template implements IdentityInterface
             $colStops = $this->_columnBrake($child->getChildren(), $limit);
         }
 
-        $html .= '<ul class="level' . $childLevel . ' submenu">';
+        $html .= '<ul class="level' . $childLevel . ' ' . $childrenWrapClass .'">';
         $html .= $this->_getHtml($child, $childrenWrapClass, $limit, $colStops);
         $html .= '</ul>';
 


### PR DESCRIPTION
in [topmenu.phtml](https://github.com/magento/magento2/blob/develop/app/code/Magento/Theme/view/frontend/templates/html/topmenu.phtml#L18) there is a call to 

```$block->getHtml('level-top', 'submenu', $columnsLimit)```

from [Topmenu.php](https://github.com/magento/magento2/blob/develop/app/code/Magento/Theme/Block/Html/Topmenu.php).
Then after some step we arrive at [```_addSubMenu()```](https://github.com/magento/magento2/blob/develop/app/code/Magento/Theme/Block/Html/Topmenu.php#L178) where ```$childrenWrapClass``` is supposed to be added to the submenu ```ul``` but instead we have an hardcoded class:

```$html .= '<ul class="level' . $childLevel . ' submenu">';```

So:

```$block->getHtml('level-top', 'myCustomClass', $columnsLimit)```

will return a menu where submenus have a ```submenu``` class instead of ```myCustomClass```