### PR TITLE
Fixed coding standard violations in the Framework\Code namespace

### DIFF
--- a/lib/internal/Magento/Framework/Code/Test/Unit/GeneratorTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/GeneratorTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Code\Test\Unit;
 
 use Magento\Framework\Code\Generator;

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Reader/_files/ClassesForArgumentsReader.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Reader/_files/ClassesForArgumentsReader.php
@@ -5,8 +5,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 class ClassWithAllArgumentTypes
 {
     const DEFAULT_VALUE = 'Const Value';

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Validator/ConstructorArgumentTypesTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Validator/ConstructorArgumentTypesTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Code\Test\Unit\Validator;
 
 class ConstructorArgumentTypesTest extends \PHPUnit_Framework_TestCase

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Validator/_files/ClassesForArgumentSequence.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Validator/_files/ClassesForArgumentSequence.php
@@ -5,8 +5,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace ArgumentSequence;
 
 class ContextObject implements \Magento\Framework\ObjectManager\ContextInterface

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Validator/_files/ClassesForConstructorIntegrity.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Validator/_files/ClassesForConstructorIntegrity.php
@@ -5,8 +5,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 class ClassA
 {
 }
@@ -16,16 +14,16 @@ class ClassB
 class ClassC
 {
 }
-interface InterfaceA
+interface FirstInterface
 {
 }
-class ImplementationOfInterfaceA implements InterfaceA
+class ImplementationOfFirstInterface implements FirstInterface
 {
 }
-interface InterfaceB
+interface SecondInterface
 {
 }
-class ImplementationOfInterfaceB implements InterfaceB
+class ImplementationOfSecondInterface implements SecondInterface
 {
 }
 class Context implements \Magento\Framework\ObjectManager\ContextInterface
@@ -46,12 +44,12 @@ class Context implements \Magento\Framework\ObjectManager\ContextInterface
     protected $_exC;
 
     /**
-     * @var InterfaceA
+     * @var FirstInterface
      */
     protected $_interfaceA;
 
     /**
-     * @var ImplementationOfInterfaceB
+     * @var ImplementationOfSecondInterface
      */
     protected $_implOfBInterface;
 
@@ -59,8 +57,8 @@ class Context implements \Magento\Framework\ObjectManager\ContextInterface
         \ClassA $exA,
         \ClassB $exB,
         \ClassC $exC,
-        \InterfaceA $interfaceA,
-        \ImplementationOfInterfaceB $implOfBInterface
+        \FirstInterface $interfaceA,
+        \ImplementationOfSecondInterface $implOfBInterface
     ) {
         $this->_exA = $exA;
         $this->_exB = $exB;

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Validator/_files/ClassesForContextAggregation.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Validator/_files/ClassesForContextAggregation.php
@@ -5,8 +5,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 class ClassFirst
 {
 }
@@ -19,16 +17,16 @@ class ClassThird
 class ClassD
 {
 }
-interface InterfaceFirst
+interface ThirdInterface
 {
 }
-class ImplementationOfInterfaceFirst implements InterfaceFirst
+class ImplementationOfThirdInterface implements ThirdInterface
 {
 }
-interface InterfaceSecond
+interface FourthInterface
 {
 }
-class ImplementationOfInterfaceSecond implements InterfaceSecond
+class ImplementationOfFourthInterface implements FourthInterface
 {
 }
 class ContextFirst implements \Magento\Framework\ObjectManager\ContextInterface
@@ -49,12 +47,12 @@ class ContextFirst implements \Magento\Framework\ObjectManager\ContextInterface
     protected $_exC;
 
     /**
-     * @var InterfaceFirst
+     * @var ThirdInterface
      */
     protected $_interfaceA;
 
     /**
-     * @var ImplementationOfInterfaceSecond
+     * @var ImplementationOfFourthInterface
      */
     protected $_implOfBInterface;
 
@@ -62,15 +60,15 @@ class ContextFirst implements \Magento\Framework\ObjectManager\ContextInterface
      * @param ClassFirst $exA
      * @param ClassSecond $exB
      * @param ClassThird $exC
-     * @param InterfaceFirst $interfaceA
-     * @param ImplementationOfInterfaceSecond $implOfBInterface
+     * @param ThirdInterface $interfaceA
+     * @param ImplementationOfFourthInterface $implOfBInterface
      */
     public function __construct(
         \ClassFirst $exA,
         \ClassSecond $exB,
         \ClassThird $exC,
-        \InterfaceFirst $interfaceA,
-        \ImplementationOfInterfaceSecond $implOfBInterface
+        \ThirdInterface $interfaceA,
+        \ImplementationOfFourthInterface $implOfBInterface
     ) {
         $this->_exA = $exA;
         $this->_exB = $exB;
@@ -109,15 +107,15 @@ class ClassArgumentWithInterfaceImplementation
     protected $_context;
 
     /**
-     * @var ImplementationOfInterfaceFirst
+     * @var ImplementationOfThirdInterface
      */
     protected $_exA;
 
     /**
      * @param ContextFirst $context
-     * @param ImplementationOfInterfaceFirst $exA
+     * @param ImplementationOfThirdInterface $exA
      */
-    public function __construct(\ContextFirst $context, \ImplementationOfInterfaceFirst $exA)
+    public function __construct(\ContextFirst $context, \ImplementationOfThirdInterface $exA)
     {
         $this->_context = $context;
         $this->_exA = $exA;
@@ -131,15 +129,15 @@ class ClassArgumentWithInterface
     protected $_context;
 
     /**
-     * @var InterfaceSecond
+     * @var FourthInterface
      */
     protected $_exB;
 
     /**
      * @param ContextFirst $context
-     * @param InterfaceSecond $exB
+     * @param FourthInterface $exB
      */
-    public function __construct(\ContextFirst $context, \InterfaceSecond $exB)
+    public function __construct(\ContextFirst $context, \FourthInterface $exB)
     {
         $this->_context = $context;
         $this->_exB = $exB;
@@ -153,15 +151,15 @@ class ClassArgumentWithAlreadyInjectedInterface
     protected $_context;
 
     /**
-     * @var InterfaceFirst
+     * @var ThirdInterface
      */
     protected $_exA;
 
     /**
      * @param ContextFirst $context
-     * @param InterfaceFirst $exA
+     * @param ThirdInterface $exA
      */
-    public function __construct(\ContextFirst $context, \InterfaceFirst $exA)
+    public function __construct(\ContextFirst $context, \ThirdInterface $exA)
     {
         $this->_context = $context;
         $this->_exA = $exA;

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Validator/_files/ClassesForTypeDuplication.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Validator/_files/ClassesForTypeDuplication.php
@@ -5,8 +5,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace TypeDuplication;
 
 interface ArgumentInterface

--- a/lib/internal/Magento/Framework/Code/Test/Unit/_files/app/code/Magento/SomeModule/Model/SevenInterface.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/_files/app/code/Magento/SomeModule/Model/SevenInterface.php
@@ -27,7 +27,7 @@ interface SevenInterface extends \Magento\Framework\Code\Generator\CodeGenerator
      * @param array $data
      * @return TestThree
      */
-    public static function testMethod1(array &$data = array());
+    public static function testMethod1(array &$data = []);
 
     /**
      * Method short description
@@ -41,6 +41,4 @@ interface SevenInterface extends \Magento\Framework\Code\Generator\CodeGenerator
     public function testMethod2($data = 'test_default', $flag = true);
 
     public function testMethod3();
-
-
 }

--- a/lib/internal/Magento/Framework/Code/Test/Unit/_files/app/code/Magento/SomeModule/Model/SevenInterface.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/_files/app/code/Magento/SomeModule/Model/SevenInterface.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\SomeModule\Model;
 
 use Magento\SomeModule\Model\Two\Test as TestTwo;

--- a/lib/internal/Magento/Framework/Code/Test/Unit/_files/app/code/Magento/SomeModule/Model/SevenInterface.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/_files/app/code/Magento/SomeModule/Model/SevenInterface.php
@@ -27,7 +27,7 @@ interface SevenInterface extends \Magento\Framework\Code\Generator\CodeGenerator
      * @param array $data
      * @return TestThree
      */
-    public static function testMethod1(array &$data = []);
+    public static function testMethod1(array &$data = array());
 
     /**
      * Method short description


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Code namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:

- Removed @codingStandardsIgnoreFile from the head of the file.
- Changed interfaces in tests to actually end with the name "Interface".
