### PR TITLE
Fixed coding standard violations in the Framework namespace 

### DIFF
--- a/lib/internal/Magento/Framework/CurrencyFactory.php
+++ b/lib/internal/Magento/Framework/CurrencyFactory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework;
 
 class CurrencyFactory
@@ -24,8 +22,10 @@ class CurrencyFactory
      * @param ObjectManagerInterface $objectManager
      * @param string $instanceName
      */
-    public function __construct(ObjectManagerInterface $objectManager, $instanceName = CurrencyInterface::class)
-    {
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        $instanceName = CurrencyInterface::class
+    ) {
         $this->_objectManager = $objectManager;
         $this->_instanceName = $instanceName;
     }

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework;
 
 use Magento\Framework\App\ObjectManager;
@@ -43,6 +41,7 @@ use Magento\Framework\Url\HostChecker;
  * - query_array: array('param1'=>'value1', 'param2'=>'value2')
  * - fragment: (#)'fragment-anchor'
  *
+ * @codingStandardsIgnoreStart
  * URL structure:
  *
  * https://user:password@host:443/base_path/[base_script][scopeview_path]route_name/controller_name/action_name/param1/value1?query_param=query_value#fragment
@@ -50,6 +49,7 @@ use Magento\Framework\Url\HostChecker;
  * \__________________C___________________/              \__________________D_________________/ \_____E_____/
  * \_____________F______________/                        \___________________________G______________________/
  * \___________________________________________________H____________________________________________________/
+ * @codingStandardsIgnoreEnd
  *
  * - A: authority
  * - B: path
@@ -145,6 +145,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
      * @var \Magento\Framework\Url\RouteParamsResolverFactory
      */
     private $_routeParamsResolverFactory;
+
     /**
      * @var \Magento\Framework\Url\ScopeResolverInterface
      */
@@ -290,7 +291,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
      */
     public function getUseSession()
     {
-        if (is_null($this->_useSession)) {
+        if ($this->_useSession === null) {
             $this->_useSession = $this->_sidResolver->getUseSessionInUrl();
         }
         return $this->_useSession;
@@ -305,7 +306,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
      */
     public function getConfigData($key, $prefix = null)
     {
-        if (is_null($prefix)) {
+        if ($prefix === null) {
             $prefix = 'web/' . ($this->_isSecure() ? 'secure' : 'unsecure') . '/';
         }
         $path = $prefix . $key;
@@ -583,7 +584,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             $routePath = $this->_getActionPath();
             if ($this->_getRouteParams()) {
                 foreach ($this->_getRouteParams() as $key => $value) {
-                    if (is_null($value) || false === $value || '' === $value || !is_scalar($value)) {
+                    if ($value === null || false === $value || '' === $value || !is_scalar($value)) {
                         continue;
                     }
                     $routePath .= $key . '/' . $value . '/';
@@ -855,7 +856,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             );
         }
 
-        if(!$isCached) {
+        if (!$isCached) {
             return $this->getUrlModifier()->execute(
                 $this->createUrl($routePath, $routeParams)
             );
@@ -953,7 +954,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             $this->_queryParamsResolver->unsetData('query_params');
         }
 
-        if (!is_null($fragment)) {
+        if ($fragment !== null) {
             $url .= '#' . $this->getEscaper()->encodeUrlParam($fragment);
         }
         $this->getRouteParamsResolver()->unsetData('secure');
@@ -1065,7 +1066,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             function ($match) {
                 if ($this->useSessionIdForUrl($match[2] == 'S' ? true : false)) {
                     return $match[1] . $this->_sidResolver->getSessionIdQueryParam($this->_session) . '='
-                    . $this->_session->getSessionId() . (isset($match[3]) ? $match[3] : '');
+                        . $this->_session->getSessionId() . (isset($match[3]) ? $match[3] : '');
                 } else {
                     if ($match[1] == '?') {
                         return isset($match[3]) ? '?' : '';
@@ -1087,9 +1088,12 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
     public function useSessionIdForUrl($secure = false)
     {
         $key = 'use_session_id_for_url_' . (int)$secure;
-        if (is_null($this->getData($key))) {
+        if ($this->getData($key) === null) {
             $httpHost = $this->_request->getHttpHost();
-            $urlHost = parse_url($this->_getScope()->getBaseUrl(UrlInterface::URL_TYPE_LINK, $secure), PHP_URL_HOST);
+            $urlHost = parse_url(
+                $this->_getScope()->getBaseUrl(UrlInterface::URL_TYPE_LINK, $secure),
+                PHP_URL_HOST
+            );
 
             if ($httpHost != $urlHost) {
                 $this->setData($key, true);
@@ -1192,7 +1196,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
     {
         if ($this->escaper == null) {
             $this->escaper = \Magento\Framework\App\ObjectManager::getInstance()
-                    ->get(\Magento\Framework\Escaper::class);
+                ->get(\Magento\Framework\Escaper::class);
         }
         return $this->escaper;
     }

--- a/lib/internal/Magento/Framework/UrlFactory.php
+++ b/lib/internal/Magento/Framework/UrlFactory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework;
 
 class UrlFactory
@@ -24,8 +22,10 @@ class UrlFactory
      * @param ObjectManagerInterface $objectManager
      * @param string $instanceName
      */
-    public function __construct(ObjectManagerInterface $objectManager, $instanceName = UrlInterface::class)
-    {
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        $instanceName = UrlInterface::class
+    ) {
         $this->_objectManager = $objectManager;
         $this->_instanceName = $instanceName;
     }


### PR DESCRIPTION
Fixed coding standard violation in the Framework namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:

- Removed the @codingStandardsIgnoreFile from the head of the file.
- Fixed line length (expect command in the Url class where the comment is to long, so ignoring that specific line)
- Fixed identation
- Changed all is_null functions to a === null compare.