### PR TITLE
Page meta title fix in case breadcrumb section is removed via XML

### DIFF
--- a/app/code/Magento/Catalog/Block/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/Block/Breadcrumbs.php
@@ -54,6 +54,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      */
     protected function _prepareLayout()
     {
+        $title = [];
         if ($breadcrumbsBlock = $this->getLayout()->getBlock('breadcrumbs')) {
             $breadcrumbsBlock->addCrumb(
                 'home',
@@ -64,7 +65,6 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
                 ]
             );
 
-            $title = [];
             $path = $this->_catalogData->getBreadcrumbPath();
 
             foreach ($path as $name => $breadcrumb) {
@@ -73,16 +73,18 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
             }
 
             $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
-        } else {
-            $title = [];
-            $path = $this->_catalogData->getBreadcrumbPath();
 
-            foreach ($path as $name => $breadcrumb) {
-                $title[] = $breadcrumb['label'];
-            }
-
-            $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
+            return parent::_prepareLayout();
         }
+
+        $path = $this->_catalogData->getBreadcrumbPath();
+
+        foreach ($path as $name => $breadcrumb) {
+            $title[] = $breadcrumb['label'];
+        }
+
+        $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
+
         return parent::_prepareLayout();
     }
 }

--- a/app/code/Magento/Catalog/Block/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/Block/Breadcrumbs.php
@@ -73,6 +73,15 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
             }
 
             $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
+        } else {
+            $title = [];
+            $path = $this->_catalogData->getBreadcrumbPath();
+
+            foreach ($path as $name => $breadcrumb) {
+                $title[] = $breadcrumb['label'];
+            }
+
+            $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
         }
         return parent::_prepareLayout();
     }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Page meta title is visible only if *breadcrumbs* block is defined (not removed) in XML. If you remove it, page meta title disappears from category view and product view page.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4427:SEO/HEAD - Meta title is null when breadcrumb section is removed via XML

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Remove *breadcrumbs* block in XML `<referenceBlock name="breadcrumbs" remove="true"/>`
2. Go to the category view or product view page
3. Check Page title in browser tab

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
