### PR TITLE
Fixed coding standard violations in the Framework\Interception namespace

### DIFF
--- a/lib/internal/Magento/Framework/Interception/Code/Generator/Interceptor.php
+++ b/lib/internal/Magento/Framework/Interception/Code/Generator/Interceptor.php
@@ -85,13 +85,8 @@ class Interceptor extends \Magento\Framework\Code\Generator\EntityAbstract
      */
     protected function isInterceptedMethod(\ReflectionMethod $method)
     {
-        return !($method->isConstructor() ||
-                $method->isFinal() ||
-                $method->isStatic() ||
-                $method->isDestructor()) && !in_array(
-                $method->getName(),
-                ['__sleep', '__wakeup', '__clone']
-            );
+        return !($method->isConstructor() || $method->isFinal() || $method->isStatic() || $method->isDestructor()) &&
+            !in_array($method->getName(), ['__sleep', '__wakeup', '__clone']);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Interception/Code/Generator/Interceptor.php
+++ b/lib/internal/Magento/Framework/Interception/Code/Generator/Interceptor.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Interception\Code\Generator;
 
 class Interceptor extends \Magento\Framework\Code\Generator\EntityAbstract
@@ -88,9 +86,9 @@ class Interceptor extends \Magento\Framework\Code\Generator\EntityAbstract
     protected function isInterceptedMethod(\ReflectionMethod $method)
     {
         return !($method->isConstructor() ||
-            $method->isFinal() ||
-            $method->isStatic() ||
-            $method->isDestructor()) && !in_array(
+                $method->isFinal() ||
+                $method->isStatic() ||
+                $method->isDestructor()) && !in_array(
                 $method->getName(),
                 ['__sleep', '__wakeup', '__clone']
             );
@@ -113,13 +111,13 @@ class Interceptor extends \Magento\Framework\Code\Generator\EntityAbstract
             'name' => $method->getName(),
             'parameters' => $parameters,
             'body' => "\$pluginInfo = \$this->pluginList->getNext(\$this->subjectType, '{$method->getName()}');\n" .
-            "if (!\$pluginInfo) {\n" .
-            "    return parent::{$method->getName()}({$this->_getParameterList(
+                "if (!\$pluginInfo) {\n" .
+                "    return parent::{$method->getName()}({$this->_getParameterList(
                 $parameters
             )});\n" .
-            "} else {\n" .
-            "    return \$this->___callPlugins('{$method->getName()}', func_get_args(), \$pluginInfo);\n" .
-            "}",
+                "} else {\n" .
+                "    return \$this->___callPlugins('{$method->getName()}', func_get_args(), \$pluginInfo);\n" .
+                "}",
             'docblock' => ['shortDescription' => '{@inheritdoc}'],
         ];
 
@@ -159,8 +157,8 @@ class Interceptor extends \Magento\Framework\Code\Generator\EntityAbstract
         } else {
             $this->_classGenerator->setExtendedClass($typeName);
         }
-        $this->_classGenerator->addTrait('\Magento\Framework\Interception\Interceptor');
-        $interfaces[] = '\Magento\Framework\Interception\InterceptorInterface';
+        $this->_classGenerator->addTrait('\\'. \Magento\Framework\Interception\Interceptor::class);
+        $interfaces[] =  '\\'. \Magento\Framework\Interception\InterceptorInterface::class;
         $this->_classGenerator->setImplementedInterfaces($interfaces);
         return parent::_generateCode();
     }

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Code/Generator/InterceptorTest.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Code/Generator/InterceptorTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Interception\Test\Unit\Code\Generator;
 
 class InterceptorTest extends \PHPUnit_Framework_TestCase

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Code/InterfaceValidatorTest.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Code/InterfaceValidatorTest.php
@@ -4,11 +4,14 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Interception\Test\Unit\Code;
 
 use \Magento\Framework\Interception\Code\InterfaceValidator;
+use \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin\ValidPlugin;
+use \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin\IncompatibleInterface;
+use \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin\IncorrectSubject;
+use \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin\ExtraParameters;
+use \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin\InvalidProceed;
 
 class InterfaceValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -51,7 +54,7 @@ class InterfaceValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidate()
     {
         $this->model->validate(
-            \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin\ValidPlugin::class,
+            ValidPlugin::class,
             \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments::class
         );
     }
