### PR TITLE
Fixed coding standard violations in the Framework\Event namespace

### DIFF
--- a/lib/internal/Magento/Framework/Event/Invoker/InvokerDefault.php
+++ b/lib/internal/Magento/Framework/Event/Invoker/InvokerDefault.php
@@ -6,12 +6,9 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Event\Invoker;
 
 use Magento\Framework\Event\Observer;
-use Zend\Stdlib\Exception\LogicException;
 
 class InvokerDefault implements \Magento\Framework\Event\InvokerInterface
 {
@@ -33,8 +30,10 @@ class InvokerDefault implements \Magento\Framework\Event\InvokerInterface
      * @param \Magento\Framework\Event\ObserverFactory $observerFactory
      * @param \Magento\Framework\App\State $appState
      */
-    public function __construct(\Magento\Framework\Event\ObserverFactory $observerFactory, \Magento\Framework\App\State $appState)
-    {
+    public function __construct(
+        \Magento\Framework\Event\ObserverFactory $observerFactory,
+        \Magento\Framework\App\State $appState
+    ) {
         $this->_observerFactory = $observerFactory;
         $this->_appState = $appState;
     }
@@ -75,7 +74,8 @@ class InvokerDefault implements \Magento\Framework\Event\InvokerInterface
             throw new \LogicException(
                 sprintf(
                     'Observer "%s" must implement interface "%s"',
-                    get_class($object), \Magento\Framework\Event\ObserverInterface::class
+                    get_class($object),
+                    \Magento\Framework\Event\ObserverInterface::class
                 )
             );
         }


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Event namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile
- Fixed indentation
- Fixed number of chars per line
- Removed unused "use" namespace at the top of the file.
