### PR TITLE
Fixed coding standard violations in the Framework\Message namespace

### DIFF
--- a/lib/internal/Magento/Framework/Message/Factory.php
+++ b/lib/internal/Magento/Framework/Message/Factory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Message;
 
 use Magento\Framework\ObjectManagerInterface;
@@ -63,7 +61,9 @@ class Factory
 
         $message = $this->objectManager->create($className, $text === null ? [] : ['text' => $text]);
         if (!$message instanceof MessageInterface) {
-            throw new \InvalidArgumentException($className . ' doesn\'t implement \Magento\Framework\Message\MessageInterface');
+            throw new \InvalidArgumentException(
+                $className . ' doesn\'t implement \Magento\Framework\Message\MessageInterface'
+            );
         }
 
         return $message;


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Encryption namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:

- Removed @codingStandardsIgnoreFile at the head of the file
- Fixed number of chars per line