### PR TITLE
Use page result instead of rendering layout directly and add page tit…

### DIFF
--- a/app/code/Magento/CatalogSearch/Controller/Advanced/Result.php
+++ b/app/code/Magento/CatalogSearch/Controller/Advanced/Result.php
@@ -9,9 +9,17 @@ namespace Magento\CatalogSearch\Controller\Advanced;
 use Magento\CatalogSearch\Model\Advanced as ModelAdvanced;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\UrlFactory;
 
 class Result extends \Magento\Framework\App\Action\Action
 {
+
+    /**
+     * Url factory
+     *
+     * @var UrlFactory
+     */
+    protected $_urlFactory;
 
     /**
      * Catalog search advanced
@@ -25,14 +33,16 @@ class Result extends \Magento\Framework\App\Action\Action
      *
      * @param Context $context
      * @param ModelAdvanced $catalogSearchAdvanced
+     * @param UrlFactory $urlFactory
      */
     public function __construct(
         Context $context,
-        ModelAdvanced $catalogSearchAdvanced
-
+        ModelAdvanced $catalogSearchAdvanced,
+        UrlFactory $urlFactory
     ) {
         parent::__construct($context);
         $this->_catalogSearchAdvanced = $catalogSearchAdvanced;
+        $this->_urlFactory = $urlFactory;
     }
 
     /**
@@ -51,7 +61,7 @@ class Result extends \Magento\Framework\App\Action\Action
             $resultRedirect->setPath('*/*/');
             return $resultRedirect;
         }
-
+        /** @var \Magento\Framework\View\Result\Page $resultPage */
         $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
         $resultPage->getConfig()->getTitle()->set(__('Catalog Advanced Search'));
         return $resultPage;

--- a/app/code/Magento/CatalogSearch/Controller/Advanced/Result.php
+++ b/app/code/Magento/CatalogSearch/Controller/Advanced/Result.php
@@ -6,19 +6,12 @@
  */
 namespace Magento\CatalogSearch\Controller\Advanced;
 
-use Magento\Catalog\Model\Layer\Resolver;
 use Magento\CatalogSearch\Model\Advanced as ModelAdvanced;
 use Magento\Framework\App\Action\Context;
-use Magento\Framework\UrlFactory;
+use Magento\Framework\Controller\ResultFactory;
 
 class Result extends \Magento\Framework\App\Action\Action
 {
-    /**
-     * Url factory
-     *
-     * @var UrlFactory
-     */
-    protected $_urlFactory;
 
     /**
      * Catalog search advanced
@@ -32,33 +25,35 @@ class Result extends \Magento\Framework\App\Action\Action
      *
      * @param Context $context
      * @param ModelAdvanced $catalogSearchAdvanced
-     * @param UrlFactory $urlFactory
      */
     public function __construct(
         Context $context,
-        ModelAdvanced $catalogSearchAdvanced,
-        UrlFactory $urlFactory
+        ModelAdvanced $catalogSearchAdvanced
+
     ) {
         parent::__construct($context);
         $this->_catalogSearchAdvanced = $catalogSearchAdvanced;
-        $this->_urlFactory = $urlFactory;
     }
 
     /**
-     * @return void
+     * Advanced Search Result page
+     *
+     * @return \Magento\Framework\Controller\ResultInterface
      */
     public function execute()
     {
         try {
             $this->_catalogSearchAdvanced->addFilters($this->getRequest()->getQueryValue());
-            $this->_view->loadLayout();
-            $this->_view->renderLayout();
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError($e->getMessage());
-            $defaultUrl = $this->_urlFactory->create()
-                ->addQueryParams($this->getRequest()->getQueryValue())
-                ->getUrl('*/*/');
-            $this->getResponse()->setRedirect($this->_redirect->error($defaultUrl));
+            $this->messageManager->addErrorMessage($e->getMessage());
+            /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
+            $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
+            $resultRedirect->setPath('*/*/');
+            return $resultRedirect;
         }
+
+        $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
+        $resultPage->getConfig()->getTitle()->set(__('Catalog Advanced Search'));
+        return $resultPage;
     }
 }

--- a/app/code/Magento/Cms/view/frontend/layout/default.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/default.xml
@@ -13,7 +13,7 @@
         <referenceBlock name="footer_links">
             <block class="Magento\Framework\View\Element\Html\Link\Current" name="privacy-policy-link">
                 <arguments>
