### PR TITLE
Add "catalog_product_attribute_update_after" event back to Action

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Action.php
+++ b/app/code/Magento/Catalog/Model/Product/Action.php
@@ -112,6 +112,12 @@ class Action extends \Magento\Framework\Model\AbstractModel
         if (!$categoryIndexer->isScheduled()) {
             $categoryIndexer->reindexList(array_unique($productIds));
         }
+        
+        $this->_eventManager->dispatch(
+            'catalog_product_attribute_update_after',
+            ['product_ids' => $productIds]
+        );
+        
         return $this;
     }
 


### PR DESCRIPTION
This event existed in Magento 1.x and has been removed - this commit adds it back in, passing an array of product IDs for reference (original behaviour).

### Description
The `catalog_product_attribute_update_after` event existed in Magento 1.x and has been removed - this commit adds it back in, passing an array of product IDs for reference (original behaviour).

I'm unsure around the decisions for why this was removed, but this PR is in case it was a mistake.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - ~All new or changed code is covered with unit/integration tests (if applicable)~
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
