### PR TITLE
Log level for caught exception

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/GeneratorPool.php
+++ b/lib/internal/Magento/Framework/View/Layout/GeneratorPool.php
@@ -251,7 +251,7 @@ class GeneratorPool
             $structure->setAsChild($element, $destination, $alias);
             $structure->reorderChildElement($destination, $element, $siblingName, $isAfter);
         } catch (\OutOfBoundsException $e) {
-            $this->logger->critical('Broken reference: '. $e->getMessage());
+            $this->logger->warning('Broken reference: '. $e->getMessage());
         }
         $scheduledStructure->unsetElementFromBrokenParentList($element);
         return $this;


### PR DESCRIPTION
"Broken reference" exception is logged every time when customer goes to /checkout/ page (in my case). There are some other [reports](http://magento.stackexchange.com/questions/133618/got-error-critical-broken-reference-no-element-found-with-id-checkout-header) about this behavior. Please decrease log level for caught exceptions or don't catch them if these are really critical cases.