### PR TITLE
Remove superfluous character in class

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductOptions/Config/_files/invalidProductOptionsXmlArray.php
@@ -33,7 +33,7 @@ return [
         '</option></config>',
         [
             "Element 'option', attribute 'renderer': [facet 'pattern'] The value 'true12' is not accepted by the " .
-            "pattern '[a-zA-Z_\\\\\\\\]+'.\nLine: 1\n",
+            "pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
             "Element 'option', attribute 'renderer': 'true12' is not a valid value of the atomic" .
             " type 'modelName'.\nLine: 1\n"
         ],

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/Config/_files/invalidProductTypesXmlArray.php
@@ -23,7 +23,7 @@ return [
         '<?xml version="1.0"?><config><type name="some_name" modelInstance="123" /></config>',
         [
             "Element 'type', attribute 'modelInstance': [facet 'pattern'] The value '123' is not accepted by the" .
-            " pattern '[a-zA-Z_\\\\\\\\]+'.\nLine: 1\n",
+            " pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
             "Element 'type', attribute 'modelInstance': '123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
@@ -57,7 +57,7 @@ return [
         '<?xml version="1.0"?><config><type name="some_name"><priceModel instance="123123" /></type></config>',
         [
             "Element 'priceModel', attribute 'instance': [facet 'pattern'] The value '123123' is not accepted " .
-            "by the pattern '[a-zA-Z_\\\\\\\\]+'.\nLine: 1\n",
+            "by the pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
             "Element 'priceModel', attribute 'instance': '123123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
@@ -66,7 +66,7 @@ return [
         '<?xml version="1.0"?><config><type name="some_name"><indexerModel instance="123" /></type></config>',
         [
             "Element 'indexerModel', attribute 'instance': [facet 'pattern'] The value '123' is not accepted by " .
-            "the pattern '[a-zA-Z_\\\\\\\\]+'.\nLine: 1\n",
+            "the pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
             "Element 'indexerModel', attribute 'instance': '123' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
@@ -83,7 +83,7 @@ return [
         '<?xml version="1.0"?><config><type name="some_name"><stockIndexerModel instance="1234"/></type></config>',
         [
             "Element 'stockIndexerModel', attribute 'instance': [facet 'pattern'] The value '1234' is not " .
-            "accepted by the pattern '[a-zA-Z_\\\\\\\\]+'.\nLine: 1\n",
+            "accepted by the pattern '[a-zA-Z_\\\\]+'.\nLine: 1\n",
             "Element 'stockIndexerModel', attribute 'instance': '1234' is not a valid value of the atomic " .
             "type 'modelName'.\nLine: 1\n"
         ],

--- a/app/code/Magento/Catalog/etc/product_options.xsd
+++ b/app/code/Magento/Catalog/etc/product_options.xsd
@@ -61,11 +61,11 @@
     <xs:simpleType name="modelName">
         <xs:annotation>
             <xs:documentation>
-                Model name can contain only [a-zA-Z_\\\\].
+                Model name can contain only [a-zA-Z_\\].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z_\\\\]+" />
+            <xs:pattern value="[a-zA-Z_\\]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/app/code/Magento/Catalog/etc/product_types_base.xsd
+++ b/app/code/Magento/Catalog/etc/product_types_base.xsd
@@ -92,11 +92,11 @@
     <xs:simpleType name="modelName">
         <xs:annotation>
             <xs:documentation>
-                Model name can contain only [a-zA-Z_\\\\].
+                Model name can contain only [a-zA-Z_\\].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z_\\\\]+" />
+            <xs:pattern value="[a-zA-Z_\\]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/app/code/Magento/Config/Test/Unit/Model/Config/_files/invalidSystemXmlArray.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/_files/invalidSystemXmlArray.php
@@ -63,7 +63,7 @@ return [
             "Element 'config_path': [facet 'minLength'] The value has a length of '2'; this underruns " .
             "the allowed minimum length of '5'.\nLine: 1\n",
             "Element 'config_path': [facet 'pattern'] The value 'co' is not " .
-            "accepted by the pattern '[a-zA-Z0-9_\\\\\\\\]+/[a-zA-Z0-9_\\\\\\\\]+/[a-zA-Z0-9_\\\\\\\\]+'.\nLine: 1\n",
+            "accepted by the pattern '[a-zA-Z0-9_\\\\]+/[a-zA-Z0-9_\\\\]+/[a-zA-Z0-9_\\\\]+'.\nLine: 1\n",
             "Element 'config_path': 'co' is " . "not a valid value of the atomic type 'typeConfigPath'.\nLine: 1\n"
         ],
     ],
@@ -76,7 +76,7 @@ return [
             "Element 'if_module_enabled': [facet 'minLength'] The value has a length of '3'; this underruns the " .
             "allowed minimum length of '5'.\nLine: 1\n",
             "Element 'if_module_enabled': [facet 'pattern'] The value 'Som' is not " .
-            "accepted by the pattern '[A-Z]+[a-zA-Z0-9]{1,}[_\\\\\\\\][A-Z]+[A-Z0-9a-z]{1,}'.\nLine: 1\n",
+            "accepted by the pattern '[A-Z]+[a-zA-Z0-9]{1,}[_\\\\][A-Z]+[A-Z0-9a-z]{1,}'.\nLine: 1\n",
             "Element 'if_module_enabled': 'Som' " . "is not a valid value of the atomic type 'typeModule'.\nLine: 1\n"
         ],
     ],

--- a/app/code/Magento/Config/etc/system.xsd
+++ b/app/code/Magento/Config/etc/system.xsd
@@ -317,7 +317,7 @@
         </xs:annotation>
 
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9_///\\\\*]{3,}" />
+            <xs:pattern value="[a-zA-Z0-9_///\\*]{3,}" />
             <xs:minLength value="3" />
         </xs:restriction>
     </xs:simpleType>
@@ -395,7 +395,7 @@
         </xs:annotation>
 
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9_\\\\]{1,}" />
+            <xs:pattern value="[a-zA-Z0-9_\\]{1,}" />
             <xs:minLength value="3" />
         </xs:restriction>
     </xs:simpleType>
@@ -408,7 +408,7 @@
         </xs:annotation>
 
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9_\\\\]{1,}" />
+            <xs:pattern value="[a-zA-Z0-9_\\]{1,}" />
             <xs:minLength value="2" />
         </xs:restriction>
     </xs:simpleType>
@@ -433,7 +433,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Z]+[a-zA-Z0-9]{1,}[_\\\\][A-Z]+[A-Z0-9a-z]{1,}" />
+            <xs:pattern value="[A-Z]+[a-zA-Z0-9]{1,}[_\\][A-Z]+[A-Z0-9a-z]{1,}" />
             <xs:minLength value="5" />
         </xs:restriction>
     </xs:simpleType>
@@ -445,7 +445,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Za-z0-9_\\\\:]+" />
+            <xs:pattern value="[A-Za-z0-9_\\:]+" />
             <xs:minLength value="5" />
         </xs:restriction>
     </xs:simpleType>
