### PR TITLE
Fixed empty submenu group in backend menu

### DIFF
--- a/app/code/Magento/Backend/Block/AnchorRenderer.php
+++ b/app/code/Magento/Backend/Block/AnchorRenderer.php
@@ -49,9 +49,12 @@ class AnchorRenderer
     public function renderAnchor($activeItem, Item $menuItem, $level)
     {
         if ($level == 1 && $menuItem->getUrl() == '#') {
-            $output = '<strong class="submenu-group-title" role="presentation">'
-                . '<span>' . $this->escaper->escapeHtml(__($menuItem->getTitle())) . '</span>'
-                . '</strong>';
+            $output = '';
+            if ($menuItem->hasChildren()) {
+                $output = '<strong class="submenu-group-title" role="presentation">'
+                    . '<span>' . $this->escaper->escapeHtml(__($menuItem->getTitle())) . '</span>'
+                    . '</strong>';
+            }
         } else {
             $target = $menuItem->getTarget() ? ('target=' . $menuItem->getTarget()) : '';
             $output = '<a href="' . $menuItem->getUrl() . '" ' . $target . ' ' . $this->_renderItemAnchorTitle(

--- a/app/code/Magento/Backend/Test/Unit/Block/AnchorRendererTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/AnchorRendererTest.php
@@ -51,6 +51,9 @@ class AnchorRendererTest extends \PHPUnit_Framework_TestCase
         $this->menuItemMock = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->menuItemWithoutChildrenMock = $this->getMockBuilder(Item::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->menuItemCheckerMock = $this->getMockBuilder(MenuItemChecker::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -74,6 +77,7 @@ class AnchorRendererTest extends \PHPUnit_Framework_TestCase
         $html =  'Test html';
         $this->menuItemMock->expects($this->once())->method('getUrl')->willReturn('#');
         $this->menuItemMock->expects($this->once())->method('getTitle')->willReturn($title);
+        $this->menuItemMock->expects($this->once())->method('hasChildren')->willReturn(true);
         $this->escaperMock->expects($this->once())->method('escapeHtml')->with(__($title))->willReturn($html);
 
         $expected =  '<strong class="submenu-group-title" role="presentation">'
@@ -83,6 +87,19 @@ class AnchorRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             $expected,
             $this->anchorRenderer->renderAnchor($this->activeMenuItemMock, $this->menuItemMock, 1)
+        );
+    }
+
+    public function testRenderAnchorWithoutChildrenAndLevelIsOne()
+    {
+        $this->menuItemWithoutChildrenMock->expects($this->once())->method('getUrl')->willReturn('#');
+        $this->menuItemWithoutChildrenMock->expects($this->once())->method('hasChildren')->willReturn(false);
+
+        $expected =  '';
+
+        $this->assertEquals(
+            $expected,
+            $this->anchorRenderer->renderAnchor($this->activeMenuItemMock, $this->menuItemWithoutChildrenMock, 1)
         );
     }
 


### PR DESCRIPTION
### Description
This PR fixes empty submenu groups in case if group is added by one module and items inserted with another one, but customer disable it.

### Manual testing scenarios

> Synthetic steps, just to reproduce possible issue:

1. Open _app/code/Magento/Customer/etc/adminhtml/menu.xml_
2. Remove "Magento_Customer::customer_group" item
3. Navigate to backend and see "Stores" menu. ("Other setting" submenu looks bad and it's useless):

    ![image](https://cloud.githubusercontent.com/assets/306080/24289429/eed1795c-1089-11e7-9fc5-c0bc7f42aee4.png)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
