### PR TITLE
Fixed coding standard violations in the Framework\Data namespace

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
@@ -260,9 +260,9 @@ class Editor extends Textarea
             $buttonsHtml .= $this->_getButtonHtml(
                 [
                     'title' => $this->translate('Insert Widget...'),
-                    'onclick' => "widgetTools.openDialog('" . $this->getConfig(
-                            'widget_window_url'
-                        ) . "widget_target_id/" . $this->getHtmlId() . "')",
+                    'onclick' => "widgetTools.openDialog('"
+                        . $this->getConfig('widget_window_url')
+                        . "widget_target_id/" . $this->getHtmlId() . "')",
                     'class' => 'action-add-widget plugin',
                     'style' => $visible ? '' : 'display:none',
                 ]
@@ -274,13 +274,12 @@ class Editor extends Textarea
             $buttonsHtml .= $this->_getButtonHtml(
                 [
                     'title' => $this->translate('Insert Image...'),
-                    'onclick' => "MediabrowserUtility.openDialog('" . $this->getConfig(
-                            'files_browser_window_url'
-                        ) . "target_element_id/" . $this->getHtmlId() . "/" . (null !== $this->getConfig(
-                            'store_id'
-                        ) ? 'store/' . $this->getConfig(
-                                'store_id'
-                            ) . '/' : '') . "')",
+                    'onclick' => "MediabrowserUtility.openDialog('"
+                        . $this->getConfig('files_browser_window_url')
+                        . "target_element_id/" . $this->getHtmlId() . "/"
+                        . (null !== $this->getConfig('store_id') ? 'store/'
+                            . $this->getConfig('store_id') . '/' : '')
+                        . "')",
                     'class' => 'action-add-image plugin',
                     'style' => $visible ? '' : 'display:none',
                 ]
@@ -395,13 +394,11 @@ class Editor extends Textarea
             return '<div class="admin__control-wysiwig">' .$html . '</div>';
         }
 
-        $html = '<div id="editor' . $this->getHtmlId() . '"' . ($this->getConfig(
-                'no_display'
-            ) ? ' style="display:none;"' : '') . ($this->getConfig(
-                'container_class'
-            ) ? ' class="admin__control-wysiwig ' . $this->getConfig(
-                    'container_class'
-                ) . '"' : '') . '>' . $html . '</div>';
+        $html = '<div id="editor' . $this->getHtmlId() . '"'
+            . ($this->getConfig('no_display') ? ' style="display:none;"' : '')
+            . ($this->getConfig('container_class') ? ' class="admin__control-wysiwig '
+                . $this->getConfig('container_class') . '"' : '')
+            . '>' . $html . '</div>';
 
         return $html;
     }

--- a/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Data\Form\Element;
 
 use Magento\Framework\Escaper;
@@ -123,7 +121,15 @@ class Editor extends Textarea
                 '
                 <script type="text/javascript">
                 //<![CDATA[
