### PR TITLE
Redundant expression */1 in crontab.xml

### DIFF
--- a/app/code/Magento/Sales/etc/crontab.xml
+++ b/app/code/Magento/Sales/etc/crontab.xml
@@ -31,7 +31,7 @@
             <schedule>* * * * *</schedule>
         </job>
         <job name="sales_grid_order_invoice_async_insert" instance="SalesInvoiceIndexGridAsyncInsertCron" method="execute">
-            <schedule>*/1 * * * *</schedule>
+            <schedule>* * * * *</schedule>
         </job>
         <job name="sales_grid_order_shipment_async_insert" instance="SalesShipmentIndexGridAsyncInsertCron" method="execute">
             <schedule>* * * * *</schedule>

--- a/app/code/Magento/Sales/etc/crontab.xml
+++ b/app/code/Magento/Sales/etc/crontab.xml
@@ -28,28 +28,28 @@
             <schedule>0 0 * * *</schedule>
         </job>
         <job name="sales_grid_order_async_insert" instance="SalesOrderIndexGridAsyncInsertCron" method="execute">
-            <schedule>*/1 * * * *</schedule>
+            <schedule>* * * * *</schedule>
         </job>
         <job name="sales_grid_order_invoice_async_insert" instance="SalesInvoiceIndexGridAsyncInsertCron" method="execute">
             <schedule>*/1 * * * *</schedule>
         </job>
         <job name="sales_grid_order_shipment_async_insert" instance="SalesShipmentIndexGridAsyncInsertCron" method="execute">
-            <schedule>*/1 * * * *</schedule>
+            <schedule>* * * * *</schedule>
         </job>
         <job name="sales_grid_order_creditmemo_async_insert" instance="SalesCreditmemoIndexGridAsyncInsertCron" method="execute">
-            <schedule>*/1 * * * *</schedule>
+            <schedule>* * * * *</schedule>
         </job>
         <job name="sales_send_order_emails" instance="SalesOrderSendEmailsCron" method="execute">
-            <schedule>*/1 * * * *</schedule>
+            <schedule>* * * * *</schedule>
         </job>
         <job name="sales_send_order_invoice_emails" instance="SalesInvoiceSendEmailsCron" method="execute">
-            <schedule>*/1 * * * *</schedule>
+            <schedule>* * * * *</schedule>
         </job>
         <job name="sales_send_order_shipment_emails" instance="SalesShipmentSendEmailsCron" method="execute">
-            <schedule>*/1 * * * *</schedule>
+            <schedule>* * * * *</schedule>
         </job>
         <job name="sales_send_order_creditmemo_emails" instance="SalesCreditmemoSendEmailsCron" method="execute">
-            <schedule>*/1 * * * *</schedule>
+            <schedule>* * * * *</schedule>
         </job>
     </group>
 </config>


### PR DESCRIPTION
In Magento_Sales crontab.xml there are several cron expressions like this `*\1` that is redundant since `*` already means "every time unit". I changed them to a regular `*` in order to:

- Have an uniform style with the other crontab.xml files
- Remove the "wtf effect" when one sees that strange thing.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
