### PR TITLE
Stop $this->validColumnNames array from growing and growing

### DIFF
--- a/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
@@ -569,11 +569,11 @@ class Customer extends AbstractCustomer
      */
     public function getValidColumnNames()
     {
-        $this->validColumnNames = array_merge(
-            $this->validColumnNames,
-            $this->customerFields
+        return array_unique(
+            array_merge(
+                $this->validColumnNames,
+                $this->customerFields
+            )
         );
-
-        return $this->validColumnNames;
     }
 }

--- a/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/CustomerComposite.php
@@ -488,13 +488,13 @@ class CustomerComposite extends \Magento\ImportExport\Model\Import\AbstractEntit
      */
     public function getValidColumnNames()
     {
-        $this->validColumnNames = array_merge(
-            $this->validColumnNames,
-            $this->_customerAttributes,
-            $this->_addressAttributes,
-            $this->_customerEntity->getValidColumnNames()
+        return array_unique(
+            array_merge(
+                $this->validColumnNames,
+                $this->_customerAttributes,
+                $this->_addressAttributes,
+                $this->_customerEntity->getValidColumnNames()
+            )
         );
-
-        return $this->validColumnNames;
     }
 }


### PR DESCRIPTION
Optimise customer import getValidColumnNames() method

* Stop $this->validColumnNames array from growing and growing as its value is recursively updated with its own data several times. 
* Importing hundred of customers was affecting performance and even breaking due to memory limits.

