### PR TITLE
Expose final price in the API

### DIFF
--- a/app/code/Magento/Catalog/Api/Data/ProductInterface.php
+++ b/app/code/Magento/Catalog/Api/Data/ProductInterface.php
@@ -105,6 +105,13 @@ interface ProductInterface extends \Magento\Framework\Api\CustomAttributesDataIn
     public function getPrice();
 
     /**
+     * Product final price
+     *
+     * @return float|null
+     */
+    public function getFinalPrice();
+
+    /**
      * Set product price
      *
      * @param float $price


### PR DESCRIPTION
Hi,

In order to use the API in a SPA, the final price is needed.  
Especially for configurable products that have a price at 0.

Should I add a test for this ? If yes, where should it be ? I didn't find anything specifically related to the API yet.