### PR TITLE
Fixed coding standard violations in the Framework\ObjectManager namespace

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Persistor.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Persistor.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\ObjectManager\Code\Generator;
 
 /**

--- a/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Repository.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Code/Generator/Repository.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\ObjectManager\Code\Generator;
 
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Relations/RuntimeTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Relations/RuntimeTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Framework\ObjectManager\Test\Unit\Relations;
 
 require_once __DIR__ . '/../_files/Child.php';


### PR DESCRIPTION
Fixed coding standard violations in the Framework\ObjectManager namespace, so that it will be checked bij PHP CS and no longer be ignored while doing CI checks. Made the following changes:
- Removed @codingStandardsIgnoreFile from the head of the file.