### PR TITLE
Support null value for custom attributes.

### DIFF
--- a/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
@@ -260,7 +260,7 @@ class ServiceInputProcessor implements ServicePayloadConverterInterface
             throw new SerializationException(new Phrase('There is an empty custom attribute specified.'));
         } elseif (!$customAttributeCode) {
             throw new SerializationException(new Phrase('A custom attribute is specified without an attribute code.'));
-        } elseif (!isset($customAttribute[AttributeValue::VALUE])) {
+        } elseif (!array_key_exists(AttributeValue::VALUE, $customAttribute)) {
             throw new SerializationException(
                 new Phrase('Value is not set for attribute code "' . $customAttributeCode . '"')
             );


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This pull request add `null` value support for custom attributes of web api. Previously, providing `null` value to custom attribute `xyz` will get exception `Value is not set for attribute code xyz`. The exception is caused by using `!isset` to examine whether a value exists. `!isset` return true when value is `null`.

With this pull request, `!array_key_exists` will be used instead of `!isset`. This makes`null` value also work for custom attributes.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
