### PR TITLE
Fixed coding standard violations in the Framework\App namespace

### DIFF
--- a/lib/internal/Magento/Framework/App/Test/Unit/Action/ActionFake.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Action/ActionFake.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\App\Test\Unit\Action;
+
+use \Magento\Framework\App\Action\Action;
+
+class ActionFake extends Action
+{
+    /**
+     * Fake action to check a method call from a parent
+     */
+    public function execute()
+    {
+        $this->_forward(
+            ActionTest::ACTION_NAME,
+            ActionTest::CONTROLLER_NAME,
+            ActionTest::MODULE_NAME,
+            ActionTest::$actionParams
+        );
+        $this->_redirect(ActionTest::FULL_ACTION_NAME, ActionTest::$actionParams);
+        return;
+    }
+}

--- a/lib/internal/Magento/Framework/App/Test/Unit/Action/ActionTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Action/ActionTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\App\Test\Unit\Action;
 
 use \Magento\Framework\App\Action\Action;
@@ -183,22 +181,5 @@ class ActionTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals($this->_responseMock, $this->action->dispatch($this->_requestMock));
-    }
-}
-
-class ActionFake extends Action
-{
-    /**
-     * Fake action to check a method call from a parent
-     */
-    public function execute()
-    {
-        $this->_forward(
-            ActionTest::ACTION_NAME,
-            ActionTest::CONTROLLER_NAME,
-            ActionTest::MODULE_NAME,
-            ActionTest::$actionParams);
-        $this->_redirect(ActionTest::FULL_ACTION_NAME, ActionTest::$actionParams);
-        return;
     }
 }

--- a/lib/internal/Magento/Framework/App/Test/Unit/AreaListTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/AreaListTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\App\Test\Unit;
 
 use \Magento\Framework\App\AreaList;
@@ -48,12 +46,12 @@ class AreaListTest extends \PHPUnit_Framework_TestCase
         $this->_resolverFactory->expects(
             $this->any()
         )->method(
-                'create'
-            )->with(
-                'testValue'
-            )->will(
-                $this->returnValue($resolverMock)
-            );
+            'create'
+        )->with(
+            'testValue'
+        )->will(
+            $this->returnValue($resolverMock)
+        );
 
         $actual = $this->_model->getCodeByFrontName('testFrontName');
         $this->assertEquals($expected, $actual);
@@ -106,7 +104,10 @@ class AreaListTest extends \PHPUnit_Framework_TestCase
     {
         $areas = ['area1' => 'value1', 'area2' => 'value2'];
         $this->_model = new \Magento\Framework\App\AreaList(
-            $this->objectManagerMock, $this->_resolverFactory, $areas, ''
+            $this->objectManagerMock,
+            $this->_resolverFactory,
+            $areas,
+            ''
         );
 
         $expected = array_keys($areas);
@@ -118,7 +119,10 @@ class AreaListTest extends \PHPUnit_Framework_TestCase
     {
         $areas = ['area1' => ['router' => 'value1'], 'area2' => 'value2'];
         $this->_model = new \Magento\Framework\App\AreaList(
-            $this->objectManagerMock, $this->_resolverFactory, $areas, ''
+            $this->objectManagerMock,
+            $this->_resolverFactory,
+            $areas,
+            ''
         );
 
         $this->assertEquals($this->_model->getDefaultRouter('area1'), $areas['area1']['router']);
@@ -131,7 +135,10 @@ class AreaListTest extends \PHPUnit_Framework_TestCase
         $objectManagerMock = $this->getObjectManagerMockGetArea();
         $areas = ['area1' => ['router' => 'value1'], 'area2' => 'value2'];
         $this->_model = new AreaList(
-            $objectManagerMock, $this->_resolverFactory, $areas, ''
+            $objectManagerMock,
+            $this->_resolverFactory,
+            $areas,
+            ''
         );
 
         $this->assertEquals($this->_model->getArea('testArea'), 'ok');

--- a/lib/internal/Magento/Framework/App/Test/Unit/BootstrapTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/BootstrapTest.php
@@ -83,9 +83,27 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
             '',
             false
         );
-        $this->maintenanceMode = $this->getMock(\Magento\Framework\App\MaintenanceMode::class, ['isOn'], [], '', false);
-        $this->remoteAddress = $this->getMock('Magento\Framework\HTTP\PhpEnvironment\RemoteAddress', [], [], '', false);
-        $filesystem = $this->getMock(\Magento\Framework\Filesystem::class, [], [], '', false);
+        $this->maintenanceMode = $this->getMock(
+            \Magento\Framework\App\MaintenanceMode::class,
+            ['isOn'],
+            [],
+            '',
+            false
+        );
+        $this->remoteAddress = $this->getMock(
+            \Magento\Framework\HTTP\PhpEnvironment\RemoteAddress::class,
+            [],
+            [],
+            '',
+            false
+        );
+        $filesystem = $this->getMock(
+            \Magento\Framework\Filesystem::class,
+            [],
+            [],
+            '',
+            false
+        );
 
         $this->logger = $this->getMock(\Psr\Log\LoggerInterface::class);
 

--- a/lib/internal/Magento/Framework/App/Test/Unit/BootstrapTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/BootstrapTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\App\Test\Unit;
 
 use Magento\Framework\App\Bootstrap;
@@ -99,7 +97,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
             [\Magento\Framework\HTTP\PhpEnvironment\RemoteAddress::class, $this->remoteAddress],
             [\Magento\Framework\Filesystem::class, $filesystem],
             [\Magento\Framework\App\DeploymentConfig::class, $this->deploymentConfig],
-            ['Psr\Log\LoggerInterface', $this->logger],
+            [\Psr\Log\LoggerInterface::class, $this->logger],
         ];
 
         $this->objectManager->expects($this->any())->method('get')
