### PR TITLE
Fixed coding standard violations in the Framework\Api namespace

### DIFF
--- a/lib/internal/Magento/Framework/Api/Test/Unit/Api/ImageContentValidatorTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/Api/ImageContentValidatorTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Api\Test\Unit\Api;
 
 /**

--- a/lib/internal/Magento/Framework/Api/Test/Unit/Api/ImageProcessorTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/Api/ImageProcessorTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Api\Test\Unit\Api;
 
 /**
@@ -67,7 +65,8 @@ class ImageProcessorTest extends \PHPUnit_Framework_TestCase
             ->method('getDirectoryWrite')
             ->willReturn($this->directoryWriteMock);
         $this->contentValidatorMock = $this->getMockBuilder(
-            \Magento\Framework\Api\ImageContentValidatorInterface::class)
+            \Magento\Framework\Api\ImageContentValidatorInterface::class
+        )
             ->disableOriginalConstructor()
             ->getMock();
         $this->dataObjectHelperMock = $this->getMockBuilder(\Magento\Framework\Api\DataObjectHelper::class)

--- a/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/ExtensionAttributesGeneratorTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/ExtensionAttributesGeneratorTest.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-// @codingStandardsIgnoreFile
+
 namespace Magento\Framework\Api\Test\Unit\Code\Generator;
 
 use Magento\Framework\Api\ExtensionAttribute\Config\Converter;

--- a/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/ExtensionAttributesInterfaceGeneratorTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/ExtensionAttributesInterfaceGeneratorTest.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-// @codingStandardsIgnoreFile
+
 namespace Magento\Framework\Api\Test\Unit\Code\Generator;
 
 use Magento\Framework\Api\ExtensionAttribute\Config\Converter;

--- a/lib/internal/Magento/Framework/Api/Test/Unit/DataObjectHelperTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/DataObjectHelperTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Api\Test\Unit;
 
 use Magento\Framework\Api\CustomAttributesDataInterface;
@@ -144,7 +142,8 @@ class DataObjectHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->dataObjectHelper->populateWithArray(
             $addressDataObject,
-            $data, \Magento\Customer\Api\Data\AddressInterface::class
+            $data,
+            \Magento\Customer\Api\Data\AddressInterface::class
         );
 
         $this->assertEquals($id, $addressDataObject->getId());
@@ -198,7 +197,8 @@ class DataObjectHelperTest extends \PHPUnit_Framework_TestCase
             ->willReturn($customAttribute);
         $this->dataObjectHelper->populateWithArray(
             $addressDataObject,
-            $data, \Magento\Customer\Api\Data\AddressInterface::class
+            $data,
+            \Magento\Customer\Api\Data\AddressInterface::class
         );
 
         $this->assertEquals($id, $addressDataObject->getId());
@@ -260,7 +260,8 @@ class DataObjectHelperTest extends \PHPUnit_Framework_TestCase
             ->willReturn($customAttribute);
         $this->dataObjectHelper->populateWithArray(
             $addressDataObject,
-            $data, \Magento\Customer\Api\Data\AddressInterface::class
+            $data,
+            \Magento\Customer\Api\Data\AddressInterface::class
         );
 
         $this->assertEquals($id, $addressDataObject->getId());


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Api namespace, so that they will be included in the CI tools. Fixed the following:
- Removed @codingStandardsIgnoreFile from the head of the files.
- Fixed multiple arguments on the same line
- Fixed closing function call on correct line