### PR TITLE
Correctly consider .html files in "template" path to for translation JSON generation.

### DIFF
--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -810,14 +810,21 @@ class Files
                 }
             }
         }
+        
+         // Original paths, to preserve backwards compatibility:
+        $legacyThemePaths = $this->getThemePaths($area, $namespace . '_' . $module, '/web/templates');
+        // Correct paths:
         $themePaths = $this->getThemePaths($area, $namespace . '_' . $module, '/web/template');
+
         $files = self::getFiles(
             array_merge(
+                $legacyThemePaths,
                 $themePaths,
                 $moduleTemplatePaths
             ),
             '*.html'
         );
+        
         $result = self::composeDataSets($files);
         self::$_cache[$key] = $result;
         return $result;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
Certain static html files were not found. For example src/app/design/frontend/MyVendor/mytheme/MyVendor_MyModule/web/template
while files in
src/app/design/frontend/MyVendor/mytheme/MyVendor_MyModule/web/templates
were found.
To my knowledge, "template" is the correct naming for this path, not "templates".

This caused a problem when the translation JSON was generated, translatable strings from files in such directories were not considered.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This pull request adds the proper proper path /template, as well as leaving the /templates path in there to prevent BC breaks.

### Fixed Issues (if relevant)
(Could not find the issue on github)
