### PR TITLE
Replace Zend_Log with Psr\Log\LoggerInterface

### DIFF
--- a/dev/tests/api-functional/framework/bootstrap.php
+++ b/dev/tests/api-functional/framework/bootstrap.php
@@ -39,11 +39,11 @@ try {
     require_once __DIR__ . '/../../integration/framework/deployTestModules.php';
 
     $installConfigFile = $settings->getAsConfigFile('TESTS_INSTALL_CONFIG_FILE');
-    if ( ! file_exists($installConfigFile)) {
+    if (!file_exists($installConfigFile)) {
         $installConfigFile = $installConfigFile . '.dist';
     }
     $globalConfigFile = $settings->getAsConfigFile('TESTS_GLOBAL_CONFIG_FILE');
-    if ( ! file_exists($installConfigFile)) {
+    if (!file_exists($installConfigFile)) {
         $installConfigFile = $installConfigFile . '.dist';
     }
     $dirList     = new \Magento\Framework\App\Filesystem\DirectoryList(BP);
@@ -77,10 +77,10 @@ try {
     $application->initialize();
 
     \Magento\TestFramework\Helper\Bootstrap::setInstance(new \Magento\TestFramework\Helper\Bootstrap($bootstrap));
-    $dirSearch        = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
-                                                               ->create(\Magento\Framework\Component\DirSearch::class);
+    $dirSearch = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+       ->create(\Magento\Framework\Component\DirSearch::class);
     $themePackageList = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
-                                                               ->create(\Magento\Framework\View\Design\Theme\ThemePackageList::class);
+       ->create(\Magento\Framework\View\Design\Theme\ThemePackageList::class);
     \Magento\Framework\App\Utility\Files::setInstance(
         new \Magento\Framework\App\Utility\Files(
             new \Magento\Framework\Component\ComponentRegistrar(),

--- a/dev/tests/api-functional/framework/bootstrap.php
+++ b/dev/tests/api-functional/framework/bootstrap.php
@@ -22,7 +22,7 @@ try {
 
     if ($settings->get('TESTS_EXTRA_VERBOSE_LOG')) {
         $filesystem = new \Magento\Framework\Filesystem\Driver\File();
-        $exceptionHandler = new \Magento\Framework\Logger\Handler\Exception();
+        $exceptionHandler = new \Magento\Framework\Logger\Handler\Exception($filesystem);
         $loggerHandlers = [
             'system'    => new \Magento\Framework\Logger\Handler\System($filesystem, $exceptionHandler),
             'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem)

--- a/dev/tests/api-functional/framework/bootstrap.php
+++ b/dev/tests/api-functional/framework/bootstrap.php
@@ -14,70 +14,84 @@ $testsBaseDir = dirname(__DIR__);
 $integrationTestsDir = realpath("{$testsBaseDir}/../integration");
 $fixtureBaseDir = $integrationTestsDir . '/testsuite';
 
-setCustomErrorHandler();
+try {
+    setCustomErrorHandler();
 
-$logWriter = new \Zend_Log_Writer_Stream('php://output');
-$logWriter->setFormatter(new \Zend_Log_Formatter_Simple('%message%' . PHP_EOL));
-$logger = new \Zend_Log($logWriter);
+    /* Bootstrap the application */
+    $settings = new \Magento\TestFramework\Bootstrap\Settings($testsBaseDir, get_defined_constants());
 
-$testFrameworkDir = __DIR__;
-require_once  __DIR__ . '/../../integration/framework/deployTestModules.php';
-
-/* Bootstrap the application */
-$settings = new \Magento\TestFramework\Bootstrap\Settings($testsBaseDir, get_defined_constants());
-$shell = new \Magento\Framework\Shell(new \Magento\Framework\Shell\CommandRenderer(), $logger);
-
-$installConfigFile = $settings->getAsConfigFile('TESTS_INSTALL_CONFIG_FILE');
-if (!file_exists($installConfigFile)) {
-    $installConfigFile = $installConfigFile . '.dist';
-}
-$globalConfigFile = $settings->getAsConfigFile('TESTS_GLOBAL_CONFIG_FILE');
-if (!file_exists($installConfigFile)) {
-    $installConfigFile = $installConfigFile . '.dist';
-}
-$dirList = new \Magento\Framework\App\Filesystem\DirectoryList(BP);
-$application =  new \Magento\TestFramework\WebApiApplication(
-    $shell,
-    $dirList->getPath(DirectoryList::VAR_DIR),
-    $installConfigFile,
-    $globalConfigFile,
-    BP . '/app/etc/',
-    $settings->get('TESTS_MAGENTO_MODE'),
-    AutoloaderRegistry::getAutoloader()
-);
-
-if (defined('TESTS_MAGENTO_INSTALLATION') && TESTS_MAGENTO_INSTALLATION === 'enabled') {
-    if (defined('TESTS_CLEANUP') && TESTS_CLEANUP === 'enabled') {
-        $application->cleanup();
+    if ($settings->get('TESTS_EXTRA_VERBOSE_LOG')) {
+        $filesystem = new \Magento\Framework\Filesystem\Driver\File();
+        $loggerHandlers = [
+            'system'    => new \Magento\Framework\Logger\Handler\System($filesystem),
+            'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem)
+        ];
+        $shell = new \Magento\Framework\Shell(
+            new \Magento\Framework\Shell\CommandRenderer(),
+            new \Monolog\Logger('main', $loggerHandlers)
+        );
+    } else {
+        $shell = new \Magento\Framework\Shell(new \Magento\Framework\Shell\CommandRenderer());
     }
-    $application->install();
+
+    $testFrameworkDir = __DIR__;
+    require_once __DIR__ . '/../../integration/framework/deployTestModules.php';
+
+    $installConfigFile = $settings->getAsConfigFile('TESTS_INSTALL_CONFIG_FILE');
+    if ( ! file_exists($installConfigFile)) {
+        $installConfigFile = $installConfigFile . '.dist';
+    }
+    $globalConfigFile = $settings->getAsConfigFile('TESTS_GLOBAL_CONFIG_FILE');
+    if ( ! file_exists($installConfigFile)) {
+        $installConfigFile = $installConfigFile . '.dist';
+    }
+    $dirList     = new \Magento\Framework\App\Filesystem\DirectoryList(BP);
+    $application = new \Magento\TestFramework\WebApiApplication(
+        $shell,
+        $dirList->getPath(DirectoryList::VAR_DIR),
+        $installConfigFile,
+        $globalConfigFile,
+        BP . '/app/etc/',
+        $settings->get('TESTS_MAGENTO_MODE'),
+        AutoloaderRegistry::getAutoloader()
+    );
+
+    if (defined('TESTS_MAGENTO_INSTALLATION') && TESTS_MAGENTO_INSTALLATION === 'enabled') {
+        if (defined('TESTS_CLEANUP') && TESTS_CLEANUP === 'enabled') {
+            $application->cleanup();
+        }
+        $application->install();
+    }
+
+    $bootstrap = new \Magento\TestFramework\Bootstrap(
+        $settings,
+        new \Magento\TestFramework\Bootstrap\Environment(),
+        new \Magento\TestFramework\Bootstrap\WebapiDocBlock("{$integrationTestsDir}/testsuite"),
+        new \Magento\TestFramework\Bootstrap\Profiler(new \Magento\Framework\Profiler\Driver\Standard()),
+        $shell,
+        $application,
+        new \Magento\TestFramework\Bootstrap\MemoryFactory($shell)
+    );
+    $bootstrap->runBootstrap();
+    $application->initialize();
+
+    \Magento\TestFramework\Helper\Bootstrap::setInstance(new \Magento\TestFramework\Helper\Bootstrap($bootstrap));
+    $dirSearch        = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+                                                               ->create(\Magento\Framework\Component\DirSearch::class);
+    $themePackageList = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+                                                               ->create(\Magento\Framework\View\Design\Theme\ThemePackageList::class);
+    \Magento\Framework\App\Utility\Files::setInstance(
+        new \Magento\Framework\App\Utility\Files(
+            new \Magento\Framework\Component\ComponentRegistrar(),
+            $dirSearch,
+            $themePackageList
+        )
+    );
+    unset($bootstrap, $application, $settings, $shell);
+} catch (\Exception $e) {
+    echo $e . PHP_EOL;
+    exit(1);
 }
-
-$bootstrap = new \Magento\TestFramework\Bootstrap(
-    $settings,
-    new \Magento\TestFramework\Bootstrap\Environment(),
-    new \Magento\TestFramework\Bootstrap\WebapiDocBlock("{$integrationTestsDir}/testsuite"),
-    new \Magento\TestFramework\Bootstrap\Profiler(new \Magento\Framework\Profiler\Driver\Standard()),
-    $shell,
-    $application,
-    new \Magento\TestFramework\Bootstrap\MemoryFactory($shell)
-);
-$bootstrap->runBootstrap();
-$application->initialize();
-
-\Magento\TestFramework\Helper\Bootstrap::setInstance(new \Magento\TestFramework\Helper\Bootstrap($bootstrap));
-$dirSearch = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
-    ->create(\Magento\Framework\Component\DirSearch::class);
-$themePackageList = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
-    ->create(\Magento\Framework\View\Design\Theme\ThemePackageList::class);
-\Magento\Framework\App\Utility\Files::setInstance(
-    new \Magento\Framework\App\Utility\Files(
-        new \Magento\Framework\Component\ComponentRegistrar(),
-        $dirSearch,
-        $themePackageList
-    )
-);
-unset($bootstrap, $application, $settings, $shell);
 
 /**
  * Set custom error handler

--- a/dev/tests/api-functional/framework/bootstrap.php
+++ b/dev/tests/api-functional/framework/bootstrap.php
@@ -22,9 +22,10 @@ try {
 
     if ($settings->get('TESTS_EXTRA_VERBOSE_LOG')) {
         $filesystem = new \Magento\Framework\Filesystem\Driver\File();
+        $exceptionHandler = new \Magento\Framework\Logger\Handler\Exception();
         $loggerHandlers = [
-            'system'    => new \Magento\Framework\Logger\Handler\System($filesystem),
-            'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem)
+            'system'    => new \Magento\Framework\Logger\Handler\System($filesystem, $exceptionHandler),
+            'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem, $exceptionHandler)
         ];
         $shell = new \Magento\Framework\Shell(
             new \Magento\Framework\Shell\CommandRenderer(),

--- a/dev/tests/api-functional/framework/bootstrap.php
+++ b/dev/tests/api-functional/framework/bootstrap.php
@@ -25,7 +25,7 @@ try {
         $exceptionHandler = new \Magento\Framework\Logger\Handler\Exception();
         $loggerHandlers = [
             'system'    => new \Magento\Framework\Logger\Handler\System($filesystem, $exceptionHandler),
-            'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem, $exceptionHandler)
+            'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem)
         ];
         $shell = new \Magento\Framework\Shell(
             new \Magento\Framework\Shell\CommandRenderer(),

--- a/dev/tests/integration/framework/bootstrap.php
+++ b/dev/tests/integration/framework/bootstrap.php
@@ -25,11 +25,14 @@ try {
     $settings = new \Magento\TestFramework\Bootstrap\Settings($testsBaseDir, get_defined_constants());
 
     if ($settings->get('TESTS_EXTRA_VERBOSE_LOG')) {
-        $logWriter = new \Zend_Log_Writer_Stream('php://output');
-        $logWriter->setFormatter(new \Zend_Log_Formatter_Simple('%message%' . PHP_EOL));
+        $filesystem = new \Magento\Framework\Filesystem\Driver\File();
+        $loggerHandlers = [
+            'system'    => new \Magento\Framework\Logger\Handler\System($filesystem),
+            'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem)
+        ];
         $shell = new \Magento\Framework\Shell(
             new \Magento\Framework\Shell\CommandRenderer(),
-            new \Zend_Log($logWriter)
+            new \Monolog\Logger('main', $loggerHandlers)
         );
     } else {
         $shell = new \Magento\Framework\Shell(new \Magento\Framework\Shell\CommandRenderer());

--- a/dev/tests/integration/framework/bootstrap.php
+++ b/dev/tests/integration/framework/bootstrap.php
@@ -26,7 +26,7 @@ try {
 
     if ($settings->get('TESTS_EXTRA_VERBOSE_LOG')) {
         $filesystem = new \Magento\Framework\Filesystem\Driver\File();
-        $exceptionHandler = new \Magento\Framework\Logger\Handler\Exception();
+        $exceptionHandler = new \Magento\Framework\Logger\Handler\Exception($filesystem);
         $loggerHandlers = [
             'system'    => new \Magento\Framework\Logger\Handler\System($filesystem, $exceptionHandler),
             'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem)

--- a/dev/tests/integration/framework/bootstrap.php
+++ b/dev/tests/integration/framework/bootstrap.php
@@ -26,9 +26,10 @@ try {
 
     if ($settings->get('TESTS_EXTRA_VERBOSE_LOG')) {
         $filesystem = new \Magento\Framework\Filesystem\Driver\File();
+        $exceptionHandler = new \Magento\Framework\Logger\Handler\Exception();
         $loggerHandlers = [
-            'system'    => new \Magento\Framework\Logger\Handler\System($filesystem),
-            'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem)
+            'system'    => new \Magento\Framework\Logger\Handler\System($filesystem, $exceptionHandler),
+            'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem, $exceptionHandler)
         ];
         $shell = new \Magento\Framework\Shell(
             new \Magento\Framework\Shell\CommandRenderer(),

--- a/dev/tests/integration/framework/bootstrap.php
+++ b/dev/tests/integration/framework/bootstrap.php
@@ -29,7 +29,7 @@ try {
         $exceptionHandler = new \Magento\Framework\Logger\Handler\Exception();
         $loggerHandlers = [
             'system'    => new \Magento\Framework\Logger\Handler\System($filesystem, $exceptionHandler),
-            'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem, $exceptionHandler)
+            'debug'     => new \Magento\Framework\Logger\Handler\Debug($filesystem)
         ];
         $shell = new \Magento\Framework\Shell(
             new \Magento\Framework\Shell\CommandRenderer(),

--- a/dev/tests/integration/phpunit.xml.dist
+++ b/dev/tests/integration/phpunit.xml.dist
@@ -61,6 +61,8 @@
         <!--<const name="TESTS_BAMBOO_PROFILER_FILE" value="profiler.csv"/>-->
         <!-- Metrics for Bamboo Profiler Output in PHP file that returns array -->
         <!--<const name="TESTS_BAMBOO_PROFILER_METRICS_FILE" value="../../build/profiler_metrics.php"/>-->
+        <!-- Whether to output all CLI commands executed by the bootstrap and tests -->
+        <const name="TESTS_EXTRA_VERBOSE_LOG" value="1"/>
         <!-- Magento mode for tests execution. Possible values are "default", "developer" and "production". -->
         <const name="TESTS_MAGENTO_MODE" value="developer"/>
         <!-- Minimum error log level to listen for. Possible values: -1 ignore all errors, and level constants form http://tools.ietf.org/html/rfc5424 standard -->

--- a/lib/internal/Magento/Framework/Shell.php
+++ b/lib/internal/Magento/Framework/Shell.php
@@ -15,7 +15,7 @@ class Shell implements ShellInterface
     /**
      * Logger instance
      *
-     * @var \Zend_Log
+     * @var \Psr\Log\LoggerInterface
      */
     protected $logger;
 
@@ -26,11 +26,11 @@ class Shell implements ShellInterface
 
     /**
      * @param CommandRendererInterface $commandRenderer
-     * @param \Zend_Log $logger Logger instance to be used to log commands and their output
+     * @param \Psr\Log\LoggerInterface $logger Logger instance to be used to log commands and their output
      */
     public function __construct(
         CommandRendererInterface $commandRenderer,
-        \Zend_Log $logger = null
+        \Psr\Log\LoggerInterface $logger = null
     ) {
         $this->logger = $logger;
         $this->commandRenderer = $commandRenderer;
@@ -76,7 +76,7 @@ class Shell implements ShellInterface
     protected function log($message)
     {
         if ($this->logger) {
-            $this->logger->log($message, \Zend_Log::INFO);
+            $this->logger->info($message);
         }
     }
 }

--- a/lib/internal/Magento/Framework/Test/Unit/ShellTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/ShellTest.php
@@ -16,14 +16,13 @@ class ShellTest extends \PHPUnit_Framework_TestCase
     protected $commandRenderer;
 
     /**
-     * @var \Zend_Log|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Psr\Log\LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $logger;
 
     protected function setUp()
     {
-        $this->logger = $this->getMockBuilder(\Zend_Log::class)
-            ->setMethods(['log'])
+        $this->logger = $this->getMockBuilder(\Psr\Log\LoggerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->commandRenderer = new \Magento\Framework\Shell\CommandRenderer();
@@ -72,8 +71,8 @@ class ShellTest extends \PHPUnit_Framework_TestCase
         foreach ($expectedLogRecords as $logRecordIndex => $expectedLogMessage) {
             $expectedLogMessage = str_replace('`', $quoteChar, $expectedLogMessage);
             $this->logger->expects($this->at($logRecordIndex))
-                ->method('log')
-                ->with($expectedLogMessage, \Zend_Log::INFO);
+                ->method('info')
+                ->with($expectedLogMessage);
         }
         $this->_testExecuteCommand(
             new \Magento\Framework\Shell($this->commandRenderer, $this->logger),


### PR DESCRIPTION
Replace `Zend_Log` with `Psr\Log\LoggerInterface` to prepare for upgrade to higher ZF versions.

### Description
I replaced `Zend_Log` with `Psr\Log\LoggerInterface` in Magento Framework. 

To simplify the conversion I changed method call
`$logger->log($message, \Zend_Log::INFO)` 
into
`$logger->info($message)`.

Obviously, I had to change the ShellTest a bit to make it compatible with the `Psr\Log\LoggerInterface`.

### Fixed Issues
1. magento/magento2#9237: Upgrade ZF components. Zend_Log

### Testing scenarios
Run the unit test `\Magento\Framework\Test\Unit\ShellTest`. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
