### PR TITLE
Enable/Disable DB query logging commands

### DIFF
--- a/app/code/Magento/Developer/Console/Command/QueryLogDisableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/QueryLogDisableCommand.php
@@ -21,6 +21,11 @@ class QueryLogDisableCommand extends Command
     const COMMAND_NAME = 'dev:query-log:disable';
 
     /**
+     * Success message
+     */
+    const SUCCESS_MESSAGE = "DB query logging disabled.";
+
+    /**
      * @var Writer
      */
     private $deployConfigWriter;
@@ -58,6 +63,6 @@ class QueryLogDisableCommand extends Command
         $data = [LoggerProxy::PARAM_ALIAS => LoggerProxy::LOGGER_ALIAS_DISABLED];
         $this->deployConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $data]);
 
-        $output->writeln("<info>DB query logging disabled.</info>");
+        $output->writeln("<info>". self::SUCCESS_MESSAGE . "</info>");
     }
 }

--- a/app/code/Magento/Developer/Console/Command/QueryLogDisableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/QueryLogDisableCommand.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Developer\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\Config\File\ConfigFilePool;
+
+class QueryLogDisableCommand extends Command
+{
+    /**
+     * command name
+     */
+    const COMMAND_NAME = 'dev:query-log:disable';
+
+    /**
+     * File logger alias
+     */
+    const QUIET_LOGGER_ALIAS = 'quiet';
+
+    /**
+     * @var Writer
+     */
+    private $deploymentConfigWriter;
+
+    public function __construct(
+        Writer $deploymentConfigWriter,
+        $name = null
+    )
+    {
+        parent::__construct($name);
+        $this->deploymentConfigWriter = $deploymentConfigWriter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName(self::COMMAND_NAME)
+            ->setDescription('Disable DB query logging');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \InvalidArgumentException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $data = ['db_logger_alias' => 'quiet'];
+        $this->deploymentConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $data]);
+
+        $output->writeln("<info>DB query logging disabled.</info>");
+    }
+}

--- a/app/code/Magento/Developer/Console/Command/QueryLogDisableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/QueryLogDisableCommand.php
@@ -61,7 +61,7 @@ class QueryLogDisableCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $data = [LoggerProxy::PARAM_ALIAS => LoggerProxy::LOGGER_ALIAS_DISABLED];
-        $this->deployConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $data]);
+        $this->deployConfigWriter->saveConfig([ConfigFilePool::APP_ENV => [LoggerProxy::CONF_GROUP_NAME => $data]]);
 
         $output->writeln("<info>". self::SUCCESS_MESSAGE . "</info>");
     }