@@ -64,20 +67,20 @@ class InterfaceValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidateIncorrectInterface()
     {
         $this->model->validate(
-            \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin\IncompatibleInterface::class,
+            IncompatibleInterface::class,
             \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item::class
         );
     }
 
     /**
      * @expectedException \Magento\Framework\Exception\ValidatorException
-     * @expectedExceptionMessage Invalid [\Magento\Framework\Interception\Test\Unit\Custom\Module\Model\Item] $subject type
+     * @expectedExceptionMessage $subject type
      * @covers \Magento\Framework\Interception\Code\InterfaceValidator::validate
      */
     public function testValidateIncorrectSubjectType()
     {
         $this->model->validate(
-            \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin\IncorrectSubject::class,
+            IncorrectSubject::class,
             \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item::class
         );
     }
@@ -91,8 +94,8 @@ class InterfaceValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidateIncompatibleMethodArgumentsCount()
     {
         $this->model->validate(
-            \Magento\Framework\Interception\Test\Unit\Custom\Module\Model::class
-                . '\InterfaceValidator\ItemPlugin\IncompatibleArgumentsCount',
+            \Magento\Framework\Interception\Test\Unit\Custom\Module\Model::class .
+            '\InterfaceValidator\ItemPlugin\IncompatibleArgumentsCount',
             \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item::class
         );
     }
@@ -106,8 +109,8 @@ class InterfaceValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidateIncompatibleMethodArgumentsType()
     {
         $this->model->validate(
-            \Magento\Framework\Interception\Test\Unit\Custom\Module\Model::class
-                . '\InterfaceValidator\ItemPlugin\IncompatibleArgumentsType',
+            \Magento\Framework\Interception\Test\Unit\Custom\Module\Model::class .
+            '\InterfaceValidator\ItemPlugin\IncompatibleArgumentsType',
             \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments::class
         );
     }
@@ -120,7 +123,7 @@ class InterfaceValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidateExtraParameters()
     {
         $this->model->validate(
-            \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin\ExtraParameters::class,
+            ExtraParameters::class,
             \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item::class
         );
     }
@@ -133,7 +136,7 @@ class InterfaceValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidateInvalidProceed()
     {
         $this->model->validate(
-            \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin\InvalidProceed::class,
+            InvalidProceed::class,
             \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item::class
         );
     }

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Config/ConfigTest.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Config/ConfigTest.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-// @codingStandardsIgnoreFile
+
 namespace Magento\Framework\Interception\Test\Unit\Config;
 
 use Magento\Framework\Serialize\SerializerInterface;
@@ -130,12 +130,15 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                         \Magento\Framework\Interception\Custom\Module\Model\Backslash\ItemProxy::class
                     ],
                     [
-                        'virtual_custom_item', \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\Item::class,
+                        'virtual_custom_item',
+                        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\Item::class
                     ],
                 ]
             ));
         $this->definitionMock->expects($this->any())->method('getClasses')->will($this->returnValue(
-            [\Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemProxy::class, \Magento\Framework\Interception\Custom\Module\Model\Backslash\ItemProxy::class,
+            [
+                \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemProxy::class,
+                \Magento\Framework\Interception\Custom\Module\Model\Backslash\ItemProxy::class
             ]
         ));
         $this->relationsMock->expects($this->any())->method('has')->will($this->returnValue($expectedResult));
@@ -155,7 +158,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 'relations' => $this->relationsMock,
                 'omConfig' => $this->omConfigMock,
                 'classDefinitions' => $this->definitionMock,
-                'serializer' => $this->serializerMock,
+                'serializer' => $this->serializerMock
             ]
         );
 
@@ -177,7 +180,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemContainer\Enhanced::class => true,
             \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemContainer\Proxy::class => true,
             \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemProxy::class => false,
-            'virtual_custom_item' => true,
+            'virtual_custom_item' => true
         ];
         $this->readerMock->expects($this->never())->method('read');
         $this->cacheMock->expects($this->never())->method('save');
@@ -205,7 +208,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 'omConfig' => $this->omConfigMock,
                 'classDefinitions' => $this->definitionMock,
                 'cacheId' => $cacheId,
-                'serializer' => $this->serializerMock,
+                'serializer' => $this->serializerMock
             ]
         );
 
