### PR TITLE
Remove zend json from theme

### DIFF
--- a/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Tree.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Tree.php
@@ -23,19 +23,29 @@ class Tree extends \Magento\Backend\Block\Template
     protected $urlEncoder;
 
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Theme\Helper\Storage $storageHelper
      * @param \Magento\Framework\Url\EncoderInterface $urlEncoder
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Theme\Helper\Storage $storageHelper,
         \Magento\Framework\Url\EncoderInterface $urlEncoder,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->_storageHelper = $storageHelper;
         $this->urlEncoder = $urlEncoder;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         parent::__construct($context, $data);
     }
 
@@ -57,7 +67,7 @@ class Tree extends \Magento\Backend\Block\Template
      */
     public function getTreeJson($data)
     {
-        return \Zend_Json::encode($data);
+        return $this->serializer->serialize($data);
     }
 
     /**

--- a/app/code/Magento/Theme/Controller/Result/MessagePlugin.php
+++ b/app/code/Magento/Theme/Controller/Result/MessagePlugin.php
@@ -40,28 +40,29 @@ class MessagePlugin
     private $interpretationStrategy;
 
     /**
-     * @var \Magento\Framework\Json\Helper\Data
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
-    private $jsonHelper;
+    private $serializer;
 
     /**
      * @param \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager
      * @param \Magento\Framework\Stdlib\Cookie\CookieMetadataFactory $cookieMetadataFactory
      * @param \Magento\Framework\Message\ManagerInterface $messageManager
      * @param \Magento\Framework\View\Element\Message\InterpretationStrategyInterface $interpretationStrategy
-     * @param \Magento\Framework\Json\Helper\Data $jsonHelper
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
      */
     public function __construct(
         \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager,
         \Magento\Framework\Stdlib\Cookie\CookieMetadataFactory $cookieMetadataFactory,
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Framework\View\Element\Message\InterpretationStrategyInterface $interpretationStrategy,
-        \Magento\Framework\Json\Helper\Data $jsonHelper
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         $this->cookieManager = $cookieManager;
         $this->cookieMetadataFactory = $cookieMetadataFactory;
         $this->messageManager = $messageManager;
-        $this->jsonHelper = $jsonHelper;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
         $this->interpretationStrategy = $interpretationStrategy;
     }
 
@@ -118,7 +119,7 @@ class MessagePlugin
 
             $this->cookieManager->setPublicCookie(
                 self::MESSAGES_COOKIES_NAME,
-                $this->jsonHelper->jsonEncode($messages),
+                $this->serializer->serialize($messages),
                 $publicCookieMetadata
             );
         }
