### PR TITLE
Product Wizard: Use result type Layout instead of page layout

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Controller/Adminhtml/Product/Wizard.php
+++ b/app/code/Magento/ConfigurableProduct/Controller/Adminhtml/Product/Wizard.php
@@ -38,9 +38,7 @@ class Wizard extends Action
         $this->productBuilder->build($this->getRequest());
 
         /** @var \Magento\Framework\View\Result\Layout $resultLayout */
-        $resultLayout = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
-        $resultLayout->getLayout()->getUpdate()->removeHandle('default');
-
+        $resultLayout = $this->resultFactory->create(ResultFactory::TYPE_LAYOUT);
         return $resultLayout;
     }
 }


### PR DESCRIPTION
To avoid unnecessary removal of default layout handle and to fit type hint

### Description

It doesn't make sense at all to use a page layout and remove the default handle. You can get the same result by using the Layout type directly.