### PR TITLE
Fixed coding standard violations in the Framework\Controller, Framework\CSS, Framework\Phrase and Framework\Pricing namespace

### DIFF
--- a/lib/internal/Magento/Framework/Controller/Test/Unit/Result/RedirectFactoryTest.php
+++ b/lib/internal/Magento/Framework/Controller/Test/Unit/Result/RedirectFactoryTest.php
@@ -6,8 +6,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Controller\Test\Unit\Result;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;

--- a/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/Instruction/ImportTest.php
+++ b/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/Instruction/ImportTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Css\Test\Unit\PreProcessor\Instruction;
 
 use Magento\Framework\Css\PreProcessor\FileGenerator\RelatedGenerator;
@@ -40,13 +38,26 @@ class ImportTest extends \PHPUnit_Framework_TestCase
     {
 
         $this->notationResolver = $this->getMock(
-            \Magento\Framework\View\Asset\NotationResolver\Module::class, [], [], '', false
+            \Magento\Framework\View\Asset\NotationResolver\Module::class,
+            [],
+            [],
+            '',
+            false
         );
         $contextMock = $this->getMockForAbstractClass(
-            \Magento\Framework\View\Asset\ContextInterface::class, [], '', false
+            \Magento\Framework\View\Asset\ContextInterface::class,
+            [],
+            '',
+            false
         );
         $contextMock->expects($this->any())->method('getPath')->willReturn('');
-        $this->asset = $this->getMock(\Magento\Framework\View\Asset\File::class, [], [], '', false);
+        $this->asset = $this->getMock(
+            \Magento\Framework\View\Asset\File::class,
+            [],
+            [],
+            '',
+            false
+        );
         $this->asset->expects($this->any())->method('getContentType')->will($this->returnValue('css'));
         $this->asset->expects($this->any())->method('getContext')->willReturn($contextMock);
 
@@ -67,7 +78,12 @@ class ImportTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcess($originalContent, $foundPath, $resolvedPath, $expectedContent)
     {
-        $chain = new \Magento\Framework\View\Asset\PreProcessor\Chain($this->asset, $originalContent, 'less', 'path');
+        $chain = new \Magento\Framework\View\Asset\PreProcessor\Chain(
+            $this->asset,
+            $originalContent,
+            'less',
+            'path'
+        );
         $invoke =  $this->once();
         if (preg_match('/^(http:|https:|\/+)/', $foundPath)) {
             $invoke = $this->never();
@@ -160,7 +176,12 @@ class ImportTest extends \PHPUnit_Framework_TestCase
         $originalContent = 'color: #000000;';
         $expectedContent = 'color: #000000;';
 
-        $chain = new \Magento\Framework\View\Asset\PreProcessor\Chain($this->asset, $originalContent, 'css', 'path');
+        $chain = new \Magento\Framework\View\Asset\PreProcessor\Chain(
+            $this->asset,
+            $originalContent,
+            'css',
+            'path'
+        );
         $this->notationResolver->expects($this->never())
             ->method('convertModuleNotationToPath');
         $this->object->process($chain);
@@ -186,7 +207,12 @@ class ImportTest extends \PHPUnit_Framework_TestCase
             'path'
         );
         $this->object->process($chain);
-        $chain = new \Magento\Framework\View\Asset\PreProcessor\Chain($this->asset, 'color: #000000;', 'css', 'path');
+        $chain = new \Magento\Framework\View\Asset\PreProcessor\Chain(
+            $this->asset,
+            'color: #000000;',
+            'css',
+            'path'
+        );
         $this->object->process($chain);
 
         $expected = [['Magento_Module::something.css', $this->asset]];

--- a/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/Instruction/MagentoImportTest.php
+++ b/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/Instruction/MagentoImportTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Css\Test\Unit\PreProcessor\Instruction;
 
 use Magento\Framework\Css\PreProcessor\Instruction\MagentoImport;
@@ -181,7 +179,10 @@ class MagentoImportTest extends \PHPUnit_Framework_TestCase
     public function testProcessException()
     {
         $chain = new \Magento\Framework\View\Asset\PreProcessor\Chain(
-            $this->asset, '//@magento_import "some/file.css";', 'css', 'path'
+            $this->asset,
+            '//@magento_import "some/file.css";',
+            'css',
+            'path'
         );
         $exception = new \LogicException('Error happened');
         $this->assetRepo->expects($this->once())

--- a/lib/internal/Magento/Framework/Phrase/Test/Unit/Renderer/CompositeTest.php
+++ b/lib/internal/Magento/Framework/Phrase/Test/Unit/Renderer/CompositeTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Phrase\Test\Unit\Renderer;
 
 use \Magento\Framework\Phrase\Renderer\Composite;
@@ -53,27 +51,27 @@ class CompositeTest extends \PHPUnit_Framework_TestCase
         $this->rendererOne->expects(
             $this->once()
         )->method(
-                'render'
-            )->with(
-                [$text],
-                $arguments
-            )->will(
-                $this->returnValue($resultAfterFirst)
-            );
+            'render'
+        )->with(
+            [$text],
+            $arguments
+        )->will(
+            $this->returnValue($resultAfterFirst)
+        );
 
         $this->rendererTwo->expects(
             $this->once()
         )->method(
-                'render'
-            )->with(
-                [
-                    $text,
-                    $resultAfterFirst,
-                ],
-                $arguments
-            )->will(
-                $this->returnValue($resultAfterSecond)
-            );
+            'render'
+        )->with(
+            [
+                $text,
+                $resultAfterFirst,
+            ],
+            $arguments
+        )->will(
+            $this->returnValue($resultAfterSecond)
+        );
 
         $this->assertEquals($resultAfterSecond, $this->object->render([$text], $arguments));
     }

