### PR TITLE
Replace framework's Zend_Session interface usage with SessionHandlerInterface

### DIFF
--- a/lib/internal/Magento/Framework/Session/SaveHandlerInterface.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandlerInterface.php
@@ -7,7 +7,7 @@
  */
 namespace Magento\Framework\Session;
 
-interface SaveHandlerInterface extends \Zend_Session_SaveHandler_Interface
+interface SaveHandlerInterface extends \SessionHandlerInterface
 {
     /**
      * Default session save handler


### PR DESCRIPTION
Replace framework's `Zend_Session_SaveHandler_Interface` usage with php's builtin `SessionHandlerInterface`.

### Description
This seems to be the cleanest solution, the two interfaces declare exactly the same methods, so there shouldn't be any difference.

### Fixed Issues (if relevant)
1. magento/magento2#9242: Upgrade ZF components. Zend_Session

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
