### PR TITLE
Remove redundant check in if-condition

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteValidator.php
+++ b/app/code/Magento/Quote/Model/QuoteValidator.php
@@ -51,7 +51,7 @@ class QuoteValidator
             }
             $method = $quote->getShippingAddress()->getShippingMethod();
             $rate = $quote->getShippingAddress()->getShippingRateByCode($method);
-            if (!$quote->isVirtual() && (!$method || !$rate)) {
+            if (!$method || !$rate) {
                 throw new \Magento\Framework\Exception\LocalizedException(__('Please specify a shipping method.'));
             }
         }


### PR DESCRIPTION
Removed the part of an if condition that tests whether a quote is virtual or not. The part that was removed is redundant because of line 43.