### PR TITLE
Add getShippingAddress() to order interface (resolves #6919)

### DIFF
--- a/app/code/Magento/Sales/Api/Data/OrderInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderInterface.php
@@ -1529,6 +1529,13 @@ interface OrderInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     public function getBillingAddress();
 
     /**
+     * Gets the shipping address, if any, for the order.
+     *
+     * @return \Magento\Sales\Api\Data\OrderAddressInterface|null Billing address. Otherwise, null.
+     */
+    public function getShippingAddress();
+
+    /**
      * Sets the billing address, if any, for the order.
      *
      * @param \Magento\Sales\Api\Data\OrderAddressInterface $billingAddress

--- a/app/code/Magento/Sales/Api/Data/OrderInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderInterface.php
@@ -1531,7 +1531,7 @@ interface OrderInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     /**
      * Gets the shipping address, if any, for the order.
      *
-     * @return \Magento\Sales\Api\Data\OrderAddressInterface|null Billing address. Otherwise, null.
+     * @return \Magento\Sales\Api\Data\OrderAddressInterface|null Shipping address. Otherwise, null.
      */
     public function getShippingAddress();
 
@@ -1542,6 +1542,14 @@ interface OrderInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * @return $this
      */
     public function setBillingAddress(\Magento\Sales\Api\Data\OrderAddressInterface $billingAddress = null);
+
+    /**
+     * Sets the shipping address, if any, for the order.
+     *
+     * @param \Magento\Sales\Api\Data\OrderAddressInterface $shippingAddress
+     * @return $this
+     */
+    public function setShippingAddress(\Magento\Sales\Api\Data\OrderAddressInterface $shippingAddress = null);
 
     /**
      * Gets order payment

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderGetTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderGetTest.php
@@ -83,8 +83,8 @@ class OrderGetTest extends WebapiAbstract
             $this->assertArrayHasKey(
                 $field,
                 $result['billing_address'],
-                "Billing address should have field {$field}")
-            ;
+                "Billing address should have field {$field}"
+            );
             $this->assertArrayHasKey(
                 $field,
                 $result['shipping_address'],

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderGetTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderGetTest.php
@@ -39,7 +39,7 @@ class OrderGetTest extends WebapiAbstract
             'increment_id' => self::ORDER_INCREMENT_ID,
         ];
         $expectedPayments = ['method' => 'checkmo'];
-        $expectedBillingAddressNotEmpty = [
+        $expectedAddressNotEmpty = [
             'city',
             'postcode',
             'lastname',
@@ -78,8 +78,18 @@ class OrderGetTest extends WebapiAbstract
         }
 
         $this->assertArrayHasKey('billing_address', $result);
-        foreach ($expectedBillingAddressNotEmpty as $field) {
-            $this->assertArrayHasKey($field, $result['billing_address']);
+        $this->assertArrayHasKey('shipping_address', $result);
+        foreach ($expectedAddressNotEmpty as $field) {
+            $this->assertArrayHasKey(
+                $field,
+                $result['billing_address'],
+                "Billing address should have field {$field}")
+            ;
+            $this->assertArrayHasKey(
+                $field,
+                $result['shipping_address'],
+                "Shipping address should have field {$field}"
+            );
         }
 
         //check that nullable fields were marked as optional and were not sent


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description

Adding `getShippingMethod()` to the order interface, analogous to the existing `getBillingMethod()`.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6919: API improvement: OrderInterface should have a getShippingAddress method #6919

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. GET an order via API
2. See if there is a "shipping_address"

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
