### PR TITLE
FPT label not translatable in the totals on the cart page. 

### DIFF
--- a/app/code/Magento/Weee/view/frontend/layout/checkout_cart_index.xml
+++ b/app/code/Magento/Weee/view/frontend/layout/checkout_cart_index.xml
@@ -17,7 +17,7 @@
                                 <item name="weee" xsi:type="array">
                                     <item name="component" xsi:type="string">Magento_Weee/js/view/cart/totals/weee</item>
                                     <item name="config" xsi:type="array">
-                                        <item name="title" xsi:type="string">FPT</item>
+                                        <item name="title" xsi:type="string" translate="true">FPT</item>
                                     </item>
                                 </item>
                             </item>


### PR DESCRIPTION
### Description
Restored PR: FPT label not translatable in the totals on the cart page. #5732

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#5731: FPT label not translatable in the totals on the cart page.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
