### PR TITLE
Improved text of exception message in case of error in module's composer.json

### DIFF
--- a/lib/internal/Magento/Framework/Module/PackageInfo.php
+++ b/lib/internal/Magento/Framework/Module/PackageInfo.php
@@ -82,7 +82,15 @@ class PackageInfo
             foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
                 $key = $moduleDir . '/composer.json';
                 if (isset($jsonData[$key]) && $jsonData[$key]) {
-                    $packageData = \Zend_Json::decode($jsonData[$key]);
+                    try {
+                        $packageData = \Zend_Json::decode($jsonData[$key]);
+                    } catch (\Zend_Json_Exception $e) {
+                        throw new \Zend_Json_Exception(
+                            sprintf("%s's composer.json error: ", $moduleName) .
+                            $e->getMessage()
+                        );
+                    }
+
                     if (isset($packageData['name'])) {
                         $this->packageModuleMap[$packageData['name']] = $moduleName;
                     }

--- a/lib/internal/Magento/Framework/Module/PackageInfo.php
+++ b/lib/internal/Magento/Framework/Module/PackageInfo.php
@@ -87,8 +87,8 @@ class PackageInfo
                     } catch (\Zend_Json_Exception $e) {
                         throw new \Zend_Json_Exception(
                             sprintf(
-                                "%s composer.json error: %s", 
-                                $moduleName, 
+                                "%s composer.json error: %s",
+                                $moduleName,
                                 $e->getMessage()
                             )
                         );

--- a/lib/internal/Magento/Framework/Module/PackageInfo.php
+++ b/lib/internal/Magento/Framework/Module/PackageInfo.php
@@ -86,8 +86,11 @@ class PackageInfo
                         $packageData = \Zend_Json::decode($jsonData[$key]);
                     } catch (\Zend_Json_Exception $e) {
                         throw new \Zend_Json_Exception(
-                            sprintf("%s's composer.json error: ", $moduleName) .
-                            $e->getMessage()
+                            sprintf(
+                                "%s composer.json error: %s", 
+                                $moduleName, 
+                                $e->getMessage()
+                            )
                         );
                     }
 


### PR DESCRIPTION
### Description

When some third-party module has syntax error inside its composer.json, it's very hard to determine which
module caused an exception. 

This PR changes default message with the following:

```
Some_Module's composer.json error: Decoding failed: Syntax error
```

where `Decoding failed: Syntax error` - is a message of the original exception

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
> Sample data must be installed to test this behavior.
1. Make an error in `app/code/Magento/Cms/composer.json`:
2. Run `php bin/magento sampeladata:reset`. You'll receive a message:

    ```
    [Zend_Json_Exception]          
    Decoding failed: Syntax error
    ```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
