### PR TITLE
magento/magento2#8863: Malta zipcode validation incomplete

### DIFF
--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -277,8 +277,9 @@
     </zip>
     <zip countryCode="MT">
         <codes>
-            <code id="pattern_1" active="true" example="ABC 123">^[a-zA-Z]{3}\s[0-9]{3}$</code>
-            <code id="pattern_2" active="true" example="ABC 12">^[a-zA-Z]{3}\s[0-9]{2}$</code>
+            <code id="pattern_1" active="true" example="ABC 1234">^[a-zA-Z]{3}\s[0-9]{4}$</code>
+            <code id="pattern_2" active="true" example="ABC 123">^[a-zA-Z]{3}\s[0-9]{3}$</code>
+            <code id="pattern_3" active="true" example="ABC 12">^[a-zA-Z]{3}\s[0-9]{2}$</code>
         </codes>
     </zip>
     <zip countryCode="MH">


### PR DESCRIPTION
Added one more pattern in Malta countryCode nod

### Description
Added one more pattern and changed order of all others in MT zip codes list, here:
app/code/Magento/Directory/etc/zip_codes.xml on line 280
`<code id="pattern_1" active="true" example="ABC 1234">^[a-zA-Z]{3}\s[0-9]{4}$</code>`

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magetno2#<issue_number>, if relevant  -->
1. magento/magetno2#8863: Malta zipcode validation incomplete

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. go to cart or checkout and insert ABC 1234. Validation pass.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