--- a/lib/internal/Magento/Framework/Pricing/Render/RendererPool.php
+++ b/lib/internal/Magento/Framework/Pricing/Render/RendererPool.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Pricing\Render;
 
 use Magento\Framework\Pricing\Amount\AmountInterface;
@@ -79,7 +77,9 @@ class RendererPool extends AbstractBlock
         $renderBlock = $this->getLayout()->createBlock($renderClassName, '', $arguments);
         if (!$renderBlock instanceof PriceBoxRenderInterface) {
             throw new \InvalidArgumentException(
-                'Block "' . $renderClassName . '" must implement \Magento\Framework\Pricing\Render\PriceBoxRenderInterface'
+                'Block "' .
+                $renderClassName .
+                '" must implement \Magento\Framework\Pricing\Render\PriceBoxRenderInterface'
             );
         }
         $renderBlock->setTemplate($this->getRenderBlockTemplate($type, $priceCode));
@@ -142,7 +142,9 @@ class RendererPool extends AbstractBlock
         $amountBlock = $this->getLayout()->createBlock($renderClassName, '', $arguments);
         if (!$amountBlock instanceof AmountRenderInterface) {
             throw new \InvalidArgumentException(
-                'Block "' . $renderClassName . '" must implement \Magento\Framework\Pricing\Render\AmountRenderInterface'
+                'Block "' .
+                $renderClassName .
+                '" must implement \Magento\Framework\Pricing\Render\AmountRenderInterface'
             );
         }
         $amountBlock->setTemplate($this->getAmountRenderBlockTemplate($type, $priceCode));
@@ -156,15 +158,15 @@ class RendererPool extends AbstractBlock
      */
     public function getAdjustmentRenders(SaleableInterface $saleableItem = null, PriceInterface $price = null)
     {
-        $itemType = is_null($saleableItem) ? 'default' : $saleableItem->getTypeId();
-        $priceType = is_null($price) ? 'default' : $price->getPriceCode();
+        $itemType = $saleableItem === null ? 'default' : $saleableItem->getTypeId();
+        $priceType = $price === null ? 'default' : $price->getPriceCode();
 
         $fallbackPattern = [
             "{$itemType}/adjustments/{$priceType}",
             "{$itemType}/adjustments/default",
             "default/adjustments/{$priceType}",
             "default/adjustments/default",
-            ];
+        ];
         $renders = $this->findDataByPattern($fallbackPattern);
         if ($renders) {
             foreach ($renders as $code => $configuration) {


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Controller, Framework\CSS, Framework\Phrase and Framework\Pricing namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile at the head of the files
- Fixed indentation
- Fixed line length
- Changed is_null function call to a === null compare