@@ -149,14 +150,13 @@ class MessagePlugin
      */
     protected function getCookiesMessages()
     {
-        try {
-            $messages = $this->jsonHelper->jsonDecode(
-                $this->cookieManager->getCookie(self::MESSAGES_COOKIES_NAME, $this->jsonHelper->jsonEncode([]))
-            );
-            if (!is_array($messages)) {
-                $messages = [];
-            }
-        } catch (\Zend_Json_Exception $e) {
+        $messages = $this->serializer->unserialize(
+            $this->cookieManager->getCookie(
+                self::MESSAGES_COOKIES_NAME,
+                $this->serializer->serialize([])
+            )
+        );
+        if (!is_array($messages)) {
             $messages = [];
         }
         return $messages;

--- a/app/code/Magento/Theme/Test/Unit/Controller/Result/MessagePluginTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Result/MessagePluginTest.php
@@ -37,8 +37,8 @@ class MessagePluginTest extends \PHPUnit_Framework_TestCase
     /** @var InterpretationStrategyInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $interpretationStrategyMock;
 
-    /** @var Data|\PHPUnit_Framework_MockObject_MockObject */
-    protected $dataMock;
+    /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject */
+    private $serializerMock;
 
     protected function setUp()
     {
@@ -51,8 +51,7 @@ class MessagePluginTest extends \PHPUnit_Framework_TestCase
             ->getMockForAbstractClass();
         $this->interpretationStrategyMock = $this->getMockBuilder(InterpretationStrategyInterface::class)
             ->getMockForAbstractClass();
-        $this->dataMock = $this->getMockBuilder(Data::class)
-            ->disableOriginalConstructor()
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)
             ->getMock();
 
         $this->model = new MessagePlugin(
@@ -60,7 +59,7 @@ class MessagePluginTest extends \PHPUnit_Framework_TestCase
             $this->cookieMetadataFactoryMock,
             $this->managerMock,
             $this->interpretationStrategyMock,
-            $this->dataMock
+            $this->serializerMock
         );
     }
 
@@ -120,22 +119,22 @@ class MessagePluginTest extends \PHPUnit_Framework_TestCase
             ->method('getCookie')
             ->with(
                 MessagePlugin::MESSAGES_COOKIES_NAME,
-                \Zend_Json::encode([])
+                json_encode([])
             )
-            ->willReturn(\Zend_Json::encode($existingMessages));
+            ->willReturn(json_encode($existingMessages));
 
-        $this->dataMock->expects($this->once())
-            ->method('jsonDecode')
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
             ->willReturnCallback(
                 function ($data) {
-                    return \Zend_Json::decode($data);
+                    return json_decode($data, true);
                 }
             );
-        $this->dataMock->expects($this->exactly(2))
-            ->method('jsonEncode')
+        $this->serializerMock->expects($this->exactly(2))
+            ->method('serialize')
             ->willReturnCallback(
                 function ($data) {
-                    return \Zend_Json::encode($data);
+                    return json_encode($data);
                 }
             );
 
@@ -178,22 +177,22 @@ class MessagePluginTest extends \PHPUnit_Framework_TestCase
             ->method('getCookie')
             ->with(
                 MessagePlugin::MESSAGES_COOKIES_NAME,
-                \Zend_Json::encode([])
+                json_encode([])
             )
-            ->willReturn(\Zend_Json::encode([]));
+            ->willReturn(json_encode([]));
 
-        $this->dataMock->expects($this->once())
-            ->method('jsonDecode')
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
             ->willReturnCallback(
                 function ($data) {
-                    return \Zend_Json::decode($data);
+                    return json_decode($data, true);
                 }
             );
-        $this->dataMock->expects($this->once())
-            ->method('jsonEncode')
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
             ->willReturnCallback(
                 function ($data) {
-                    return \Zend_Json::encode($data);
+                    return json_encode($data);
                 }
             );
 
@@ -246,29 +245,29 @@ class MessagePluginTest extends \PHPUnit_Framework_TestCase
             ->method('setPublicCookie')
             ->with(
                 MessagePlugin::MESSAGES_COOKIES_NAME,
-                \Zend_Json::encode($messages),
+                json_encode($messages),
                 $cookieMetadataMock
             );
         $this->cookieManagerMock->expects($this->once())
             ->method('getCookie')
             ->with(
                 MessagePlugin::MESSAGES_COOKIES_NAME,
-                \Zend_Json::encode([])
+                json_encode([])
             )
-            ->willReturn(\Zend_Json::encode([]));
+            ->willReturn(json_encode([]));
 
-        $this->dataMock->expects($this->any())
-            ->method('jsonDecode')
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
             ->willReturnCallback(
                 function ($data) {
-                    return \Zend_Json::decode($data);
+                    return json_decode($data, true);
                 }
             );
-        $this->dataMock->expects($this->any())
-            ->method('jsonEncode')
+        $this->serializerMock->expects($this->exactly(2))
+            ->method('serialize')
             ->willReturnCallback(
                 function ($data) {
-                    return \Zend_Json::encode($data);
+                    return json_encode($data);
                 }
             );
 
@@ -329,25 +328,29 @@ class MessagePluginTest extends \PHPUnit_Framework_TestCase
             ->method('setPublicCookie')
             ->with(
                 MessagePlugin::MESSAGES_COOKIES_NAME,
-                \Zend_Json::encode($messages),
+                json_encode($messages),
                 $cookieMetadataMock
             );
         $this->cookieManagerMock->expects($this->once())
             ->method('getCookie')
             ->with(
                 MessagePlugin::MESSAGES_COOKIES_NAME,
-                \Zend_Json::encode([])
+                json_encode([])
             )
-            ->willReturn(\Zend_Json::encode([]));
+            ->willReturn(json_encode([]));
 
-        $this->dataMock->expects($this->any())
-            ->method('jsonDecode')
-            ->willThrowException(new \Zend_Json_Exception);
-        $this->dataMock->expects($this->any())
-            ->method('jsonEncode')
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
             ->willReturnCallback(
                 function ($data) {
-                    return \Zend_Json::encode($data);
+                    return json_decode($data, true);
+                }
+            );
+        $this->serializerMock->expects($this->exactly(2))
+            ->method('serialize')
+            ->willReturnCallback(
+                function ($data) {
+                    return json_encode($data);
                 }
             );
 
@@ -415,22 +418,22 @@ class MessagePluginTest extends \PHPUnit_Framework_TestCase
             ->method('getCookie')
             ->with(
                 MessagePlugin::MESSAGES_COOKIES_NAME,
-                \Zend_Json::encode([])
+                json_encode([])
             )
-            ->willReturn(\Zend_Json::encode('string'));
+            ->willReturn(json_encode('string'));
 
-        $this->dataMock->expects($this->any())
-            ->method('jsonDecode')
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
             ->willReturnCallback(
                 function ($data) {
-                    return \Zend_Json::decode($data);
+                    return json_decode($data, true);
                 }
             );
-        $this->dataMock->expects($this->any())
-            ->method('jsonEncode')
+        $this->serializerMock->expects($this->exactly(2))
+            ->method('serialize')
             ->willReturnCallback(
                 function ($data) {
-                    return \Zend_Json::encode($data);
+                    return json_encode($data);
                 }
             );
 

--- a/app/code/Magento/Theme/Test/Unit/Controller/Result/MessagePluginTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Result/MessagePluginTest.php
@@ -112,7 +112,7 @@ class MessagePluginTest extends \PHPUnit_Framework_TestCase
             ->method('setPublicCookie')
             ->with(
                 MessagePlugin::MESSAGES_COOKIES_NAME,
-                \Zend_Json::encode($messages),
+                json_encode($messages),
                 $cookieMetadataMock
             );
         $this->cookieManagerMock->expects($this->once())
@@ -411,7 +411,7 @@ class MessagePluginTest extends \PHPUnit_Framework_TestCase
             ->method('setPublicCookie')
             ->with(
                 MessagePlugin::MESSAGES_COOKIES_NAME,
-                \Zend_Json::encode($messages),
+                json_encode($messages),
                 $cookieMetadataMock
             );
         $this->cookieManagerMock->expects($this->once())

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/DataTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/DataTest.php
@@ -18,7 +18,69 @@ class DataTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->model = (new ObjectManager($this))->getObject(\Magento\Theme\Model\Theme\Data::class);
+        $customizationConfig = $this->getMock(\Magento\Theme\Model\Config\Customization::class, [], [], '', false);
+        $this->customizationFactory = $this->getMock(
+            \Magento\Framework\View\Design\Theme\CustomizationFactory::class,
+            ['create'],
+            [],
+            '',
+            false
+        );
+        $this->resourceCollection = $this->getMock(
+            \Magento\Theme\Model\ResourceModel\Theme\Collection::class,
+            [],
+            [],
+            '',
+            false
+        );
+        $this->_imageFactory = $this->getMock(
+            \Magento\Framework\View\Design\Theme\ImageFactory::class,
+            ['create'],
+            [],
+            '',
+            false
+        );
+        $this->themeFactory = $this->getMock(
+            \Magento\Framework\View\Design\Theme\FlyweightFactory::class,
+            ['create'],
+            [],
+            '',
+            false
+        );
+        $this->domainFactory = $this->getMock(
+            \Magento\Framework\View\Design\Theme\Domain\Factory::class,
+            ['create'],
+            [],
+            '',
+            false
+        );
+        $this->themeModelFactory = $this->getMock(
+            \Magento\Theme\Model\ThemeFactory::class,
+            ['create'],
+            [],
+            '',
+            false
+        );
+        $this->validator = $this->getMock(\Magento\Framework\View\Design\Theme\Validator::class, [], [], '', false);
+        $this->appState = $this->getMock(\Magento\Framework\App\State::class, [], [], '', false);
+
+        $objectManagerHelper = new ObjectManager($this);
+        $arguments = $objectManagerHelper->getConstructArguments(
+            \Magento\Theme\Model\Theme\Data::class,
+            [
+                'customizationFactory' => $this->customizationFactory,
+                'customizationConfig' => $customizationConfig,
+                'imageFactory' => $this->_imageFactory,
+                'resourceCollection' => $this->resourceCollection,
+                'themeFactory' => $this->themeFactory,
+                'domainFactory' => $this->domainFactory,
+                'validator' => $this->validator,
+                'appState' => $this->appState,
+                'themeModelFactory' => $this->themeModelFactory
+            ]
+        );
+
+        $this->model = $objectManagerHelper->getObject(\Magento\Theme\Model\Theme\Data::class, $arguments);
     }
 
     /**

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/ThemePackageInfoTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/ThemePackageInfoTest.php
@@ -29,6 +29,9 @@ class ThemePackageInfoTest extends \PHPUnit_Framework_TestCase
      */
     private $dirReadFactory;
 
