### PR TITLE
Do not di:compile tests/ folder

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DiCompileCommand.php
@@ -227,6 +227,7 @@ class DiCompileCommand extends Command
 
         $excludedModulePaths = [
             '#^(?:' . join('|', $basePathsRegExps) . ')/Test#',
+            '#^(?:' . join('|', $basePathsRegExps) . ')/tests#',
         ];
         return $excludedModulePaths;
     }
@@ -241,6 +242,7 @@ class DiCompileCommand extends Command
     {
         $excludedLibraryPaths = [
             '#^(?:' . join('|', $libraryPaths) . ')/([\\w]+/)?Test#',
+            '#^(?:' . join('|', $libraryPaths) . ')/([\\w]+/)?tests#',
         ];
         return $excludedLibraryPaths;
     }


### PR DESCRIPTION
### Description

`setup:di:compile` failes when you have `magento/data-migration-tool` as a regular dependency and you haven't installed the dev dependencies with composer (--no-dev).

### Manual testing scenarios

1. Install dependencies using `composer install --no-dev`
2. `composer require magento/data-migration-tool:2.1.4` and enable the module
3. `php bin/magento setup:di:compile`

### Current result

    PHP Fatal error:  Class 'PHPUnit_Framework_TestCase' not found in /var/www/html/vendor/magento/data-migration-tool/tests/static/testsuite/Migration/Php/LiveCodeTest.php on line 19

### Expected result

`setup:di:compile` runs without failures.


