### PR TITLE
Define custom paths for logs without writing extra handlers

### DIFF
--- a/app/code/Magento/Developer/Model/Logger/Handler/Debug.php
+++ b/app/code/Magento/Developer/Model/Logger/Handler/Debug.php
@@ -37,15 +37,17 @@ class Debug extends \Magento\Framework\Logger\Handler\Debug
      * @param ScopeConfigInterface $scopeConfig
      * @param DeploymentConfig $deploymentConfig
      * @param string $filePath
+     * @param string $fileDirectory
      */
     public function __construct(
         DriverInterface $filesystem,
         State $state,
         ScopeConfigInterface $scopeConfig,
         DeploymentConfig $deploymentConfig,
-        $filePath = null
+        $filePath = null,
+        $fileDirectory = null
     ) {
-        parent::__construct($filesystem, $filePath);
+        parent::__construct($filesystem, $filePath, $fileDirectory);
 
         $this->state = $state;
         $this->scopeConfig = $scopeConfig;

--- a/lib/internal/Magento/Framework/Logger/Handler/Base.php
+++ b/lib/internal/Magento/Framework/Logger/Handler/Base.php
@@ -13,6 +13,13 @@ use Monolog\Logger;
 
 class Base extends StreamHandler
 {
+    const DEFAULT_LOG_DIRECTORY = '/var/log';
+
+    /**
+     * @var string
+     */
+    protected $fileDirectory;
+
     /**
      * @var string
      */
@@ -30,15 +37,18 @@ class Base extends StreamHandler
 
     /**
      * @param DriverInterface $filesystem
-     * @param string $filePath
+     * @param string $filePath Full path to the log file
+     * @param string $fileDirectory Directory relative to the Magento root directory
      */
     public function __construct(
         DriverInterface $filesystem,
-        $filePath = null
+        $filePath = null,
+        $fileDirectory = null
     ) {
         $this->filesystem = $filesystem;
+        $this->fileDirectory = $fileDirectory;
         parent::__construct(
-            $filePath ? $filePath . $this->fileName : BP . $this->fileName,
+            $filePath ? $filePath : BP . self::DEFAULT_LOG_DIRECTORY . $this->fileDirectory . DIRECTORY_SEPARATOR . $this->fileName,
             $this->loggerType
         );
         $this->setFormatter(new LineFormatter(null, null, true));

--- a/lib/internal/Magento/Framework/Logger/Handler/Debug.php
+++ b/lib/internal/Magento/Framework/Logger/Handler/Debug.php
@@ -13,7 +13,7 @@ class Debug extends Base
     /**
      * @var string
      */
-    protected $fileName = '/var/log/debug.log';
+    protected $fileName = 'debug.log';
 
     /**
      * @var int

--- a/lib/internal/Magento/Framework/Logger/Handler/Exception.php
+++ b/lib/internal/Magento/Framework/Logger/Handler/Exception.php
@@ -13,7 +13,7 @@ class Exception extends Base
     /**
      * @var string
      */
-    protected $fileName = '/var/log/exception.log';
+    protected $fileName = 'exception.log';
 
     /**
      * @var int

--- a/lib/internal/Magento/Framework/Logger/Handler/System.php
+++ b/lib/internal/Magento/Framework/Logger/Handler/System.php
@@ -14,7 +14,7 @@ class System extends Base
     /**
      * @var string
      */
-    protected $fileName = '/var/log/system.log';
+    protected $fileName = 'system.log';
 
     /**
      * @var int
@@ -30,14 +30,16 @@ class System extends Base
      * @param DriverInterface $filesystem
      * @param Exception $exceptionHandler
      * @param string $filePath
+     * @param string $fileDirectory
      */
     public function __construct(
         DriverInterface $filesystem,
         Exception $exceptionHandler,
-        $filePath = null
+        $filePath = null,
+        $fileDirectory = null
     ) {
         $this->exceptionHandler = $exceptionHandler;
-        parent::__construct($filesystem, $filePath);
+        parent::__construct($filesystem, $filePath, $fileDirectory);
     }
 
     /**

--- a/setup/src/Magento/Setup/Model/Cron/SetupStreamHandler.php
+++ b/setup/src/Magento/Setup/Model/Cron/SetupStreamHandler.php
@@ -16,7 +16,7 @@ class SetupStreamHandler extends \Magento\Framework\Logger\Handler\Base
     /**
      * @var string
      */
-    protected $fileName = '/var/log/update.log';
+    protected $fileName = 'update.log';
 
     /**
      * @var int

--- a/setup/src/Magento/Setup/Model/Cron/SetupStreamHandler.php
+++ b/setup/src/Magento/Setup/Model/Cron/SetupStreamHandler.php
@@ -26,11 +26,13 @@ class SetupStreamHandler extends \Magento\Framework\Logger\Handler\Base
     /**
      * @param DriverInterface $filesystem
      * @param string $filePath
+     * @param string $fileDirectory
      */
     public function __construct(
         DriverInterface $filesystem,
-        $filePath = null
+        $filePath = null,
+        $fileDirectory = null
     ) {
-        parent::__construct($filesystem, $filePath);
+        parent::__construct($filesystem, $filePath, $fileDirectory);
     }
 }


### PR DESCRIPTION
Enhances the base log system and provide a way to define custom log directories/files through the di.xml file without having to create extra handlers just to change the path of log files.

This enhancement can lead to broken behaviors for custom handlers defined with $filename using the full path. I do not know if it is considered as a BC break or not.

### Description

_Problem 1_
Actually, there is no way to define custom paths for log handler without creating an extra handler redefining the paths.

This article presents a good way to define custom paths for logs: https://www.maxpronko.com/blog/how-to-create-custom-logger-in-magento-2
But this implementation lacks of flexibility and forces developers to create an extra class. It can become fastidious if you have multiple modules and have to create the same handler just with the filename property changing. Plus, for each new handler defined you have to keep tracking of eventuals BC breaks.
In my opinion, developers should be free to custom this kind of things with ease without writing new classes.

_Problem 2_
With $filePath, we could think at first that the developer can choose a full custom location for its log paths but instead, $filePath is concatened with the $fileName property, which is kind of a misleading from my point of view.

_Solution_
The provided changes allow developers to define custom log files using the di.xml file and do not force them to implement extra class. The developer can choose to:
- Store the log just in a custom directory in var/log
- Store the log somewhere else in the server with the path of his choice (directory and filename)

### Manual testing scenarios
Here is a way to define custom paths for existing handlers with the provided changes:
**1. Edit the _di.xml_ file of your module and add the below code**
```
<virtualType name="customLogger" type="Magento\Framework\Logger\Monolog">
   <arguments>
        <argument name="handlers"  xsi:type="array">
            <item name="debug" xsi:type="object">customDebugHandler</item>
        </argument>
    </arguments>
</virtualType>

<virtualType name="customDebugHandler" type="Magento\Framework\Logger\Handler\System">
    <arguments>
        <argument name="fileDirectory" xsi:type="string">/myvendor/mymodule</argument>
    </arguments>
</virtualType>
```

**2. Use the customLogger defined as a depency of an existing or newly created class**

**Edit your _di.xml_**

```
<type name="MyVendor\MyModule\MyClass">
        <arguments>
            <argument name="logger">customLogger</argument>
        </arguments>
</type>
```
**Create a class _MyVendor/MyModule/MyClass.php_**
```
<?php
namespace MyVendor\MyModule;

class MyClass {

    /**
     * @var \Psr\Log\LoggerInterface
     */
    protected $logger;
    
    public function __construct(\Psr\Log\LoggerInterface $logger)
    {
        $this->logger = $logger;
        $this->logger->debug('Logged to my custom debug path');
    }
}
```
As I said above, this enhancement might lead to broken paths for module with handlers re-defining the $fileName property by using a full path. (i.g: /var/log/mycustomfile.log) and would force developers to update theirs modules and change the $fileName property of their handlers.

Tell me what you think of this enhancement, if the break described should be taken in consideration, if you find this enhancement useful or not, etc...

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