-                window.tinyMCE_GZ = window.tinyMCE_GZ || {}; window.tinyMCE_GZ.loaded = true;require(["jquery", "mage/translate", "mage/adminhtml/events", "mage/adminhtml/wysiwyg/tiny_mce/setup", "mage/adminhtml/wysiwyg/widget"], function(jQuery){' .
+                window.tinyMCE_GZ = window.tinyMCE_GZ || {}; 
+                window.tinyMCE_GZ.loaded = true;
+                require([
+                "jquery", 
+                "mage/translate", 
+                "mage/adminhtml/events", 
+                "mage/adminhtml/wysiwyg/tiny_mce/setup", 
+                "mage/adminhtml/wysiwyg/widget"
+                ], function(jQuery){' .
                 "\n" .
                 '  (function($) {$.mage.translate.add(' .
                 \Zend_Json::encode(
@@ -255,8 +261,8 @@ class Editor extends Textarea
                 [
                     'title' => $this->translate('Insert Widget...'),
                     'onclick' => "widgetTools.openDialog('" . $this->getConfig(
-                        'widget_window_url'
-                    ) . "widget_target_id/" . $this->getHtmlId() . "')",
+                            'widget_window_url'
+                        ) . "widget_target_id/" . $this->getHtmlId() . "')",
                     'class' => 'action-add-widget plugin',
                     'style' => $visible ? '' : 'display:none',
                 ]
@@ -269,12 +275,12 @@ class Editor extends Textarea
                 [
                     'title' => $this->translate('Insert Image...'),
                     'onclick' => "MediabrowserUtility.openDialog('" . $this->getConfig(
-                        'files_browser_window_url'
-                    ) . "target_element_id/" . $this->getHtmlId() . "/" . (null !== $this->getConfig(
-                        'store_id'
-                    ) ? 'store/' . $this->getConfig(
-                        'store_id'
-                    ) . '/' : '') . "')",
+                            'files_browser_window_url'
+                        ) . "target_element_id/" . $this->getHtmlId() . "/" . (null !== $this->getConfig(
+                            'store_id'
+                        ) ? 'store/' . $this->getConfig(
+                                'store_id'
+                            ) . '/' : '') . "')",
                     'class' => 'action-add-image plugin',
                     'style' => $visible ? '' : 'display:none',
                 ]
@@ -390,12 +396,12 @@ class Editor extends Textarea
         }
 
         $html = '<div id="editor' . $this->getHtmlId() . '"' . ($this->getConfig(
-            'no_display'
-        ) ? ' style="display:none;"' : '') . ($this->getConfig(
-            'container_class'
-        ) ? ' class="admin__control-wysiwig ' . $this->getConfig(
-            'container_class'
-        ) . '"' : '') . '>' . $html . '</div>';
+                'no_display'
+            ) ? ' style="display:none;"' : '') . ($this->getConfig(
+                'container_class'
+            ) ? ' class="admin__control-wysiwig ' . $this->getConfig(
+                    'container_class'
+                ) . '"' : '') . '>' . $html . '</div>';
 
         return $html;
     }

--- a/lib/internal/Magento/Framework/Data/Form/Element/Gallery.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Gallery.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Category form input image element
  *
@@ -43,10 +41,18 @@ class Gallery extends AbstractElement
         $gallery = $this->getValue();
 
         $html = '<table id="gallery" class="gallery" border="0" cellspacing="3" cellpadding="0">';
-        $html .= '<thead id="gallery_thead" class="gallery"><tr class="gallery"><td class="gallery" valign="middle" align="center">Big Image</td><td class="gallery" valign="middle" align="center">Thumbnail</td><td class="gallery" valign="middle" align="center">Small Thumb</td><td class="gallery" valign="middle" align="center">Sort Order</td><td class="gallery" valign="middle" align="center">Delete</td></tr></thead>';
+        $html .= '<thead id="gallery_thead" class="gallery">' .
+            '<tr class="gallery">' .
+            '<td class="gallery" valign="middle" align="center">Big Image</td>' .
+            '<td class="gallery" valign="middle" align="center">Thumbnail</td>' .
+            '<td class="gallery" valign="middle" align="center">Small Thumb</td>' .
+            '<td class="gallery" valign="middle" align="center">Sort Order</td>' .
+            '<td class="gallery" valign="middle" align="center">Delete</td>' .
+            '</tr>'.
+            '</thead>';
         $widgetButton = $this->getForm()->getParent()->getLayout();
         $buttonHtml = $widgetButton->createBlock(
-             \Magento\Backend\Block\Widget\Button::class
+            \Magento\Backend\Block\Widget\Button::class
         )->setData(
             ['label' => 'Add New Image', 'onclick' => 'addNewImg()', 'class' => 'add']
         )->toHtml();
@@ -60,7 +66,7 @@ class Gallery extends AbstractElement
         $html .= '<tbody class="gallery">';
 
         $i = 0;
-        if (!is_null($this->getValue())) {
+        if ($this->getValue() !== null) {
             foreach ($this->getValue() as $image) {
                 $i++;
                 $html .= '<tr class="gallery">';
@@ -102,7 +108,8 @@ class Gallery extends AbstractElement
                             'file'
                         ) . ' ></td>';
                 }
-                $html .= '<td class="gallery" align="center" style="vertical-align:bottom;"><input type="input" name="' .
+                $html .= '<td class="gallery" align="center" style="vertical-align:bottom;">' .
+                    '<input type="input" name="' .
                     parent::getName() .
                     '[position][' .
                     $image->getValueId() .
@@ -116,7 +123,8 @@ class Gallery extends AbstractElement
                     $this->_getUiId(
                         'position-' . $image->getValueId()
                     ) . '/></td>';
-                $html .= '<td class="gallery" align="center" style="vertical-align:bottom;"><input type="checkbox" name="' .
+                $html .= '<td class="gallery" align="center" style="vertical-align:bottom;">' .
+                    '<input type="checkbox" name="' .
                     parent::getName() .
                     '[delete][' .
                     $image->getValueId() .
@@ -134,7 +142,9 @@ class Gallery extends AbstractElement
             }
         }
         if ($i == 0) {
-            $html .= '<script type="text/javascript">document.getElementById("gallery_thead").style.visibility="hidden";</script>';
+            $html .= '<script type="text/javascript">' .
+                'document.getElementById("gallery_thead").style.visibility="hidden";' .
+                '</script>';
         }
 
         $html .= '</tbody></table>';

