### PR TITLE
Varnish "Connection reset by peer" error when large catalog is reindexed on schedule Issue #8815

### DIFF
--- a/app/code/Magento/CacheInvalidate/Observer/InvalidateVarnishObserver.php
+++ b/app/code/Magento/CacheInvalidate/Observer/InvalidateVarnishObserver.php
@@ -23,6 +23,18 @@ class InvalidateVarnishObserver implements ObserverInterface
     protected $purgeCache;
 
     /**
+     * Batch size of the purge request.
+     *
+     * Based on default Varnish 4 http_req_hdr_len size minus a 512 bytes margin for method,
+     * header name, line feeds etc.
+     *
+     * @see http://www.varnish-cache.org/docs/4.0/reference/varnishd.html#http-req-hdr-len
+     *
+     * @var int
+     */
+    private $requestSize = 7680;
+
+    /**
      * Invalidation tags resolver
      *
      * @var \Magento\Framework\App\Cache\Tag\Resolver
@@ -45,6 +57,8 @@ class InvalidateVarnishObserver implements ObserverInterface
      * If Varnish caching is enabled it collects array of tags
      * of incoming object and asks to clean cache.
      *
+     * For scaling reason the purge request is chopped down to fix batch size.
+     *
      * @param \Magento\Framework\Event\Observer $observer
      * @return void
      */
@@ -57,10 +71,21 @@ class InvalidateVarnishObserver implements ObserverInterface
         if ($this->config->getType() == \Magento\PageCache\Model\Config::VARNISH && $this->config->isEnabled()) {
             $bareTags = $this->getTagResolver()->getTags($object);
 
+            $tagsBatchSize = 0;
             $tags = [];
-            $pattern = "((^|,)%s(,|$))";
+            $pattern = '((^|,)%s(,|$))';
             foreach ($bareTags as $tag) {
-                $tags[] = sprintf($pattern, $tag);
+                $formattedTag = sprintf($pattern, $tag);
+
+                // Send request if batch size is reached and add the implode with pipe to the computation
+                if ($tagsBatchSize + strlen($formattedTag) > $this->requestSize - count($tags) - 1) {
+                    $this->purgeCache->sendPurgeRequest(implode('|', array_unique($tags)));
+                    $tags = [];
+                    $tagsBatchSize = 0;
+                }
+
+                $tagsBatchSize += strlen($formattedTag);
+                $tags[] = $formattedTag;
             }
             if (!empty($tags)) {
                 $this->purgeCache->sendPurgeRequest(implode('|', array_unique($tags)));


### PR DESCRIPTION
### Description
Currently the Varnish purge request is made with one big request containing all the tags, this is not scalable as Varnish has a limit to the accepted request header size.

Rising the Varnish configuration of http_req_hdr_len has a consequence to Varnish memory footprint and is anyway not scalable to any number of tags, at some point you might again reach the Varnish limit if your catalog continue to grow.

The goal of this change is to send the purge request by fix batch size, based on request size, this way the purge request can scale to any number of tags.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8815: Varnish "Connection reset by peer" error when large catalog is reindexed on schedule
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)