### PR TITLE
Fix method named class being interpreted as a class

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/PhpScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/PhpScanner.php
@@ -237,7 +237,7 @@ class PhpScanner implements ScannerInterface
             }
 
             if (($tokens[$tokenIterator][0] == T_CLASS || $tokens[$tokenIterator][0] == T_INTERFACE)
-                && $tokens[$tokenIterator - 1][0] != T_DOUBLE_COLON
+                && $tokens[$tokenIterator - 1][0] != T_DOUBLE_COLON && $tokens[$tokenIterator - 2][0] != T_FUNCTION
             ) {
                 $classes = array_merge($classes, $this->_fetchClasses($namespace, $tokenIterator, $count, $tokens));
             }

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Reader/ClassesScannerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Reader/ClassesScannerTest.php
@@ -22,6 +22,6 @@ class ClassesScannerTest extends \PHPUnit_Framework_TestCase
         $pathToScan = str_replace('\\', '/', realpath(__DIR__ . '/../../') . '/_files/app/code/Magento/SomeModule');
         $actual = $this->model->getList($pathToScan);
         $this->assertTrue(is_array($actual));
-        $this->assertCount(5, $actual);
+        $this->assertCount(6, $actual);
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/PhpScannerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/PhpScannerTest.php
@@ -66,4 +66,19 @@ class PhpScannerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $this->_model->collectEntities($this->_testFiles));
     }
+
+    public function testMethodNamedClassDoesNotGetRecognisedAsAClass()
+    {
+        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+            $this->markTestSkipped('Test only runs on PHP > 7');
+        }
+
+        try {
+            $this->_model->collectEntities([
+                $this->_testDir . '/app/code/Magento/SomeModule/Model/MethodNamedClass.php'
+            ]);
+        } catch (\ReflectionException $e) {
+            $this->fail('Method should not be parsed as a class');
+        }
+    }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/_files/app/code/Magento/SomeModule/Model/MethodNamedClass.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/_files/app/code/Magento/SomeModule/Model/MethodNamedClass.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\SomeModule\Model;
+
+class MethodNamedClass
+{
+    public function class($someArg)
+    {
+        $someArg++;
+    }
+}


### PR DESCRIPTION
`PhpScanner` incorrectly interprets a method named `class` (valid PHP) as an actual class.

In the future this code should probably be refactored to make sure it *is* actually a class definition rather than the current method of blacklisting any other conflicting token streams.