### PR TITLE
Fixed coding standard violations in the Framework\Backup namespace

### DIFF
--- a/lib/internal/Magento/Framework/Backup/Archive/Tar.php
+++ b/lib/internal/Magento/Framework/Backup/Archive/Tar.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Extended version of \Magento\Framework\Archive\Tar that supports filtering
  *
@@ -23,14 +21,15 @@ class Tar extends \Magento\Framework\Archive\Tar
     protected $_skipFiles = [];
 
     /**
-     * Overridden \Magento\Framework\Archive\Tar::_createTar method that does the same actions as it's parent but filters
-     * files using \Magento\Framework\Backup\Filesystem\Iterator\Filter
+     * Overridden \Magento\Framework\Archive\Tar::_createTar method that does the same actions as it's parent but
+     * filters files using \Magento\Framework\Backup\Filesystem\Iterator\Filter
      *
      * @param bool $skipRoot
      * @param bool $finalize
      * @return void
      *
      * @see \Magento\Framework\Archive\Tar::_createTar()
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function _createTar($skipRoot = false, $finalize = false)
     {
@@ -41,7 +40,10 @@ class Tar extends \Magento\Framework\Archive\Tar
             \RecursiveIteratorIterator::SELF_FIRST
         );
 
-        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter($filesystemIterator, $this->_skipFiles);
+        $iterator = new \Magento\Framework\Backup\Filesystem\Iterator\Filter(
+            $filesystemIterator,
+            $this->_skipFiles
+        );
 
         foreach ($iterator as $item) {
             $this->_setCurrentFile($item->getPathname());

--- a/lib/internal/Magento/Framework/Backup/Db/BackupFactory.php
+++ b/lib/internal/Magento/Framework/Backup/Db/BackupFactory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Backup\Db;
 
 class BackupFactory
@@ -32,8 +30,11 @@ class BackupFactory
      * @param string $backupInstanceName
      * @param string $backupDbInstanceName
      */
-    public function __construct(\Magento\Framework\ObjectManagerInterface $objectManager, $backupInstanceName, $backupDbInstanceName)
-    {
+    public function __construct(
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        $backupInstanceName,
+        $backupDbInstanceName
+    ) {
         $this->_objectManager = $objectManager;
         $this->_backupInstanceName = $backupInstanceName;
         $this->_backupDbInstanceName = $backupDbInstanceName;

--- a/lib/internal/Magento/Framework/Backup/Factory.php
+++ b/lib/internal/Magento/Framework/Backup/Factory.php
@@ -1,13 +1,12 @@
 <?php
 /**
- * Backup object factory.
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
+/**
+ * Backup object factory.
+ */
 namespace Magento\Framework\Backup;
 
 class Factory

--- a/lib/internal/Magento/Framework/Backup/Filesystem.php
+++ b/lib/internal/Magento/Framework/Backup/Filesystem.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Backup;
 
 use Magento\Framework\App\ObjectManager;
@@ -108,7 +106,8 @@ class Filesystem extends AbstractBackup
 
         $filesInfo = $fsHelper->getInfo(
             $this->getRootDir(),
-            \Magento\Framework\Backup\Filesystem\Helper::INFO_READABLE | \Magento\Framework\Backup\Filesystem\Helper::INFO_SIZE,
+            \Magento\Framework\Backup\Filesystem\Helper::INFO_READABLE |
+            \Magento\Framework\Backup\Filesystem\Helper::INFO_SIZE,
             $this->getIgnorePaths()
         );
 
@@ -162,8 +161,8 @@ class Filesystem extends AbstractBackup
         if ($requiredSpace > $freeSpace) {
             throw new \Magento\Framework\Backup\Exception\NotEnoughFreeSpace(
                 new \Magento\Framework\Phrase(
-                'Warning: necessary space for backup is ' . (ceil($requiredSpace) / 1024)
-                . 'MB, but your free disc space is ' . (ceil($freeSpace) / 1024) . 'MB.'
+                    'Warning: necessary space for backup is ' . (ceil($requiredSpace) / 1024)
+                    . 'MB, but your free disc space is ' . (ceil($freeSpace) / 1024) . 'MB.'
                 )
             );
         }


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Backup namespace, so that they will be included in the CI tools. Fixed the following:
- Removed @codingStandardsIgnoreFile from the head of the files.
- Fixed line length
- Fixed identation
- Changed class comment to the top of the class where it is in every other file instead of the top of the file.
