### PR TITLE
Improved check when CategoryProcessor attempts to create a new category

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1529,6 +1529,9 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
             $existingImages = $this->getExistingImages($bunch);
 
             foreach ($bunch as $rowNum => $rowData) {
+                // reset category processor's failed categories array
+                $this->categoryProcessor->clearFailedCategories();
+
                 if (!$this->validateRow($rowData, $rowNum)) {
                     continue;
                 }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
@@ -230,10 +230,6 @@ class CategoryProcessor
      */
     protected function standardizeString($string)
     {
-        if (function_exists('mb_strtolower')) {
-            return mb_strtolower($string);
-        }
-
-        return strtolower($string);
+        return mb_strtolower($string);
     }
 }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
@@ -223,12 +223,14 @@ class CategoryProcessor
     }
 
     /**
-     * Standardize a string by lowercase-ing it
+     * Standardize a string.
+     * For now it performs only a lowercase action, this method is here to include more complex checks in the future
+     * if needed.
      *
      * @param string $string
      * @return string
      */
-    protected function standardizeString($string)
+    private function standardizeString($string)
     {
         return mb_strtolower($string);
     }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
@@ -231,11 +231,9 @@ class CategoryProcessor
     protected function standardizeString($string)
     {
         if (function_exists('mb_strtolower')) {
-            $string = mb_strtolower($string);
-        } else {
-            $string = strtolower($string);
+            return mb_strtolower($string);
         }
 
-        return $string;
+        return strtolower($string);
     }
 }

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
@@ -228,7 +228,7 @@ class CategoryProcessor
      * @param string $string
      * @return string
      */
-    protected function standardizeString(string $string)
+    protected function standardizeString($string)
     {
         if (function_exists('mb_strtolower')) {
             $string = mb_strtolower($string);

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/CategoryProcessorTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/CategoryProcessorTest.php
@@ -44,7 +44,7 @@ class CategoryProcessorTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $childCategory->method('getId')->will($this->returnValue(self::CHILD_CATEGORY_ID));
-        $childCategory->method('getName')->will($this->returnValue('Child'));
+        $childCategory->method('getName')->will($this->returnValue(self::CHILD_CATEGORY_NAME));
         $childCategory->method('getPath')->will($this->returnValue(
             self::PARENT_CATEGORY_ID . CategoryProcessor::DELIMITER_CATEGORY
             . self::CHILD_CATEGORY_ID
@@ -113,6 +113,22 @@ class CategoryProcessorTest extends \PHPUnit_Framework_TestCase
         $categoriesSeparator = ',';
         $categoryIds = $this->categoryProcessor->upsertCategories(self::CHILD_CATEGORY_NAME, $categoriesSeparator);
         $this->assertArrayHasKey(self::CHILD_CATEGORY_ID, array_flip($categoryIds));
+    }
+
+    public function testClearFailedCategories()
+    {
+        $dummyFailedCategory = [
+            [
+                'category' => 'dummy category',
+                'exception' => 'dummy exception',
+            ]
+        ];
+
+        $this->setPropertyValue($this->categoryProcessor, 'failedCategories', $dummyFailedCategory);
+        $this->assertCount(count($dummyFailedCategory), $this->categoryProcessor->getFailedCategories());
+
+        $this->categoryProcessor->clearFailedCategories();
+        $this->assertEmpty($this->categoryProcessor->getFailedCategories());
     }
 
     /**


### PR DESCRIPTION
Improved check perfomed by CategoryProcessor when it checks if it has to create a new category or not. 

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
The original check didn't consider that a category must be supplied with uppercase or lowecase characters. In this case, if you're trying to import a category named Foo, and a category named FOO, the system will create both categories but fails when attempts to create URL keys because the first url already exists causing an exception. Checking path existence by lowercase-ing it will avoid duplicate url keys creation attempts. I've also added a method to clear failed categories between bunches import, and updated related unit test file. Lastly, i've fixed a typo in CategoryProcessor's PHPDoc.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
