### PR TITLE
Backport of MAGETWO-54401 for Magento 2.1 - Unable to click "Insert image" twice

### DIFF
--- a/lib/web/mage/adminhtml/browser.js
+++ b/lib/web/mage/adminhtml/browser.js
@@ -14,7 +14,7 @@ define([
     "jquery/jstree/jquery.jstree",
     "mage/mage"
 ], function($, tinyMCEm, prompt, confirm, alert){
-    
+
     MediabrowserUtility = {
         windowId: 'modal_dialog_message',
         getMaxZIndex: function() {
@@ -31,12 +31,14 @@ define([
         },
         openDialog: function(url, width, height, title, options) {
             var windowId = this.windowId,
-                content = '<div class="popup-window magento-message" "id="' + windowId + '"></div>',
+                content = '<div class="popup-window magento-message" id="' + windowId + '"></div>',
                 self = this;
 
             if (this.modal) {
                 this.modal.html($(content).html());
-                this.modal.modal('option', 'closed', options.closed);
+                if (options && typeof options.closed !== 'undefined') {
+                    this.modal.modal('option', 'closed', options.closed);
+                }
             } else {
                 this.modal = $(content).modal($.extend({
                     title:  title || 'Insert File...',


### PR DESCRIPTION
### Description
This is a backport of issue MAGETWO-54401 for Magento 2.1

### Fixed Issues (if relevant)
1. MAGETWO-54401
References to commits on the develop branch:
https://github.com/magento/magento2/commit/c08792b0f20c5da496ef17bb631792ce57318caa & https://github.com/magento/magento2/commit/04a020a2e1db9f38378473733d65925b18dbdd15 & https://github.com/magento/magento2/commit/753c9cec2f4bcad231779d8252088744b7ab4865

### Discussion
I saw @okorshenko mentioning that the community can now suggest backporting certain issues for Magento 2.1 by sending PR's to the `2.1-develop` branch.
So this is my first attempt at one.
I have around 10 others ready, which we backported ourselves manually over the last couple of months, so if this one goes good, I'll try to send PR's for the others as well.
