### PR TITLE
add middle name to checkout address html templates #8878

### DIFF
--- a/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
+++ b/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
@@ -321,24 +321,14 @@ class AttributeMerger
                     return $this->getCustomer()->getFirstname();
                 }
                 break;
-            case 'lastname':
-                if ($this->getCustomer()) {
-                    return $this->getCustomer()->getLastname();
-                }
-                break;
             case 'middlename':
                 if ($this->getCustomer()) {
                     return $this->getCustomer()->getMiddlename();
                 }
                 break;
-            case 'prefix':
+            case 'lastname':
                 if ($this->getCustomer()) {
-                    return $this->getCustomer()->getPrefix();
-                }
-                break;
-            case 'suffix':
-                if ($this->getCustomer()) {
-                    return $this->getCustomer()->getSuffix();
+                    return $this->getCustomer()->getLastname();
                 }
                 break;
             case 'country_id':

--- a/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
+++ b/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
@@ -326,6 +326,21 @@ class AttributeMerger
                     return $this->getCustomer()->getLastname();
                 }
                 break;
+            case 'middlename':
+                if ($this->getCustomer()) {
+                    return $this->getCustomer()->getMiddlename();
+                }
+                break;
+            case 'prefix':
+                if ($this->getCustomer()) {
+                    return $this->getCustomer()->getPrefix();
+                }
+                break;
+            case 'suffix':
+                if ($this->getCustomer()) {
+                    return $this->getCustomer()->getSuffix();
+                }
+                break;
             case 'country_id':
                 return $this->directoryHelper->getDefaultCountry();
         }

--- a/app/code/Magento/Checkout/view/frontend/web/template/billing-address/details.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/billing-address/details.html
@@ -5,7 +5,7 @@
  */
 -->
 <div class="billing-address-details" data-bind="if: isAddressDetailsVisible() && currentBillingAddress()">
-    <!-- ko text: currentBillingAddress().prefix --><!-- /ko --> <!-- ko text: currentBillingAddress().firstname --><!-- /ko -->
+    <!-- ko text: currentBillingAddress().prefix --><!-- /ko --> <!-- ko text: currentBillingAddress().firstname --><!-- /ko --> <!-- ko text: currentBillingAddress().middlename --><!-- /ko -->
     <!-- ko text: currentBillingAddress().lastname --><!-- /ko --> <!-- ko text: currentBillingAddress().suffix --><!-- /ko --><br/>
     <!-- ko text: currentBillingAddress().street --><!-- /ko --><br/>
     <!-- ko text: currentBillingAddress().city --><!-- /ko -->, <span data-bind="html: currentBillingAddress().region"></span> <!-- ko text: currentBillingAddress().postcode --><!-- /ko --><br/>

--- a/app/code/Magento/Checkout/view/frontend/web/template/shipping-address/address-renderer/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/shipping-address/address-renderer/default.html
@@ -5,7 +5,7 @@
  */
 -->
 <div class="shipping-address-item" data-bind="css: isSelected() ? 'selected-item' : 'not-selected-item'">
-    <!-- ko text: address().prefix --><!-- /ko --> <!-- ko text: address().firstname --><!-- /ko -->
+    <!-- ko text: address().prefix --><!-- /ko --> <!-- ko text: address().firstname --><!-- /ko --> <!-- ko text: address().middlename --><!-- /ko -->
     <!-- ko text: address().lastname --><!-- /ko --> <!-- ko text: address().suffix --><!-- /ko --><br/>
     <!-- ko text: address().street --><!-- /ko --><br/>
     <!-- ko text: address().city --><!-- /ko -->, <span data-bind="html: address().region"></span> <!-- ko text: address().postcode --><!-- /ko --><br/>

--- a/app/code/Magento/Checkout/view/frontend/web/template/shipping-information/address-renderer/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/shipping-information/address-renderer/default.html
@@ -5,7 +5,7 @@
  */
 -->
 <!-- ko if: (visible()) -->
-    <!-- ko text: address().prefix --><!-- /ko --> <!-- ko text: address().firstname --><!-- /ko -->
+    <!-- ko text: address().prefix --><!-- /ko --> <!-- ko text: address().firstname --><!-- /ko --> <!-- ko text: address().middlename --><!-- /ko -->
     <!-- ko text: address().lastname --><!-- /ko --> <!-- ko text: address().suffix --><!-- /ko --><br/>
     <!-- ko text: address().street --><!-- /ko --><br/>
     <!-- ko text: address().city --><!-- /ko -->, <span data-bind="html: address().region"></span> <!-- ko text: address().postcode --><!-- /ko --><br/>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Three checkout address templates were lacking the middle name. they are now added.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magetno2#<issue_number>, if relevant  -->
1. magento/magetno2#8878: middle name is missing from the checkout address html templates

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create an account with a middle name and log in
2. Add a product to the cart and go to the checkout
3. Visit the shipping address step
4. You should now see the middle name appear in the address name

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