--- a/lib/internal/Magento/Framework/Data/Form/Element/Time.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Time.php
@@ -66,11 +66,9 @@ class Time extends AbstractElement
         }
 
         $html = '<input type="hidden" id="' . $this->getHtmlId() . '" ' . $this->_getUiId() . '/>';
-        $html .= '<select name="' . $this->getName() . '" style="width:80px" ' . $this->serialize(
-                $this->getHtmlAttributes()
-            ) . $this->_getUiId(
-                'hour'
-            ) . '>' . "\n";
+        $html .= '<select name="' . $this->getName() . '" style="width:80px" '
+            . $this->serialize($this->getHtmlAttributes())
+            . $this->_getUiId('hour') . '>' . "\n";
         for ($i = 0; $i < 24; $i++) {
             $hour = str_pad($i, 2, '0', STR_PAD_LEFT);
             $html .= '<option value="' . $hour . '" ' . ($valueHrs ==
@@ -78,11 +76,9 @@ class Time extends AbstractElement
         }
         $html .= '</select>' . "\n";
 
-        $html .= ':&nbsp;<select name="' . $this->getName() . '" style="width:80px" ' . $this->serialize(
-                $this->getHtmlAttributes()
-            ) . $this->_getUiId(
-                'minute'
-            ) . '>' . "\n";
+        $html .= ':&nbsp;<select name="' . $this->getName() . '" style="width:80px" '
+            . $this->serialize($this->getHtmlAttributes())
+            . $this->_getUiId('minute') . '>' . "\n";
         for ($i = 0; $i < 60; $i++) {
             $hour = str_pad($i, 2, '0', STR_PAD_LEFT);
             $html .= '<option value="' . $hour . '" ' . ($valueMin ==
@@ -90,11 +86,9 @@ class Time extends AbstractElement
         }
         $html .= '</select>' . "\n";
 
-        $html .= ':&nbsp;<select name="' . $this->getName() . '" style="width:80px" ' . $this->serialize(
-                $this->getHtmlAttributes()
-            ) . $this->_getUiId(
-                'second'
-            ) . '>' . "\n";
+        $html .= ':&nbsp;<select name="' . $this->getName() . '" style="width:80px" '
+            . $this->serialize($this->getHtmlAttributes())
+            . $this->_getUiId('second') . '>' . "\n";
         for ($i = 0; $i < 60; $i++) {
             $hour = str_pad($i, 2, '0', STR_PAD_LEFT);
             $html .= '<option value="' . $hour . '" ' . ($valueSec ==

--- a/lib/internal/Magento/Framework/Data/Form/Element/Time.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Time.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Form time element
  *
@@ -54,52 +52,52 @@ class Time extends AbstractElement
     {
         $this->addClass('select admin__control-select');
 
-        $value_hrs = 0;
-        $value_min = 0;
-        $value_sec = 0;
+        $valueHrs = 0;
+        $valueMin = 0;
+        $valueSec = 0;
 
         if ($value = $this->getValue()) {
             $values = explode(',', $value);
             if (is_array($values) && count($values) == 3) {
-                $value_hrs = $values[0];
-                $value_min = $values[1];
-                $value_sec = $values[2];
+                $valueHrs = $values[0];
+                $valueMin = $values[1];
+                $valueSec = $values[2];
             }
         }
 
         $html = '<input type="hidden" id="' . $this->getHtmlId() . '" ' . $this->_getUiId() . '/>';
         $html .= '<select name="' . $this->getName() . '" style="width:80px" ' . $this->serialize(
-            $this->getHtmlAttributes()
-        ) . $this->_getUiId(
-            'hour'
-        ) . '>' . "\n";
+                $this->getHtmlAttributes()
+            ) . $this->_getUiId(
+                'hour'
+            ) . '>' . "\n";
         for ($i = 0; $i < 24; $i++) {
             $hour = str_pad($i, 2, '0', STR_PAD_LEFT);
-            $html .= '<option value="' . $hour . '" ' . ($value_hrs ==
+            $html .= '<option value="' . $hour . '" ' . ($valueHrs ==
                 $i ? 'selected="selected"' : '') . '>' . $hour . '</option>';
         }
         $html .= '</select>' . "\n";
 
         $html .= ':&nbsp;<select name="' . $this->getName() . '" style="width:80px" ' . $this->serialize(
-            $this->getHtmlAttributes()
-        ) . $this->_getUiId(
-            'minute'
-        ) . '>' . "\n";
+                $this->getHtmlAttributes()
+            ) . $this->_getUiId(
+                'minute'
+            ) . '>' . "\n";
         for ($i = 0; $i < 60; $i++) {
             $hour = str_pad($i, 2, '0', STR_PAD_LEFT);
-            $html .= '<option value="' . $hour . '" ' . ($value_min ==
+            $html .= '<option value="' . $hour . '" ' . ($valueMin ==
                 $i ? 'selected="selected"' : '') . '>' . $hour . '</option>';
         }
         $html .= '</select>' . "\n";
 
         $html .= ':&nbsp;<select name="' . $this->getName() . '" style="width:80px" ' . $this->serialize(
-            $this->getHtmlAttributes()
-        ) . $this->_getUiId(
-            'second'
-        ) . '>' . "\n";
+                $this->getHtmlAttributes()
+            ) . $this->_getUiId(
+                'second'
+            ) . '>' . "\n";
         for ($i = 0; $i < 60; $i++) {
             $hour = str_pad($i, 2, '0', STR_PAD_LEFT);
-            $html .= '<option value="' . $hour . '" ' . ($value_sec ==
+            $html .= '<option value="' . $hour . '" ' . ($valueSec ==
                 $i ? 'selected="selected"' : '') . '>' . $hour . '</option>';
         }
         $html .= '</select>' . "\n";

--- a/lib/internal/Magento/Framework/Data/FormFactory.php
+++ b/lib/internal/Magento/Framework/Data/FormFactory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Data;
 
 /**
@@ -54,7 +52,10 @@ class FormFactory
         $form = $this->_objectManager->create($this->_instanceName, $data);
         if (!$form instanceof \Magento\Framework\Data\Form) {
             throw new \Magento\Framework\Exception\LocalizedException(
-                new \Magento\Framework\Phrase('%1 doesn\'t extend \Magento\Framework\Data\Form', [$this->_instanceName])
+                new \Magento\Framework\Phrase(
+                    '%1 doesn\'t extend \Magento\Framework\Data\Form',
+                    [$this->_instanceName]
+                )
             );
         }
         return $form;

--- a/lib/internal/Magento/Framework/Data/Test/Unit/Collection/DbTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/Collection/DbTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Data\Test\Unit\Collection;
 
 /**
@@ -44,10 +42,18 @@ class DbTest extends \PHPUnit_Framework_TestCase
     {
         $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->fetchStrategyMock = $this->getMock(
-            \Magento\Framework\Data\Collection\Db\FetchStrategy\Query::class, ['fetchAll'], [], '', false
+            \Magento\Framework\Data\Collection\Db\FetchStrategy\Query::class,
+            ['fetchAll'],
+            [],
+            '',
+            false
         );
         $this->entityFactoryMock = $this->getMock(
-            \Magento\Framework\Data\Collection\EntityFactory::class, ['create'], [], '', false
+            \Magento\Framework\Data\Collection\EntityFactory::class,
+            ['create'],
+            [],
+            '',
+            false
         );
         $this->loggerMock = $this->getMock(\Psr\Log\LoggerInterface::class);
         $this->collection = new \Magento\Framework\Data\Test\Unit\Collection\DbCollection(
@@ -375,7 +381,11 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
         $adapterMock = $this->getMock(
             \Magento\Framework\DB\Adapter\Pdo\Mysql::class,
-            ['select', 'query'], [], '', false);
+            ['select', 'query'],
+            [],
+            '',
+            false
+        );
         $selectMock = $this->getMock(
             \Magento\Framework\DB\Select::class,
             [],
@@ -430,9 +440,9 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $adapterMock->expects($this->exactly(2))
             ->method('quoteInto')
             ->will($this->returnValueMap([
-                        ['testField1=?', 'testValue1', null, null, 'testField1=testValue1'],
-                        ['testField4=?', 'testValue4', null, null, 'testField4=testValue4'],
-                    ]));
+                ['testField1=?', 'testValue1', null, null, 'testField1=testValue1'],
+                ['testField4=?', 'testValue4', null, null, 'testField4=testValue4'],
+            ]));
         $selectMock->expects($this->once())
             ->method('orWhere')
             ->with('testField1=testValue1');
@@ -558,7 +568,11 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $data = [10 => 'test'];
         $adapterMock = $this->getMock(
             \Magento\Framework\DB\Adapter\Pdo\Mysql::class,
-            ['select', 'query'], [], '', false);
+            ['select', 'query'],
+            [],
+            '',
+            false
+        );
         $selectMock = $this->getMock(
             \Magento\Framework\DB\Select::class,
             [],

--- a/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/AbstractElementTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/AbstractElementTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Tests for \Magento\Framework\Data\Form\Element\AbstractElement
  */
@@ -36,19 +34,29 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->_factoryMock = $this->getMock(
-            \Magento\Framework\Data\Form\Element\Factory::class, [], [], '', false
+            \Magento\Framework\Data\Form\Element\Factory::class,
+            [],
+            [],
+            '',
+            false
         );
         $this->_collectionFactoryMock = $this->getMock(
-            \Magento\Framework\Data\Form\Element\CollectionFactory::class, [], [], '', false
+            \Magento\Framework\Data\Form\Element\CollectionFactory::class,
+            [],
+            [],
+            '',
+            false
         );
         $this->_escaperMock = $this->getMock(\Magento\Framework\Escaper::class, [], [], '', false);
 
         $this->_model = $this->getMockForAbstractClass(
-            \Magento\Framework\Data\Form\Element\AbstractElement::class, [
-            $this->_factoryMock,
-            $this->_collectionFactoryMock,
-            $this->_escaperMock
-        ]);
+            \Magento\Framework\Data\Form\Element\AbstractElement::class,
+            [
+                $this->_factoryMock,
+                $this->_collectionFactoryMock,
+                $this->_escaperMock
+            ]
+        );
     }
 
     /**
@@ -58,7 +66,13 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
     {
         $elementId = 11;
         $elementMock = $this->getMockForAbstractClass(
-            \Magento\Framework\Data\Form\Element\AbstractElement::class, [], '', false, true, true, ['getId']
+            \Magento\Framework\Data\Form\Element\AbstractElement::class,
+            [],
+            '',
+            false,
+            true,
+            true,
+            ['getId']
         );
         $elementMock->expects($this->once())
             ->method('getId')
@@ -98,7 +112,11 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
         $htmlId = 'some_id';
 
         $formMock = $this->getMock(
-            \Magento\Framework\Data\Form\AbstractForm::class, ['getHtmlIdPrefix', 'getHtmlIdSuffix'], [], '', false
+            \Magento\Framework\Data\Form\AbstractForm::class,
+            ['getHtmlIdPrefix', 'getHtmlIdSuffix'],
+            [],
+            '',
+            false
         );
         $formMock->expects($this->any())
             ->method('getHtmlIdPrefix')
@@ -168,14 +186,22 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
         $elementId = 'element_id';
 
         $formMock = $this->getMock(
-            \Magento\Framework\Data\Form\AbstractForm::class, ['removeField'], [], '', false
+            \Magento\Framework\Data\Form\AbstractForm::class,
+            ['removeField'],
+            [],
+            '',
+            false
         );
         $formMock->expects($this->once())
             ->method('removeField')
             ->with($elementId);
 
         $collectionMock = $this->getMock(
-            \Magento\Framework\Data\Form\Element\Collection::class, ['remove'], [], '', false
+            \Magento\Framework\Data\Form\Element\Collection::class,
+            ['remove'],
+            [],
+            '',
+            false
         );
         $collectionMock->expects($this->once())
             ->method('remove')
@@ -250,7 +276,8 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
     {
         $this->_model->setValue('<a href="#hash_tag">my \'quoted\' string</a>');
         $this->assertEquals(
-            '&lt;a href=&quot;#hash_tag&quot;&gt;my \'quoted\' string&lt;/a&gt;', $this->_model->getEscapedValue()
+            '&lt;a href=&quot;#hash_tag&quot;&gt;my \'quoted\' string&lt;/a&gt;',
+            $this->_model->getEscapedValue()
         );
     }
 
@@ -329,8 +356,10 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
         $this->_model->setForm(
             $this->getMock(\Magento\Framework\Data\Form\AbstractForm::class, [], [], '', false)
         );
-        $expectedHtml = '<div class="admin__field">' . "\n"
-            . '<input id="" name=""  data-ui-id="form-element-" value="" class=" required-entry _required"/></div>' . "\n";
+        $expectedHtml = '<div class="admin__field">'
+            . "\n"
+            . '<input id="" name=""  data-ui-id="form-element-" value="" class=" required-entry _required"/></div>'
+            . "\n";
 
         $this->assertEquals($expectedHtml, $this->_model->getHtml());
         $this->assertEquals(' required-entry _required', $this->_model->getClass());
@@ -407,7 +436,11 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
         $id = 'id';
         $prefix = 'prefix_';
         $formMock = $this->getMock(
-            \Magento\Framework\Data\Form\AbstractForm::class, ['getFieldContainerIdPrefix'], [], '', false
+            \Magento\Framework\Data\Form\AbstractForm::class,
+            ['getFieldContainerIdPrefix'],
+            [],
+            '',
+            false
         );
         $formMock->expects($this->once())
             ->method('getFieldContainerIdPrefix')
@@ -531,7 +564,7 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
             [
                 [],
                 '<div class="admin__field">' . "\n"
-                    . '<input id="" name=""  data-ui-id="form-element-" value="" /></div>' . "\n",
+                . '<input id="" name=""  data-ui-id="form-element-" value="" /></div>' . "\n",
             ],
             [
                 ['default_html' => 'some default html'],
@@ -545,10 +578,10 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
                     'value' => 'some-value',
                 ],
                 '<div class="admin__field">' . "\n"
-                    . '<label class="label admin__field-label" for="html-id" data-ui-id="form-element-some-namelabel">'
-                    . '<span>some label</span></label>' . "\n"
-                    . '<input id="html-id" name="some-name"  data-ui-id="form-element-some-name" value="some-value" />'
-                    . '</div>' . "\n"
+                . '<label class="label admin__field-label" for="html-id" data-ui-id="form-element-some-namelabel">'
+                . '<span>some label</span></label>' . "\n"
+                . '<input id="html-id" name="some-name"  data-ui-id="form-element-some-name" value="some-value" />'
+                . '</div>' . "\n"
             ],
             [
                 [
@@ -559,8 +592,8 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
                     'no_span' => true,
                 ],
                 '<label class="label admin__field-label" for="html-id" data-ui-id="form-element-some-namelabel">'
-                    . '<span>some label</span></label>' . "\n"
-                    . '<input id="html-id" name="some-name"  data-ui-id="form-element-some-name" value="some-value" />'
+                . '<span>some label</span></label>' . "\n"
+                . '<input id="html-id" name="some-name"  data-ui-id="form-element-some-name" value="some-value" />'
             ],
         ];
     }
@@ -587,7 +620,7 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
                     'html_id' => 'some-html-id',
                 ],
                 '<label class="label admin__field-label" for="some-html-id" data-ui-id="form-element-label">'
-                    . '<span>some-label</span></label>' . "\n"
+                . '<span>some-label</span></label>' . "\n"
             ],
             [
                 [
@@ -596,7 +629,7 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
                     'html_id' => 'some-html-id',
                 ],
                 '<label class="label admin__field-label" for="some-html-idsuffix" data-ui-id="form-element-label">'
-                    . '<span>some-label</span></label>' . "\n"
+                . '<span>some-label</span></label>' . "\n"
             ],
         ];
     }
@@ -627,7 +660,7 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
                     'before_element_html' => 'some-html',
                 ],
                 '<label class="addbefore" for="html-id">some-html</label>'
-                    . '<input id="html-id" name="some-name"  data-ui-id="form-element-some-name" value="some-value" />'
+                . '<input id="html-id" name="some-name"  data-ui-id="form-element-some-name" value="some-value" />'
             ],
             [
                 [
@@ -646,7 +679,7 @@ class AbstractElementTest extends \PHPUnit_Framework_TestCase
                     'after_element_html' => 'some-html',
                 ],
                 '<input id="html-id" name="some-name"  data-ui-id="form-element-some-name" value="some-value" />'
-                    . '<label class="addafter" for="html-id">some-html</label>'
+                . '<label class="addafter" for="html-id">some-html</label>'
             ]
         ];
     }


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Data namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile at the head of the files
- Fixed indentation
- Changed is_null function call to a === null compare