### PR TITLE
Fixed coding standard violations in the Framework\Test namespace

### DIFF
--- a/lib/internal/Magento/Framework/Test/Unit/ShellTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/ShellTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Test\Unit;
 
 class ShellTest extends \PHPUnit_Framework_TestCase
@@ -54,7 +52,10 @@ class ShellTest extends \PHPUnit_Framework_TestCase
     public function testExecute($command, $commandArgs, $expectedResult)
     {
         $this->_testExecuteCommand(
-            new \Magento\Framework\Shell($this->commandRenderer, $this->logger), $command, $commandArgs, $expectedResult
+            new \Magento\Framework\Shell($this->commandRenderer, $this->logger),
+            $command,
+            $commandArgs,
+            $expectedResult
         );
     }
 

--- a/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
@@ -4,9 +4,8 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Test\Unit;
+
 use Magento\Framework\Url\HostChecker;
 
 /**
@@ -125,7 +124,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         );
         if ($resolve) {
             $routeParamsResolverFactoryMock->expects($this->once())->method('create')
-                    ->will($this->returnValue($this->routeParamsResolverMock));
+                ->will($this->returnValue($this->routeParamsResolverMock));
         }
         return $routeParamsResolverFactoryMock;
     }
@@ -292,7 +291,6 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
         $this->urlModifier->expects($this->exactly(1))->method('execute');
 
-        $this->assertEquals('catalog/product/view', $model->getUrl('catalog/product/view'));
         $this->assertEquals('catalog/product/view', $model->getUrl('catalog/product/view'));
     }
 
@@ -650,7 +648,8 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             ->method('getValue')
             ->with(
                 'web/secure/base_url_secure_forced',
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $this->scopeMock
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $this->scopeMock
             )
             ->will($this->returnValue('http://localhost/'));
         $this->routeParamsResolverMock->expects($this->once())->method('hasData')->with('secure_is_forced')

--- a/lib/internal/Magento/Framework/Test/Unit/ValidatorFactoryTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/ValidatorFactoryTest.php
@@ -6,8 +6,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Test\Unit;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Test namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile from the head of the file
- Fixed indentation
- Removed duplicate code line in UrlTest class