### PR TITLE
Empty resolvedScopeCodes when config cache is cleaned

### DIFF
--- a/lib/internal/Magento/Framework/App/Config.php
+++ b/lib/internal/Magento/Framework/App/Config.php
@@ -95,6 +95,7 @@ class Config implements ScopeConfigInterface
 
     /**
      * Invalidate cache by type
+     * Clean scopeCodeResolver
      *
      * @return void
      */
@@ -103,6 +104,7 @@ class Config implements ScopeConfigInterface
         foreach ($this->types as $type) {
             $type->clean();
         }
+        $this->scopeCodeResolver->clean();
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -58,4 +58,14 @@ class ScopeCodeResolver
         $this->resolvedScopeCodes[$scopeType][$scopeCode] = $resolverScopeCode;
         return $resolverScopeCode;
     }
+
+    /**
+     * Clean resolvedScopeCodes, store codes may have been renamed
+     *
+     * @return void
+     */
+    public function clean()
+    {
+        $this->resolvedScopeCodes = [];
+    }
 }


### PR DESCRIPTION
Also empty resolvedScopeCodes when config cache is cleaned.

### Description
During setup:upgrade we change the name of the default store; magento will clean the config cache as part of saving the store view. However, ScopeCodeResolver's resolvedScopeCodes is not emptied, which means that it still maps 'stores',null to 'default', not the new name of the default store. This will break access to configurations. 

### Manual testing scenarios
With
    /** @var \Magento\Store\Api\Data\WebsiteInterface */
    protected $website;

    /** @var \Magento\Store\Api\Data\GroupInterface */
    protected $storeGroup;

    /** @var \Magento\Store\Api\Data\StoreInterface */
    protected $storeView;
we do
        $this->website->getDefault();
        $this->website->setCode($siteData['website']['code']);
        $this->website->setName($siteData['website']['name']);
        $this->website->setSortOrder($siteData['website']['sort_order']);
        $this->website->setId(1);
        $this->website->save();

        $this->storeGroup->load(1);
        $this->storeGroup->setName($siteData['store_group']['name']);
        $this->storeGroup->setId(1);
        $this->storeGroup->save();

        $this->storeView->load(1);
        $this->storeView->setCode($siteData['store_view']['code']);
        $this->storeView->setName($siteData['store_view']['name']);
        $this->storeView->setId(1);
        $this->storeView->save();
        $this->setLocale($siteData['store_view']['locale_code']);

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [?] All automated tests passed successfully (all builds on Travis CI are green)
