### PR TITLE
Remove zend json from weee

### DIFF
--- a/app/code/Magento/Weee/Helper/Data.php
+++ b/app/code/Magento/Weee/Helper/Data.php
@@ -86,7 +86,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @param \Magento\Framework\App\Helper\Context $context
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
-     * @param WeeeDisplayConfig $weeeTax
+     * @param \Magento\Weee\Model\Tax $weeeTax
      * @param \Magento\Weee\Model\Config $weeeConfig
      * @param \Magento\Tax\Helper\Data $taxData
      * @param \Magento\Framework\Registry $coreRegistry

--- a/app/code/Magento/Weee/Helper/Data.php
+++ b/app/code/Magento/Weee/Helper/Data.php
@@ -77,12 +77,21 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     protected $cacheProductWeeeAmount = '_cache_product_weee_amount';
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
+     * Data constructor.
+     *
      * @param \Magento\Framework\App\Helper\Context $context
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
-     * @param \Magento\Weee\Model\Tax $weeeTax
+     * @param WeeeDisplayConfig $weeeTax
      * @param \Magento\Weee\Model\Config $weeeConfig
      * @param \Magento\Tax\Helper\Data $taxData
      * @param \Magento\Framework\Registry $coreRegistry
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
@@ -90,13 +99,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Weee\Model\Tax $weeeTax,
         \Magento\Weee\Model\Config $weeeConfig,
         \Magento\Tax\Helper\Data $taxData,
-        \Magento\Framework\Registry $coreRegistry
+        \Magento\Framework\Registry $coreRegistry,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->_storeManager = $storeManager;
         $this->_weeeTax = $weeeTax;
         $this->_coreRegistry = $coreRegistry;
         $this->_taxData = $taxData;
         $this->_weeeConfig = $weeeConfig;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         parent::__construct($context);
     }
 
@@ -373,7 +385,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         if (empty($data)) {
             return [];
         }
-        return \Zend_Json::decode($item->getWeeeTaxApplied());
+        return $this->serializer->unserialize($item->getWeeeTaxApplied());
     }
 
     /**
@@ -385,7 +397,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function setApplied($item, $value)
     {
-        $item->setWeeeTaxApplied(\Zend_Json::encode($value));
+        $item->setWeeeTaxApplied($this->serializer->serialize($value));
         return $this;
     }
 

--- a/app/code/Magento/Weee/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Helper/DataTest.php
@@ -42,6 +42,9 @@ class DataTest extends \PHPUnit_Framework_TestCase
      */
     protected $helperData;
 
+    /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject */
+    private $serializerMock;
+
     protected function setUp()
     {
         $this->product = $this->getMock(\Magento\Catalog\Model\Product::class, [], [], '', false);
@@ -57,10 +60,14 @@ class DataTest extends \PHPUnit_Framework_TestCase
             '',
             false
         );
+
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
+
         $arguments = [
             'weeeConfig' => $weeeConfig,
             'weeeTax' => $this->weeeTax,
-            'taxData' => $this->taxData
+            'taxData' => $this->taxData,
+            'serializer'  => $this->serializerMock
         ];
         $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->helperData = $helper->getObject(\Magento\Weee\Helper\Data::class, $arguments);
@@ -84,33 +91,38 @@ class DataTest extends \PHPUnit_Framework_TestCase
             ->setMethods(['__wakeup'])
             ->getMock();
 
