### PR TITLE
Invalidate and refresh customer data sections on HTTP DELETE requests

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -344,7 +344,7 @@ define([
         var sections,
             redirects;
 
-        if (settings.type.match(/post|put/i)) {
+        if (settings.type.match(/post|put|delete/i)) {
             sections = sectionConfig.getAffectedSections(settings.url);
 
             if (sections) {
@@ -365,7 +365,7 @@ define([
     $(document).on('submit', function (event) {
         var sections;
 
-        if (event.target.method.match(/post|put/i)) {
+        if (event.target.method.match(/post|put|delete/i)) {
             sections = sectionConfig.getAffectedSections(event.target.action);
 
             if (sections) {


### PR DESCRIPTION
The customer-data sections are invalidated and updated whenever a state changing request is sent to Magento.
Currently this happens for POST and PUT requests. However, DELETE is also a state modifying HTTP method, so it would be good if the customer data sections where updated in case of such a request, too.
Otherwise ugly workarounds with POST or PUT to special endpoints like `/rest/V1/foo/123/delete` have to be created.

### Description
This PR updates the client side customer-data model to also invalidate and update the section data for DELETE requests.

I think this is a backward compatible change.

### Manual testing scenarios
- Create a REST endpoint that is configured to respond to DELETE requests.
- Create a customer data section that is linked to that REST endpoint URL path.
- Create a JavaScript module that uses the customer-data section and triggers the DELETE request.

**Expected outcome:** 
The customer data section observable updates after the DELETE request.  

**Actual outcome:**
The customer data section is not refreshed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
