### PR TITLE
Fixed coding standard violations in the Framework\Locale namespace

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Test/Unit/ConfigTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/ConfigTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Locale\Test\Unit;
 
 class ConfigTest extends \PHPUnit_Framework_TestCase
@@ -43,9 +41,9 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     ];
 
     private static $samplePresentLocales = [
-         'en_US', 'lv_LV', 'pt_BR', 'it_IT', 'ar_EG', 'bg_BG', 'en_IE', 'es_ES',
-         'en_AU', 'pt_PT', 'ru_RU', 'en_CA', 'vi_VN', 'ja_JP', 'en_GB', 'zh_CN',
-         'zh_TW', 'fr_FR', 'ar_KW', 'pl_PL', 'ko_KR', 'sk_SK', 'el_GR', 'hi_IN',
+        'en_US', 'lv_LV', 'pt_BR', 'it_IT', 'ar_EG', 'bg_BG', 'en_IE', 'es_ES',
+        'en_AU', 'pt_PT', 'ru_RU', 'en_CA', 'vi_VN', 'ja_JP', 'en_GB', 'zh_CN',
+        'zh_TW', 'fr_FR', 'ar_KW', 'pl_PL', 'ko_KR', 'sk_SK', 'el_GR', 'hi_IN',
     ];
 
     private static $sampleAbsentLocales = [

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/CurrencyTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/CurrencyTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Locale\Test\Unit;
 
 use Magento\Framework\Locale\Currency;

--- a/lib/internal/Magento/Framework/Locale/TranslatedLists.php
+++ b/lib/internal/Magento/Framework/Locale/TranslatedLists.php
@@ -105,11 +105,8 @@ class TranslatedLists implements ListsInterface
         $zones = \DateTimeZone::listIdentifiers(\DateTimeZone::ALL) ?: [];
         foreach ($zones as $code) {
             $options[] = [
-                'label' => \IntlTimeZone::createTimeZone($code)->getDisplayName(
-                        false,
-                        \IntlTimeZone::DISPLAY_LONG,
-                        $locale
-                    ) . ' (' . $code . ')',
+                'label' => \IntlTimeZone::createTimeZone($code)
+                    ->getDisplayName(false, \IntlTimeZone::DISPLAY_LONG, $locale) . ' (' . $code . ')',
                 'value' => $code,
             ];
         }

--- a/lib/internal/Magento/Framework/Locale/TranslatedLists.php
+++ b/lib/internal/Magento/Framework/Locale/TranslatedLists.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Locale;
 
 use Magento\Framework\Locale\Bundle\CurrencyBundle;
@@ -26,6 +24,7 @@ class TranslatedLists implements ListsInterface
     protected $localeResolver;
 
     /**
+     * @param \Magento\Framework\Locale\ConfigInterface $config
      * @param \Magento\Framework\Locale\ResolverInterface $localeResolver
      * @param string $locale
      */


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Locale namespace, s…o that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:

- Removed @codingStandardsIgnoreFile from the head of the file
- Fixed indentation
- Fixed missing parameter in docblock comment