@@ -218,34 +221,34 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             // item container has plugins only in the backend scope
             [
                 true, \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemContainer::class,
-                [],
+                []
             ],
             [
                 true, \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\Item::class,
-                [],
+                []
             ],
             [
                 true, \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\Item\Enhanced::class,
-                [],
+                []
             ],
             [
                 // the following model has only inherited plugins
                 true, \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemContainer\Proxy::class,
-                [\Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemContainer::class],
+                [\Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemContainer::class]
             ],
             [
                 // the following model has only inherited plugins
                 true, \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemContainer\Proxy::class,
-                [\Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemContainer::class],
+                [\Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemContainer::class]
             ],
             [
                 false, \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\ItemProxy::class,
-                [],
+                []
             ],
             [
                 true,
                 'virtual_custom_item',
-                [],
+                []
             ]
         ];
     }

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Custom/Module/Model/InterfaceValidator/ItemPlugin/ExtraParameters.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Custom/Module/Model/InterfaceValidator/ItemPlugin/ExtraParameters.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin;
 
 class ExtraParameters
@@ -19,7 +17,9 @@ class ExtraParameters
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterGetItem(
-        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item $subject, $name, $surname
+        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item $subject,
+        $name,
+        $surname
     ) {
         return $name . $surname;
     }

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Custom/Module/Model/InterfaceValidator/ItemPlugin/IncompatibleArgumentsCount.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Custom/Module/Model/InterfaceValidator/ItemPlugin/IncompatibleArgumentsCount.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin;
 
 class IncompatibleArgumentsCount
@@ -19,7 +17,9 @@ class IncompatibleArgumentsCount
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function beforeGetItem(
-        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item $subject, $name, $surname
+        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item $subject,
+        $name,
+        $surname
     ) {
         return $name . $surname;
     }

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Custom/Module/Model/InterfaceValidator/ItemPlugin/IncompatibleArgumentsType.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Custom/Module/Model/InterfaceValidator/ItemPlugin/IncompatibleArgumentsType.php
@@ -4,21 +4,22 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin;
+
+use \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments;
 
 class IncompatibleArgumentsType
 {
     /**
-     * @param \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments $subject
+     * @param ItemWithArguments $subject
      * @param array $names
      * @return int
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function beforeGetItem(
-        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments $subject, array $names
+        ItemWithArguments $subject,
+        array $names
     ) {
         return count($names);
     }

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Custom/Module/Model/InterfaceValidator/ItemPlugin/InvalidProceed.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Custom/Module/Model/InterfaceValidator/ItemPlugin/InvalidProceed.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin;
 
 class InvalidProceed
@@ -19,7 +17,9 @@ class InvalidProceed
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function aroundGetItem(
-        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item $subject, $name, $surname
+        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\Item $subject,
+        $name,
+        $surname
     ) {
         return $name . $surname;
     }

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Custom/Module/Model/InterfaceValidator/ItemPlugin/ValidPlugin.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Custom/Module/Model/InterfaceValidator/ItemPlugin/ValidPlugin.php
@@ -4,40 +4,42 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemPlugin;
+
+use \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments;
 
 class ValidPlugin
 {
     /**
-     * @param \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments $subject
+     * @param ItemWithArguments $subject
      * @param string $result
      * @return string
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterGetItem(
-        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments $subject, $result
+        ItemWithArguments $subject,
+        $result
     ) {
         return $result . '!';
     }
 
     /**
-     * @param \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments $subject
+     * @param ItemWithArguments $subject
      * @param $name
      * @return string
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function beforeGetItem(
-        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments $subject, $name
+        ItemWithArguments $subject,
+        $name
     ) {
         return '|' . $name;
     }
 
     /**
-     * @param \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments $subject
+     * @param ItemWithArguments $subject
      * @param Closure $proceed
      * @param string $name
      * @return string
@@ -45,7 +47,7 @@ class ValidPlugin
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function aroundGetItem(
-        \Magento\Framework\Interception\Test\Unit\Custom\Module\Model\InterfaceValidator\ItemWithArguments $subject,
+        ItemWithArguments $subject,
         \Closure $proceed,
         $name
     ) {


### PR DESCRIPTION
Fixed coding standard violations in the Framework\Interception namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:

- Removed @codingStandardsIgnoreFile from the head of the file.
- Added use statement to so files in order to get shortes class names and fix line length
- Fixed identation
- Fixed unnecessary comma at the end of arrays