### PR TITLE
Replace Zend_Json from the Magento Review module

### DIFF
--- a/app/code/Magento/Review/Block/Form.php
+++ b/app/code/Magento/Review/Block/Form.php
@@ -67,6 +67,13 @@ class Form extends \Magento\Framework\View\Element\Template
     protected $jsLayout;
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
+     * Form constructor.
+     *
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Framework\Url\EncoderInterface $urlEncoder
      * @param \Magento\Review\Helper\Data $reviewData
@@ -74,8 +81,10 @@ class Form extends \Magento\Framework\View\Element\Template
      * @param \Magento\Review\Model\RatingFactory $ratingFactory
      * @param \Magento\Framework\Message\ManagerInterface $messageManager
      * @param \Magento\Framework\App\Http\Context $httpContext
-     * @param \Magento\Customer\Model\Url $customerUrl
+     * @param Url $customerUrl
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -87,7 +96,8 @@ class Form extends \Magento\Framework\View\Element\Template
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Framework\App\Http\Context $httpContext,
         \Magento\Customer\Model\Url $customerUrl,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->urlEncoder = $urlEncoder;
         $this->_reviewData = $reviewData;
@@ -98,6 +108,8 @@ class Form extends \Magento\Framework\View\Element\Template
         $this->customerUrl = $customerUrl;
         parent::__construct($context, $data);
         $this->jsLayout = isset($data['jsLayout']) ? $data['jsLayout'] : [];
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
@@ -133,13 +145,13 @@ class Form extends \Magento\Framework\View\Element\Template
      */
     public function getJsLayout()
     {
-        return \Zend_Json::encode($this->jsLayout);
+        return $this->serializer->serialize($this->jsLayout);
     }
 
     /**
      * Get product info
      *
-     * @return Product
+     * @return \Magento\Catalog\Api\Data\ProductInterface
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function getProductInfo()
@@ -171,6 +183,7 @@ class Form extends \Magento\Framework\View\Element\Template
      * Get collection of ratings
      *
      * @return RatingCollection
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getRatings()
     {

--- a/app/code/Magento/Review/Test/Unit/Block/FormTest.php
+++ b/app/code/Magento/Review/Test/Unit/Block/FormTest.php
@@ -37,6 +37,9 @@ class FormTest extends \PHPUnit_Framework_TestCase
     /** @var \Magento\Framework\UrlInterface|PHPUnit_Framework_MockObject_MockObject */
     protected $urlBuilder;
 
+    /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject */
+    private $serializerMock;
+
     protected function setUp()
     {
         $this->storeManager = $this->getMock(\Magento\Store\Model\StoreManagerInterface::class);
@@ -64,6 +67,8 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->any())->method('getUrlBuilder')->willReturn($this->urlBuilder);
         $this->productRepository = $this->getMock(\Magento\Catalog\Api\ProductRepositoryInterface::class);
 
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
+
         $this->objectManagerHelper = new ObjectManagerHelper($this);
         $this->object = $this->objectManagerHelper->getObject(
             \Magento\Review\Block\Form::class,
@@ -71,6 +76,12 @@ class FormTest extends \PHPUnit_Framework_TestCase
                 'context' => $this->context,
                 'reviewData' => $this->reviewDataMock,
                 'productRepository' => $this->productRepository,
+                'data' => [
+                    'jsLayout' => [
+                        'some-layout' => 'layout information'
+                    ]
+                ],
+                'serializer' => $this->serializerMock
             ]
         );
     }
@@ -131,5 +142,16 @@ class FormTest extends \PHPUnit_Framework_TestCase
             [false, 'http://localhost/review/product/post', 3],
             [true, 'https://localhost/review/product/post' ,3],
         ];
+    }
+
+    public function testGetJsLayout()
+    {
+        $jsLayout = [
+            'some-layout' => 'layout information'
+        ];
+
+        $this->serializerMock->expects($this->once())->method('serialize')
+            ->will($this->returnValue(json_encode($jsLayout)));
+        $this->assertEquals('{"some-layout":"layout information"}', $this->object->getJsLayout());
     }
 }


### PR DESCRIPTION
Since Zend Framework1 is EOF then we should start to move away from it.

This PR removes the usage of Zend_Json in the Review module.