### PR TITLE
Update AbstractFrontend.php

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/AbstractFrontend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/AbstractFrontend.php
@@ -120,8 +120,6 @@ abstract class AbstractFrontend implements \Magento\Eav\Model\Entity\Attribute\F
         } elseif ($this->getConfigField('input') == 'multiselect') {
             if (is_array($value)) {
                 $value = implode(', ', array_map([$this, 'getOption'], $value));
-            } else {
-                $value = $this->getOption($value);
             }
         }
 

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/AbstractFrontend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/AbstractFrontend.php
@@ -118,9 +118,10 @@ abstract class AbstractFrontend implements \Magento\Eav\Model\Entity\Attribute\F
             }
             $value = $valueOption;
         } elseif ($this->getConfigField('input') == 'multiselect') {
-            $value = $this->getOption($value);
             if (is_array($value)) {
-                $value = implode(', ', $value);
+                $value = implode(', ', array_map([$this, 'getOption'], $value));
+            } else {
+                $value = $this->getOption($value);
             }
         }
 


### PR DESCRIPTION
Update AbstractFrontend.php to let `\Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend::getValue` work with array attribute values.

### Description
The `getOptionText` method (called by `getOption`) does not support an array as parameter and therefor `getOption` cannot be used with an array.

###Reason
I got an error (invalid key type) because `\Magento\Eav\Model\Entity\Attribute\Source\AbstractSource::getOptionText` was trying to use an array as an array key.