### PR TITLE
Remove superfluous realpath call

### DIFF
--- a/pub/index.php
+++ b/pub/index.php
@@ -10,7 +10,7 @@ use Magento\Framework\App\Bootstrap;
 use Magento\Framework\App\Filesystem\DirectoryList;
 
 try {
-    require realpath(__DIR__) . '/../app/bootstrap.php';
+    require __DIR__ . '/../app/bootstrap.php';
 } catch (\Exception $e) {
     echo <<<HTML
 <div style="font:12px/1.35em arial, helvetica, sans-serif;">


### PR DESCRIPTION
Calling realpath is not necessary for __DIR__

Refs:

- http://php.net/manual/language.constants.predefined.php

(Previously reported against wrong base branch in #5518)