### PR TITLE
Fixed coding standard violations in the Framework\Stdlib namespace

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Stdlib\DateTime;
 
 /**

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/Cookie/CookieScopeTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/Cookie/CookieScopeTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Stdlib\Test\Unit\Cookie;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
@@ -117,7 +115,8 @@ class CookieScopeTest extends \PHPUnit_Framework_TestCase
                 SensitiveCookieMetadata::KEY_HTTP_ONLY => true,
                 SensitiveCookieMetadata::KEY_SECURE => true,
             ],
-            $cookieScope->getSensitiveCookieMetadata()->__toArray());
+            $cookieScope->getSensitiveCookieMetadata()->__toArray()
+        );
     }
 
     /**

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/Cookie/PhpCookieManagerTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/Cookie/PhpCookieManagerTest.php
@@ -4,19 +4,18 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 // @codingStandardsIgnoreStart
 namespace {
     $mockTranslateSetCookie = false;
 }
 
-namespace Magento\Framework\Stdlib\Test\Unit\Cookie {
-    // @codingStandardsIgnoreEnd
+namespace Magento\Framework\Stdlib\Test\Unit\Cookie
+{
     use Magento\Framework\Stdlib\Cookie\PhpCookieManager;
     use Magento\Framework\Exception\InputException;
     use Magento\Framework\Stdlib\Cookie\FailureToSendException;
     use Magento\Framework\Stdlib\Cookie\CookieSizeLimitReachedException;
+    // @codingStandardsIgnoreEnd
 
     /**
      * Test PhpCookieManager
@@ -49,7 +48,7 @@ namespace Magento\Framework\Stdlib\Test\Unit\Cookie {
         /**
          * Mapping from constant names to functions that handle the assertions.
          */
-        static $functionTestAssertionMapping = [
+        protected static $functionTestAssertionMapping = [
             self::DELETE_COOKIE_NAME => 'self::assertDeleteCookie',
             self::DELETE_COOKIE_NAME_NO_METADATA => 'self::assertDeleteCookieWithNoMetadata',
             self::SENSITIVE_COOKIE_NAME_NO_METADATA_HTTPS => 'self::assertSensitiveCookieWithNoMetaDataHttps',
@@ -75,6 +74,7 @@ namespace Magento\Framework\Stdlib\Test\Unit\Cookie {
          * @var \Magento\Framework\Stdlib\Cookie\PhpCookieManager
          */
         protected $cookieManager;
+
         /**
          * @var \PHPUnit_Framework_MockObject_MockObject|CookieScopeInterface
          */
@@ -233,7 +233,7 @@ namespace Magento\Framework\Stdlib\Test\Unit\Cookie {
                     [
                         'request' => $this->requestMock
                     ]
-                 );
+                );
             $this->scopeMock->expects($this->once())
                 ->method('getSensitiveCookieMetadata')
                 ->with()


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Stdlib namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile at the head of the files
- Fixed indentation
- Fixed class property which type was not defined.
- Wrapped header of PhpCookieManagerTest with a codingstandardignorestart and end, because another namespace is given in the same class file, which is not allowed by PSR-2