### PR TITLE
Remove unnecessary FQCN in ObserverInterface

### DIFF
--- a/lib/internal/Magento/Framework/Event/ObserverInterface.php
+++ b/lib/internal/Magento/Framework/Event/ObserverInterface.php
@@ -13,5 +13,5 @@ interface ObserverInterface
      * @param Observer $observer
      * @return void
      */
-    public function execute(\Magento\Framework\Event\Observer $observer);
+    public function execute(Observer $observer);
 }


### PR DESCRIPTION
Removes an unnecessary FQCN. In some IDEs this was causing problems with auto-completion.
