### PR TITLE
Fix to allow Zend_Db_Expr as column default

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -2422,7 +2422,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
          *  where default value can be quoted already.
          *  We need to avoid "double-quoting" here
          */
-        if ($cDefault !== null && strlen($cDefault)) {
+        if ($cDefault !== null && is_string($cDefault) && strlen($cDefault)) {
             $cDefault = str_replace("'", '', $cDefault);
         }
 


### PR DESCRIPTION
### Description
Currently if you attempt to use a `Zend_Db_Expr` as the default value for a column, it fails because it is accidentally converted to a string too early, which results in a malformed SQL query.

This is due to a check that attempts to avoid double quoting but isn't careful to ensure the passed value is a string, triggering an implicit type conversion.

### Manual testing scenarios
Create a column in a setup script similar to this:

        /** @var \Magento\Framework\Setup\SchemaSetupInterface $setup */
        $setup->getConnection()->addColumn(
            'test_table',
            'test_column',
            [
                'type' => Table::TYPE_DATETIME,
                'default' => new \Zend_Db_Expr('CURRENT_TIMESTAMP'),
                'comment' => 'Test column comment'
            ]
        );

Before this PR that fails with the exception:

> Syntax error or access violation: 1067 Invalid default value for 'test_column'

After this PR the column is created correctly.