### PR TITLE
Fix attribute label on product page at different store views

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
@@ -23,7 +23,7 @@ $_attributeType = $block->getAtType();
 $_attributeAddAttribute = $block->getAddAttribute();
 
 if ($_attributeLabel && $_attributeLabel == 'default') {
-    $_attributeLabel = $_product->getResource()->getAttribute($_code)->getFrontendLabel();
+    $_attributeLabel = $_product->getResource()->getAttribute($_code)->getStoreLabel();
 }
 if ($_attributeType && $_attributeType == 'text') {
     $_attributeValue = ($_helper->productAttribute($_product, $_product->$_call(), $_code)) ? $_product->getAttributeText($_code) : '';


### PR DESCRIPTION
### Description
On Product attribute we can manage labels for different store views in admin area, but the product page view simply ignore it. 

### Manual testing scenarios
1. Go to administration area -> stores -> product attributes -> sku
2. Click on Manage Labels -> write / change label for default .. other store views
3. Go to product page at storefront and you still see string "sku" what is the default label for attribute