+    /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject */
+    private $serializerMock;
+
     protected function setUp()
     {
         $this->componentRegistrar = $this->getMock(
@@ -47,20 +50,27 @@ class ThemePackageInfoTest extends \PHPUnit_Framework_TestCase
             false
         );
         $this->dirReadFactory->expects($this->any())->method('create')->willReturn($this->dirRead);
+        $this->serializerMock = $this->getMockBuilder(\Magento\Framework\Serialize\Serializer\Json::class)
+            ->getMock();
         $this->themePackageInfo = new ThemePackageInfo(
             $this->componentRegistrar,
-            $this->dirReadFactory
+            $this->dirReadFactory,
+            $this->serializerMock
         );
     }
 
     public function testGetPackageName()
     {
+        $themeFileContents = '{"name": "package"}';
         $this->componentRegistrar->expects($this->once())->method('getPath')->willReturn('path/to/A');
         $this->dirRead->expects($this->once())->method('isExist')->with('composer.json')->willReturn(true);
         $this->dirRead->expects($this->once())
             ->method('readFile')
             ->with('composer.json')
-            ->willReturn('{"name": "package"}');
+            ->willReturn($themeFileContents);
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->willReturn(json_decode($themeFileContents, true));
         $this->assertEquals('package', $this->themePackageInfo->getPackageName('themeA'));
     }
 
