### PR TITLE
Update AbstractModel.php

### DIFF
--- a/app/code/Magento/Rule/Model/AbstractModel.php
+++ b/app/code/Magento/Rule/Model/AbstractModel.php
@@ -335,7 +335,7 @@ abstract class AbstractModel extends \Magento\Framework\Model\AbstractExtensible
                 /**
                  * Convert dates into \DateTime
                  */
-                if (in_array($key, ['from_date', 'to_date']) && $value) {
+                if (in_array($key, ['from_date', 'to_date'], true) && $value) {
                     $value = new \DateTime($value);
                 }
                 $this->setData($key, $value);


### PR DESCRIPTION
PHP's function `in_array` returns `TRUE` when evaluating a needle `0` against a list of strings, which is a known issue. In my case I got an exception because a small integer was used to construct a new `DateTime` object. Calling the function in strict mode fixes this. See also http://stackoverflow.com/questions/13846769/php-in-array-0-value.