--- a/app/code/Magento/Developer/Console/Command/QueryLogDisableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/QueryLogDisableCommand.php
@@ -7,11 +7,11 @@
 namespace Magento\Developer\Console\Command;
 
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Magento\Framework\App\DeploymentConfig\Writer;
 use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\DB\Logger\LoggerProxy;
 
 class QueryLogDisableCommand extends Command
 {
@@ -21,22 +21,21 @@ class QueryLogDisableCommand extends Command
     const COMMAND_NAME = 'dev:query-log:disable';
 
     /**
-     * File logger alias
-     */
-    const QUIET_LOGGER_ALIAS = 'quiet';
-
-    /**
      * @var Writer
      */
-    private $deploymentConfigWriter;
+    private $deployConfigWriter;
 
+    /**
+     * QueryLogDisableCommand constructor.
+     * @param Writer $deployConfigWriter
+     * @param null $name
+     */
     public function __construct(
-        Writer $deploymentConfigWriter,
+        Writer $deployConfigWriter,
         $name = null
-    )
-    {
+    ) {
         parent::__construct($name);
-        $this->deploymentConfigWriter = $deploymentConfigWriter;
+        $this->deployConfigWriter = $deployConfigWriter;
     }
 
     /**
@@ -56,8 +55,8 @@ class QueryLogDisableCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $data = ['db_logger_alias' => 'quiet'];
-        $this->deploymentConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $data]);
+        $data = [LoggerProxy::PARAM_ALIAS => LoggerProxy::LOGGER_ALIAS_DISABLED];
+        $this->deployConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $data]);
 
         $output->writeln("<info>DB query logging disabled.</info>");
     }

--- a/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php
@@ -107,7 +107,9 @@ class QueryLogEnableCommand extends Command
         $data[LoggerProxy::PARAM_QUERY_TIME] = number_format($logQueryTime, 3);
         $data[LoggerProxy::PARAM_CALL_STACK] = (int)($logCallStack != 'false');
 
-        $this->deployConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $data]);
+        $configGroup[LoggerProxy::CONF_GROUP_NAME] = $data;
+
+        $this->deployConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $configGroup]);
 
         $output->writeln("<info>". self::SUCCESS_MESSAGE . "</info>");
     }

--- a/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php
@@ -8,8 +8,8 @@ namespace Magento\Developer\Console\Command;
 
 use Magento\Framework\DB\Logger\LoggerProxy;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Magento\Framework\App\DeploymentConfig\Writer;
 use Magento\Framework\Config\File\ConfigFilePool;
@@ -19,17 +19,17 @@ class QueryLogEnableCommand extends Command
     /**
      * input parameter log-all-queries
      */
-    const INPUT_ARG_LOG_ALL_QUERIES = 'log-all-queries';
+    const INPUT_ARG_LOG_ALL_QUERIES = 'include-all-queries';
 
     /**
      * input parameter log-query-time
      */
-    const INPUT_ARG_LOG_QUERY_TIME = 'log-query-time';
+    const INPUT_ARG_LOG_QUERY_TIME = 'query-time-threshold';
 
     /**
      * input parameter log-call-stack
      */
-    const INPUT_ARG_LOG_CALL_STACK = 'log-call-stack';
+    const INPUT_ARG_LOG_CALL_STACK = 'include-call-stack';
 
     /**
      * command name
@@ -65,28 +65,32 @@ class QueryLogEnableCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME)
-            ->setDescription('Enable DB query logging');
-
-        $this->addArgument(
-            self::INPUT_ARG_LOG_ALL_QUERIES,
-            InputArgument::OPTIONAL,
-            'Log all queries. Options: "true" or "false"',
-            'true'
-        );
-
-        $this->addArgument(
-            self::INPUT_ARG_LOG_QUERY_TIME,
-            InputArgument::OPTIONAL,
-            'Log query time.',
-            '0.001'
-        );
-
-        $this->addArgument(
-            self::INPUT_ARG_LOG_CALL_STACK,
-            InputArgument::OPTIONAL,
-            'Log call stack. Options: "true" or "false"',
-            'true'
-        );
+            ->setDescription('Enable DB query logging')
+            ->setDefinition(
+                [
+                    new InputOption(
+                        self::INPUT_ARG_LOG_ALL_QUERIES,
+                        null,
+                        InputOption::VALUE_OPTIONAL,
+                        'Log all queries. [true|false]',
+                        "true"
+                    ),
+                    new InputOption(
+                        self::INPUT_ARG_LOG_QUERY_TIME,
+                        null,
+                        InputOption::VALUE_OPTIONAL,
+                        'Query time thresholds.',
+                        "0.001"
+                    ),
+                    new InputOption(
+                        self::INPUT_ARG_LOG_CALL_STACK,
+                        null,
+                        InputOption::VALUE_OPTIONAL,
+                        'Include call stack. [true|false]',
+                        "true"
+                    ),
+                ]
+            );
 
         parent::configure();
     }
@@ -99,9 +103,9 @@ class QueryLogEnableCommand extends Command
     {
         $data = [LoggerProxy::PARAM_ALIAS => LoggerProxy::LOGGER_ALIAS_FILE];
 
-        $logAllQueries = $input->getArgument(self::INPUT_ARG_LOG_ALL_QUERIES);
-        $logQueryTime = $input->getArgument(self::INPUT_ARG_LOG_QUERY_TIME);
-        $logCallStack = $input->getArgument(self::INPUT_ARG_LOG_CALL_STACK);
+        $logAllQueries = $input->getOption(self::INPUT_ARG_LOG_ALL_QUERIES);
+        $logQueryTime = $input->getOption(self::INPUT_ARG_LOG_QUERY_TIME);
+        $logCallStack = $input->getOption(self::INPUT_ARG_LOG_CALL_STACK);
 
         $data[LoggerProxy::PARAM_LOG_ALL] = (int)($logAllQueries != 'false');
         $data[LoggerProxy::PARAM_QUERY_TIME] = number_format($logQueryTime, 3);

--- a/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php
@@ -37,6 +37,11 @@ class QueryLogEnableCommand extends Command
     const COMMAND_NAME = 'dev:query-log:enable';
 
     /**
+     * Success message
+     */
+    const SUCCESS_MESSAGE = "DB query logging enabled.";
+
+    /**
      * @var Writer
      */
     private $deployConfigWriter;
@@ -104,6 +109,6 @@ class QueryLogEnableCommand extends Command
 
         $this->deployConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $data]);
 
-        $output->writeln("<info>DB query logging enabled.</info>");
+        $output->writeln("<info>". self::SUCCESS_MESSAGE . "</info>");
     }
 }

