### PR TITLE
fix issue #4884 "insert images..." btn in backend

### DIFF
--- a/lib/web/mage/adminhtml/browser.js
+++ b/lib/web/mage/adminhtml/browser.js
@@ -51,7 +51,7 @@ define([
                 content = '<div class="popup-window magento-message" id="' + windowId + '"></div>',
                 self = this;
 
-            if (this.modal) {
+            if (this.modal && options !== undefined) {
                 this.modal.html($(content).html());
 
                 if (options && typeof options.closed !== 'undefined') {


### PR DESCRIPTION
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4884: Button Insert Image - only insert one image

### Manual testing scenarios
1. open a static block
2. click "Insert images..."
3. close modal
4. click again "Insert images..."

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
