### PR TITLE
Replace Zend_Json from the Magento Quote module

### DIFF
--- a/app/code/Magento/Quote/Model/Cart/Totals/ItemConverter.php
+++ b/app/code/Magento/Quote/Model/Cart/Totals/ItemConverter.php
@@ -38,23 +38,33 @@ class ItemConverter
     private $dataObjectHelper;
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
      * Constructs a totals item converter object.
      *
      * @param ConfigurationPool $configurationPool
      * @param EventManager $eventManager
      * @param \Magento\Quote\Api\Data\TotalsItemInterfaceFactory $totalsItemFactory
      * @param DataObjectHelper $dataObjectHelper
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         ConfigurationPool $configurationPool,
         EventManager $eventManager,
         \Magento\Quote\Api\Data\TotalsItemInterfaceFactory $totalsItemFactory,
-        DataObjectHelper $dataObjectHelper
+        DataObjectHelper $dataObjectHelper,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->configurationPool = $configurationPool;
         $this->eventManager = $eventManager;
         $this->totalsItemFactory = $totalsItemFactory;
         $this->dataObjectHelper = $dataObjectHelper;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
@@ -103,6 +113,6 @@ class ItemConverter
             $optionsData[$index] = $option;
             $optionsData[$index]['label'] = $optionValue['label'];
         }
-        return \Zend_Json::encode($optionsData);
+        return $this->serializer->serialize($optionsData);
     }
 }

--- a/app/code/Magento/Quote/Test/Unit/Model/Cart/Totals/ItemConverterTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Cart/Totals/ItemConverterTest.php
@@ -33,6 +33,9 @@ class ItemConverterTest extends \PHPUnit_Framework_TestCase
      */
     private $model;
 
+    /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject */
+    private $serializerMock;
+
     protected function setUp()
     {
         $this->configPoolMock = $this->getMock(
@@ -52,11 +55,14 @@ class ItemConverterTest extends \PHPUnit_Framework_TestCase
             false
         );
 
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
+
         $this->model = new \Magento\Quote\Model\Cart\Totals\ItemConverter(
             $this->configPoolMock,
             $this->eventManagerMock,
             $this->totalsFactoryMock,
-            $this->dataObjectHelperMock
+            $this->dataObjectHelperMock,
+            $this->serializerMock
         );
     }
 
@@ -91,6 +97,19 @@ class ItemConverterTest extends \PHPUnit_Framework_TestCase
         ];
         $this->dataObjectHelperMock->expects($this->once())->method('populateWithArray')
             ->with(null, $expectedData, \Magento\Quote\Api\Data\TotalsItemInterface::class);
+
+        $optionData = [
+            '1' => [
+                'data' => 'optionsData',
+                'label' => 'option1'
+            ],
+            '2' => [
+                'data' => 'optionsData',
+                'label' => 'option2'
+            ]
+        ];
+        $this->serializerMock->expects($this->once())->method('serialize')
+            ->will($this->returnValue(json_encode($optionData)));
 
         $this->model->modelToDataObject($itemMock);
     }


### PR DESCRIPTION
Since Zend 1 is past EOL we should migrate from Zend_Json to the `\Magento\Framework\Serialize\Serializer\Json` class.