@@ -211,7 +209,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
             [State::MODE_DEVELOPER, State::MODE_PRODUCTION, true],
             [State::MODE_PRODUCTION, State::MODE_DEVELOPER, false],
             [null, State::MODE_DEVELOPER, true],
-            [null, State::MODE_PRODUCTION, false],
+            [null, State::MODE_PRODUCTION, false]
         ];
     }
 
@@ -280,7 +278,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [true, false],
-            [false, true],
+            [false, true]
         ];
     }
 

--- a/lib/internal/Magento/Framework/App/Test/Unit/ObjectManager/ConfigLoaderTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/ObjectManager/ConfigLoaderTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\App\Test\Unit\ObjectManager;
 
 use Magento\Framework\Serialize\SerializerInterface;
@@ -55,15 +53,18 @@ class ConfigLoaderTest extends \PHPUnit_Framework_TestCase
             false
         );
 
-        $this->readerFactoryMock->expects(
-            $this->any()
-        )->method(
-            'create'
-        )->will(
-            $this->returnValue($this->readerMock)
+        $this->readerFactoryMock->expects($this->any())
+            ->method('create')
+            ->will($this->returnValue($this->readerMock));
+
+        $this->cacheMock = $this->getMock(
+            \Magento\Framework\App\Cache\Type\Config::class,
+            [],
+            [],
+            '',
+            false
         );
 
-        $this->cacheMock = $this->getMock(\Magento\Framework\App\Cache\Type\Config::class, [], [], '', false);
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
         $this->object = $objectManagerHelper->getObject(
@@ -98,7 +99,10 @@ class ConfigLoaderTest extends \PHPUnit_Framework_TestCase
         $this->cacheMock->expects($this->once())
             ->method('save')
             ->with($serializedData);
-        $this->readerMock->expects($this->once())->method('read')->with($area)->will($this->returnValue($configData));
+        $this->readerMock->expects($this->once())
+            ->method('read')
+            ->with($area)
+            ->will($this->returnValue($configData));
 
         $this->serializerMock->expects($this->once())
             ->method('serialize')

--- a/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpTest.php
@@ -5,8 +5,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\App\Test\Unit\Request;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -345,8 +343,10 @@ class HttpTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $configMock->expects($this->exactly($configCall))
             ->method('getValue')
-            ->with(\Magento\Framework\App\Request\Http::XML_PATH_OFFLOADER_HEADER, ScopeConfigInterface::SCOPE_TYPE_DEFAULT)
-            ->willReturn($configOffloadHeader);
+            ->with(
+                \Magento\Framework\App\Request\Http::XML_PATH_OFFLOADER_HEADER,
+                ScopeConfigInterface::SCOPE_TYPE_DEFAULT
+            )->willReturn($configOffloadHeader);
 
         $this->objectManager->setBackwardCompatibleProperty($this->_model, 'appConfig', $configMock);
         $this->objectManager->setBackwardCompatibleProperty($this->_model, 'sslOffloadHeader', null);

--- a/lib/internal/Magento/Framework/App/Test/Unit/Response/HttpTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Response/HttpTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\App\Test\Unit\Response;
 
 use \Magento\Framework\App\Response\Http;
@@ -53,7 +51,8 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         )->disableOriginalConstructor()->getMock();
         $this->cookieManagerMock = $this->getMock(\Magento\Framework\Stdlib\CookieManagerInterface::class);
         $this->contextMock = $this->getMockBuilder(
-            \Magento\Framework\App\Http\Context::class)->disableOriginalConstructor()
+            \Magento\Framework\App\Http\Context::class
+        )->disableOriginalConstructor()
             ->getMock();
 
         $this->dateTimeMock = $this->getMockBuilder(\Magento\Framework\Stdlib\DateTime::class)
