### PR TITLE
Fixed coding standard violations in the Framework\DB namespace

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -26,6 +26,7 @@ use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\Stdlib\DateTime;
 use Magento\Framework\Stdlib\StringUtils;
 
+// @codingStandardsIgnoreStart
 /**
  * MySQL database adapter
  *
@@ -33,10 +34,11 @@ use Magento\Framework\Stdlib\StringUtils;
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- * @codingStandardsIgnoreFile
  */
 class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
 {
+    // @codingStandardsIgnoreEnd
+
     const TIMESTAMP_FORMAT      = 'Y-m-d H:i:s';
     const DATETIME_FORMAT       = 'Y-m-d H:i:s';
     const DATE_FORMAT           = 'Y-m-d';
@@ -520,7 +522,9 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                 $pdoException = null;
                 if ($e instanceof \PDOException) {
                     $pdoException = $e;
-                } elseif (($e instanceof \Zend_Db_Statement_Exception) && ($e->getPrevious() instanceof \PDOException)) {
+                } elseif (($e instanceof \Zend_Db_Statement_Exception)
+                    && ($e->getPrevious() instanceof \PDOException)
+                ) {
                     $pdoException = $e->getPrevious();
                 }
 
@@ -749,7 +753,6 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * @return array
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
-
      * @deprecated
      */
     protected function _splitMultiQuery($sql)
@@ -1640,9 +1643,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         if ($columnData['PRIMARY'] === true) {
             $options['primary'] = true;
         }
-        if (!is_null($columnData['DEFAULT'])
-            && $type != Table::TYPE_TEXT
-        ) {
+        if ($columnData['DEFAULT'] !== null && $type != Table::TYPE_TEXT) {
             $options['default'] = $this->quote($columnData['DEFAULT']);
         }
         if (strlen($columnData['SCALE']) > 0) {
@@ -1747,7 +1748,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     {
         $definition = array_change_key_case($definition, CASE_UPPER);
         $definition['COLUMN_TYPE'] = $this->_getColumnTypeByDdl($definition);
-        if (array_key_exists('DEFAULT', $definition) && is_null($definition['DEFAULT'])) {
+        if (array_key_exists('DEFAULT', $definition) && $definition['DEFAULT'] === null) {
             unset($definition['DEFAULT']);
         }
 
@@ -2441,7 +2442,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             } else {
                 $cDefault = false;
             }
-        } elseif (is_null($cDefault) && $cNullable) {
+        } elseif ($cDefault === null && $cNullable) {
             $cDefault = new \Zend_Db_Expr('NULL');
         }
 
@@ -2937,7 +2938,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         }
 
         // return null
-        if (is_null($value) && $column['NULLABLE']) {
+        if ($value === null && $column['NULLABLE']) {
             return null;
         }
 
@@ -3202,7 +3203,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      */
     public function getSubstringSql($stringExpression, $pos, $len = null)
     {
-        if (is_null($len)) {
+        if ($len === null) {
             return new \Zend_Db_Expr(sprintf('SUBSTRING(%s, %s)', $stringExpression, $pos));
         }
         return new \Zend_Db_Expr(sprintf('SUBSTRING(%s, %s, %s)', $stringExpression, $pos, $len));
@@ -3826,7 +3827,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      */
     public function getTables($likeCondition = null)
     {
-        $sql = is_null($likeCondition) ? 'SHOW TABLES' : sprintf("SHOW TABLES LIKE '%s'", $likeCondition);
+        $sql = ($likeCondition === null) ? 'SHOW TABLES' : sprintf("SHOW TABLES LIKE '%s'", $likeCondition);
         $result = $this->query($sql);
         $tables = [];
         while ($row = $result->fetchColumn()) {

--- a/lib/internal/Magento/Framework/DB/MapperFactory.php
+++ b/lib/internal/Magento/Framework/DB/MapperFactory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\DB;
 
 /**

--- a/lib/internal/Magento/Framework/DB/QueryFactory.php
+++ b/lib/internal/Magento/Framework/DB/QueryFactory.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\DB;
 
 /**

--- a/lib/internal/Magento/Framework/DB/Statement/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Statement/Pdo/Mysql.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Mysql DB Statement
  *

--- a/lib/internal/Magento/Framework/DB/Test/Unit/AbstractMapperTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/AbstractMapperTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\DB\Test\Unit;
 
 use Magento\Framework\DB\Select;
@@ -247,8 +245,10 @@ class AbstractMapperTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($resultCondition));
 
         if (is_array($field)) {
-            $resultCondition = '(' . implode(') ' . \Magento\Framework\DB\Select::SQL_OR
-                    . ' (', array_fill(0, count($field), $resultCondition)) . ')';
+            $resultCondition = '(' . implode(
+                ') ' . \Magento\Framework\DB\Select::SQL_OR . ' (',
+                array_fill(0, count($field), $resultCondition)
+            ) . ')';
         }
 
         $this->selectMock->expects($this->once())

--- a/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\DB\Test\Unit\Adapter\Pdo;
 
 use Magento\Framework\DB\Adapter\AdapterInterface;
@@ -56,11 +54,6 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-//        StringUtils $string,
-//        DateTime $dateTime,
-//        LoggerInterface $logger,
-//        SelectFactory $selectFactory,
-//        array $config = []
         $this->_mockAdapter = $this->getMock(
             \Magento\Framework\DB\Adapter\Pdo\Mysql::class,
             ['beginTransaction', 'getTransactionLevel'],
@@ -80,8 +73,8 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->_mockAdapter->expects($this->any())
-             ->method('getTransactionLevel')
-             ->will($this->returnValue(1));
+            ->method('getTransactionLevel')
+            ->will($this->returnValue(1));
 
         $this->_adapter = $this->getMock(
             \Magento\Framework\DB\Adapter\Pdo\Mysql::class,
@@ -471,7 +464,10 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     {
         $connectionMock = $this->getMock(
             \Magento\Framework\DB\Adapter\Pdo\Mysql::class,
-            ['tableColumnExists', '_getTableName', 'rawQuery', 'resetDdlCache', 'quote'], [], '', false
+            ['tableColumnExists', '_getTableName', 'rawQuery', 'resetDdlCache', 'quote'],
+            [],
+            '',
+            false
         );
 
         $connectionMock->expects($this->any())->method('_getTableName')->will($this->returnArgument(0));


### PR DESCRIPTION
Fixed coding standard violations in the Framework\DB namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile from the head of the file
- Fixed indentation
- Changed is_null to strict === null compare 
- Added codeignorestart and end around \Zend_Db_Adapter_Pdo, because it's not using namespace which is not allowed by PSR-2
- Removed commented out code from MysqlTest class