### PR TITLE
Deprecate unused navigation-menu.js file in blank theme

### DIFF
--- a/app/design/frontend/Magento/blank/web/js/navigation-menu.js
+++ b/app/design/frontend/Magento/blank/web/js/navigation-menu.js
@@ -2,7 +2,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
+/**
+ * @deprecated
+ * @see lib/web/mage/menu.js
+ */
 define([
     'jquery',
     'matchMedia',


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Deprecating unused `navigation-menu.js` file in the blank theme to comply with the backward compatibility policy mentioned by @okorshenko in #9035 
