### PR TITLE
Generalize fix from GitHub issue #7000

### DIFF
--- a/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/paypal.js
+++ b/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/paypal.js
@@ -296,21 +296,20 @@ define([
         getShippingAddress: function () {
             var address = quote.shippingAddress();
 
-            if (_.isNull(address.postcode) || _.isUndefined(address.postcode)) {
-
+            try {
+                return {
+                    recipientName: address.firstname + ' ' + address.lastname,
+                    streetAddress: address.street[0],
+                    locality: address.city,
+                    countryCodeAlpha2: address.countryId,
+                    postalCode: address.postcode,
+                    region: address.regionCode,
+                    phone: address.telephone,
+                    editable: this.isAllowOverrideShippingAddress()
+                };
+            } catch (e) {
                 return {};
             }
-
-            return {
-                recipientName: address.firstname + ' ' + address.lastname,
-                streetAddress: address.street[0],
-                locality: address.city,
-                countryCodeAlpha2: address.countryId,
-                postalCode: address.postcode,
-                region: address.regionCode,
-                phone: address.telephone,
-                editable: this.isAllowOverrideShippingAddress()
-            };
         },
 
         /**


### PR DESCRIPTION
Issue #7000 fixed a particular case where the Braintree PayPal payment method renderer would cause a JavaScript crash when trying to use unavailable address information.

However, there are other edge cases where this still occurs (such as when a registered user doesn't have a default shipping address set). This generalizes the fix to use a try/catch, which avoids having to test for every single possibility in the conditional. **Any time** that we can't retrieve the necessary address information, the best option is to simply return an empty object to PayPal, as this now does.