### PR TITLE
Fixed coding standard violations in the Framework\Autoload, Framework\Session & Framework\Webapi namespaces

### DIFF
--- a/lib/internal/Magento/Framework/Autoload/Test/Unit/ClassLoaderWrapperTest.php
+++ b/lib/internal/Magento/Framework/Autoload/Test/Unit/ClassLoaderWrapperTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Autoload\Test\Unit;
 
 use Composer\Autoload\ClassLoader;
@@ -32,7 +30,8 @@ class ClassLoaderWrapperTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->autoloaderMock = $this->getMock(\Composer\Autoload\ClassLoader::class);
-        $this->model = (new ObjectManager($this))->getObject(\Magento\Framework\Autoload\ClassLoaderWrapper::class,
+        $this->model = (new ObjectManager($this))->getObject(
+            \Magento\Framework\Autoload\ClassLoaderWrapper::class,
             [
                 'autoloader' => $this->autoloaderMock
             ]

--- a/lib/internal/Magento/Framework/Session/Test/Unit/ConfigTest.php
+++ b/lib/internal/Magento/Framework/Session/Test/Unit/ConfigTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Test class for \Magento\Framework\Session\Config
  */

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceInputProcessorTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceInputProcessorTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Webapi\Test\Unit;
 
 use Magento\Framework\Serialize\SerializerInterface;
@@ -68,7 +66,8 @@ class ServiceInputProcessorTest extends \PHPUnit_Framework_TestCase
         $cache->expects($this->any())->method('load')->willReturn(false);
 
         $this->customAttributeTypeLocator = $this->getMockBuilder(
-            \Magento\Eav\Model\EavCustomAttributeTypeLocator::class)
+            \Magento\Eav\Model\EavCustomAttributeTypeLocator::class
+        )
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -472,7 +471,7 @@ class ServiceInputProcessorTest extends \PHPUnit_Framework_TestCase
     {
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $customAttributeValue = null;
-        switch($type) {
+        switch ($type) {
             case 'integer':
                 $customAttributeValue = $value;
                 break;


### PR DESCRIPTION
Fixed coding standard in Framework\Autoload, Framework\Session, Framework\Webapi namepsaces. Made the following changes: 
- Removed @codingStandardsIgnoreFile from the head of the file.
- Fixed identation