### PR TITLE
Fix grammar mistakes with subscriptions - fixes #7498

### DIFF
--- a/app/code/Magento/Customer/Block/Account/Dashboard.php
+++ b/app/code/Magento/Customer/Block/Account/Dashboard.php
@@ -170,10 +170,10 @@ class Dashboard extends \Magento\Framework\View\Element\Template
     public function getSubscriptionText()
     {
         if ($this->getSubscriptionObject()->isSubscribed()) {
-            return __('You subscribe to our newsletter.');
+            return __('You are subscribed to our newsletter.');
         }
 
-        return __('You don\'t subscribe to our newsletter.');
+        return __('You aren\'t subscribed to our newsletter.');
     }
 
     /**

--- a/app/code/Magento/Customer/i18n/en_US.csv
+++ b/app/code/Magento/Customer/i18n/en_US.csv
@@ -1,7 +1,7 @@
 "Sign Out","Sign Out"
 "Sign In","Sign In"
-"You subscribe to our newsletter.","You subscribe to our newsletter."
-"You don\'t subscribe to our newsletter.","You don\'t subscribe to our newsletter."
+"You are subscribed to our newsletter.","You are subscribed to our newsletter."
+"You aren't subscribed to our newsletter.","You aren't subscribed to our newsletter."
 "You have not set a default shipping address.","You have not set a default shipping address."
 "You have not set a default billing address.","You have not set a default billing address."
 "Address Book","Address Book"
@@ -308,7 +308,7 @@ Change,Change
 "Contact Information","Contact Information"
 "Change Password","Change Password"
 Newsletters,Newsletters
-"You subscribe to ""General Subscription"".","You subscribe to ""General Subscription""."
+"You are subscribed to ""General Subscription"".","You are subscribed to ""General Subscription""."
 or,or
 "Default Addresses","Default Addresses"
 "Change Billing Address","Change Billing Address"

--- a/app/code/Magento/Customer/view/frontend/templates/account/dashboard/info.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/dashboard/info.phtml
@@ -38,9 +38,9 @@
                 <div class="box-content">
                     <p>
                         <?php if ($block->getIsSubscribed()): ?>
-                            <?php echo $block->escapeHtml(__('You subscribe to "General Subscription".')) ?>
+                            <?php echo $block->escapeHtml(__('You are subscribed to "General Subscription".')) ?>
                         <?php else: ?>
-                            <?php echo $block->escapeHtml(__('You don\'t subscribe to our newsletter.')) ?>
+                            <?php echo $block->escapeHtml(__('You aren\'t subscribed to our newsletter.')) ?>
                         <?php endif; ?>
                     </p>
                     <?php /* Extensions placeholder */ ?>


### PR DESCRIPTION
There are some grammar mistake in customer dashboard, in regards to showing if customer is subscribed to newsletter or not.

### Description
Fixes typos and replaces texts with grammar mistakes with correct ones

### Fixed Issues (if relevant)
1. magento/magento2#7498

### Manual testing scenarios
1. Log in to customer account
2. Observe "Newsletter" part and see text with typos http://prntscr.com/eqv0c4
3. Edit subscription
4. Subscribe to "General Subscription"
5. Observe "Newsletter" part and see text with typos http://prntscr.com/eqv0rs

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
