### PR TITLE
Fixed coding standard violations in the Framework\Config namespace 

### DIFF
--- a/lib/internal/Magento/Framework/Config/Dom.php
+++ b/lib/internal/Magento/Framework/Config/Dom.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Magento configuration XML DOM utility
  */
@@ -120,7 +118,7 @@ class Dom
     /**
      * Retrieve array of xml errors
      *
-     * @param $errorFormat
+     * @param string $errorFormat
      * @return string[]
      */
     private static function getXmlErrors($errorFormat)
@@ -172,14 +170,14 @@ class Dom
         if ($matchedNode) {
             //different node type
             if ($this->typeAttributeName && $node->hasAttribute(
-                $this->typeAttributeName
-            ) && $matchedNode->hasAttribute(
-                $this->typeAttributeName
-            ) && $node->getAttribute(
-                $this->typeAttributeName
-            ) !== $matchedNode->getAttribute(
-                $this->typeAttributeName
-            )
+                    $this->typeAttributeName
+                ) && $matchedNode->hasAttribute(
+                    $this->typeAttributeName
+                ) && $node->getAttribute(
+                    $this->typeAttributeName
+                ) !== $matchedNode->getAttribute(
+                    $this->typeAttributeName
+                )
             ) {
                 $parentMatchedNode = $this->_getMatchedNode($parentPath);
                 $newNode = $this->dom->importNode($node, true);
@@ -247,7 +245,7 @@ class Dom
      */
     protected function _getNodePathByParent(\DOMElement $node, $parentPath)
     {
-        $prefix = is_null($this->rootNamespace) ? '' : self::ROOT_NAMESPACE_PREFIX . ':';
+        $prefix = $this->rootNamespace === null ? '' : self::ROOT_NAMESPACE_PREFIX . ':';
         $path = $parentPath . '/' . $prefix . $node->tagName;
         $idAttribute = $this->nodeMergingConfig->getIdAttribute($path);
         if (is_array($idAttribute)) {
@@ -441,7 +439,7 @@ class Dom
      */
     private function _getAttributeName($attribute)
     {
-        if (!is_null($attribute->prefix) && !empty($attribute->prefix)) {
+        if ($attribute->prefix !== null && !empty($attribute->prefix)) {
             $attributeName = $attribute->prefix . ':' . $attribute->name;
         } else {
             $attributeName = $attribute->name;

--- a/lib/internal/Magento/Framework/Config/Dom.php
+++ b/lib/internal/Magento/Framework/Config/Dom.php
@@ -169,15 +169,10 @@ class Dom
         /* Update matched node attributes and value */
         if ($matchedNode) {
             //different node type
-            if ($this->typeAttributeName && $node->hasAttribute(
-                    $this->typeAttributeName
-                ) && $matchedNode->hasAttribute(
-                    $this->typeAttributeName
-                ) && $node->getAttribute(
-                    $this->typeAttributeName
-                ) !== $matchedNode->getAttribute(
-                    $this->typeAttributeName
-                )
+            if ($this->typeAttributeName &&
+                $node->hasAttribute($this->typeAttributeName) &&
+                $matchedNode->hasAttribute($this->typeAttributeName) &&
+                $node->getAttribute($this->typeAttributeName) !== $matchedNode->getAttribute($this->typeAttributeName)
             ) {
                 $parentMatchedNode = $this->_getMatchedNode($parentPath);
                 $newNode = $this->dom->importNode($node, true);

--- a/lib/internal/Magento/Framework/Config/Test/Unit/Composer/PackageTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/Composer/PackageTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Config\Test\Unit\Composer;
 
 use \Magento\Framework\Config\Composer\Package;

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
@@ -8,7 +8,7 @@ namespace Magento\Framework\Config\Test\Unit;
 
 class DataTest extends \PHPUnit_Framework_TestCase
 {
-   /**
+    /**
      * @var \Magento\Framework\Config\ReaderInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $readerMock;

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Config\Test\Unit;
 
 class DataTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Config namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile at the head of the files
- Fixed indentation
- Changed is_null call to the === null compare
