### PR TITLE
Fixed coding standard violations in Framework\Image namespace

### DIFF
--- a/lib/internal/Magento/Framework/Image/Factory.php
+++ b/lib/internal/Magento/Framework/Image/Factory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Image;
 
 use Magento\Framework\ObjectManagerInterface;
@@ -26,8 +24,10 @@ class Factory
      * @param ObjectManagerInterface $objectManager
      * @param AdapterFactory $adapterFactory
      */
-    public function __construct(ObjectManagerInterface $objectManager, AdapterFactory $adapterFactory)
-    {
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        AdapterFactory $adapterFactory
+    ) {
         $this->objectManager = $objectManager;
         $this->adapterFactory = $adapterFactory;
     }
@@ -43,6 +43,8 @@ class Factory
     {
         $adapter = $this->adapterFactory->create($adapterName);
         return $this->objectManager->create(
-            \Magento\Framework\Image::class, ['adapter' => $adapter, 'fileName' => $fileName]);
+            \Magento\Framework\Image::class,
+            ['adapter' => $adapter, 'fileName' => $fileName]
+        );
     }
 }


### PR DESCRIPTION
Fixed coding standard violation in the Framework\Image namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed the @codingStandardsIgnoreFile from the head of the file.
- Fixed line length