### PR TITLE
Fix Google Analytics typo in printing Account Number, fixes #7549

### DIFF
--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -86,7 +86,7 @@ class Ga extends \Magento\Framework\View\Element\Template
         }
 
         return "\nga('create', '" . $this->escapeHtmlAttr($accountId, false)
-           . ", 'auto');{$anonymizeIp}\nga('send', 'pageview'{$optPageURL});\n";
+           . "', 'auto');{$anonymizeIp}\nga('send', 'pageview'{$optPageURL});\n";
     }
 
     /**


### PR DESCRIPTION
Once Account Number is entered in Google Analytics part of Magento admin, there's a bug in printing it out on frontend - apostrophe sign that wraps the GTM ID is missing.

### Description
Apostrophe is added during GTM print, which fixes this issue.

### Fixed Issues (if relevant)
1. magento/magento2#7549

### Manual testing scenarios
1. Enable Google Analytics and set Account Number in Magento Analytics module via administration http://prntscr.com/eqwf6m
2. Observe that GTM ID is missing apostrophe sign after it, which wraps the value http://prntscr.com/eqwfrl

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
