### PR TITLE
Update design_config_form.xml

### DIFF
--- a/app/code/Magento/Theme/view/adminhtml/ui_component/design_config_form.xml
+++ b/app/code/Magento/Theme/view/adminhtml/ui_component/design_config_form.xml
@@ -67,7 +67,7 @@
                         <item name="componentType" xsi:type="string">fileUploader</item>
                         <item name="notice" xsi:type="string" translate="true">Allowed file types: ico, png, gif, jpg, jpeg, apng, svg. Not all browsers support all these formats!</item>
                         <item name="maxFileSize" xsi:type="number">2097152</item>
-                        <item name="allowedExtensions" xsi:type="string">jpg jpeg gif png svg</item>
+                        <item name="allowedExtensions" xsi:type="string">ico jpg jpeg gif png svg apng</item>
                         <item name="uploaderConfig" xsi:type="array">
                             <item name="url" xsi:type="string">theme/design_config_fileUploader/save</item>
                         </item>


### PR DESCRIPTION
Missing ico and apng extension in 'allowedExtensions' parameter

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Trying to upload favicon image with .ico extension, you receive this error: "We don't recognize or support this file extension type."


### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
