### PR TITLE
Make deployed_version.txt editor friendly

### DIFF
--- a/lib/internal/Magento/Framework/App/View/Deployment/Version/Storage/File.php
+++ b/lib/internal/Magento/Framework/App/View/Deployment/Version/Storage/File.php
@@ -41,7 +41,7 @@ class File implements \Magento\Framework\App\View\Deployment\Version\StorageInte
     public function load()
     {
         if ($this->directory->isReadable($this->fileName)) {
-            return $this->directory->readFile($this->fileName);
+            return trim($this->directory->readFile($this->fileName));
         }
         return false;
     }


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->

In production environments with a CDN for static files it comes in handy that you can force a browser cache refresh by changing the number manually without having to go into maintenance for a full deploy.

If you edit the `pub/static/deployed_version.txt` with vim, nano or `echo '123456789' > pub/static/deployed_version.txt` you can unintentionally create a newline at the end of the file.
This will result in:

```html
    var BASE_URL = 'https://magento2.dev/sitemanager/admin/index/index/key/ec38dd3ded42b71db14166d6bcdfc56d4e7d4b7801b9808373ae4b3563b65513/';
    var FORM_KEY = 'dKArsQU6NhimXr6Z';
    var require = {
        "baseUrl": "https://magento2.dev/pub/static/version1492766286
/adminhtml/Magento/backend/en_US"
    };
```

With that baseUrl all resources using baseUrl will return the 404 page.

Adding a simple `trim()` here will remove that risk.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. edit the `pub/static/deployed_version.txt` with vim in a shop that is in production mode
2. see the admin and frontend throw many js errors

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
