### PR TITLE
magento/magento2#3356: XML syntax to change block's template

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
@@ -211,12 +211,15 @@ class Block implements Layout\GeneratorInterface
 
         // create block
         $className = $attributes['class'];
-        $block = $this->createBlock($className, $elementName, [
-            'data' => $this->evaluateArguments($data['arguments'])
-        ]);
-        if (!empty($attributes['template'])) {
+        $arguments = $this->evaluateArguments($data['arguments']);
+        $block = $this->createBlock($className, $elementName, ['data' => $arguments]);
+
+        if (!empty($arguments['template'])) {
+            $block->setTemplate($arguments['template']);
+        } elseif (!empty($attributes['template'])) {
             $block->setTemplate($attributes['template']);
         }
+
         if (!empty($attributes['ttl'])) {
             $ttl = (int)$attributes['ttl'];
             $block->setTtl($ttl);


### PR DESCRIPTION
Fixed setting block template with arguments node.

### Description
Fixed setting the template with arguments node and is prioritised over setTemplate action.

### Fixed Issues
1. magento/magento2#3356: XML syntax to change block's template

### Manual testing scenarios
1. Change a block's template with arguments node in layout XML

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
