### PR TITLE
Improved check for attribute codes in "additional_attributes" field

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2201,9 +2201,13 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
      */
     public function retrieveAttributeByCode($attrCode)
     {
+        /** @var string $attrCode */
+        $attrCode = mb_strtolower($attrCode);
+
         if (!isset($this->_attributeCache[$attrCode])) {
             $this->_attributeCache[$attrCode] = $this->getResource()->getAttribute($attrCode);
         }
+
         return $this->_attributeCache[$attrCode];
     }
 
@@ -2537,6 +2541,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 continue;
             }
             list($code, $value) = explode(self::PAIR_NAME_VALUE_SEPARATOR, $attributeData, 2);
+            $code = mb_strtolower($code);
             $preparedAttributes[$code] = $value;
         }
         return $preparedAttributes;
@@ -2563,7 +2568,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     private function parseAttributesWithWrappedValues($attributesData)
     {
         $attributes = [];
-        preg_match_all('~((?:[a-z0-9_])+)="((?:[^"]|""|"' . $this->getMultiLineSeparatorForRegexp() . '")+)"+~',
+        preg_match_all('~((?:[a-zA-Z0-9_])+)="((?:[^"]|""|"' . $this->getMultiLineSeparatorForRegexp() . '")+)"+~',
             $attributesData,
             $matches
         );
@@ -2572,7 +2577,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
             $value = 'multiselect' != $attribute->getFrontendInput()
                 ? str_replace('""', '"', $matches[2][$i])
                 : '"' . $matches[2][$i] . '"';
-            $attributes[$attributeCode] = $value;
+            $attributes[mb_strtolower($attributeCode)] = $value;
         }
         return $attributes;
     }


### PR DESCRIPTION
This PR adds the capability to handle uppercased attribute codes in "additional_attributes" field.
Assume that you have this content in additional_attributes field: 

attributecode1=value1,ATTRIBUTECODE2=value2

and in your database both attributes have code in lowercase.
With current behavior the second attribute is skipped, with this PR the system also handles the second attribute without skipping it.

I've added also two new test cases to test both methods `parseAttributesWithoutWrappedValues` and `parseAttributesWithWrappedValues`