### PR TITLE
remove duplicate calls to initObjectManager in bootstrap class

### DIFF
--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -373,20 +373,7 @@ class Bootstrap
     {
         $handler = new ErrorHandler();
         set_error_handler([$handler, 'handler']);
-    }
-
-    /**
-     * Initializes object manager
-     *
-     * @return void
-     */
-    private function initObjectManager()
-    {
-        if (!$this->objectManager) {
-            $this->objectManager = $this->factory->create($this->server);
-            $this->maintenance = $this->objectManager->get(\Magento\Framework\App\MaintenanceMode::class);
-        }
-    }
+    }   
 
     /**
      * Getter for error code

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -205,7 +205,6 @@ class Bootstrap
         $this->rootDir = $rootDir;
         $this->server = $initParams;
         $this->objectManager = $this->factory->create($this->server);
-        $this->maintenance = $this->objectManager->get(\Magento\Framework\App\MaintenanceMode::class);
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -204,6 +204,7 @@ class Bootstrap
         $this->factory = $factory;
         $this->rootDir = $rootDir;
         $this->server = $initParams;
+        $this->objectManager = $this->factory->create($this->server);
     }
 
     /**
@@ -226,8 +227,7 @@ class Bootstrap
      */
     public function createApplication($type, $arguments = [])
     {
-        try {
-            $this->initObjectManager();
+        try {        
             $application = $this->objectManager->create($type, $arguments);
             if (!($application instanceof AppInterface)) {
                 throw new \InvalidArgumentException("The provided class doesn't implement AppInterface: {$type}");
@@ -249,8 +249,7 @@ class Bootstrap
         try {
             try {
                 \Magento\Framework\Profiler::start('magento');
-                $this->initErrorHandler();
-                $this->initObjectManager();
+                $this->initErrorHandler();              
                 $this->assertMaintenance();
                 $this->assertInstalled();
                 $response = $application->launch();
@@ -278,8 +277,7 @@ class Bootstrap
         $isExpected = $this->getIsExpected(self::PARAM_REQUIRE_MAINTENANCE, self::DEFAULT_REQUIRE_MAINTENANCE);
         if (null === $isExpected) {
             return;
-        }
-        $this->initObjectManager();
+        }     
         /** @var \Magento\Framework\App\MaintenanceMode $maintenance */
         $this->maintenance = $this->objectManager->get(\Magento\Framework\App\MaintenanceMode::class);
 
@@ -311,8 +309,7 @@ class Bootstrap
         $isExpected = $this->getIsExpected(self::PARAM_REQUIRE_IS_INSTALLED, self::DEFAULT_REQUIRE_IS_INSTALLED);
         if (null === $isExpected) {
             return;
-        }
-        $this->initObjectManager();
+        }     
         $isInstalled = $this->isInstalled();
         if (!$isInstalled && $isExpected) {
             $this->errorCode = self::ERR_IS_INSTALLED;
@@ -351,7 +348,6 @@ class Bootstrap
      */
     private function isInstalled()
     {
-        $this->initObjectManager();
         /** @var \Magento\Framework\App\DeploymentConfig $deploymentConfig */
         $deploymentConfig = $this->objectManager->get(\Magento\Framework\App\DeploymentConfig::class);
         return $deploymentConfig->isAvailable();
@@ -364,7 +360,6 @@ class Bootstrap
      */
     public function getObjectManager()
     {
-        $this->initObjectManager();
         return $this->objectManager;
     }
 

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -228,7 +228,7 @@ class Bootstrap
      */
     public function createApplication($type, $arguments = [])
     {
-        try {        
+        try {
             $application = $this->objectManager->create($type, $arguments);
             if (!($application instanceof AppInterface)) {
                 throw new \InvalidArgumentException("The provided class doesn't implement AppInterface: {$type}");
@@ -250,7 +250,7 @@ class Bootstrap
         try {
             try {
                 \Magento\Framework\Profiler::start('magento');
-                $this->initErrorHandler();              
+                $this->initErrorHandler();
                 $this->assertMaintenance();
                 $this->assertInstalled();
                 $response = $application->launch();
@@ -278,7 +278,7 @@ class Bootstrap
         $isExpected = $this->getIsExpected(self::PARAM_REQUIRE_MAINTENANCE, self::DEFAULT_REQUIRE_MAINTENANCE);
         if (null === $isExpected) {
             return;
-        }     
+        }
         /** @var \Magento\Framework\App\MaintenanceMode $maintenance */
         $this->maintenance = $this->objectManager->get(\Magento\Framework\App\MaintenanceMode::class);
 
@@ -310,7 +310,7 @@ class Bootstrap
         $isExpected = $this->getIsExpected(self::PARAM_REQUIRE_IS_INSTALLED, self::DEFAULT_REQUIRE_IS_INSTALLED);
         if (null === $isExpected) {
             return;
-        }     
+        }
         $isInstalled = $this->isInstalled();
         if (!$isInstalled && $isExpected) {
             $this->errorCode = self::ERR_IS_INSTALLED;
@@ -373,8 +373,8 @@ class Bootstrap
     {
         $handler = new ErrorHandler();
         set_error_handler([$handler, 'handler']);
-    }   
-
+    }
+    
     /**
      * Getter for error code
      *

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -205,6 +205,7 @@ class Bootstrap
         $this->rootDir = $rootDir;
         $this->server = $initParams;
         $this->objectManager = $this->factory->create($this->server);
+        $this->maintenance = $this->objectManager->get(\Magento\Framework\App\MaintenanceMode::class);
     }
 
     /**


### PR DESCRIPTION
There are duplicate calls for initobjectManager method,i think we can initialize objectmanager in constructor,so that object manager class will be available at the time of bootstrap object creation.