### PR TITLE
magento/magento2#8590: M2.1.4 : ArrayBackend cannot save and Added country regions for Croatia

### DIFF
--- a/app/code/Magento/Directory/Setup/InstallData.php
+++ b/app/code/Magento/Directory/Setup/InstallData.php
@@ -808,7 +808,28 @@ class InstallData implements InstallDataInterface
             ['BR', 'SP', 'São Paulo'],
             ['BR', 'SE', 'Sergipe'],
             ['BR', 'TO', 'Tocantins'],
-            ['BR', 'DF', 'Distrito Federal']
+            ['BR', 'DF', 'Distrito Federal'],
+            ['HR', 'HR-01', 'Zagrebačka županija'],
+            ['HR', 'HR-02', 'Krapinsko-zagorska županija'],
+            ['HR', 'HR-03', 'Sisačko-moslavačka županija'],
+            ['HR', 'HR-04', 'Karlovačka županija'],
+            ['HR', 'HR-05', 'Varaždinska županija'],
+            ['HR', 'HR-06', 'Koprivničko-križevačka županija'],
+            ['HR', 'HR-07', 'Bjelovarsko-bilogorska županija'],
+            ['HR', 'HR-08', 'Primorsko-goranska županija'],
+            ['HR', 'HR-09', 'Ličko-senjska županija'],
+            ['HR', 'HR-10', 'Virovitičko-podravska županija'],
+            ['HR', 'HR-11', 'Požeško-slavonska županija'],
+            ['HR', 'HR-12', 'Brodsko-posavska županija'],
+            ['HR', 'HR-13', 'Zadarska županija'],
+            ['HR', 'HR-14', 'Osječko-baranjska županija'],
+            ['HR', 'HR-15', 'Šibensko-kninska županija'],
+            ['HR', 'HR-16', 'Vukovarsko-srijemska županija'],
+            ['HR', 'HR-17', 'Splitsko-dalmatinska županija'],
+            ['HR', 'HR-18', 'Istarska županija'],
+            ['HR', 'HR-19', 'Dubrovačko-neretvanska županija'],
+            ['HR', 'HR-20', 'Međimurska županija'],
+            ['HR', 'HR-21', 'Grad Zagreb']
         ];
 
         foreach ($data as $row) {

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Backend/ArrayBackend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Backend/ArrayBackend.php
@@ -23,7 +23,9 @@ class ArrayBackend extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractB
         $attributeCode = $this->getAttribute()->getAttributeCode();
         $data = $object->getData($attributeCode);
         if (is_array($data)) {
-            $data = array_filter($data);
+            $data = array_filter($data, function ($value) {
+                return $value === '0' || !empty($value);
+            });
             $object->setData($attributeCode, implode(',', $data));
         }
 


### PR DESCRIPTION
### Description
1. Changed Magento\Eav\Model\Entity\Attribute\Backend\ArrayBackend.php to pass '0' values inside beforeSave() function
2. Added country regions for Croatia

### Fixed Issues (if relevant)
1. magento/magetno2#8590: M2.1.4 : ArrayBackend cannot save
2. (Update) Added country regions for Croatia - data from https://en.wikipedia.org/wiki/ISO_3166-2:HR

### Manual testing scenarios
1. Create a mutliselect attribute
2. Set it's source model (in the database to a custom source model.
3. Have this source model return options that have a value of '0'.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
