### PR TITLE
Fixed coding standard violations in the Framework\File namespace

### DIFF
--- a/lib/internal/Magento/Framework/File/Csv.php
+++ b/lib/internal/Magento/Framework/File/Csv.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\File;
 
 use Magento\Framework\Filesystem\Driver\File;

--- a/lib/internal/Magento/Framework/File/CsvMulty.php
+++ b/lib/internal/Magento/Framework/File/CsvMulty.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Csv parse
  *
@@ -27,25 +25,23 @@ class CsvMulty extends \Magento\Framework\File\Csv
     {
         $data = [];
         $csvData = $this->getData($file);
-        $line_number = 0;
+        $lineNumber = 0;
         foreach ($csvData as $rowData) {
-            $line_number++;
+            $lineNumber++;
             if (isset($rowData[$keyIndex])) {
                 if (isset($data[$rowData[$keyIndex]])) {
                     if (isset($data[$rowData[$keyIndex]]['duplicate'])) {
-                        #array_push($data[$rowData[$keyIndex]]['duplicate'],array('line' => $line_number,'value' => isset($rowData[$valueIndex]) ? $rowData[$valueIndex] : null));
-                        $data[$rowData[$keyIndex]]['duplicate']['line'] .= ', ' . $line_number;
+                        $data[$rowData[$keyIndex]]['duplicate']['line'] .= ', ' . $lineNumber;
                     } else {
-                        $tmp_value = $data[$rowData[$keyIndex]]['value'];
-                        $tmp_line = $data[$rowData[$keyIndex]]['line'];
+                        $tmpValue = $data[$rowData[$keyIndex]]['value'];
+                        $tmpLine = $data[$rowData[$keyIndex]]['line'];
                         $data[$rowData[$keyIndex]]['duplicate'] = [];
-                        #array_push($data[$rowData[$keyIndex]]['duplicate'],array('line' => $tmp_line.' ,'.$line_number,'value' => $tmp_value));
-                        $data[$rowData[$keyIndex]]['duplicate']['line'] = $tmp_line . ' ,' . $line_number;
-                        $data[$rowData[$keyIndex]]['duplicate']['value'] = $tmp_value;
+                        $data[$rowData[$keyIndex]]['duplicate']['line'] = $tmpLine . ' ,' . $lineNumber;
+                        $data[$rowData[$keyIndex]]['duplicate']['value'] = $tmpValue;
                     }
                 } else {
                     $data[$rowData[$keyIndex]] = [];
-                    $data[$rowData[$keyIndex]]['line'] = $line_number;
+                    $data[$rowData[$keyIndex]]['line'] = $lineNumber;
                     $data[$rowData[$keyIndex]]['value'] = isset($rowData[$valueIndex]) ? $rowData[$valueIndex] : null;
                 }
             }

--- a/lib/internal/Magento/Framework/File/Test/Unit/CsvTest.php
+++ b/lib/internal/Magento/Framework/File/Test/Unit/CsvTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\File\Test\Unit;
 
 use Magento\Framework\Filesystem\Driver\File;

--- a/lib/internal/Magento/Framework/File/Transfer/Adapter/Http.php
+++ b/lib/internal/Magento/Framework/File/Transfer/Adapter/Http.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\File\Transfer\Adapter;
 
 class Http
@@ -21,11 +19,13 @@ class Http
     private $mime;
 
     /**
-     * @param \Magento\Framework\App\Response\Http
+     * @param \Magento\Framework\App\Response\Http $response
      * @param \Magento\Framework\File\Mime $mime
      */
-    public function __construct(\Magento\Framework\HTTP\PhpEnvironment\Response $response, \Magento\Framework\File\Mime $mime)
-    {
+    public function __construct(
+        \Magento\Framework\HTTP\PhpEnvironment\Response $response,
+        \Magento\Framework\File\Mime $mime
+    ) {
         $this->response = $response;
         $this->mime = $mime;
     }


### PR DESCRIPTION
Fixed coding standard violations in the Framework\File namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile from the head of the file
- Fixed indentation
- Fixed missing parameter variable in docblock comment
- Fixed camel case strings in function