@@ -74,9 +84,13 @@ class ThemePackageInfoTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFullThemePath()
     {
+        $themeFileContents = '{"name": "package"}';
         $this->componentRegistrar->expects($this->once())->method('getPaths')->willReturn(['themeA' => 'path/to/A']);
         $this->dirRead->expects($this->once())->method('isExist')->willReturn(true);
-        $this->dirRead->expects($this->once())->method('readFile')->willReturn('{"name": "package"}');
+        $this->dirRead->expects($this->once())->method('readFile')->willReturn($themeFileContents);
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->willReturn(json_decode($themeFileContents, true));
         $this->assertEquals('themeA', $this->themePackageInfo->getFullThemePath('package'));
         // call one more time to make sure only initialize once
         $this->assertEquals('themeA', $this->themePackageInfo->getFullThemePath('package'));
@@ -90,14 +104,14 @@ class ThemePackageInfoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $this->themePackageInfo->getFullThemePath('package-other'));
     }
 
-    /**
-     * @expectedException \Zend_Json_Exception
-     */
     public function testGetPackageNameInvalidJson()
     {
         $this->componentRegistrar->expects($this->once())->method('getPath')->willReturn('path/to/A');
         $this->dirRead->expects($this->once())->method('isExist')->willReturn(true);
         $this->dirRead->expects($this->once())->method('readFile')->willReturn('{"name": }');
-        $this->themePackageInfo->getPackageName('themeA');
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->willReturn(null);
+        $this->assertEquals('', $this->themePackageInfo->getPackageName('themeA'));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Since Zend Framework1 is EOL we should replace the usages. In this PR I replace the usage of Zend_Json in Magento Theme with the new serializer class. Part of the #9236 task.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1.   magento/magento2#9236 
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
