### PR TITLE
Popup-Modal not closing on Safari/Windows

### DIFF
--- a/lib/web/css/source/components/_modals.less
+++ b/lib/web/css/source/components/_modals.less
@@ -48,9 +48,15 @@
     right: 0;
     top: 0;
     visibility: hidden;
+    opacity: 0;
+    -webkit-transition: visibility 0s .3s, opacity .3s ease;
+            transition: visibility 0s .3s, opacity .3s ease;
 
     &._show {
         visibility: visible;
+        opacity: 1;
+        -webkit-transition: opacity .3s ease;
+                transition: opacity .3s ease;
 
         .modal-inner-wrap {
             -webkit-transform: translate(0, 0);
@@ -83,10 +89,8 @@
         position: static;
         -webkit-transform: translateX(100%);
                 transform: translateX(100%);
-        transition-duration: .3s;
-        -webkit-transition-property: -webkit-transform, visibility;
-                transition-property:         transform, visibility;
-        transition-timing-function: ease-in-out;
+        -webkit-transition: -webkit-transform .3s ease-in-out;
+                transition:         transform .3s ease-in-out;
         width: auto;
     }
 }
@@ -115,10 +119,8 @@
         right: 0;
         -webkit-transform: translateY(-200%);
                 transform: translateY(-200%);
-        transition-duration: .2s;
-        -webkit-transition-property: -webkit-transform, visibility;
-                transition-property:         transform, visibility;
-        transition-timing-function: ease;
+        -webkit-transition: -webkit-transform .2s ease;
+                transition:         transform .2s ease;
 
     }
 }


### PR DESCRIPTION
This pull request is a fix for issue: [#8761](https://github.com/magento/magento2/issues/8761)

The first thing I noticed when looking into the css was that the `-webkit-transition-duration` was missing. Therefore, the transition event was never triggered in Safari. The modal directly popped up on clicking the *remove item* button in the shopping cart.
After adding the transition duration, Safari did no longer show the modal at all. This was because the visibility transition acts on the parent, while the transition is set on its child. I divided the animation into a visibility transition at the parent `.modal-slide, .modal-popup` and a transform transition at its child `.modal-inner-wrap`. As a result, Safari users can now remove items from cart without the need to refresh a greyed out page.

While debugging I replicated the issue in JSFiddle:
http://jsfiddle.net/muL7Lpnx/
And wrote the following fix:
http://jsfiddle.net/muL7Lpnx/1/

After updating the Magento Less source files, I successfully tested the fix in the following browsers:
Safari 5.1.7
Chrome 56
IE 11
Microsoft Edge 38
Firefox 50.1.0
Opera 43