### PR TITLE
Improve performances by improving composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -243,6 +243,9 @@
         "files": [
             "app/etc/NonComposerComponentRegistration.php"
         ],
+        "classmap": [
+            "var/generation/Magento/"
+        ],
         "exclude-from-classmap": [
             "**/dev/**",
             "**/update/**",


### PR DESCRIPTION
Improve the autoload by removing a lot of `file_exists()` calls.

### Description

I just added the classmap element in autoload in `composer.json`.

If the directory doesn't exist composer will complaint about it. So I also added a `.gitkeep` file.
Which for me is a good way to make it work.
It's worth the improvement.

### Fixed Issues

Didn't find a relevant one.

### Manual testing scenarios

Use `composer dumpautoload -o` before the change, load the page (all caches enabled, but works also without).
Then calculate the number of `file_exists` calls.

Make the change, re-run the dump of the autoload, then call your page again.

Don't forget of course to flush the cache between operations.

Here is the comparison with cache enabled: https://blackfire.io/profiles/compare/7a733717-695d-495f-8bfe-0ffc65154894/graph

The `autoload_classmap.php` has +3k lines after this. So, in best scenarios it can avoid 3k `file_exists`.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
