### PR TITLE
Avoid: Undefined index: value in app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php on line 157 in Ajax return

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -154,11 +154,11 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
      */
     private function checkUniqueOption(DataObject $response, array $options = null)
     {
-        if (
-            is_array($options)
+        if (is_array($options)
             && isset($options['value'])
             && isset($options['delete'])
-            && !$this->isUniqueAdminValues($options['value'], $options['delete'])) {
+            && !$this->isUniqueAdminValues($options['value'], $options['delete'])
+        ) {
             $this->setMessageToResponse($response, [__("The value of Admin must be unique.")]);
             $response->setError(true);
         }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -154,7 +154,11 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
      */
     private function checkUniqueOption(DataObject $response, array $options = null)
     {
-        if (is_array($options) && !$this->isUniqueAdminValues($options['value'], $options['delete'])) {
+        if (
+            is_array($options)
+            && isset($options['value'])
+            && isset($options['delete'])
+            && !$this->isUniqueAdminValues($options['value'], $options['delete'])) {
             $this->setMessageToResponse($response, [__("The value of Admin must be unique.")]);
             $response->setError(true);
         }


### PR DESCRIPTION
When saving an Attribute and the array $options doesn't contain a key named 'value' or 'delete' it will return a Notice Warning instead of the expected ajax result in `admin/catalog/product_attribute/validate/attribute_id/XXX/` 

### Description
This PR will check if the keys 'value' and 'delete' are set.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. #8202: Cannot save attribute
2. #8271: Visibility save attribute error

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