+        $weeeTaxApplied = [
+            [
+                WeeeHelper::KEY_WEEE_AMOUNT_INVOICED => self::ROW_AMOUNT_INVOICED,
+                WeeeHelper::KEY_BASE_WEEE_AMOUNT_INVOICED => self::BASE_ROW_AMOUNT_INVOICED,
+                WeeeHelper::KEY_WEEE_TAX_AMOUNT_INVOICED => self::TAX_AMOUNT_INVOICED,
+                WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_INVOICED => self::BASE_TAX_AMOUNT_INVOICED,
+                WeeeHelper::KEY_WEEE_AMOUNT_REFUNDED => self::ROW_AMOUNT_REFUNDED,
+                WeeeHelper::KEY_BASE_WEEE_AMOUNT_REFUNDED => self::BASE_ROW_AMOUNT_REFUNDED,
+                WeeeHelper::KEY_WEEE_TAX_AMOUNT_REFUNDED => self::TAX_AMOUNT_REFUNDED,
+                WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_REFUNDED => self::BASE_TAX_AMOUNT_REFUNDED,
+            ],
+            [
+                WeeeHelper::KEY_WEEE_AMOUNT_INVOICED => self::ROW_AMOUNT_INVOICED,
+                WeeeHelper::KEY_BASE_WEEE_AMOUNT_INVOICED => self::BASE_ROW_AMOUNT_INVOICED,
+                WeeeHelper::KEY_WEEE_TAX_AMOUNT_INVOICED => self::TAX_AMOUNT_INVOICED,
+                WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_INVOICED => self::BASE_TAX_AMOUNT_INVOICED,
+                WeeeHelper::KEY_WEEE_AMOUNT_REFUNDED => self::ROW_AMOUNT_REFUNDED,
+                WeeeHelper::KEY_BASE_WEEE_AMOUNT_REFUNDED => self::BASE_ROW_AMOUNT_REFUNDED,
+                WeeeHelper::KEY_WEEE_TAX_AMOUNT_REFUNDED => self::TAX_AMOUNT_REFUNDED,
+                WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_REFUNDED => self::BASE_TAX_AMOUNT_REFUNDED,
+            ],
+        ];
+
         $orderItem->setData(
             'weee_tax_applied',
-            \Zend_Json::encode(
-                [
-                    [
-                        WeeeHelper::KEY_WEEE_AMOUNT_INVOICED => self::ROW_AMOUNT_INVOICED,
-                        WeeeHelper::KEY_BASE_WEEE_AMOUNT_INVOICED => self::BASE_ROW_AMOUNT_INVOICED,
-                        WeeeHelper::KEY_WEEE_TAX_AMOUNT_INVOICED => self::TAX_AMOUNT_INVOICED,
-                        WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_INVOICED => self::BASE_TAX_AMOUNT_INVOICED,
-                        WeeeHelper::KEY_WEEE_AMOUNT_REFUNDED => self::ROW_AMOUNT_REFUNDED,
-                        WeeeHelper::KEY_BASE_WEEE_AMOUNT_REFUNDED => self::BASE_ROW_AMOUNT_REFUNDED,
-                        WeeeHelper::KEY_WEEE_TAX_AMOUNT_REFUNDED => self::TAX_AMOUNT_REFUNDED,
-                        WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_REFUNDED => self::BASE_TAX_AMOUNT_REFUNDED,
-                    ],
-                    [
-                        WeeeHelper::KEY_WEEE_AMOUNT_INVOICED => self::ROW_AMOUNT_INVOICED,
-                        WeeeHelper::KEY_BASE_WEEE_AMOUNT_INVOICED => self::BASE_ROW_AMOUNT_INVOICED,
-                        WeeeHelper::KEY_WEEE_TAX_AMOUNT_INVOICED => self::TAX_AMOUNT_INVOICED,
-                        WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_INVOICED => self::BASE_TAX_AMOUNT_INVOICED,
-                        WeeeHelper::KEY_WEEE_AMOUNT_REFUNDED => self::ROW_AMOUNT_REFUNDED,
-                        WeeeHelper::KEY_BASE_WEEE_AMOUNT_REFUNDED => self::BASE_ROW_AMOUNT_REFUNDED,
-                        WeeeHelper::KEY_WEEE_TAX_AMOUNT_REFUNDED => self::TAX_AMOUNT_REFUNDED,
-                        WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_REFUNDED => self::BASE_TAX_AMOUNT_REFUNDED,
-                    ],
-                ]
-            )
+            json_encode($weeeTaxApplied)
         );
+
+        $this->serializerMock->expects($this->any())
+            ->method('unserialize')
+            ->will($this->returnValue($weeeTaxApplied));
+
         return $orderItem;
     }
 
@@ -290,14 +302,18 @@ class DataTest extends \PHPUnit_Framework_TestCase
     public function testGetAppliedSimple()
     {
         $testArray = ['key' => 'value'];
-        $itemProductSimple=$this->getMock(\Magento\Quote\Model\Quote\Item::class, ['getWeeeTaxApplied'], [], '', false);
+        $itemProductSimple = $this->getMock(\Magento\Quote\Model\Quote\Item::class, ['getWeeeTaxApplied'], [], '', false);
         $itemProductSimple->expects($this->any())
             ->method('getHasChildren')
             ->will($this->returnValue(false));
 
         $itemProductSimple->expects($this->any())
             ->method('getWeeeTaxApplied')
-            ->will($this->returnValue(\Zend_Json::encode($testArray)));
+            ->will($this->returnValue(json_encode($testArray)));
+
+        $this->serializerMock->expects($this->any())
+            ->method('unserialize')
+            ->will($this->returnValue($testArray));
 
         $this->assertEquals($testArray, $this->helperData->getApplied($itemProductSimple));
     }
@@ -326,11 +342,11 @@ class DataTest extends \PHPUnit_Framework_TestCase
 
         $itemProductSimple1->expects($this->any())
             ->method('getWeeeTaxApplied')
-            ->will($this->returnValue(\Zend_Json::encode($testArray1)));
+            ->will($this->returnValue(json_encode($testArray1)));
 
         $itemProductSimple2->expects($this->any())
             ->method('getWeeeTaxApplied')