--- a/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Developer\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\Config\File\ConfigFilePool;
+
+class QueryLogEnableCommand extends Command
+{
+    /**
+     * input parameter log-all-queries
+     */
+    const INPUT_ARG_LOG_ALL_QUERIES = 'log-all-queries';
+
+    /**
+     * input parameter log-query-time
+     */
+    const INPUT_ARG_LOG_QUERY_TIME = 'log-query-time';
+
+    /**
+     * input parameter log-call-stack
+     */
+    const INPUT_ARG_LOG_CALL_STACK = 'log-call-stack';
+
+    /**
+     * command name
+     */
+    const COMMAND_NAME = 'dev:query-log:enable';
+
+    /**
+     * File logger alias
+     */
+    const FILE_LOGGER_ALIAS = 'file';
+
+    /**
+     * @var Writer
+     */
+    private $deploymentConfigWriter;
+
+    public function __construct(
+        Writer $deploymentConfigWriter,
+        $name = null
+    )
+    {
+        parent::__construct($name);
+        $this->deploymentConfigWriter = $deploymentConfigWriter;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName(self::COMMAND_NAME)
+            ->setDescription('Enable DB query logging');
+
+        $this->addArgument(
+            self::INPUT_ARG_LOG_ALL_QUERIES,
+            InputArgument::OPTIONAL,
+            'Log all queries.',
+            'false'
+        );
+
+        $this->addArgument(
+            self::INPUT_ARG_LOG_QUERY_TIME,
+            InputArgument::OPTIONAL,
+            'Query time.',
+            '0.05'
+        );
+
+        $this->addArgument(
+            self::INPUT_ARG_LOG_CALL_STACK,
+            InputArgument::OPTIONAL,
+            'Log call stack.',
+            'false'
+        );
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \InvalidArgumentException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $data = ['db_logger_alias' => 'file'];
+        $this->deploymentConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $data]);
+
+//        $data = [
+//            'db_logger' => [
+//                'logger_alias' => 'file',
+//                'log_all_queries' => false,
+//                'log_query_time' => '0.05',
+//                'log_call_stack' => false,
+//            ]
+//        ];
+//        $this->deploymentConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $data]);
+
+        $output->writeln("<info>DB query logging enabled.</info>");
+    }
+}

--- a/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php
@@ -99,7 +99,7 @@ class QueryLogEnableCommand extends Command
         $logCallStack = $input->getArgument(self::INPUT_ARG_LOG_CALL_STACK);
 
         $data[LoggerProxy::PARAM_LOG_ALL] = (int)($logAllQueries != 'false');
-        $data[LoggerProxy::PARAM_QUERY_TIME] = number_format($logQueryTime,3);
+        $data[LoggerProxy::PARAM_QUERY_TIME] = number_format($logQueryTime, 3);
         $data[LoggerProxy::PARAM_CALL_STACK] = (int)($logCallStack != 'false');
 
         $this->deployConfigWriter->saveConfig([ConfigFilePool::APP_ENV => $data]);

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/QueryLogDisableCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/QueryLogDisableCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Developer\Test\Unit\Console\Command;
+
+use Magento\Developer\Console\Command\QueryLogDisableCommand;
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\DB\Logger\LoggerProxy;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class QueryLogDisableCommandTest
+ *
+ * Tests dev:query-log:disable command.
+ * Tests that the correct configuration is passed to the deployment config writer.
+ */
+class QueryLogDisableCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\App\DeploymentConfig\Writer
+     */
+    private $configWriter;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Developer\Console\Command\QueryLogEnableCommand
+     */
+    private $command;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->configWriter = $this->getMockBuilder(Writer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->command = new QueryLogDisableCommand($this->configWriter);
+    }
+
+    /**
+     * Test execute()
+     */
+    public function testExecute()
+    {
+        $data = [LoggerProxy::PARAM_ALIAS => LoggerProxy::LOGGER_ALIAS_DISABLED];
+
+        $this->configWriter
+            ->expects($this->once())
+            ->method('saveConfig')
+            ->with([ConfigFilePool::APP_ENV => $data]);
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([]);
+        $this->assertSame(
+            QueryLogDisableCommand::SUCCESS_MESSAGE . PHP_EOL,
+            $commandTester->getDisplay()
+        );
+    }
+}

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/QueryLogDisableCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/QueryLogDisableCommandTest.php
@@ -51,7 +51,7 @@ class QueryLogDisableCommandTest extends \PHPUnit_Framework_TestCase
         $this->configWriter
             ->expects($this->once())
             ->method('saveConfig')
-            ->with([ConfigFilePool::APP_ENV => $data]);
+            ->with([ConfigFilePool::APP_ENV => [LoggerProxy::CONF_GROUP_NAME => $data]]);
 
         $commandTester = new CommandTester($this->command);
         $commandTester->execute([]);

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/QueryLogEnableCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/QueryLogEnableCommandTest.php
@@ -86,7 +86,13 @@ class QueryLogEnableCommandTest extends \PHPUnit_Framework_TestCase
             ->with([ConfigFilePool::APP_ENV => [LoggerProxy::CONF_GROUP_NAME => $data]]);
 
         $commandTester = new CommandTester($this->command);
