### PR TITLE
Add `mergeData` method to DataObject

### DIFF
--- a/lib/internal/Magento/Framework/DataObject.php
+++ b/lib/internal/Magento/Framework/DataObject.php
@@ -91,8 +91,8 @@ class DataObject implements \ArrayAccess
      * If the provided key is an array, the merge will be done against the
      * entire dataset.
      *
-     * @param string $key
-     * @param array $value
+     * @param string|array $key
+     * @param array|null $value
      *
      * @return $this
      */

--- a/lib/internal/Magento/Framework/DataObject.php
+++ b/lib/internal/Magento/Framework/DataObject.php
@@ -79,6 +79,76 @@ class DataObject implements \ArrayAccess
     }
 
     /**
+     * Deeply merge array data, instead of replacing it.
+     *
+     * If a key already has array data in it, it is common to want to merge the
+     * data in the arrays, with the newer array overwriting any conflicting keys,
+     * instead of the entire array being replaced.
+     *
+     * If the key does not exist in the DataObject, or the current value of the
+     * key is not an array, the usual setData handling will be applied.
+     *
+     * If the provided key is an array, the merge will be done against the
+     * entire dataset.
+     *
+     * @param string $key
+     * @param array $value
+     *
+     * @return $this
+     */
+    public function mergeData($key, array $value = null)
+    {
+        if (is_array($key)) {
+            $this->_data = $this->deepArrayMerge(
+                $this->_data,
+                $key
+            );
+        } else if (is_array($value) && isset($this->_data[$key]) && is_array($this->_data[$key])) {
+            $this->_data[$key] = $this->deepArrayMerge(
+                $this->_data[$key],
+                $value
+            );
+        } else {
+            $this->setData($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Recursively merge two arrays, replacing any conflicting keys with the
+     * value from the new array.
+     *
+     * Using references avoids copying the entire array. This method has no side
+     * effects on the provided arrays.
+     *
+     * This is a slightly refactored version of the deep recursive merge
+     * function found in the PHP documentation.
+     *
+     * @see http://php.net/manual/en/function.array-merge-recursive.php#92195
+     * @param array $original
+     * @param array $new
+     * @return array
+     */
+    protected function deepArrayMerge(array &$original, array &$new)
+    {
+        $merged = $original;
+
+        foreach ($new as $key => &$value) {
+            if (isset($merged[$key]) && is_array($value) && is_array($merged[$key])) {
+                $merged[$key] = $this->deepArrayMerge(
+                    $merged[$key],
+                    $value
+                );
+            } else {
+                $merged[$key] = $value;
+            }
+        }
+
+        return $merged;
+    }
+
+    /**
      * Unset data from the object.
      *
      * @param null|string|array $key

--- a/lib/internal/Magento/Framework/Test/Unit/ObjectTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/ObjectTest.php
@@ -83,6 +83,28 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests \Magento\Framework\DataObject->mergeData
+     */
+    public function testMergeData()
+    {
+        $data = ['key1' => ['key4' => 5, 'key5' => ['changed' => 'no']], 'key2' => 'value2', 'key3' => 3];
+        $this->_object->setData($data);
+        $this->assertEquals($data, $this->_object->getData());
+
+        $newData = ['key1' => ['key5' => ['changed' => 'yes'] ]];
+        $this->_object->mergeData($newData);
+        $this->assertEquals('yes', $this->_object->getData('key1/key5/changed'));
+        $this->assertEquals('5', $this->_object->getData('key1/key4'));
+        $this->assertEquals('value2', $this->_object->getData('key2'));
+
+        $newData = ['key5' => ['changed' => 'again'] ];
+        $this->_object->mergeData('key1', $newData);
+        $this->assertEquals('again', $this->_object->getData('key1/key5/changed'));
+        $this->assertEquals('5', $this->_object->getData('key1/key4'));
+        $this->assertEquals('value2', $this->_object->getData('key2'));
+    }
+
+    /**
      * Tests \Magento\Framework\DataObject->unsetData()
      */
     public function testUnsetData()


### PR DESCRIPTION
It's not uncommon to have two arrays that you wish to merge together recursively, for later descent. `\Magento\Framework\DataObject` provides the retrieval method through `getData`, where a slash separated path can be used to descend into an array to retrieve a specific item, without having to extract the whole array and do a bunch of `isset` checks.

However, there's no equivalent for setting data. If a key already exists in the DataObject with an array value, setting another array will always overwrite the existing data completely.

This pull request proposes adding a new `mergeData` method. This method will perform a recursive merge between the current data in the given key and the provided data. If the key is an array, it will merge against the entire dataset.  If the key does not currently exist in the DataObject, it will fall back to the standard behavior of `setData`.

Making this a separate method instead of adding it to `addData` or `setData` ensures that this functionality must be used explicitly, avoiding any backwards compatibility issues.

The merge method is from http://php.net/manual/en/function.array-merge-recursive.php#92195. It has been slightly refactored to adhere to the style guide.