-                    <argument name="label" xsi:type="string">Privacy and Cookie Policy</argument>
+                    <argument name="label" xsi:type="string" translate="true">Privacy and Cookie Policy</argument>
                     <argument name="path" xsi:type="string">privacy-policy-cookie-restriction-mode</argument>
                 </arguments>
             </block>

--- a/app/code/Magento/Downloadable/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/customer_account.xml
@@ -11,7 +11,7 @@
             <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-downloadable-products-link">
                 <arguments>
                     <argument name="path" xsi:type="string">downloadable/customer/products</argument>
-                    <argument name="label" xsi:type="string">My Downloadable Products</argument>
+                    <argument name="label" xsi:type="string" translate="true">My Downloadable Products</argument>
                     <argument name="sortOrder" xsi:type="number">220</argument>
                 </arguments>
             </block>

--- a/app/code/Magento/Review/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Review/view/frontend/layout/customer_account.xml
@@ -11,7 +11,7 @@
             <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-product-reviews-link">
                 <arguments>
                     <argument name="path" xsi:type="string">review/customer</argument>
-                    <argument name="label" xsi:type="string">My Product Reviews</argument>
+                    <argument name="label" xsi:type="string" translate="true">My Product Reviews</argument>
                     <argument name="sortOrder" xsi:type="number">50</argument>
                 </arguments>
             </block>

--- a/app/code/Magento/Rss/view/frontend/layout/default.xml
+++ b/app/code/Magento/Rss/view/frontend/layout/default.xml
@@ -10,7 +10,7 @@
         <referenceBlock name="footer_links">
             <block class="Magento\Framework\View\Element\Html\Link\Current" name="rss-link" ifconfig="rss/config/active">
                 <arguments>
-                    <argument name="label" xsi:type="string">RSS</argument>
+                    <argument name="label" xsi:type="string" translate="true">RSS</argument>
                     <argument name="path" xsi:type="string">rss</argument>
                 </arguments>
             </block>

--- a/app/code/Magento/Shipping/i18n/en_US.csv
+++ b/app/code/Magento/Shipping/i18n/en_US.csv
@@ -180,3 +180,4 @@ City,City
 "Shipping Policy","Shipping Policy"
 "Shipping Methods","Shipping Methods"
 "Track your order","Track your order"
+"Track All Shipments", "Track All Shipments"

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_guest_shipment.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_guest_shipment.xml
@@ -14,7 +14,7 @@
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.shipment.renderers" as="renderer.list"/>
                     <block class="Magento\Shipping\Block\Tracking\Link" name="track-all-link" template="tracking/link.phtml">
                         <arguments>
-                            <argument name="label" xsi:type="string">Track All Shipments</argument>
+                            <argument name="label" xsi:type="string" translate="true">Track All Shipments</argument>
                         </arguments>
                     </block>
                     <block class="Magento\Sales\Block\Order\Comments" name="shipment_comments" template="order/comments.phtml"/>

--- a/app/code/Magento/Shipping/view/frontend/layout/sales_order_shipment.xml
+++ b/app/code/Magento/Shipping/view/frontend/layout/sales_order_shipment.xml
@@ -14,7 +14,7 @@
                     <block class="Magento\Framework\View\Element\RendererList" name="sales.order.shipment.renderers" as="renderer.list"/>
                     <block class="Magento\Shipping\Block\Tracking\Link" name="track-all-link" template="tracking/link.phtml">
                         <arguments>
-                            <argument name="label" xsi:type="string">Track All Shipments</argument>
+                            <argument name="label" xsi:type="string" translate="true">Track All Shipments</argument>
                         </arguments>
                     </block>
                     <block class="Magento\Sales\Block\Order\Comments" name="shipment_comments" template="order/comments.phtml"/>

--- a/app/code/Magento/Wishlist/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/customer_account.xml
@@ -11,7 +11,7 @@
             <block class="Magento\Customer\Block\Account\SortLinkInterface" ifconfig="wishlist/general/active" name="customer-account-navigation-wish-list-link">
                 <arguments>
                     <argument name="path" xsi:type="string">wishlist</argument>
-                    <argument name="label" xsi:type="string">My Wish List</argument>
+                    <argument name="label" xsi:type="string" translate="true">My Wish List</argument>
                     <argument name="sortOrder" xsi:type="number">210</argument>
                 </arguments>
             </block>


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
- Use page result instead of rendering layout directly in Advanced Search controller.
- Add Title page on Advanced search page.
### Fixed Issues:
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
-  Missing Title page on Advanced search page.


