### PR TITLE
Fixed coding standard violations in the Framework\Module namespace 

### DIFF
--- a/lib/internal/Magento/Framework/Module/ModuleResource.php
+++ b/lib/internal/Magento/Framework/Module/ModuleResource.php
@@ -4,14 +4,14 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Module;
+
+use \Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
 /**
  * Resource Model
  */
-class ModuleResource extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implements \Magento\Framework\Module\ResourceInterface
+class ModuleResource extends AbstractDb implements ResourceInterface
 {
     /**
      * Database versions
@@ -49,7 +49,9 @@ class ModuleResource extends \Magento\Framework\Model\ResourceModel\Db\AbstractD
      */
     protected function _loadVersion($needType)
     {
-        if ($needType == 'db' && is_null(self::$schemaVersions) || $needType == 'data' && is_null(self::$dataVersions)) {
+        if ($needType == 'db' && self::$schemaVersions === null ||
+            $needType == 'data' && self::$dataVersions === null
+        ) {
             self::$schemaVersions = [];
             // Db version column always exists
             self::$dataVersions = null;
@@ -61,7 +63,7 @@ class ModuleResource extends \Magento\Framework\Model\ResourceModel\Db\AbstractD
                 foreach ($rowset as $row) {
                     self::$schemaVersions[$row['module']] = $row['schema_version'];
                     if (array_key_exists('data_version', $row)) {
-                        if (is_null(self::$dataVersions)) {
+                        if (self::$dataVersions === null) {
                             self::$dataVersions = [];
                         }
                         self::$dataVersions[$row['module']] = $row['data_version'];

--- a/lib/internal/Magento/Framework/Module/Setup/MigrationFactory.php
+++ b/lib/internal/Magento/Framework/Module/Setup/MigrationFactory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Module\Setup;
 
 /**


### PR DESCRIPTION
Fixed coding standard violation in the Framework\Module namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:

- Removed the @codingStandardsIgnoreFile from the head of the file.
- Fixed line length
- Changed is_null to === null comparison