@@ -473,14 +473,14 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9_\\\\]+/[a-zA-Z0-9_\\\\]+/[a-zA-Z0-9_\\\\]+" />
+            <xs:pattern value="[a-zA-Z0-9_\\]+/[a-zA-Z0-9_\\]+/[a-zA-Z0-9_\\]+" />
             <xs:minLength value="5" />
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="typeUploadDirRestriction">
         <xs:restriction base="xs:string">
-            <xs:pattern value="([a-zA-Z0-9_\\\\]+/{0,1}){1,}" />
+            <xs:pattern value="([a-zA-Z0-9_\\]+/{0,1}){1,}" />
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="typeUploadDir">

--- a/app/code/Magento/Config/etc/system_file.xsd
+++ b/app/code/Magento/Config/etc/system_file.xsd
@@ -474,7 +474,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Za-z0-9\\\\:]+" />
+            <xs:pattern value="[A-Za-z0-9\\:]+" />
             <xs:minLength value="5" />
         </xs:restriction>
     </xs:simpleType>

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Export/Config/_files/invalidExportXmlArray.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Export/Config/_files/invalidExportXmlArray.php
@@ -25,11 +25,11 @@ return [
             . ' <fileFormat name="name_one" model="model1"/></config>',
         [
             "Element 'entityType', attribute 'model': [facet 'pattern'] The value '1' is not accepted by the " .
-            "pattern '[A-Za-z_\\\\\\\\]+'.\nLine: 1\n",
+            "pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
             "Element 'entityType', attribute 'model': '1' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n",
             "Element 'fileFormat', attribute 'model': [facet 'pattern'] The value 'model1' is not " .
-            "accepted by the pattern '[A-Za-z_\\\\\\\\]+'.\nLine: 1\n",
+            "accepted by the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
             "Element 'fileFormat', attribute 'model': 'model1' is not a valid " .
             "value of the atomic type 'modelName'.\nLine: 1\n"
         ],

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportMergedXmlArray.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportMergedXmlArray.php
@@ -30,7 +30,7 @@ return [
         'behaviorModel="test" /></config>',
         [
             "Element 'entity', attribute 'model': [facet 'pattern'] The value 'afwer34' is not " .
-            "accepted by the pattern '[A-Za-z_\\\\\\\\]+'.\nLine: 1\n",
+            "accepted by the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
             "Element 'entity', attribute 'model': 'afwer34' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
@@ -40,7 +40,7 @@ return [
         '</config>',
         [
             "Element 'entity', attribute 'behaviorModel': [facet 'pattern'] The value '666' is not accepted by " .
-            "the pattern '[A-Za-z_\\\\\\\\]+'.\nLine: 1\n",
+            "the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
             "Element 'entity', attribute 'behaviorModel': '666' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportXmlArray.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Import/Config/_files/invalidImportXmlArray.php
@@ -19,7 +19,7 @@ return [
         '<?xml version="1.0"?><config><entity name="some_name" model="12345"/></config>',
         [
             "Element 'entity', attribute 'model': [facet 'pattern'] The value '12345' is not accepted by " .
-            "the pattern '[A-Za-z_\\\\\\\\]+'.\nLine: 1\n",
+            "the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
             "Element 'entity', attribute 'model': '12345' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
@@ -28,7 +28,7 @@ return [
         '<?xml version="1.0"?><config><entity name="some_name" behaviorModel="=--09"/></config>',
         [
             "Element 'entity', attribute 'behaviorModel': [facet 'pattern'] The value '=--09' is not " .
-            "accepted by the pattern '[A-Za-z_\\\\\\\\]+'.\nLine: 1\n",
+            "accepted by the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
             "Element 'entity', attribute 'behaviorModel': '=--09' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],
@@ -49,7 +49,7 @@ return [
         '<?xml version="1.0"?><config><entityType entity="entity_name" name="some_name" model="test1"/></config>',
         [
             "Element 'entityType', attribute 'model': [facet 'pattern'] The value 'test1' is not " .
-            "accepted by the pattern '[A-Za-z_\\\\\\\\]+'.\nLine: 1\n",
+            "accepted by the pattern '[A-Za-z_\\\\]+'.\nLine: 1\n",
             "Element 'entityType', attribute 'model': 'test1' is not a valid value of the atomic type" .
             " 'modelName'.\nLine: 1\n"
         ],

--- a/app/code/Magento/ImportExport/etc/export.xsd
+++ b/app/code/Magento/ImportExport/etc/export.xsd
@@ -71,11 +71,11 @@
     <xs:simpleType name="modelName">
         <xs:annotation>
             <xs:documentation>
-                Model name can contain only [A-Za-z_\\\\].
+                Model name can contain only [A-Za-z_\\].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Za-z_\\\\]+" />
+            <xs:pattern value="[A-Za-z_\\]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/app/code/Magento/ImportExport/etc/import.xsd
+++ b/app/code/Magento/ImportExport/etc/import.xsd
@@ -61,11 +61,11 @@
     <xs:simpleType name="modelName">
         <xs:annotation>
             <xs:documentation>
-                Model name can contain only [A-Za-z_\\\\].
+                Model name can contain only [A-Za-z_\\].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Za-z_\\\\]+" />
+            <xs:pattern value="[A-Za-z_\\]+" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
The backslash character ("`\`")  was put more than once in the same
regex character class across some XSD files. Per each character class
there is no need to specify it twice.

I ran over this while looking into an issue with class-name validation
which do not allow digits within class names.

Refs:

- https://www.w3.org/TR/xmlschema11-2/#cces

- #4470

- #5420

- #8307
