### PR TITLE
Remove php-5.6 environment from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     - postfix
 language: php
 php:
-  - 5.6.29
   - 7.0
 env:
   global:
@@ -30,12 +29,6 @@ cache:
     - $HOME/.nvm
     - $HOME/node_modules
     - $HOME/yarn.lock
-matrix:
-  exclude:
-    - php: 5.6.29
-      env: TEST_SUITE=static
-    - php: 5.6.29
-      env: TEST_SUITE=js
 before_install: ./dev/travis/before_install.sh
 install: composer install --no-interaction --prefer-dist
 before_script: ./dev/travis/before_script.sh


### PR DESCRIPTION
### Description
Removed php-5.6 environment from travis configuration since Magento 2.2 does not support it officially

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
