### PR TITLE
Range filter doesn't works with 0  values in admin #7103

### DIFF
--- a/app/code/Magento/Ui/Component/Filters/Type/Range.php
+++ b/app/code/Magento/Ui/Component/Filters/Type/Range.php
@@ -53,7 +53,7 @@ class Range extends AbstractFilter
      */
     protected function applyFilterByType($type, $value)
     {
-        if (!empty($value) && $value !== '0') {
+        if (is_numeric($value)) {
             $filter = $this->filterBuilder->setConditionType($type)
                 ->setField($this->getName())
                 ->setValue($value)

--- a/app/code/Magento/Ui/Test/Unit/Component/Filters/Type/RangeTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/Filters/Type/RangeTest.php
@@ -97,12 +97,33 @@ class RangeTest extends \PHPUnit_Framework_TestCase
      *
      * @param string $name
      * @param array $filterData
-     * @param array|null $expectedCondition
+     * @param array|null $expectedCalls
      * @dataProvider getPrepareDataProvider
      * @return void
      */
-    public function testPrepare($name, $filterData, $expectedCondition)
+    public function testPrepare($name, $filterData, $expectedCalls)
     {
+        $filter = $this->getMock(
+            \Magento\Framework\Api\Filter::class,
+            [],
+            [],
+            '',
+            false,
+            false
+        );
+        $this->filterBuilderMock->expects($this->any())
+            ->method('setConditionType')
+            ->willReturnSelf();
+        $this->filterBuilderMock->expects($this->any())
+            ->method('setField')
+            ->willReturnSelf();
+        $this->filterBuilderMock->expects($this->any())
+            ->method('setValue')
+            ->willReturnSelf();
+        $this->filterBuilderMock->expects($this->any())
+            ->method('create')
+            ->willReturn($filter);
+
         $this->contextMock->expects($this->any())
             ->method('getNamespace')
             ->willReturn(Range::NAME);
@@ -110,9 +131,9 @@ class RangeTest extends \PHPUnit_Framework_TestCase
             ->method('addComponentDefinition')
             ->with(Range::NAME, ['extends' => Range::NAME]);
         $this->contextMock->expects($this->any())
-            ->method('getRequestParam')
-            ->with(UiContext::FILTER_VAR)
+            ->method('getFiltersParams')
             ->willReturn($filterData);
+
         /** @var DataProviderInterface $dataProvider */
         $dataProvider = $this->getMockForAbstractClass(
             \Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderInterface::class,
@@ -120,14 +141,14 @@ class RangeTest extends \PHPUnit_Framework_TestCase
             '',
             false
         );
-        $this->contextMock->expects($this->any())
+
+        $this->contextMock->expects($this->atLeastOnce())
             ->method('getDataProvider')
             ->willReturn($dataProvider);
-        if ($expectedCondition !== null) {
-            $dataProvider->expects($this->any())
-                ->method('addFilter')
-                ->with($expectedCondition, $name);
-        }
+
+        $dataProvider->expects($this->exactly($expectedCalls))
+            ->method('addFilter')
+            ->with($filter);
 
         $range = new Range(
             $this->contextMock,
@@ -149,37 +170,67 @@ class RangeTest extends \PHPUnit_Framework_TestCase
             [
                 'test_date',
                 ['test_date' => ['from' => 0, 'to' => 1]],
-                ['from' => null, 'orig_from' => 0, 'to' => 1],
+                2
             ],
             [
                 'test_date',
                 ['test_date' => ['from' => '', 'to' => 2]],
-                ['from' => null, 'orig_from' => '', 'to' => 2],
+                1
             ],
             [
                 'test_date',
                 ['test_date' => ['from' => 1, 'to' => '']],
-                ['from' => 1, 'orig_to' => '', 'to' => null],
+                1
             ],
             [
                 'test_date',
                 ['test_date' => ['from' => 1, 'to' => 0]],
-                ['from' => 1, 'orig_to' => 0, 'to' => null],
+                2
             ],
             [
                 'test_date',
                 ['test_date' => ['from' => 1, 'to' => 2]],
-                ['from' => 1, 'to' => 2],
+                2
+            ],
+            [
+                'test_date',
+                ['test_date' => ['from' => 0, 'to' => 0]],
+                2
+            ],
+            [
+                'test_date',
+                ['test_date' => ['from' => '0', 'to' => '0']],
+                2
+            ],
+            [
+                'test_date',
+                ['test_date' => ['from' => '0.0', 'to' => 1]],
+                2
             ],
             [
                 'test_date',
                 ['test_date' => ['from' => '', 'to' => '']],
-                null,
+                0
+            ],
+            [
+                'test_date',
+                ['test_date' => ['from' => 'a', 'to' => 'b']],
+                0
+            ],
+            [
+                'test_date',
+                ['test_date' => ['from' => '1']],
+                1
+            ],
+            [
+                'test_date',
+                ['test_date' => ['to' => '1']],
+                1
             ],
             [
                 'test_date',
                 ['test_date' => []],
-                null,
+                0
             ],
         ];
     }


### PR DESCRIPTION
This fixes issue #7103 and refactors test for the `prepare` method of `\Magento\Ui\Component\Filters\Type\Range` class.

The old test wasn't actually checking anything. The test was still "green" even if in the meantime some methods changed name and with invalid data was passed to the dataprovider.

Now the test fails when something is wrong and there are some more data cases added to the dataprovider.