### PR TITLE
Fixed typo in method declaration

### DIFF
--- a/app/code/Magento/Dhl/Model/Carrier.php
+++ b/app/code/Magento/Dhl/Model/Carrier.php
@@ -1286,7 +1286,7 @@ class Carrier extends \Magento\Dhl\Model\AbstractDhl implements \Magento\Shippin
      * @param \Magento\Framework\DataObject $request
      * @return $this|\Magento\Framework\DataObject|boolean
      */
-    public function proccessAdditionalValidation(\Magento\Framework\DataObject $request)
+    public function processAdditionalValidation(\Magento\Framework\DataObject $request)
     {
         //Skip by item validation if there is no items in request
         if (!count($this->getAllItems($request))) {

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -327,7 +327,7 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
      * @return $this|bool|\Magento\Framework\DataObject
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function proccessAdditionalValidation(\Magento\Framework\DataObject $request)
+    public function processAdditionalValidation(\Magento\Framework\DataObject $request)
     {
         return $this;
     }

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -321,12 +321,7 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
     }
 
     /**
-     * Processing additional validation to check is carrier applicable.
-     *
-     * @param \Magento\Framework\DataObject $request
-     * @return $this|bool|\Magento\Framework\DataObject
-     * @deprecated Use processAdditionalValidation() instead
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * {@inheritdoc}
      */
     public function proccessAdditionalValidation(\Magento\Framework\DataObject $request)
     {

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -325,11 +325,20 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
      *
      * @param \Magento\Framework\DataObject $request
      * @return $this|bool|\Magento\Framework\DataObject
+     * @deprecated
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function proccessAdditionalValidation(\Magento\Framework\DataObject $request)
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function processAdditionalValidation(\Magento\Framework\DataObject $request)
     {
-        return $this;
+        return $this->proccessAdditionalValidation($request);
     }
 
     /**

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -325,7 +325,7 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
      *
      * @param \Magento\Framework\DataObject $request
      * @return $this|bool|\Magento\Framework\DataObject
-     * @deprecated
+     * @deprecated Use processAdditionalValidation() instead
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function proccessAdditionalValidation(\Magento\Framework\DataObject $request)

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierInterface.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierInterface.php
@@ -90,7 +90,7 @@ interface AbstractCarrierInterface
      * @return $this|\Magento\Framework\DataObject|boolean
      * @api
      */
-    public function proccessAdditionalValidation(\Magento\Framework\DataObject $request);
+    public function processAdditionalValidation(\Magento\Framework\DataObject $request);
 
     /**
      * Determine whether current carrier enabled for activity

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierInterface.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierInterface.php
@@ -89,6 +89,17 @@ interface AbstractCarrierInterface
      * @param \Magento\Framework\DataObject $request
      * @return $this|\Magento\Framework\DataObject|boolean
      * @api
+     * @deprecated
+     */
+    public function proccessAdditionalValidation(\Magento\Framework\DataObject $request);
+
+    /**
+     * Processing additional validation to check is carrier applicable.
+     * This method just fix a typo in the one above.
+     *
+     * @param \Magento\Framework\DataObject $request
+     * @return $this|\Magento\Framework\DataObject|boolean
+     * @api
      */
     public function processAdditionalValidation(\Magento\Framework\DataObject $request);
 

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierInterface.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierInterface.php
@@ -89,7 +89,7 @@ interface AbstractCarrierInterface
      * @param \Magento\Framework\DataObject $request
      * @return $this|\Magento\Framework\DataObject|boolean
      * @api
-     * @deprecated
+     * @deprecated Use processAdditionalValidation() instead
      */
     public function proccessAdditionalValidation(\Magento\Framework\DataObject $request);
 

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierOnline.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierOnline.php
@@ -301,7 +301,7 @@ abstract class AbstractCarrierOnline extends AbstractCarrier
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function proccessAdditionalValidation(\Magento\Framework\DataObject $request)
+    public function processAdditionalValidation(\Magento\Framework\DataObject $request)
     {
         //Skip by item validation if there is no items in request
         if (!count($this->getAllItems($request))) {

--- a/app/code/Magento/Shipping/Model/Shipping.php
+++ b/app/code/Magento/Shipping/Model/Shipping.php
@@ -259,7 +259,7 @@ class Shipping implements RateCollectorInterface
         $carrier->setActiveFlag($this->_availabilityConfigField);
         $result = $carrier->checkAvailableShipCountries($request);
         if (false !== $result && !$result instanceof \Magento\Quote\Model\Quote\Address\RateResult\Error) {
-            $result = $carrier->proccessAdditionalValidation($request);
+            $result = $carrier->processAdditionalValidation($request);
         }
         /*
          * Result will be false if the admin set not to show the shipping module

--- a/app/code/Magento/Shipping/Test/Unit/Model/Carrier/AbstractCarrierOnlineTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Model/Carrier/AbstractCarrierOnlineTest.php
@@ -105,7 +105,7 @@ class AbstractCarrierOnlineTest extends \PHPUnit_Framework_TestCase
         $this->stockItemData->expects($this->atLeastOnce())->method('getIsDecimalDivided')
             ->will($this->returnValue(true));
 
-        $this->carrier->proccessAdditionalValidation($request);
+        $this->carrier->processAdditionalValidation($request);
     }
 
     public function testParseXml()


### PR DESCRIPTION
Fixed a typo in method declaration, changed `proccessAdditionalValidation` in `processAdditionalValidation`