### PR TITLE
magento/magento2#8871: Typo in Pull Request Template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,8 @@
 <!--- Provide a description of the changes proposed in the pull request -->
 
 ### Fixed Issues (if relevant)
-<!--- Provide a list of fixed issues in the format magento/magetno2#<issue_number>, if relevant  -->
-1. magento/magetno2#<issue_number>: Issue title
+<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
+1. magento/magento2#<issue_number>: Issue title
 2. ...
 
 ### Manual testing scenarios


### PR DESCRIPTION
- Fixed the typo

### Description
Replaced occurrences of magetno with magento in the file PULL_REQUEST_TEMPLATE.md

### Fixed Issues (if relevant)
1. magento/magento2#8871: Typo in Pull Request Template

### Manual testing scenarios
1. check the file PULL_REQUEST_TEMPLATE for occurence of typo "magetno"
