### PR TITLE
Fixed coding standard violations in the Framework\Translate namespace

### DIFF
--- a/lib/internal/Magento/Framework/Translate/Adapter.php
+++ b/lib/internal/Magento/Framework/Translate/Adapter.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Magento translate adapter
  */
@@ -31,6 +29,7 @@ class Adapter extends AbstractAdapter
         }
     }
 
+    // @codingStandardsIgnoreStart
     /**
      * Translate message string.
      *
@@ -47,4 +46,5 @@ class Adapter extends AbstractAdapter
         }
         return $string;
     }
+    // @codingStandardsIgnoreEnd
 }

--- a/lib/internal/Magento/Framework/Translate/AdapterInterface.php
+++ b/lib/internal/Magento/Framework/Translate/AdapterInterface.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Translate;
 
 /**
@@ -24,6 +22,7 @@ interface AdapterInterface
      */
     public function translate($messageId, $locale = null);
 
+    // @codingStandardsIgnoreStart
     /**
      * Translate string
      *
@@ -31,4 +30,5 @@ interface AdapterInterface
      * @SuppressWarnings(PHPMD.ShortMethodName)
      */
     public function __();
+    // @codingStandardsIgnoreEnd
 }

--- a/lib/internal/Magento/Framework/Translate/Inline.php
+++ b/lib/internal/Magento/Framework/Translate/Inline.php
@@ -6,8 +6,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Translate;
 
 class Inline implements \Magento\Framework\Translate\InlineInterface
@@ -242,7 +240,11 @@ class Inline implements \Magento\Framework\Translate\InlineInterface
             }
         } else {
             if (is_string($body)) {
-                $body = preg_replace('#' . \Magento\Framework\Translate\Inline\ParserInterface::REGEXP_TOKEN . '#', '$1', $body);
+                $body = preg_replace(
+                    '#' . \Magento\Framework\Translate\Inline\ParserInterface::REGEXP_TOKEN . '#',
+                    '$1',
+                    $body
+                );
             }
         }
         return $this;


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Translate namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile from the head of the file
- Fixed indentation
- Wrapped __() functions with a codingStandardsIgnoreStart and end comment, because these will fail on the short function name. 
