### PR TITLE
magento/magetno2#8676: I can not translate title attribute in xml fil…

### DIFF
--- a/app/code/Magento/Integration/Helper/Data.php
+++ b/app/code/Magento/Integration/Helper/Data.php
@@ -21,7 +21,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         foreach ($resources as $resource) {
             $item = [];
             $item['attr']['data-id'] = $resource['id'];
-            $item['data'] = $resource['title'];
+            $item['data'] = __($resource['title']);
             $item['children'] = [];
             if (isset($resource['children'])) {
                 $item['state'] = 'open';


### PR DESCRIPTION
…es translation not working

- add translation of resource title

### Description
magento/magetno2#8676: Added translation to customer resource title

### Fixed Issues (if relevant)
1. magento/magetno2#<issue_number>: Fixed issue where resource title was not being translated

### Manual testing scenarios
1. In customer resource check if title is being translated
2. Checked if it's working with and without new code