### PR TITLE
Check of null result value in swatch-renderer.js

### DIFF
--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -840,13 +840,13 @@ define([
                 }
             );
 
-            if (result.oldPrice.amount !== result.finalPrice.amount) {
+            if (typeof result != 'undefined' && result.oldPrice.amount !== result.finalPrice.amount) {
                 $(this.options.slyOldPriceSelector).show();
             } else {
                 $(this.options.slyOldPriceSelector).hide();
             }
 
-            if (result.tierPrices.length) {
+            if (typeof result != 'undefined' && result.tierPrices.length) {
                 if (this.options.tierPriceTemplate) {
                     tierPriceHtml = mageTemplate(
                         this.options.tierPriceTemplate,


### PR DESCRIPTION
Check of null result value in swatch-renderer.js

### Description
There is an error when product has more than one kind of swatches:
Uncaught TypeError: Cannot read property 'oldPrice' of undefined - swatch-renderer.js:843

### Manual testing scenarios
1) Set Special Price for some Simple of the Configurable product which has more than one kind of swatches, for example SKU: WJ03
2) Go to PDP (../augusta-pullover-jacket.html)
3) Select some Color and look to the console - there You will be able to see the error. This is because 'result' is null before all of the swatches are selected.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