-            ->will($this->returnValue(\Zend_Json::encode($testArray2)));
+            ->will($this->returnValue(json_encode($testArray2)));
 
         $itemProductBundle=$this->getMock(
             \Magento\Quote\Model\Quote\Item::class,
@@ -348,6 +364,10 @@ class DataTest extends \PHPUnit_Framework_TestCase
         $itemProductBundle->expects($this->any())
             ->method('getChildren')
             ->will($this->returnValue([$itemProductSimple1, $itemProductSimple2]));
+
+        $this->serializerMock->expects($this->any())
+            ->method('unserialize')
+            ->will($this->returnValue($testArray));
 
         $this->assertEquals($testArray, $this->helperData->getApplied($itemProductBundle));
     }

--- a/app/code/Magento/Weee/Test/Unit/Model/Attribute/Backend/Weee/TaxTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/Attribute/Backend/Weee/TaxTest.php
@@ -16,11 +16,6 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 class TaxTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Magento\Weee\Model\Attribute\Backend\Weee\Tax
-     */
-    protected $model;
-        
-    /**
      * @var ObjectManager
      */
     protected $objectManager;
@@ -28,12 +23,14 @@ class TaxTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->objectManager = new ObjectManager($this);
-        $this->model = $this->objectManager->getObject(\Magento\Weee\Model\Attribute\Backend\Weee\Tax::class);
     }
 
     public function testGetBackendModelName()
     {
-        $this->assertEquals(\Magento\Weee\Model\Attribute\Backend\Weee\Tax::class, $this->model->getBackendModelName());
+        $this->assertEquals(
+            \Magento\Weee\Model\Attribute\Backend\Weee\Tax::class,
+            \Magento\Weee\Model\Attribute\Backend\Weee\Tax::getBackendModelName()
+        );
     }
 
     /**

--- a/app/code/Magento/Weee/Test/Unit/Model/Total/Quote/WeeeTaxTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/Total/Quote/WeeeTaxTest.php
@@ -242,8 +242,12 @@ class WeeeTaxTest extends \PHPUnit_Framework_TestCase
 
     public function testFetch()
     {
+        $serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
         $weeeTotal = 17;
-        $totalMock = new \Magento\Quote\Model\Quote\Address\Total();
+        $totalMock = new \Magento\Quote\Model\Quote\Address\Total(
+            [],
+            $serializerMock
+        );
         $taxHelper = $this->setupTaxHelper([]);
         $weeeHelper = $this->setupWeeeHelper(['getTotalAmounts' => $weeeTotal]);
         $this->weeeCollector = $this->objectManagerHelper->getObject(
@@ -262,7 +266,11 @@ class WeeeTaxTest extends \PHPUnit_Framework_TestCase
 
     public function testFetchWithZeroAmounts()
     {
-        $totalMock = new \Magento\Quote\Model\Quote\Address\Total();
+        $serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
+        $totalMock = new \Magento\Quote\Model\Quote\Address\Total(
+            [],
+            $serializerMock
+        );
         $taxHelper = $this->setupTaxHelper([]);
         $weeeHelper = $this->setupWeeeHelper(['getTotalAmounts' => null]);
         $this->weeeCollector = $this->objectManagerHelper->getObject(

--- a/app/code/Magento/Weee/Test/Unit/Model/Total/Quote/WeeeTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/Total/Quote/WeeeTest.php
@@ -298,7 +298,10 @@ class WeeeTest extends \PHPUnit_Framework_TestCase
         $storeMock = $this->getMock(\Magento\Store\Model\Store::class, [], [], '', false);
         $quoteMock->expects($this->any())->method('getStore')->will($this->returnValue($storeMock));
         $addressMock = $this->setupAddressMock($items);
-        $totalMock = new \Magento\Quote\Model\Quote\Address\Total();
+        $totalMock = new \Magento\Quote\Model\Quote\Address\Total(
+            [],
+            $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock()
+        );
         $shippingAssignmentMock = $this->setupShippingAssignmentMock($addressMock, $items);
 
         $taxHelper = $this->setupTaxHelper($taxConfig);

--- a/app/code/Magento/Weee/Test/Unit/Model/Total/Quote/WeeeTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/Total/Quote/WeeeTest.php
@@ -22,6 +22,8 @@ class WeeeTest extends \PHPUnit_Framework_TestCase
      */
     protected $weeeCollector;
 
+    private $serializerMock;
+
     /**
      * Setup tax helper with an array of methodName, returnValue
      *
@@ -77,7 +79,17 @@ class WeeeTest extends \PHPUnit_Framework_TestCase
      */
     protected function setupWeeeHelper($weeeConfig)
     {
-        $weeeHelper = $this->getMock(\Magento\Weee\Helper\Data::class, [], [], '', false);
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)->getMock();
+
+        $weeeHelper = $this->getMock(
+            \Magento\Weee\Helper\Data::class,
+            [],
+            [
+                'serializer'  => $this->serializerMock
+            ],
+            '',
+            false
+        );
 
         foreach ($weeeConfig as $method => $value) {
             $weeeHelper->expects($this->any())->method($method)->will($this->returnValue($value));


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Since Zend Framework 1 is at end of life we should remove the usage of Zend_Json. This review is part of #9236 
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json (Part fix)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
