### PR TITLE
imagento/magento2#8515: Downloadable product is available for downloa…

### DIFF
--- a/app/code/Magento/Downloadable/Observer/SetLinkStatusObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SetLinkStatusObserver.php
@@ -83,7 +83,7 @@ class SetLinkStatusObserver implements ObserverInterface
                 if ($item->getProductType() == \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
                     || $item->getRealProductType() == \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
                 ) {
-                    if (in_array($item->getStatusId(), $expiredStatuses)) {
+                    if ($order->isCanceled() || in_array($item->getStatusId(), $expiredStatuses)) {
                         $downloadableItemsStatuses[$item->getId()] = $linkStatuses['expired'];
                     } else {
                         $downloadableItemsStatuses[$item->getId()] = $linkStatuses['avail'];

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Model/Observer/SetLinkStatusObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Model/Observer/SetLinkStatusObserverTest.php
@@ -9,17 +9,13 @@ namespace Magento\Downloadable\Model\Observer;
 class SetLinkStatusObserverTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * Object manager
      * @var \Magento\Framework\ObjectManagerInterface
      */
     protected $objectManager;
 
     /**
-     * Order collection
-     * @var \Magento\Sales\Model\ResourceModel\Order\Item\CollectionFactory
-     */
-    protected $orderItemFactory;
-
-    /**
+     * Order repository
      * @var \Magento\Sales\Model\OrderRepository
      */
     protected $orderRepository;
@@ -30,11 +26,8 @@ class SetLinkStatusObserverTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $this->orderItemFactory = $this->objectManager->create(
-            \Magento\Sales\Model\ResourceModel\Order\Item\CollectionFactory::class
-        );
         $this->orderRepository = $this->objectManager->get(
-            \Magento\Sales\Model\OrderRepository::class
+            \Magento\Sales\Api\OrderRepositoryInterface::class
         );
     }
 
@@ -44,127 +37,55 @@ class SetLinkStatusObserverTest extends \PHPUnit_Framework_TestCase
      * @magentoAppIsolation enabled
      * @magentoDbIsolation enabled
      * @magentoDataFixture Magento/Downloadable/_files/product_downloadable_with_files.php
+     * @magentoDataFixture Magento/Downloadable/_files/order_with_downloadable_product_with_links.php
      */
     public function testCheckStatusOnOrderCancel()
     {
         /** @var \Magento\Sales\Model\Order $order */
-        $order = $this->prepareOrder();
-        $order = $this->orderRepository->save($order);
-        if ($orderItems = $order->getAllItems()) {
+        $order = $this->orderRepository->get(1);
 
-            $items = array_values($orderItems);
-            /** @var \Magento\Sales\Model\Order\Item $orderItem */
-            $orderItem = array_shift($items);
+        $orderItems = $order->getAllItems();
+        $items = array_values($orderItems);
+        /** @var \Magento\Sales\Model\Order\Item $orderItem */
+        $orderItem = array_shift($items);
 
-            /** @var \Magento\Sales\Model\Service\InvoiceService $invoiceService */
-            $invoiceService = $this->objectManager->create(
-                \Magento\Sales\Model\Service\InvoiceService::class
+        /** @var \Magento\Sales\Model\Service\InvoiceService $invoiceService */
+        $invoiceService = $this->objectManager->create(
+            \Magento\Sales\Model\Service\InvoiceService::class
+        );
+
+        /** @var \Magento\Sales\Model\Order\Invoice $invoice */
+        $invoice = $invoiceService->prepareInvoice($order);
+
+        /** Register invoice */
+        $invoice->register();
+        $invoice->save();
+
+        /** @var \Magento\Framework\DB\Transaction $transactionService */
+        $transactionService = $this->objectManager->create(
+            \Magento\Framework\DB\Transaction::class
+        );
+        $transactionService->addObject($invoice)
+            ->addObject($invoice->getOrder())
+            ->save();
+
+        /** Canceling order to reproduce test case */
+        $order->setState(\Magento\Sales\Model\Order::STATE_CANCELED);
+        $order->save();
+
+        /** @var \Magento\Downloadable\Model\ResourceModel\Link\Purchased\Item\Collection $linkCollection */
+        $linkCollection = $this->objectManager->create(
+            \Magento\Downloadable\Model\ResourceModel\Link\Purchased\Item\CollectionFactory::class
+        )->create();
+
+        $linkCollection->addFieldToFilter('order_item_id', $orderItem->getId());
+
+        /** @var \Magento\Downloadable\Model\Link\Purchased\Item $linkItem */
+        foreach ($linkCollection->getItems() as $linkItem) {
+            $this->assertEquals(
+                \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_EXPIRED,
+                $linkItem->getStatus()
             );
-
-            /** @var \Magento\Sales\Model\Order\Invoice $invoice */
-            $invoice = $invoiceService->prepareInvoice($order);
-
-            /** Register invoice */
-            $invoice->register();
-            $invoice->save();
-
-            /** @var \Magento\Framework\DB\Transaction $transactionService */
-            $transactionService = $this->objectManager->create(
-                \Magento\Framework\DB\Transaction::class
-            );
-            $transactionService->addObject($invoice)
-                ->addObject($invoice->getOrder())
-                ->save();
-
-            /** Canceling order to reproduce test case */
-            $order->setState(\Magento\Sales\Model\Order::STATE_CANCELED);
-            $order->save();
-
-            /** @var \Magento\Downloadable\Model\ResourceModel\Link\Purchased\Item\Collection $linkCollection */
-            $linkCollection = $this->objectManager->create(
-                \Magento\Downloadable\Model\ResourceModel\Link\Purchased\Item\CollectionFactory::class
-            )->create();
-
-            $linkCollection->addFieldToFilter('order_item_id', $orderItem->getId());
-
-            /** @var \Magento\Downloadable\Model\Link\Purchased\Item $linkItem */
-            foreach ($linkCollection->getItems() as $linkItem) {
-                $this->assertEquals(
-                    \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_EXPIRED,
-                    $linkItem->getStatus()
-                );
-            }
         }
-    }
-
-    /**
-     * Prepare specific order with downloadable items
-     * and configured links
-     *
-     * @magentoAppIsolation enabled
-     * @magentoDbIsolation enabled
-     * @return \Magento\Sales\Model\Order
-     */
-    protected function prepareOrder()
-    {
-        $billingAddress = $this->objectManager->create(
-            \Magento\Sales\Model\Order\Address::class,
-            [
-                'data' => [
-                    'firstname' => 'guest',
-                    'lastname' => 'guest',
-                    'email' => 'customer@example.com',
-                    'street' => 'street',
-                    'city' => 'Los Angeles',
-                    'region' => 'CA',
-                    'postcode' => '1',
-                    'country_id' => 'US',
-                    'telephone' => '1',
-                ]
-            ]
-        );
-        $billingAddress->setAddressType('billing');
-
-        $payment = $this->objectManager->create(
-            \Magento\Sales\Model\Order\Payment::class
-        );
-        $payment->setMethod('checkmo');
-
-        $orderItem = $this->objectManager->create(
-            \Magento\Sales\Model\Order\Item::class
-        );
-        $orderItem->setProductId(
-            1
-        )->setQtyOrdered(
-            1
-        )->setProductType(
-            \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
-        )->setProductOptions(
-            [
-                'links' => [1]
-            ]
-        );
-
-        $order = $this->objectManager->create(
-            \Magento\Sales\Model\Order::class
-        );
-
-        $order->setCustomerEmail('mail@to.co')
-            ->addItem(
-                $orderItem
-            )->setIncrementId(
-                '100000001'
-            )->setCustomerIsGuest(
-                true
-            )->setStoreId(
-                1
-            )->setEmailSent(
-                0
-            )->setBillingAddress(
-                $billingAddress
-            )->setPayment(
-                $payment
-            );
-        return $order;
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Model/Observer/SetLinkStatusObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Model/Observer/SetLinkStatusObserverTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Magento\Downloadable\Model\Observer;
+
+/**
+ * Integration test for case, when customer is able to download
+ * downloadable product, after order was canceled.
+ */
+class SetLinkStatusObserverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
+     * Order collection
+     * @var \Magento\Sales\Model\ResourceModel\Order\Item\CollectionFactory
+     */
+    protected $orderItemFactory;
+
+    /**
+     * @var \Magento\Sales\Model\OrderRepository
+     */
+    protected $orderRepository;
+
+    /**
+     * Initialization of dependencies
+     */
+    protected function setUp()
+    {
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->orderItemFactory = $this->objectManager->create(
+            \Magento\Sales\Model\ResourceModel\Order\Item\CollectionFactory::class
+        );
+        $this->orderRepository = $this->objectManager->get(
+            \Magento\Sales\Model\OrderRepository::class
+        );
+    }
+
+    /**
+     * Asserting, that links status is expired after canceling of order.
+     *
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     * @magentoDataFixture Magento/Downloadable/_files/product_downloadable_with_files.php
+     */
+    public function testCheckStatusOnOrderCancel()
+    {
+        /** @var \Magento\Sales\Model\Order $order */
+        $order = $this->prepareOrder();
+        $order = $this->orderRepository->save($order);
+        if ($orderItems = $order->getAllItems()) {
+
+            $items = array_values($orderItems);
+            /** @var \Magento\Sales\Model\Order\Item $orderItem */
+            $orderItem = array_shift($items);
+
+            /** @var \Magento\Sales\Model\Service\InvoiceService $invoiceService */
+            $invoiceService = $this->objectManager->create(
+                \Magento\Sales\Model\Service\InvoiceService::class
+            );
+
+            /** @var \Magento\Sales\Model\Order\Invoice $invoice */
+            $invoice = $invoiceService->prepareInvoice($order);
+
+            /** Register invoice */
+            $invoice->register();
+            $invoice->save();
+
+            /** @var \Magento\Framework\DB\Transaction $transactionService */
+            $transactionService = $this->objectManager->create(
+                \Magento\Framework\DB\Transaction::class
+            );
+            $transactionService->addObject($invoice)
+                ->addObject($invoice->getOrder())
+                ->save();
+
+            /** Canceling order to reproduce test case */
+            $order->setState(\Magento\Sales\Model\Order::STATE_CANCELED);
+            $order->save();
+
+            /** @var \Magento\Downloadable\Model\ResourceModel\Link\Purchased\Item\Collection $linkCollection */
+            $linkCollection = $this->objectManager->create(
+                \Magento\Downloadable\Model\ResourceModel\Link\Purchased\Item\CollectionFactory::class
+            )->create();
+
+            $linkCollection->addFieldToFilter('order_item_id', $orderItem->getId());
+
+            /** @var \Magento\Downloadable\Model\Link\Purchased\Item $linkItem */
+            foreach ($linkCollection->getItems() as $linkItem) {
+                $this->assertEquals(
+                    \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_EXPIRED,
+                    $linkItem->getStatus()
+                );
+            }
+        }
+    }
+
+    /**
+     * Prepare specific order with downloadable items
+     * and configured links
+     *
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     * @return \Magento\Sales\Model\Order
+     */
+    protected function prepareOrder()
+    {
+        $billingAddress = $this->objectManager->create(
+            \Magento\Sales\Model\Order\Address::class,
+            [
+                'data' => [
+                    'firstname' => 'guest',
+                    'lastname' => 'guest',
+                    'email' => 'customer@example.com',
+                    'street' => 'street',
+                    'city' => 'Los Angeles',
+                    'region' => 'CA',
+                    'postcode' => '1',
+                    'country_id' => 'US',
+                    'telephone' => '1',
+                ]
+            ]
+        );
+        $billingAddress->setAddressType('billing');
+
+        $payment = $this->objectManager->create(
+            \Magento\Sales\Model\Order\Payment::class);
+        $payment->setMethod('checkmo');
+
+        $orderItem = $this->objectManager->create(
+            \Magento\Sales\Model\Order\Item::class);
+        $orderItem->setProductId(
+            1
+        )->setQtyOrdered(
+            1
+        )->setProductType(
+            \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
+        )->setProductOptions([
+                'links' => [1]
+            ]
+        );
+
+        $order = $this->objectManager->create(
+            \Magento\Sales\Model\Order::class
+        );
+
+        $order->setCustomerEmail('mail@to.co')
+            ->addItem(
+                $orderItem
+            )->setIncrementId(
+                '100000001'
+            )->setCustomerIsGuest(
+                true
+            )->setStoreId(
+                1
+            )->setEmailSent(
+                0
+            )->setBillingAddress(
+                $billingAddress
+            )->setPayment(
+                $payment
+            );
+        return $order;
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Model/Observer/SetLinkStatusObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Model/Observer/SetLinkStatusObserverTest.php
@@ -126,18 +126,21 @@ class SetLinkStatusObserverTest extends \PHPUnit_Framework_TestCase
         $billingAddress->setAddressType('billing');
 
         $payment = $this->objectManager->create(
-            \Magento\Sales\Model\Order\Payment::class);
+            \Magento\Sales\Model\Order\Payment::class
+        );
         $payment->setMethod('checkmo');
 
         $orderItem = $this->objectManager->create(
-            \Magento\Sales\Model\Order\Item::class);
+            \Magento\Sales\Model\Order\Item::class
+        );
         $orderItem->setProductId(
             1
         )->setQtyOrdered(
             1
         )->setProductType(
             \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
-        )->setProductOptions([
+        )->setProductOptions(
+            [
                 'links' => [1]
             ]
         );

--- a/dev/tests/integration/testsuite/Magento/Downloadable/_files/order_with_downloadable_product_with_links.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/_files/order_with_downloadable_product_with_links.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+// @codingStandardsIgnoreFile
+
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+$billingAddress = $objectManager->create(
+    \Magento\Sales\Model\Order\Address::class,
+    [
+        'data' => [
+            'firstname' => 'guest',
+            'lastname' => 'guest',
+            'email' => 'customer@example.com',
+            'street' => 'street',
+            'city' => 'Los Angeles',
+            'region' => 'CA',
+            'postcode' => '1',
+            'country_id' => 'US',
+            'telephone' => '1',
+        ]
+    ]
+);
+$billingAddress->setAddressType('billing');
+
+$payment = $objectManager->create(
+    \Magento\Sales\Model\Order\Payment::class
+);
+$payment->setMethod('checkmo');
+
+$orderItem = $objectManager->create(
+    \Magento\Sales\Model\Order\Item::class
+);
+$orderItem->setProductId(
+    1
+)->setQtyOrdered(
+    1
+)->setProductType(
+    \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
+)->setProductOptions(
+    [
+        'links' => [1]
+    ]
+);
+
+$order = $objectManager->create(
+    \Magento\Sales\Model\Order::class
+);
+
+$order->setCustomerEmail('mail@to.co')
+    ->addItem(
+        $orderItem
+    )->setIncrementId(
+        '100000001'
+    )->setCustomerIsGuest(
+        true
+    )->setStoreId(
+        1
+    )->setEmailSent(
+        0
+    )->setBillingAddress(
+        $billingAddress
+    )->setPayment(
+        $payment
+    );
+$order->save();

--- a/dev/tests/integration/testsuite/Magento/Downloadable/_files/order_with_downloadable_product_with_links_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/_files/order_with_downloadable_product_with_links_rollback.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+require __DIR__ . '/product_downloadable_rollback.php';
+require __DIR__ . '/../../../Magento/Sales/_files/default_rollback.php';


### PR DESCRIPTION
- Set expired status of downloaded product during change order status to canceled.

### Description
Resolve issue with possibility to download downloadable product after order was canceled

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/8515
1. magento/magetno2#8515: Downloadable product is available for download even if order state is set canceled.

### Manual testing scenarios
1. Create an order for a downloadable product.
2. Set order state to STATE_CANCELED programatically.
3. Goto customer account dashboard, it list the order as 'canceled'.
4. Now goto "My Downloadable Products" and check if possible to download downloadable product

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
