### PR TITLE
Fix TODO: Remove direct ObjectManager usage

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -50,7 +50,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
      * @var \Magento\CatalogInventory\Model\Indexer\Stock\Processor
      */
     protected $_stockIndexerProcessor;
-    
+
     /**
      * Stock Stock registry
      *
@@ -96,7 +96,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
      * @param \Magento\Framework\Api\DataObjectHelper $dataObjectHelper
      */
     public function __construct(
-        Action\Context $context,        
+        Action\Context $context,
         \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate,
         \Magento\Eav\Model\Config $eavConfig,
         \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper,

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -15,19 +15,6 @@ use Magento\Backend\App\Action;
 class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribute
 {
     /**
-     * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
-     */
-    protected $localeDate;
-    
-    /**
-     * Eav config
-     *
-     * @var \Magento\Eav\Model\Config
-     */
-    protected $_eavConfig;
-
-    
-    /**
      * @var \Magento\Catalog\Model\Indexer\Product\Flat\Processor
      */
     protected $_productFlatIndexerProcessor;
@@ -52,72 +39,89 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
     protected $_stockIndexerProcessor;
 
     /**
-     * @var \Magento\CatalogInventory\Api\StockRegistryInterface
-     */
-    protected $stockRegistry;
-    
-     /**
-     * @var \Magento\CatalogInventory\Api\StockItemRepositoryInterface
-     */
-    protected $stockItemRepository;
-    
-    /**
-     * @var \Magento\CatalogInventory\Api\StockConfigurationInterface
-     */
-    protected $stockConfiguration;
-    
-    /**
      * @var \Magento\CatalogInventory\Api\Data\StockItemInterfaceFactory
      */
     protected $stockItemFactory;
-    
+
     /**
      * @var \Magento\Framework\Api\DataObjectHelper
      */
     protected $dataObjectHelper;
 
     /**
+     * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
+     */
+    protected $localeDate;
+
+    /**
+     * Eav config
+     *
+     * @var \Magento\Eav\Model\Config
+     */
+    protected $eavConfig;
+
+    /**
+     * @var \Magento\CatalogInventory\Api\StockRegistryInterface
+     */
+    protected $stockRegistry;
+
+     /**
+     * @var \Magento\CatalogInventory\Api\StockItemRepositoryInterface
+     */
+    protected $stockItemRepository;
+
+    /**
+     * @var \Magento\CatalogInventory\Api\StockConfigurationInterface
+     */
+    protected $stockConfiguration;
+
+    /**
      * @param Action\Context $context
-     * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate     * 
-     * @param \Magento\Eav\Model\Config $eavConfig
      * @param \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper
      * @param \Magento\Catalog\Model\Indexer\Product\Flat\Processor $productFlatIndexerProcessor
      * @param \Magento\Catalog\Model\Indexer\Product\Price\Processor $productPriceIndexerProcessor
      * @param \Magento\CatalogInventory\Model\Indexer\Stock\Processor $stockIndexerProcessor
      * @param \Magento\Catalog\Helper\Product $catalogProduct
-     * @param \Magento\CatalogInventory\Api\StockRegistryInterface $stockRegistry
-     * @param \Magento\CatalogInventory\Api\StockItemRepositoryInterface $stockItemRepository
-     * @param \Magento\CatalogInventory\Api\StockConfigurationInterface $stockConfiguration
      * @param \Magento\CatalogInventory\Api\Data\StockItemInterfaceFactory $stockItemFactory
      * @param \Magento\Framework\Api\DataObjectHelper $dataObjectHelper
+     * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface|null $localeDate
+     * @param \Magento\Eav\Model\Config|null $eavConfig
+     * @param \Magento\CatalogInventory\Api\StockRegistryInterface|null $stockRegistry
+     * @param \Magento\CatalogInventory\Api\StockItemRepositoryInterface|null $stockItemRepository
+     * @param \Magento\CatalogInventory\Api\StockConfigurationInterface|null $stockConfiguration
      */
     public function __construct(
         Action\Context $context,
-        \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate,
-        \Magento\Eav\Model\Config $eavConfig,
         \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper,
         \Magento\Catalog\Model\Indexer\Product\Flat\Processor $productFlatIndexerProcessor,
         \Magento\Catalog\Model\Indexer\Product\Price\Processor $productPriceIndexerProcessor,
         \Magento\CatalogInventory\Model\Indexer\Stock\Processor $stockIndexerProcessor,
         \Magento\Catalog\Helper\Product $catalogProduct,
-        \Magento\CatalogInventory\Api\StockRegistryInterface $stockRegistry,
-        \Magento\CatalogInventory\Api\StockItemRepositoryInterface $stockItemRepository,
-        \Magento\CatalogInventory\Api\StockConfigurationInterface $stockConfiguration,
         \Magento\CatalogInventory\Api\Data\StockItemInterfaceFactory $stockItemFactory,
-        \Magento\Framework\Api\DataObjectHelper $dataObjectHelper
+        \Magento\Framework\Api\DataObjectHelper $dataObjectHelper,
+        \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate = null,
+        \Magento\Eav\Model\Config $eavConfig = null,
+        \Magento\CatalogInventory\Api\StockRegistryInterface $stockRegistry = null,
+        \Magento\CatalogInventory\Api\StockItemRepositoryInterface $stockItemRepository = null,
+        \Magento\CatalogInventory\Api\StockConfigurationInterface $stockConfiguration = null
     ) {
-        $this->localeDate = $localeDate;
-        $this->eavConfig = $eavConfig;
         $this->_productFlatIndexerProcessor = $productFlatIndexerProcessor;
         $this->_productPriceIndexerProcessor = $productPriceIndexerProcessor;
         $this->_stockIndexerProcessor = $stockIndexerProcessor;
         $this->_catalogProduct = $catalogProduct;
-        $this->stockRegistry = $stockRegistry;
-        $this->stockItemRepository = $stockItemRepository;
-        $this->stockConfiguration = $stockConfiguration;
         $this->stockItemFactory = $stockItemFactory;
         parent::__construct($context, $attributeHelper);
         $this->dataObjectHelper = $dataObjectHelper;
+        $this->localeDate = $localeDate ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Stdlib\DateTime\TimezoneInterface::class);
+        $this->eavConfig = $eavConfig ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Eav\Model\Config::class);
+        $this->stockRegistry = $stockRegistry ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\CatalogInventory\Api\StockRegistryInterface::class);
+        $this->stockItemRepository = $stockItemRepository ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\CatalogInventory\Api\StockItemRepositoryInterface::class);
+        $this->stockConfiguration = $stockConfiguration ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\CatalogInventory\Api\StockConfigurationInterface::class);
     }
 
     /**

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -52,16 +52,12 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
     protected $_stockIndexerProcessor;
 
     /**
-     * Stock Stock registry
-     *
      * @var \Magento\CatalogInventory\Api\StockRegistryInterface
      */
     protected $stockRegistry;
     
      /**
-     * Stock Stock item repository
-     *
-     * @var \Magento\CatalogInventory\Api\StockRegistryInterface
+     * @var \Magento\CatalogInventory\Api\StockItemRepositoryInterface
      */
     protected $stockItemRepository;
     