@@ -87,7 +86,8 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         $expectedCookieName = Http::COOKIE_VARY_STRING;
         $expectedCookieValue = 'SHA1 Serialized String';
         $sensitiveCookieMetadataMock = $this->getMockBuilder(
-            \Magento\Framework\Stdlib\Cookie\SensitiveCookieMetadata::class)
+            \Magento\Framework\Stdlib\Cookie\SensitiveCookieMetadata::class
+        )
             ->disableOriginalConstructor()
             ->getMock();
         $sensitiveCookieMetadataMock->expects($this->once())

--- a/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerListTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerListTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\App\Test\Unit\Router;
 
 class NoRouteHandlerListTest extends \PHPUnit_Framework_TestCase

--- a/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerTest.php
@@ -6,8 +6,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\App\Test\Unit\Router;
 
 class NoRouteHandlerTest extends \Magento\Framework\TestFramework\Unit\BaseTestCase

--- a/lib/internal/Magento/Framework/App/Test/Unit/StateTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/StateTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\App\Test\Unit;
 
 use \Magento\Framework\App\Area;

--- a/lib/internal/Magento/Framework/App/Test/Unit/StaticResourceTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/StaticResourceTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\App\Test\Unit;
 
 use Magento\Framework\App\Bootstrap;
@@ -77,7 +75,11 @@ class StaticResourceTest extends \PHPUnit_Framework_TestCase
         $this->objectManager = $this->getMockForAbstractClass(\Magento\Framework\ObjectManagerInterface::class);
         $this->logger = $this->getMockForAbstractClass(\Psr\Log\LoggerInterface::class);
         $this->configLoader = $this->getMock(
-            \Magento\Framework\App\ObjectManager\ConfigLoader::class, [], [], '', false
+            \Magento\Framework\App\ObjectManager\ConfigLoader::class,
+            [],
+            [],
+            '',
+            false
         );
         $this->object = new \Magento\Framework\App\StaticResource(
             $this->state,
@@ -204,7 +206,7 @@ class StaticResourceTest extends \PHPUnit_Framework_TestCase
     {
         $this->objectManager->expects($this->once())
             ->method('get')
-            ->with('Psr\Log\LoggerInterface')
+            ->with(\Psr\Log\LoggerInterface::class)
             ->willReturn($this->logger);
         $this->logger->expects($this->once())
             ->method('critical');

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -33,7 +33,6 @@ use Magento\Framework\Stdlib\StringUtils;
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- * @codingStandardsIgnoreFile
  */
 class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
 {

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -33,6 +33,7 @@ use Magento\Framework\Stdlib\StringUtils;
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @codingStandardsIgnoreFile
  */
 class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
 {


### PR DESCRIPTION
Fixed coding standard violations in the Framework\App namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:

- Removed @codingStandardsIgnoreFile from the head of the file
- Move ActionFake to it's own file, because PSR-2 dicates only one class per file.
- Fixed indentation
- Fixed number of chars per line