### PR TITLE
Remove wrong '_setup' replace when getting DB connection

### DIFF
--- a/lib/internal/Magento/Framework/App/ResourceConnection/Config.php
+++ b/lib/internal/Magento/Framework/App/ResourceConnection/Config.php
@@ -63,9 +63,7 @@ class Config extends \Magento\Framework\Config\Data\Scoped implements ConfigInte
     {
         $this->initConnections();
         $connectionName = \Magento\Framework\App\ResourceConnection::DEFAULT_CONNECTION;
-
-        $resourceName = preg_replace("/_setup$/", '', $resourceName);
-
+        
         if (!isset($this->_connectionNames[$resourceName])) {
             $resourcesConfig = $this->get();
             $pointerResourceName = $resourceName;


### PR DESCRIPTION
If a custom database resource contains '_setup', default is returned as resourceName does not match after replacement.

