### PR TITLE
Fixed coding standard violations in Framework\HTTP namespace:

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * HTTP CURL Adapter
  *

--- a/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
@@ -236,7 +236,7 @@ class Curl implements \Zend_Http_Client_Adapter_Interface
      */
     protected function _getResource()
     {
-        if (is_null($this->_resource)) {
+        if ($this->_resource === null) {
             $this->_resource = curl_init();
         }
         return $this->_resource;

--- a/lib/internal/Magento/Framework/HTTP/Header.php
+++ b/lib/internal/Magento/Framework/HTTP/Header.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\HTTP;
 
 /**
@@ -29,8 +27,10 @@ class Header
      * @param \Magento\Framework\App\RequestInterface $httpRequest
      * @param \Magento\Framework\Stdlib\StringUtils $converter
      */
-    public function __construct(\Magento\Framework\App\RequestInterface $httpRequest, \Magento\Framework\Stdlib\StringUtils $converter)
-    {
+    public function __construct(
+        \Magento\Framework\App\RequestInterface $httpRequest,
+        \Magento\Framework\Stdlib\StringUtils $converter
+    ) {
         $this->_request = $httpRequest;
         $this->_converter = $converter;
     }


### PR DESCRIPTION
Fixed coding standard violations in the Framework\HTTP namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingstandardsIgnoreFile from header of the file.
- Corrected line length