@@ -76,7 +72,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
     protected $stockItemFactory;
     
     /**
-     * @var \Magento\CatalogInventory\Api\StockItemRepositoryInterface
+     * @var \Magento\Framework\Api\DataObjectHelper
      */
     protected $dataObjectHelper;
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -7,6 +7,7 @@
 namespace Magento\Catalog\Controller\Adminhtml\Product\Action\Attribute;
 
 use Magento\Backend\App\Action;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Class Save
@@ -65,7 +66,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
      */
     protected $stockRegistry;
 
-     /**
+    /**
      * @var \Magento\CatalogInventory\Api\StockItemRepositoryInterface
      */
     protected $stockItemRepository;
@@ -112,15 +113,15 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
         $this->stockItemFactory = $stockItemFactory;
         parent::__construct($context, $attributeHelper);
         $this->dataObjectHelper = $dataObjectHelper;
-        $this->localeDate = $localeDate ?: \Magento\Framework\App\ObjectManager::getInstance()
+        $this->localeDate = $localeDate ?: ObjectManager::getInstance()
             ->get(\Magento\Framework\Stdlib\DateTime\TimezoneInterface::class);
-        $this->eavConfig = $eavConfig ?: \Magento\Framework\App\ObjectManager::getInstance()
+        $this->eavConfig = $eavConfig ?: ObjectManager::getInstance()
             ->get(\Magento\Eav\Model\Config::class);
-        $this->stockRegistry = $stockRegistry ?: \Magento\Framework\App\ObjectManager::getInstance()
+        $this->stockRegistry = $stockRegistry ?: ObjectManager::getInstance()
             ->get(\Magento\CatalogInventory\Api\StockRegistryInterface::class);
-        $this->stockItemRepository = $stockItemRepository ?: \Magento\Framework\App\ObjectManager::getInstance()
+        $this->stockItemRepository = $stockItemRepository ?: ObjectManager::getInstance()
             ->get(\Magento\CatalogInventory\Api\StockItemRepositoryInterface::class);
-        $this->stockConfiguration = $stockConfiguration ?: \Magento\Framework\App\ObjectManager::getInstance()
+        $this->stockConfiguration = $stockConfiguration ?: ObjectManager::getInstance()
             ->get(\Magento\CatalogInventory\Api\StockConfigurationInterface::class);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The direct usage of `ObjectManager` should never happen. Instead it should be included in the classes constructor by dependency injection. The TODO was added in alpha in PR 2 (different repos).

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
