### PR TITLE
Issue #2802, #1146: Fixing sitemap generation folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,11 @@
 /.settings
 atlassian*
 /nbproject
+/robots.txt
 /sitemap
 /sitemap.xml
+/pub/sitemap
+/pub/sitemap.xml
 /.idea
 /.gitattributes
 /app/config_sandbox

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 atlassian*
 /nbproject
 /robots.txt
+/pub/robots.txt
 /sitemap
 /sitemap.xml
 /pub/sitemap

--- a/app/code/Magento/Config/Model/Config/Backend/Admin/Robots.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Admin/Robots.php
@@ -9,8 +9,6 @@
  */
 namespace Magento\Config\Model\Config\Backend\Admin;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
-
 class Robots extends \Magento\Framework\App\Config\Value
 {
     /**
@@ -39,12 +37,13 @@ class Robots extends \Magento\Framework\App\Config\Value
         \Magento\Framework\App\Config\ScopeConfigInterface $config,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         \Magento\Framework\Filesystem $filesystem,
+        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
-        $this->_directory = $filesystem->getDirectoryWrite(DirectoryList::ROOT);
+        $this->_directory = $filesystem->getDirectoryWrite($documentRoot->getPath());
         $this->_file = 'robots.txt';
     }
 

--- a/app/code/Magento/Config/Model/Config/Backend/Admin/Robots.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Admin/Robots.php
@@ -9,6 +9,9 @@
  */
 namespace Magento\Config\Model\Config\Backend\Admin;
 
+use Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot;
+use Magento\Framework\App\ObjectManager;
+
 class Robots extends \Magento\Framework\App\Config\Value
 {
     /**
@@ -37,12 +40,14 @@ class Robots extends \Magento\Framework\App\Config\Value
         \Magento\Framework\App\Config\ScopeConfigInterface $config,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         \Magento\Framework\Filesystem $filesystem,
-        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = []
+        array $data = [],
+        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot = null
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+
+        $documentRoot = $documentRoot ?: ObjectManager::getInstance()->get(DocumentRoot::class);
         $this->_directory = $filesystem->getDirectoryWrite($documentRoot->getPath());
         $this->_file = 'robots.txt';
     }

--- a/app/code/Magento/Config/Model/Config/Backend/Admin/Robots.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Admin/Robots.php
@@ -42,8 +42,8 @@ class Robots extends \Magento\Framework\App\Config\Value
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = [],
-        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot = null
+        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot = null,
+        array $data = []
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
 

--- a/app/code/Magento/Config/Model/Config/Backend/Admin/Robots.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Admin/Robots.php
@@ -33,6 +33,7 @@ class Robots extends \Magento\Framework\App\Config\Value
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
+     * @param DocumentRoot $documentRoot
      */
     public function __construct(
         \Magento\Framework\Model\Context $context,
@@ -42,8 +43,8 @@ class Robots extends \Magento\Framework\App\Config\Value
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot = null,
-        array $data = []
+        array $data = [],
+        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot = null
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
 

--- a/app/code/Magento/Config/Model/Config/Reader/Source/Deployed/DocumentRoot.php
+++ b/app/code/Magento/Config/Model/Config/Reader/Source/Deployed/DocumentRoot.php
@@ -1,28 +1,49 @@
 <?php
 /**
- * @by SwiftOtter, Inc., 04/01/2017
- * @website https://swiftotter.com
- **/
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 
 namespace Magento\Config\Model\Config\Reader\Source\Deployed;
 
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\App\Filesystem\DirectoryList;
 
+/**
+ * Class DocumentRoot
+ * @package Magento\Config\Model\Config\Reader\Source\Deployed
+ */
 class DocumentRoot
 {
     private $config;
 
+    /**
+     * DocumentRoot constructor.
+     * @param \Magento\Framework\App\DeploymentConfig $config
+     */
     public function __construct(\Magento\Framework\App\DeploymentConfig $config)
     {
         $this->config = $config;
     }
 
+    /**
+     * A shortcut to load the document root path from the DirectoryList based on the
+     * deployment configuration.
+     *
+     * @return string
+     */
     public function getPath()
     {
         return $this->isPub() ? DirectoryList::PUB : DirectoryList::ROOT;
     }
 
+    /**
+     * Returns whether the deployment configuration specifies that the document root is
+     * in the pub/ folder. This affects ares such as sitemaps and robots.txt (and will
+     * likely be extended to control other areas).
+     *
+     * @return bool
+     */
     public function isPub()
     {
         return (bool)$this->config->get(ConfigOptionsListConstants::CONFIG_PATH_DOCUMENT_ROOT_IS_PUB);

--- a/app/code/Magento/Config/Model/Config/Reader/Source/Deployed/DocumentRoot.php
+++ b/app/code/Magento/Config/Model/Config/Reader/Source/Deployed/DocumentRoot.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @by SwiftOtter, Inc., 04/01/2017
+ * @website https://swiftotter.com
+ **/
+
+namespace Magento\Config\Model\Config\Reader\Source\Deployed;
+
+use Magento\Framework\Config\ConfigOptionsListConstants;
+use Magento\Framework\App\Filesystem\DirectoryList;
+
+class DocumentRoot
+{
+    private $config;
+
+    public function __construct(\Magento\Framework\App\DeploymentConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    public function getPath()
+    {
+        return $this->isPub() ? DirectoryList::PUB : DirectoryList::ROOT;
+    }
+
+    public function isPub()
+    {
+        return (bool)$this->config->get(ConfigOptionsListConstants::CONFIG_PATH_DOCUMENT_ROOT_IS_PUB);
+    }
+}

--- a/app/code/Magento/Config/Model/Config/Reader/Source/Deployed/DocumentRoot.php
+++ b/app/code/Magento/Config/Model/Config/Reader/Source/Deployed/DocumentRoot.php
@@ -8,6 +8,7 @@ namespace Magento\Config\Model\Config\Reader\Source\Deployed;
 
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\DeploymentConfig;
 
 /**
  * Class DocumentRoot
@@ -15,13 +16,16 @@ use Magento\Framework\App\Filesystem\DirectoryList;
  */
 class DocumentRoot
 {
+    /**
+     * @var DeploymentConfig
+     */
     private $config;
 
     /**
      * DocumentRoot constructor.
-     * @param \Magento\Framework\App\DeploymentConfig $config
+     * @param DeploymentConfig $config
      */
-    public function __construct(\Magento\Framework\App\DeploymentConfig $config)
+    public function __construct(DeploymentConfig $config)
     {
         $this->config = $config;
     }

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Reader/Source/Deployed/DocumentRootTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Reader/Source/Deployed/DocumentRootTest.php
@@ -53,6 +53,9 @@ class DocumentRootTest extends \PHPUnit_Framework_TestCase
         $this->documentRoot = new Reader\Source\Deployed\DocumentRoot($this->configMock);
     }
 
+    /**
+     * Ensures that the path returned matches the pub/ path.
+     */
     public function testGetPath()
     {
         $this->configMockSetForDocumentRootIsPub();
@@ -60,6 +63,10 @@ class DocumentRootTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(DirectoryList::PUB, $this->documentRoot->getPath());
     }
 
+    /**
+     * Ensures that the deployment configuration returns the mocked value for
+     * the pub/ folder.
+     */
     public function testIsPub()
     {
         $this->configMockSetForDocumentRootIsPub();

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Reader/Source/Deployed/DocumentRootTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Reader/Source/Deployed/DocumentRootTest.php
@@ -25,7 +25,7 @@ class DocumentRootTest extends \PHPUnit_Framework_TestCase
     private $configMock;
 
     /**
-     * @var SettingChecker
+     * @var Reader\Source\Deployed\DocumentRoot
      */
     private $documentRoot;
 

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Reader/Source/Deployed/DocumentRootTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Reader/Source/Deployed/DocumentRootTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Config\Test\Unit\Model\Config\Reader\Source\Deployed;
+
+use Magento\Config\Model\Config\Reader;
+use Magento\Config\Model\Config\Reader\Source\Deployed\SettingChecker;
+use Magento\Framework\App\Config;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Config\Model\Placeholder\PlaceholderInterface;
+use Magento\Config\Model\Placeholder\PlaceholderFactory;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Config\ConfigOptionsListConstants;
+
+/**
+ * Test class for checking settings that defined in config file
+ */
+class DocumentRootTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Config|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $configMock;
+
+    /**
+     * @var PlaceholderInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $placeholderMock;
+
+    /**
+     * @var Config\ScopeCodeResolver|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $scopeCodeResolverMock;
+
+    /**
+     * @var SettingChecker
+     */
+    private $documentRoot;
+
+    /**
+     * @var array
+     */
+    private $env;
+
+    public function setUp()
+    {
+        $this->configMock = $this->getMockBuilder(DeploymentConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->documentRoot = new Reader\Source\Deployed\DocumentRoot($this->configMock);
+    }
+
+    public function testGetPath()
+    {
+        $this->configMockSetForDocumentRootIsPub();
+
+        $this->assertSame(DirectoryList::PUB, $this->documentRoot->getPath());
+    }
+
+    public function testIsPub()
+    {
+        $this->configMockSetForDocumentRootIsPub();
+
+        $this->assertSame(true, $this->documentRoot->isPub());
+    }
+
+    private function configMockSetForDocumentRootIsPub()
+    {
+        $this->configMock->expects($this->any())
+            ->method('get')
+            ->willReturnMap([
+                [
+                    ConfigOptionsListConstants::CONFIG_PATH_DOCUMENT_ROOT_IS_PUB,
+                    null,
+                    true
+                ],
+            ]);
+    }
+}

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Reader/Source/Deployed/DocumentRootTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Reader/Source/Deployed/DocumentRootTest.php
@@ -25,24 +25,9 @@ class DocumentRootTest extends \PHPUnit_Framework_TestCase
     private $configMock;
 
     /**
-     * @var PlaceholderInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $placeholderMock;
-
-    /**
-     * @var Config\ScopeCodeResolver|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $scopeCodeResolverMock;
-
-    /**
      * @var SettingChecker
      */
     private $documentRoot;
-
-    /**
-     * @var array
-     */
-    private $env;
 
     public function setUp()
     {

--- a/app/code/Magento/Sitemap/Block/Adminhtml/Grid/Renderer/Link.php
+++ b/app/code/Magento/Sitemap/Block/Adminhtml/Grid/Renderer/Link.php
@@ -11,6 +11,8 @@
 namespace Magento\Sitemap\Block\Adminhtml\Grid\Renderer;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot;
+use Magento\Framework\App\ObjectManager;
 
 class Link extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRenderer
 {
@@ -25,6 +27,11 @@ class Link extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRe
     protected $_sitemapFactory;
 
     /**
+     * @var \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot
+     */
+    protected $documentRoot;
+
+    /**
      * @param \Magento\Backend\Block\Context $context
      * @param \Magento\Sitemap\Model\SitemapFactory $sitemapFactory
      * @param \Magento\Framework\Filesystem $filesystem
@@ -34,10 +41,13 @@ class Link extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRe
         \Magento\Backend\Block\Context $context,
         \Magento\Sitemap\Model\SitemapFactory $sitemapFactory,
         \Magento\Framework\Filesystem $filesystem,
+        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot = null,
         array $data = []
     ) {
         $this->_sitemapFactory = $sitemapFactory;
         $this->_filesystem = $filesystem;
+        $this->documentRoot = $documentRoot ?: ObjectManager::getInstance()->get(DocumentRoot::class);
+
         parent::__construct($context, $data);
     }
 
@@ -54,7 +64,8 @@ class Link extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRe
         $url = $this->escapeHtml($sitemap->getSitemapUrl($row->getSitemapPath(), $row->getSitemapFilename()));
 
         $fileName = preg_replace('/^\//', '', $row->getSitemapPath() . $row->getSitemapFilename());
-        $directory = $this->_filesystem->getDirectoryRead(DirectoryList::ROOT);
+        $documentRootPath = $this->documentRoot->getPath();
+        $directory = $this->_filesystem->getDirectoryRead($documentRootPath);
         if ($directory->isFile($fileName)) {
             return sprintf('<a href="%1$s">%1$s</a>', $url);
         }

--- a/app/code/Magento/Sitemap/Block/Adminhtml/Grid/Renderer/Link.php
+++ b/app/code/Magento/Sitemap/Block/Adminhtml/Grid/Renderer/Link.php
@@ -27,7 +27,7 @@ class Link extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRe
     protected $_sitemapFactory;
 
     /**
-     * @var \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot
+     * @var DocumentRoot
      */
     protected $documentRoot;
 
@@ -36,13 +36,14 @@ class Link extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRe
      * @param \Magento\Sitemap\Model\SitemapFactory $sitemapFactory
      * @param \Magento\Framework\Filesystem $filesystem
      * @param array $data
+     * @param DocumentRoot $documentRoot
      */
     public function __construct(
         \Magento\Backend\Block\Context $context,
         \Magento\Sitemap\Model\SitemapFactory $sitemapFactory,
         \Magento\Framework\Filesystem $filesystem,
-        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot = null,
-        array $data = []
+        array $data = [],
+        DocumentRoot $documentRoot = null
     ) {
         $this->_sitemapFactory = $sitemapFactory;
         $this->_filesystem = $filesystem;

--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -7,6 +7,8 @@
 // @codingStandardsIgnoreFile
 
 namespace Magento\Sitemap\Model;
+use Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Sitemap model
@@ -175,13 +177,14 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Framework\App\RequestInterface $request,
         \Magento\Framework\Stdlib\DateTime $dateTime,
-        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = []
+        array $data = [],
+        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot = null
     ) {
         $this->_escaper = $escaper;
         $this->_sitemapData = $sitemapData;
+        $documentRoot = $documentRoot ?: ObjectManager::getInstance()->get(DocumentRoot::class);
         $this->_directory = $filesystem->getDirectoryWrite($documentRoot->getPath());
         $this->_categoryFactory = $categoryFactory;
         $this->_productFactory = $productFactory;

--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -8,8 +8,6 @@
 
 namespace Magento\Sitemap\Model;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
-
 /**
  * Sitemap model
  *
@@ -177,13 +175,14 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Framework\App\RequestInterface $request,
         \Magento\Framework\Stdlib\DateTime $dateTime,
+        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->_escaper = $escaper;
         $this->_sitemapData = $sitemapData;
-        $this->_directory = $filesystem->getDirectoryWrite(DirectoryList::ROOT);
+        $this->_directory = $filesystem->getDirectoryWrite($documentRoot->getPath());
         $this->_categoryFactory = $categoryFactory;
         $this->_productFactory = $productFactory;
         $this->_cmsFactory = $cmsFactory;

--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -179,8 +179,8 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel
         \Magento\Framework\Stdlib\DateTime $dateTime,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = [],
-        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot = null
+        \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot $documentRoot = null,
+        array $data = []
     ) {
         $this->_escaper = $escaper;
         $this->_sitemapData = $sitemapData;

--- a/dev/tests/integration/testsuite/Magento/Config/Model/Config/Backend/Admin/RobotsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Config/Model/Config/Backend/Admin/RobotsTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Config\Model\Config\Backend\Admin;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot;
 
 /**
  * @magentoAppArea adminhtml
@@ -33,11 +33,11 @@ class RobotsTest extends \PHPUnit_Framework_TestCase
         $this->model = $objectManager->create(\Magento\Config\Model\Config\Backend\Admin\Robots::class);
         $this->model->setPath('design/search_engine_robots/custom_instructions');
         $this->model->afterLoad();
+
+        $documentRootPath = $objectManager->get(DocumentRoot::class)->getPath();
         $this->rootDirectory = $objectManager->get(
             \Magento\Framework\Filesystem::class
-        )->getDirectoryRead(
-            DirectoryList::ROOT
-        );
+        )->getDirectoryRead($documentRootPath);
     }
 
     /**

--- a/generated/.htaccess
+++ b/generated/.htaccess
@@ -1,2 +1,0 @@
-Order deny,allow
-Deny from all

--- a/generated/.htaccess
+++ b/generated/.htaccess
@@ -1,0 +1,2 @@
+Order allow,deny
+Deny from all

--- a/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
+++ b/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
@@ -30,6 +30,8 @@ class ConfigOptionsListConstants
     const CONFIG_PATH_DB = 'db';
     const CONFIG_PATH_RESOURCE = 'resource';
     const CONFIG_PATH_CACHE_TYPES = 'cache_types';
+    const CONFIG_PATH_DOCUMENT_ROOT_IS_PUB = 'directories/document_root_is_pub';
+
     /**#@-*/
 
     /**#@+

--- a/vendor/.htaccess
+++ b/vendor/.htaccess
@@ -1,0 +1,2 @@
+Order allow,deny
+Deny from all

--- a/vendor/.htaccess
+++ b/vendor/.htaccess
@@ -1,2 +1,0 @@
-Order allow,deny
-Deny from all


### PR DESCRIPTION
### Description
Magento assumes for the above tickets that `robots.txt` and the sitemap paths are to be found in the root directory. To get the sitemap to be generated in the `pub` folder (per Magento's recommendation), you need to set the base directory to be at least `pub/`. This resolves the issue by adding new configuration to `app/etc/env.php`:

```
directories/
    document_root_is_pub (bool)
```

The default keeps backward compatibility: if the value is not specified, original functionality remains (use of the root directory). If you specify `document_root_is_pub` and set it to `true`, the sitemap is located in the correct directory.

### Fixed Issues
This is a fix for:
1. https://github.com/magento/magento2/issues/2802
2. https://github.com/magento/magento2/issues/1146

### Manual testing scenarios
*Before:*
1. Ensure that apache / nginx has the document root set to use `/pub`. 
2. Create a sitemap.
3. Click the generate link.
4. Try to access it: you will get a 404 error.

*After:*
1. Sitemap should be generated, and you will not get a 404 error.
