### PR TITLE
Fixed coding standard violations in all Factory classes located in app/code

### DIFF
--- a/app/code/Magento/Catalog/Model/Factory.php
+++ b/app/code/Magento/Catalog/Model/Factory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Model factory
  */

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Dynamic/AlgorithmFactory.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Dynamic/AlgorithmFactory.php
@@ -49,8 +49,8 @@ class AlgorithmFactory
     public function __construct(
         ObjectManagerInterface $objectManager,
         ScopeConfigInterface $scopeConfig,
-        array $algorithms)
-    {
+        array $algorithms
+    ) {
         $this->objectManager = $objectManager;
         $this->scopeConfig = $scopeConfig;
         $this->algorithms = $algorithms;

--- a/app/code/Magento/Catalog/Model/Layer/Filter/Dynamic/AlgorithmFactory.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/Dynamic/AlgorithmFactory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Catalog\Model\Layer\Filter\Dynamic;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -48,7 +46,10 @@ class AlgorithmFactory
      * @param ScopeConfigInterface $scopeConfig
      * @param array $algorithms
      */
-    public function __construct(ObjectManagerInterface $objectManager, ScopeConfigInterface $scopeConfig, array $algorithms)
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        ScopeConfigInterface $scopeConfig,
+        array $algorithms)
     {
         $this->objectManager = $objectManager;
         $this->scopeConfig = $scopeConfig;
@@ -64,7 +65,10 @@ class AlgorithmFactory
      */
     public function create(array $data = [])
     {
-        $calculationType = $this->scopeConfig->getValue(self::XML_PATH_RANGE_CALCULATION, ScopeInterface::SCOPE_STORE);
+        $calculationType = $this->scopeConfig->getValue(
+            self::XML_PATH_RANGE_CALCULATION,
+            ScopeInterface::SCOPE_STORE
+        );
 
         if (!isset($this->algorithms[$calculationType])) {
             throw new LocalizedException(__('%1 was not found in algorithms', $calculationType));

--- a/app/code/Magento/Catalog/Model/Template/Filter/Factory.php
+++ b/app/code/Magento/Catalog/Model/Template/Filter/Factory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Template filter factory
  */

--- a/app/code/Magento/Customer/Model/Metadata/ElementFactory.php
+++ b/app/code/Magento/Customer/Model/Metadata/ElementFactory.php
@@ -1,27 +1,21 @@
 <?php
 /**
- * Customer Form Element Factory
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
+/**
+ * Customer Form Element Factory
+ */
 namespace Magento\Customer\Model\Metadata;
 
 class ElementFactory
 {
     const OUTPUT_FORMAT_JSON = 'json';
-
     const OUTPUT_FORMAT_TEXT = 'text';
-
     const OUTPUT_FORMAT_HTML = 'html';
-
     const OUTPUT_FORMAT_PDF = 'pdf';
-
     const OUTPUT_FORMAT_ONELINE = 'oneline';
-
     const OUTPUT_FORMAT_ARRAY = 'array';
 
     // available only for multiply attributes
@@ -40,8 +34,10 @@ class ElementFactory
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Framework\Stdlib\StringUtils $string
      */
-    public function __construct(\Magento\Framework\ObjectManagerInterface $objectManager, \Magento\Framework\Stdlib\StringUtils $string)
-    {
+    public function __construct(
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        \Magento\Framework\Stdlib\StringUtils $string
+    ) {
         $this->_objectManager = $objectManager;
         $this->_string = $string;
     }
@@ -64,7 +60,7 @@ class ElementFactory
         $dataModelClass = $attribute->getDataModel();
         $params = [
             'entityTypeCode' => $entityTypeCode,
-            'value' => is_null($value) ? false : $value,
+            'value' => $value === null ? false : $value,
             'isAjax' => $isAjax,
             'attribute' => $attribute,
         ];

--- a/app/code/Magento/Eav/Model/AttributeDataFactory.php
+++ b/app/code/Magento/Eav/Model/AttributeDataFactory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Eav\Model;
 
 /**
@@ -16,15 +14,10 @@ namespace Magento\Eav\Model;
 class AttributeDataFactory
 {
     const OUTPUT_FORMAT_JSON = 'json';
-
     const OUTPUT_FORMAT_TEXT = 'text';
-
     const OUTPUT_FORMAT_HTML = 'html';
-
     const OUTPUT_FORMAT_PDF = 'pdf';
-
     const OUTPUT_FORMAT_ONELINE = 'oneline';
-
     const OUTPUT_FORMAT_ARRAY = 'array';
 
     // available only for multiply attributes

--- a/app/code/Magento/ImportExport/Model/Export/Entity/Factory.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/Factory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Export entity factory
  */
@@ -30,7 +28,7 @@ class Factory
 
     /**
      * @param string $className
-     * @return \Magento\ImportExport\Model\Export\Entity\AbstractEntity|\Magento\ImportExport\Model\Export\AbstractEntity
+     * @return AbstractEntity|\Magento\ImportExport\Model\Export\AbstractEntity
      * @throws \InvalidArgumentException
      */
     public function create($className)

--- a/app/code/Magento/ImportExport/Model/Import/Entity/Factory.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/Factory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Import entity factory
  */
@@ -30,7 +28,7 @@ class Factory
 
     /**
      * @param string $className
-     * @return \Magento\ImportExport\Model\Import\Entity\AbstractEntity|\Magento\ImportExport\Model\Import\AbstractEntity
+     * @return AbstractEntity|\Magento\ImportExport\Model\Import\AbstractEntity
      * @throws \InvalidArgumentException
      */
     public function create($className)

--- a/app/code/Magento/Vault/Api/Data/PaymentTokenInterfaceFactory.php
+++ b/app/code/Magento/Vault/Api/Data/PaymentTokenInterfaceFactory.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-// @codingStandardsIgnoreFile
+
 namespace Magento\Vault\Api\Data;
 
 /**

--- a/app/code/Magento/Vault/Api/Data/PaymentTokenInterfaceFactory.php
+++ b/app/code/Magento/Vault/Api/Data/PaymentTokenInterfaceFactory.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
+// @codingStandardsIgnoreFile
 namespace Magento\Vault\Api\Data;
 
 /**


### PR DESCRIPTION
Fixed coding standard violation for all factory classes in the app/code folder, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:

- Removed the @codingStandardsIgnoreFile from the head of the file.
- Fixed line length
- Changed is_null function to a === null compare.
- Grouped the same constants together