### PR TITLE
Add ability to inject exception code in LocalizedException

### DIFF
--- a/lib/internal/Magento/Framework/Exception/LocalizedException.php
+++ b/lib/internal/Magento/Framework/Exception/LocalizedException.php
@@ -26,15 +26,14 @@ class LocalizedException extends \Exception
     protected $logMessage;
 
     /**
-     * Constructor
-     *
      * @param \Magento\Framework\Phrase $phrase
      * @param \Exception $cause
+     * @param int $code
      */
-    public function __construct(Phrase $phrase, \Exception $cause = null)
+    public function __construct(Phrase $phrase, \Exception $cause = null, $code = 0)
     {
         $this->phrase = $phrase;
-        parent::__construct($phrase->render(), 0, $cause);
+        parent::__construct($phrase->render(), intval($code), $cause);
     }
 
     /**


### PR DESCRIPTION
I'm not sure why you've chosen to always pass in `0`. It's so much easier to work with codes.

This change should be BC.