### PR TITLE
Fixed coding standard violations in the Framework\Filesystem namespace

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Io/Sftp.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/Sftp.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Filesystem\Io;
 
 /**
@@ -16,7 +14,6 @@ namespace Magento\Framework\Filesystem\Io;
 class Sftp extends AbstractIo
 {
     const REMOTE_TIMEOUT = 10;
-
     const SSH2_PORT = 22;
 
     /**
@@ -48,7 +45,9 @@ class Sftp extends AbstractIo
         }
         $this->_connection = new \phpseclib\Net\SFTP($host, $port, $args['timeout']);
         if (!$this->_connection->login($args['username'], $args['password'])) {
-            throw new \Exception(sprintf("Unable to open SFTP connection as %s@%s", $args['username'], $args['host']));
+            throw new \Exception(
+                sprintf("Unable to open SFTP connection as %s@%s", $args['username'], $args['host'])
+            );
         }
     }
 
@@ -168,7 +167,7 @@ class Sftp extends AbstractIo
      */
     public function read($filename, $destination = null)
     {
-        if (is_null($destination)) {
+        if ($destination === null) {
             $destination = false;
         }
         return $this->_connection->get($filename, $destination);


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Filesystem namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile
- Fixed number of chars per line
- Removed the is_null function in order to do a normal compare. 