-        $commandTester->execute(['false', '0.05', 'false']);
+        $commandTester->execute(
+            [
+                '--include-all-queries' => 'false',
+                '--include-call-stack' => 'false',
+                '--query-time-threshold' => '0.05',
+            ]
+        );
         $this->assertSame(
             QueryLogEnableCommand::SUCCESS_MESSAGE . PHP_EOL,
             $commandTester->getDisplay()

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/QueryLogEnableCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/QueryLogEnableCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Developer\Test\Unit\Console\Command;
+
+use Magento\Developer\Console\Command\QueryLogEnableCommand;
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\DB\Logger\LoggerProxy;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class QueryLogEnableCommandTest
+ *
+ * Tests dev:query-log:enable command.
+ * Tests that the correct configuration is passed to the deployment config writer with and without parameters.
+ */
+class QueryLogEnableCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\App\DeploymentConfig\Writer
+     */
+    private $configWriter;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Developer\Console\Command\QueryLogEnableCommand
+     */
+    private $command;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->configWriter = $this->getMockBuilder(Writer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->command = new QueryLogEnableCommand($this->configWriter);
+    }
+
+    /**
+     * Test execute() without parameters.
+     */
+    public function testExecuteWithNoParams()
+    {
+        $data = [LoggerProxy::PARAM_ALIAS => LoggerProxy::LOGGER_ALIAS_FILE];
+        $data[LoggerProxy::PARAM_LOG_ALL] = 1;
+        $data[LoggerProxy::PARAM_QUERY_TIME] = 0.001;
+        $data[LoggerProxy::PARAM_CALL_STACK] = 1;
+
+        $this->configWriter = $this->getMockBuilder(Writer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->configWriter
+            ->expects($this->any())
+            ->method('saveConfig')
+            ->with([ConfigFilePool::APP_ENV => $data]);
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([]);
+        $this->assertSame(
+            QueryLogEnableCommand::SUCCESS_MESSAGE . PHP_EOL,
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * Test execute() with parameters.
+     */
+    public function testExecuteWithParams()
+    {
+        $data = [LoggerProxy::PARAM_ALIAS => LoggerProxy::LOGGER_ALIAS_FILE];
+        $data[LoggerProxy::PARAM_LOG_ALL] = 0;
+        $data[LoggerProxy::PARAM_QUERY_TIME] = '0.05';
+        $data[LoggerProxy::PARAM_CALL_STACK] = 0;
+
+        $this->configWriter = $this->getMockBuilder(Writer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->configWriter
+            ->expects($this->any())
+            ->method('saveConfig')
+            ->with([ConfigFilePool::APP_ENV => $data]);
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['false', '0.05', 'false']);
+        $this->assertSame(
+            QueryLogEnableCommand::SUCCESS_MESSAGE . PHP_EOL,
+            $commandTester->getDisplay()
+        );
+    }
+}

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/QueryLogEnableCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/QueryLogEnableCommandTest.php
@@ -57,7 +57,7 @@ class QueryLogEnableCommandTest extends \PHPUnit_Framework_TestCase
         $this->configWriter
             ->expects($this->any())
             ->method('saveConfig')
-            ->with([ConfigFilePool::APP_ENV => $data]);
+            ->with([ConfigFilePool::APP_ENV => [LoggerProxy::CONF_GROUP_NAME => $data]]);
 
         $commandTester = new CommandTester($this->command);
         $commandTester->execute([]);
@@ -83,7 +83,7 @@ class QueryLogEnableCommandTest extends \PHPUnit_Framework_TestCase
         $this->configWriter
             ->expects($this->any())
             ->method('saveConfig')
-            ->with([ConfigFilePool::APP_ENV => $data]);
+            ->with([ConfigFilePool::APP_ENV => [LoggerProxy::CONF_GROUP_NAME => $data]]);
 
         $commandTester = new CommandTester($this->command);
         $commandTester->execute(['false', '0.05', 'false']);

--- a/app/code/Magento/Developer/etc/di.xml
+++ b/app/code/Magento/Developer/etc/di.xml
@@ -98,6 +98,8 @@
                 <item name="xml_converter" xsi:type="object">Magento\Developer\Console\Command\XmlConverterCommand</item>
                 <item name="xml_catalog_generator" xsi:type="object">Magento\Developer\Console\Command\XmlCatalogGenerateCommand</item>
                 <item name="dev_di_info" xsi:type="object">Magento\Developer\Console\Command\DiInfoCommand</item>
+                <item name="dev_query_log_enable" xsi:type="object">Magento\Developer\Console\Command\QueryLogEnableCommand</item>
+                <item name="dev_query_log_disable" xsi:type="object">Magento\Developer\Console\Command\QueryLogDisableCommand</item>
             </argument>
         </arguments>
     </type>

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1320,10 +1320,10 @@
     </type>
     <type name="Magento\Framework\DB\Logger\LoggerProxy">
         <arguments>
-            <argument name="loggerAlias" xsi:type="init_parameter">\Magento\Framework\DB\Logger\LoggerProxy::PARAM_ALIAS</argument>
-            <argument name="logAllQueries" xsi:type="init_parameter">\Magento\Framework\DB\Logger\LoggerProxy::PARAM_LOG_ALL</argument>
-            <argument name="logQueryTime" xsi:type="init_parameter">\Magento\Framework\DB\Logger\LoggerProxy::PARAM_QUERY_TIME</argument>
-            <argument name="logCallStack" xsi:type="init_parameter">\Magento\Framework\DB\Logger\LoggerProxy::PARAM_CALL_STACK</argument>
+            <argument name="loggerAlias" xsi:type="init_parameter">Magento\Framework\Config\ConfigOptionsListConstants::CONFIG_PATH_DB_LOGGER_OUTPUT</argument>
+            <argument name="logAllQueries" xsi:type="init_parameter">Magento\Framework\Config\ConfigOptionsListConstants::CONFIG_PATH_DB_LOGGER_LOG_EVERYTHING</argument>
+            <argument name="logQueryTime" xsi:type="init_parameter">Magento\Framework\Config\ConfigOptionsListConstants::CONFIG_PATH_DB_LOGGER_QUERY_TIME_THRESHOLD</argument>
+            <argument name="logCallStack" xsi:type="init_parameter">Magento\Framework\Config\ConfigOptionsListConstants::CONFIG_PATH_DB_LOGGER_INCLUDE_STACKTRACE</argument>
         </arguments>
     </type>
 

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1321,6 +1321,10 @@
     <type name="Magento\Framework\DB\Logger\LoggerProxy">
         <arguments>
             <argument name="loggerAlias" xsi:type="init_parameter">\Magento\Framework\DB\Logger\LoggerProxy::PARAM_ALIAS</argument>
+            <argument name="logAllQueries" xsi:type="init_parameter">\Magento\Framework\DB\Logger\LoggerProxy::PARAM_LOG_ALL</argument>
+            <argument name="logQueryTime" xsi:type="init_parameter">\Magento\Framework\DB\Logger\LoggerProxy::PARAM_QUERY_TIME</argument>
+            <argument name="logCallStack" xsi:type="init_parameter">\Magento\Framework\DB\Logger\LoggerProxy::PARAM_CALL_STACK</argument>
         </arguments>
     </type>
+
 </config>

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -102,7 +102,7 @@
     <preference for="Magento\Framework\Api\MetadataObjectInterface" type="Magento\Framework\Api\AttributeMetadata"/>
     <preference for="Magento\Framework\Api\SearchCriteriaInterface" type="Magento\Framework\Api\SearchCriteria"/>
     <preference for="Magento\Framework\App\Rss\UrlBuilderInterface" type="Magento\Framework\App\Rss\UrlBuilder"/>
-    <preference for="Magento\Framework\DB\LoggerInterface" type="Magento\Framework\DB\Logger\Quiet"/>
+    <preference for="Magento\Framework\DB\LoggerInterface" type="Magento\Framework\DB\Logger\LoggerProxy"/>
     <preference for="Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface" type="Magento\Framework\Model\ResourceModel\Type\Db\Pdo\Mysql"/>
     <preference for="Magento\Framework\DB\QueryInterface" type="Magento\Framework\DB\Query"/>
     <preference for="Magento\Framework\App\ProductMetadataInterface" type="Magento\Framework\App\ProductMetadata"/>
@@ -1316,6 +1316,11 @@
                     <item name="renderer" xsi:type="const">\Magento\Framework\View\Element\Message\Renderer\EscapeRenderer::CODE</item>
                 </item>
             </argument>
+        </arguments>
+    </type>
+    <type name="Magento\Framework\DB\Logger\LoggerProxy">
+        <arguments>
+            <argument name="loggerAlias" xsi:type="init_parameter">\Magento\Framework\DB\Logger\LoggerProxy::PARAM_ALIAS</argument>
         </arguments>
     </type>
 </config>

--- a/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
+++ b/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
@@ -30,6 +30,10 @@ class ConfigOptionsListConstants
     const CONFIG_PATH_DB = 'db';
     const CONFIG_PATH_RESOURCE = 'resource';
     const CONFIG_PATH_CACHE_TYPES = 'cache_types';
+    const CONFIG_PATH_DB_LOGGER_OUTPUT = 'db_logger/output';
+    const CONFIG_PATH_DB_LOGGER_LOG_EVERYTHING = 'db_logger/log_everything';
+    const CONFIG_PATH_DB_LOGGER_QUERY_TIME_THRESHOLD = 'db_logger/query_time_threshold';
+    const CONFIG_PATH_DB_LOGGER_INCLUDE_STACKTRACE = 'db_logger/include_stacktrace';
     /**#@-*/
 
     /**#@+

--- a/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
+++ b/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
@@ -9,9 +9,14 @@ namespace Magento\Framework\DB\Logger;
 class LoggerProxy extends LoggerAbstract
 {
     /**
-     * Logger alias
+     * Logger alias param name
      */
     const PARAM_ALIAS = 'db_logger_alias';
+
+    /**
+     * File logger alias
+     */
+    const FILE_LOGGER_ALIAS = 'file';
 
     /**
      * @var LoggerAbstract
@@ -37,7 +42,7 @@ class LoggerProxy extends LoggerAbstract
     )
     {
         switch ($loggerAlias) {
-            case "file":
+            case self::FILE_LOGGER_ALIAS:
                 $this->logger = $loggerFileFactory->create();
                 break;
             default:

--- a/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
+++ b/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
@@ -108,9 +108,9 @@ class LoggerProxy implements LoggerInterface
      * Get logger object. Initialize if needed.
      * @return LoggerInterface
      */
-    public function getLogger()
+    private function getLogger()
     {
-        if($this->logger === null) {
+        if ($this->logger === null) {
             switch ($this->loggerAlias) {
                 case self::LOGGER_ALIAS_FILE:
                     $this->logger = $this->fileFactory->create(

--- a/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
+++ b/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
@@ -114,12 +114,12 @@ class LoggerProxy implements LoggerInterface
     }
 
     /**
-     * @param \Exception $e
+     * @param \Exception $exception
      * @return void
      */
-    public function critical(\Exception $e)
+    public function critical(\Exception $exception)
     {
-        $this->logger->critical($e);
+        $this->logger->critical($exception);
     }
 
     /**

--- a/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
+++ b/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
@@ -56,7 +56,7 @@ class LoggerProxy extends LoggerAbstract
         Quiet $quiet,
         $loggerAlias,
         $logAllQueries = true,
-        float $logQueryTime = 0.001,
+        $logQueryTime = 0.001,
         $logCallStack = true
     ) {
         switch ($loggerAlias) {

--- a/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
+++ b/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\DB\Logger;
+
+class LoggerProxy extends LoggerAbstract
+{
+    /**
+     * Logger alias
+     */
+    const PARAM_ALIAS = 'db_logger_alias';
+
+    /**
+     * @var LoggerAbstract
+     */
+    private $logger;
+
+    /**
+     * LoggerProxy constructor.
+     * @param FileFactory $loggerFileFactory
+     * @param QuietFactory $loggerQuietFactory
+     * @param bool $loggerAlias
+     * @param bool $logAllQueries
+     * @param float $logQueryTime
+     * @param bool $logCallStack
+     */
+    public function __construct(
+        FileFactory $loggerFileFactory,
+        QuietFactory $loggerQuietFactory,
+        $loggerAlias,
+        $logAllQueries = false,
+        $logQueryTime = 0.05,
+        $logCallStack = false
+    )
+    {
+        switch ($loggerAlias) {
+            case "file":
+                $this->logger = $loggerFileFactory->create();
+                break;
+            default:
+                $this->logger = $loggerQuietFactory->create();
+                break;
+        }
+
+        parent::__construct($logAllQueries, $logQueryTime, $logCallStack);
+    }
+
+    /**
+     * Adds log record
+     *
+     * @param string $str
+     * @return void
+     */
+    public function log($str)
+    {
+        $this->logger->log($str);
+    }
+
+    /**
+     * @param string $type
+     * @param string $sql
+     * @param array $bind
+     * @param \Zend_Db_Statement_Pdo|null $result
+     * @return void
+     */
+    public function logStats($type, $sql, $bind = [], $result = null)
+    {
+        $this->logger->logStats($type, $sql, $bind, $result);
+    }
+
+    /**
+     * @param \Exception $e
+     * @return void
+     */
+    public function critical(\Exception $e)
+    {
+        $this->logger->critical($e);
+    }
+}

--- a/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
+++ b/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
@@ -5,27 +5,34 @@
  */
 namespace Magento\Framework\DB\Logger;
 
-class LoggerProxy extends LoggerAbstract
+use Magento\Framework\DB\LoggerInterface;
+
+class LoggerProxy implements LoggerInterface
 {
+    /**
+     * Configuration group name
+     */
+    const CONF_GROUP_NAME = 'db_logger';
+
     /**
      * Logger alias param name
      */
-    const PARAM_ALIAS = 'db_logger_mode';
+    const PARAM_ALIAS = 'output';
 
     /**
      * Logger log all param name
      */
-    const PARAM_LOG_ALL = 'db_logger_all';
+    const PARAM_LOG_ALL = 'log_everything';
 
     /**
      * Logger query time param name
      */
-    const PARAM_QUERY_TIME = 'db_logger_query_time';
+    const PARAM_QUERY_TIME = 'query_time_threshold';
 
     /**
      * Logger call stack param name
      */
-    const PARAM_CALL_STACK = 'db_logger_stack';
+    const PARAM_CALL_STACK = 'include_stacktrace';
 
     /**
      * File logger alias
@@ -38,22 +45,22 @@ class LoggerProxy extends LoggerAbstract
     const LOGGER_ALIAS_DISABLED = 'disabled';
 
     /**
-     * @var LoggerAbstract
+     * @var LoggerInterface
      */
     private $logger;
 
     /**
      * LoggerProxy constructor.
-     * @param File $file
-     * @param Quiet $quiet
+     * @param FileFactory $fileFactory
+     * @param QuietFactory $quietFactory
      * @param bool $loggerAlias
      * @param bool $logAllQueries
      * @param float $logQueryTime
      * @param bool $logCallStack
      */
     public function __construct(
-        File $file,
-        Quiet $quiet,
+        FileFactory $fileFactory,
+        QuietFactory $quietFactory,
         $loggerAlias,
         $logAllQueries = true,
         $logQueryTime = 0.001,
@@ -61,18 +68,22 @@ class LoggerProxy extends LoggerAbstract
     ) {
         switch ($loggerAlias) {
             case self::LOGGER_ALIAS_FILE:
-                $this->logger = $file;
+                $this->logger = $fileFactory->create(
+                    [
+                        'logAllQueries' => $logAllQueries,
+                        'logQueryTime' => $logQueryTime,
+                        'logCallStack' => $logCallStack,
+                    ]
+                );
                 break;
             default:
-                $this->logger = $quiet;
+                $this->logger = $quietFactory->create();
                 break;
         }
-
-        parent::__construct($logAllQueries, $logQueryTime, $logCallStack);
     }
 
     /**
-     * @return LoggerAbstract|Quiet
+     * @return LoggerInterface
      */
     public function getLogger()
     {
@@ -109,5 +120,13 @@ class LoggerProxy extends LoggerAbstract
     public function critical(\Exception $e)
     {
         $this->logger->critical($e);
+    }
+
+    /**
+     * @return void
+     */
+    public function startTimer()
+    {
+        $this->logger->startTimer();
     }
 }

--- a/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
+++ b/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Framework\DB\Logger;
 
 class LoggerProxy extends LoggerAbstract
@@ -11,12 +10,32 @@ class LoggerProxy extends LoggerAbstract
     /**
      * Logger alias param name
      */
-    const PARAM_ALIAS = 'db_logger_alias';
+    const PARAM_ALIAS = 'db_logger_mode';
+
+    /**
+     * Logger log all param name
+     */
+    const PARAM_LOG_ALL = 'db_logger_all';
+
+    /**
+     * Logger query time param name
+     */
+    const PARAM_QUERY_TIME = 'db_logger_query_time';
+
+    /**
+     * Logger call stack param name
+     */
+    const PARAM_CALL_STACK = 'db_logger_stack';
 
     /**
      * File logger alias
      */
-    const FILE_LOGGER_ALIAS = 'file';
+    const LOGGER_ALIAS_FILE = 'file';
+
+    /**
+     * Quiet logger alias
+     */
+    const LOGGER_ALIAS_DISABLED = 'disabled';
 
     /**
      * @var LoggerAbstract
@@ -25,28 +44,27 @@ class LoggerProxy extends LoggerAbstract
 
     /**
      * LoggerProxy constructor.
-     * @param FileFactory $loggerFileFactory
-     * @param QuietFactory $loggerQuietFactory
+     * @param File $file
+     * @param Quiet $quiet
      * @param bool $loggerAlias
      * @param bool $logAllQueries
      * @param float $logQueryTime
      * @param bool $logCallStack
      */
     public function __construct(
-        FileFactory $loggerFileFactory,
-        QuietFactory $loggerQuietFactory,
+        File $file,
+        Quiet $quiet,
         $loggerAlias,
-        $logAllQueries = false,
-        $logQueryTime = 0.05,
-        $logCallStack = false
-    )
-    {
+        $logAllQueries = true,
+        float $logQueryTime = 0.001,
+        $logCallStack = true
+    ) {
         switch ($loggerAlias) {
-            case self::FILE_LOGGER_ALIAS:
-                $this->logger = $loggerFileFactory->create();
+            case self::LOGGER_ALIAS_FILE:
+                $this->logger = $file;
                 break;
             default:
-                $this->logger = $loggerQuietFactory->create();
+                $this->logger = $quiet;
                 break;
         }
 

--- a/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
+++ b/lib/internal/Magento/Framework/DB/Logger/LoggerProxy.php
@@ -72,6 +72,14 @@ class LoggerProxy extends LoggerAbstract
     }
 
     /**
+     * @return LoggerAbstract|Quiet
+     */
+    public function getLogger()
+    {
+        return $this->logger;
+    }
+
+    /**
      * Adds log record
      *
      * @param string $str

--- a/lib/internal/Magento/Framework/DB/Test/Unit/DB/Logger/LoggerProxyTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/DB/Logger/LoggerProxyTest.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Framework\Test\Unit\DB\Logger;
 
+use Magento\Framework\DB\Logger\FileFactory;
+use Magento\Framework\DB\Logger\QuietFactory;
 use Magento\Framework\DB\Logger\LoggerProxy;
 use Magento\Framework\DB\Logger\File;
 use Magento\Framework\DB\Logger\Quiet;
@@ -36,9 +38,23 @@ class LoggerProxyTest extends \PHPUnit_Framework_TestCase
      */
     public function testNewWithAliasFile()
     {
+        $fileLoggerMock = $this->getMockBuilder(File::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $fileLoggerFactoryMock = $this->getMockBuilder(FileFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+
+        $fileLoggerFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($fileLoggerMock);
+
         $this->loggerProxy = $this->objectManager->getObject(
             LoggerProxy::class,
             [
+                'fileFactory' => $fileLoggerFactoryMock,
                 'loggerAlias' => LoggerProxy::LOGGER_ALIAS_FILE,
             ]
         );
@@ -51,9 +67,23 @@ class LoggerProxyTest extends \PHPUnit_Framework_TestCase
      */
     public function testNewWithAliasDisabled()
     {
+        $quietLoggerMock = $this->getMockBuilder(Quiet::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $quietLoggerFactoryMock = $this->getMockBuilder(QuietFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+
+        $quietLoggerFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($quietLoggerMock);
+
         $this->loggerProxy = $this->objectManager->getObject(
             LoggerProxy::class,
             [
+                'quietFactory' => $quietLoggerFactoryMock,
                 'loggerAlias' => LoggerProxy::LOGGER_ALIAS_DISABLED,
             ]
         );

--- a/lib/internal/Magento/Framework/DB/Test/Unit/DB/Logger/LoggerProxyTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/DB/Logger/LoggerProxyTest.php
@@ -42,6 +42,9 @@ class LoggerProxyTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $fileLoggerMock->expects($this->once())
+            ->method('log');
+
         $fileLoggerFactoryMock = $this->getMockBuilder(FileFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
@@ -51,15 +54,28 @@ class LoggerProxyTest extends \PHPUnit_Framework_TestCase
             ->method('create')
             ->willReturn($fileLoggerMock);
 
+        $quietLoggerMock = $this->getMockBuilder(Quiet::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $quietLoggerMock->expects($this->never())
+            ->method('log');
+
+        $quietLoggerFactoryMock = $this->getMockBuilder(QuietFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+
         $this->loggerProxy = $this->objectManager->getObject(
             LoggerProxy::class,
             [
                 'fileFactory' => $fileLoggerFactoryMock,
+                'quietFactory' => $quietLoggerFactoryMock,
                 'loggerAlias' => LoggerProxy::LOGGER_ALIAS_FILE,
             ]
         );
 
-        $this->assertInstanceOf(File::class, $this->loggerProxy->getLogger());
+        $this->loggerProxy->log('test');
     }
 
     /**
@@ -67,9 +83,24 @@ class LoggerProxyTest extends \PHPUnit_Framework_TestCase
      */
     public function testNewWithAliasDisabled()
     {
+        $fileLoggerMock = $this->getMockBuilder(File::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $fileLoggerMock->expects($this->never())
+            ->method('log');
+
+        $fileLoggerFactoryMock = $this->getMockBuilder(FileFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+
         $quietLoggerMock = $this->getMockBuilder(Quiet::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $quietLoggerMock->expects($this->once())
+            ->method('log');
 
         $quietLoggerFactoryMock = $this->getMockBuilder(QuietFactory::class)
             ->disableOriginalConstructor()
@@ -83,11 +114,12 @@ class LoggerProxyTest extends \PHPUnit_Framework_TestCase
         $this->loggerProxy = $this->objectManager->getObject(
             LoggerProxy::class,
             [
+                'fileFactory' => $fileLoggerFactoryMock,
                 'quietFactory' => $quietLoggerFactoryMock,
                 'loggerAlias' => LoggerProxy::LOGGER_ALIAS_DISABLED,
             ]
         );
 
-        $this->assertInstanceOf(Quiet::class, $this->loggerProxy->getLogger());
+        $this->loggerProxy->log('test');
     }
 }

--- a/lib/internal/Magento/Framework/DB/Test/Unit/DB/Logger/LoggerProxyTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/DB/Logger/LoggerProxyTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Test\Unit\DB\Logger;
+
+use Magento\Framework\DB\Logger\LoggerProxy;
+use Magento\Framework\DB\Logger\File;
+use Magento\Framework\DB\Logger\Quiet;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+class LoggerProxyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Magento\Framework\DB\Logger\LoggerProxy
+     */
+    private $loggerProxy;
+
+    /**
+     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->objectManager = new ObjectManager($this);
+    }
+
+    /**
+     * Test new logger proxy with file alias
+     */
+    public function testNewWithAliasFile()
+    {
+        $this->loggerProxy = $this->objectManager->getObject(
+            LoggerProxy::class,
+            [
+                'loggerAlias' => LoggerProxy::LOGGER_ALIAS_FILE,
+            ]
+        );
+
+        $this->assertInstanceOf(File::class, $this->loggerProxy->getLogger());
+    }
+
+    /**
+     * Test new logger proxy with disabled alias
+     */
+    public function testNewWithAliasDisabled()
+    {
+        $this->loggerProxy = $this->objectManager->getObject(
+            LoggerProxy::class,
+            [
+                'loggerAlias' => LoggerProxy::LOGGER_ALIAS_DISABLED,
+            ]
+        );
+
+        $this->assertInstanceOf(Quiet::class, $this->loggerProxy->getLogger());
+    }
+}


### PR DESCRIPTION
### Description

Added console commands for enabling/disabling the db query logging.

### Fixed Issues (if relevant)

1. magento/magento2#9200: Create new CLI command: Enable dev settings, i.e DB logging, Profiler, Template Hints

### Manual testing scenarios

1. Run bin/magento dev:query-log:enable command.
2. Clear configuration cache.
3. Make any request to the Magento site and verify that the DB query log is being written.
4. Run bin/magento dev:query-log:disable command.
5. Clear configuration cache
6. Make any request to the site and verify that the DB query log have no new log data.
