### PR TITLE
magento/magento2: #8616

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/AbstractResource.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/AbstractResource.php
@@ -568,6 +568,6 @@ abstract class AbstractResource extends \Magento\Eav\Model\Entity\AbstractEntity
             $attributesData = $_data[1];
         }
 
-        return $attributesData!==false ? $attributesData : false;
+        return $attributesData === false ? false: $attributesData;
     }
 }

--- a/app/code/Magento/Catalog/Model/ResourceModel/AbstractResource.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/AbstractResource.php
@@ -568,6 +568,6 @@ abstract class AbstractResource extends \Magento\Eav\Model\Entity\AbstractEntity
             $attributesData = $_data[1];
         }
 
-        return $attributesData ? $attributesData : false;
+        return $attributesData!==false ? $attributesData : false;
     }
 }

--- a/app/code/Magento/Config/Model/Config/SourceFactory.php
+++ b/app/code/Magento/Config/Model/Config/SourceFactory.php
@@ -26,7 +26,7 @@ class SourceFactory
      * Create backend model by name
      *
      * @param string $modelName
-     * @return mixed
+     * @return \Magento\Framework\Option\ArrayInterface|object
      */
     public function create($modelName)
     {

--- a/app/code/Magento/Config/Model/Config/SourceFactory.php
+++ b/app/code/Magento/Config/Model/Config/SourceFactory.php
@@ -26,7 +26,7 @@ class SourceFactory
      * Create backend model by name
      *
      * @param string $modelName
-     * @return \Magento\Framework\Option\ArrayInterface|object
+     * @return \Magento\Framework\Option\ArrayInterface
      */
     public function create($modelName)
     {

--- a/setup/src/Magento/Setup/Test/Unit/Validator/DbValidatorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Validator/DbValidatorTest.php
@@ -55,7 +55,6 @@ class DbValidatorTest extends \PHPUnit_Framework_TestCase
             ['DELETE'],
             ['CREATE'],
             ['DROP'],
-            ['REFERENCES'],
             ['INDEX'],
             ['ALTER'],
             ['CREATE TEMPORARY TABLES'],
@@ -65,7 +64,6 @@ class DbValidatorTest extends \PHPUnit_Framework_TestCase
             ['SHOW VIEW'],
             ['CREATE ROUTINE'],
             ['ALTER ROUTINE'],
-            ['EVENT'],
             ['TRIGGER'],
         ];
         $accessibleDbs = ['some_db', 'name', 'another_db'];

--- a/setup/src/Magento/Setup/Validator/DbValidator.php
+++ b/setup/src/Magento/Setup/Validator/DbValidator.php
@@ -146,7 +146,6 @@ class DbValidator
             'DELETE',
             'CREATE',
             'DROP',
-            'REFERENCES',
             'INDEX',
             'ALTER',
             'CREATE TEMPORARY TABLES',
@@ -156,7 +155,6 @@ class DbValidator
             'SHOW VIEW',
             'CREATE ROUTINE',
             'ALTER ROUTINE',
-            'EVENT',
             'TRIGGER'
         ];
 


### PR DESCRIPTION
Unused mysql privileges required even if not used/not needed at all
- removed REFERENCES and EVENT privileges from DbValidator (also in Test Unit).
