### PR TITLE
Backport of MAGETWO-59685 for Magento 2.1 - Checkout pages very slow …

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart/LayoutProcessor.php
+++ b/app/code/Magento/Checkout/Block/Cart/LayoutProcessor.php
@@ -85,14 +85,14 @@ class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcesso
                 'visible' => true,
                 'formElement' => 'select',
                 'label' => __('Country'),
-                'options' => $this->countryCollection->loadByStore()->toOptionArray(),
+                'options' => [],
                 'value' => null
             ],
             'region_id' => [
                 'visible' => true,
                 'formElement' => 'select',
                 'label' => __('State/Province'),
-                'options' => $this->regionCollection->load()->toOptionArray(),
+                'options' => [],
                 'value' => null
             ],
             'postcode' => [
@@ -102,6 +102,13 @@ class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcesso
                 'value' => null
             ]
         ];
+
+        if (!isset($jsLayout['components']['checkoutProvider']['dictionaries'])) {
+            $jsLayout['components']['checkoutProvider']['dictionaries'] = [
+                'country_id' => $this->countryCollection->loadByStore()->toOptionArray(),
+                'region_id' => $this->regionCollection->addAllowedCountriesFilter()->toOptionArray(),
+            ];
+        }
 
         if (isset($jsLayout['components']['block-summary']['children']['block-shipping']['children']
             ['address-fieldsets']['children'])

--- a/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
+++ b/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
@@ -191,6 +191,15 @@ class AttributeMerger
             'visible' => isset($additionalConfig['visible']) ? $additionalConfig['visible'] : true,
         ];
 
+        if ($attributeCode === 'region_id' || $attributeCode === 'country_id') {
+            unset($element['options']);
+            $element['deps'] = [$providerName];
+            $element['imports'] = [
+                'initialOptions' => 'index = ' . $providerName . ':dictionaries.' . $attributeCode,
+                'setOptions' => 'index = ' . $providerName . ':dictionaries.' . $attributeCode
+            ];
+        }
+
         if (isset($attributeConfig['value']) && $attributeConfig['value'] != null) {
             $element['value'] = $attributeConfig['value'];
         } elseif (isset($attributeConfig['default']) && $attributeConfig['default'] != null) {
@@ -340,11 +349,11 @@ class AttributeMerger
      * @param string $attributeCode
      * @param array $attributeConfig
      * @return array
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function getFieldOptions($attributeCode, array $attributeConfig)
     {
-        $options = isset($attributeConfig['options']) ? $attributeConfig['options'] : [];
-        return ($attributeCode == 'country_id') ? $this->orderCountryOptions($options) : $options;
+        return isset($attributeConfig['options']) ? $attributeConfig['options'] : [];
     }
 
     /**
@@ -352,6 +361,7 @@ class AttributeMerger
      *
      * @param array $countryOptions
      * @return array
+     * @deprecated
      */
     protected function orderCountryOptions(array $countryOptions)
     {

--- a/app/code/Magento/Checkout/Block/Checkout/DirectoryDataProcessor.php
+++ b/app/code/Magento/Checkout/Block/Checkout/DirectoryDataProcessor.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Checkout\Block\Checkout;
+
+use Magento\Directory\Helper\Data as DirectoryHelper;
+use Magento\Store\Api\StoreResolverInterface;
+
+/**
+ * Directory data processor.
+ *
+ * This class adds various country and region dictionaries to checkout page.
+ * This data can be used by other UI components during checkout flow.
+ */
+class DirectoryDataProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcessorInterface
+{
+    /**
+     * @var array
+     */
+    private $countryOptions;
+
+    /**
+     * @var array
+     */
+    private $regionOptions;
+
+    /**
+     * @var \Magento\Directory\Model\ResourceModel\Region\CollectionFactory
+     */
+    private $regionCollectionFactory;
+
+    /**
+     * @var \Magento\Directory\Model\ResourceModel\Region\CollectionFactory
+     */
+    private $countryCollectionFactory;
+
+    /**
+     * @var StoreResolverInterface
+     */
+    private $storeResolver;
+
+    /**
+     * @var DirectoryHelper
+     */
+    private $directoryHelper;
+
+    /**
+     * @param \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollection
+     * @param \Magento\Directory\Model\ResourceModel\Region\CollectionFactory $regionCollection
+     * @param StoreResolverInterface $storeResolver
+     * @param DirectoryHelper $directoryHelper
+     */
+    public function __construct(
+        \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollection,
+        \Magento\Directory\Model\ResourceModel\Region\CollectionFactory $regionCollection,
+        StoreResolverInterface $storeResolver,
+        DirectoryHelper $directoryHelper
+    ) {
+        $this->countryCollectionFactory = $countryCollection;
+        $this->regionCollectionFactory = $regionCollection;
+        $this->storeResolver = $storeResolver;
+        $this->directoryHelper = $directoryHelper;
+    }
+
+    /**
+     * Process js Layout of block
+     *
+     * @param array $jsLayout
+     * @return array
+     */
+    public function process($jsLayout)
+    {
+        if (!isset($jsLayout['components']['checkoutProvider']['dictionaries'])) {
+            $jsLayout['components']['checkoutProvider']['dictionaries'] = [
+                'country_id' => $this->getCountryOptions(),
+                'region_id' => $this->getRegionOptions(),
+            ];
+        }
+
+        return $jsLayout;
+    }
+
+    /**
+     * Get country options list.
+     *
+     * @return array
+     */
+    private function getCountryOptions()
+    {
+        if (!isset($this->countryOptions)) {
+            $this->countryOptions = $this->countryCollectionFactory->create()->loadByStore(
+                $this->storeResolver->getCurrentStoreId()
+            )->toOptionArray();
+            $this->countryOptions = $this->orderCountryOptions($this->countryOptions);
+        }
+
+        return $this->countryOptions;
+    }
+
+    /**
+     * Get region options list.
+     *
+     * @return array
+     */
+    private function getRegionOptions()
+    {
+        if (!isset($this->regionOptions)) {
+            $this->regionOptions = $this->regionCollectionFactory->create()->addAllowedCountriesFilter(
+                $this->storeResolver->getCurrentStoreId()
+            )->toOptionArray();
+        }
+
+        return $this->regionOptions;
+    }
+
+    /**
+     * Sort country options by top country codes.
+     *
+     * @param array $countryOptions
+     * @return array
+     */
+    private function orderCountryOptions(array $countryOptions)
+    {
+        $topCountryCodes = $this->directoryHelper->getTopCountryCodes();
+        if (empty($topCountryCodes)) {
+            return $countryOptions;
+        }
+
+        $headOptions = [];
+        $tailOptions = [[
+            'value' => 'delimiter',
+            'label' => '──────────',
+            'disabled' => true,
+        ]];
+        foreach ($countryOptions as $countryOption) {
+            if (empty($countryOption['value']) || in_array($countryOption['value'], $topCountryCodes)) {
+                array_push($headOptions, $countryOption);
+            } else {
+                array_push($tailOptions, $countryOption);
+            }
+        }
+        return array_merge($headOptions, $tailOptions);
+    }
+}

--- a/app/code/Magento/Checkout/Block/Checkout/LayoutProcessor.php
+++ b/app/code/Magento/Checkout/Block/Checkout/LayoutProcessor.php
@@ -7,7 +7,11 @@ namespace Magento\Checkout\Block\Checkout;
 
 use Magento\Checkout\Helper\Data;
 use Magento\Framework\App\ObjectManager;
+use Magento\Store\Api\StoreResolverInterface;
 
+/**
+ * Class LayoutProcessor
+ */
 class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcessorInterface
 {
     /**
@@ -34,6 +38,16 @@ class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcesso
      * @var Data
      */
     private $checkoutDataHelper;
+
+    /**
+     * @var StoreResolverInterface
+     */
+    private $storeResolver;
+
+    /**
+     * @var \Magento\Shipping\Model\Config
+     */
+    private $shippingConfig;
 
     /**
      * @param \Magento\Customer\Model\AttributeMetadataDataProvider $attributeMetadataDataProvider
@@ -146,6 +160,16 @@ class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcesso
                 $elements
             );
         }
+        if (isset($jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
+            ['step-config']['children']['shipping-rates-validation']['children']
+        )) {
+            $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
+            ['step-config']['children']['shipping-rates-validation']['children'] =
+                $this->processShippingChildrenComponents(
+                    $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
+                    ['step-config']['children']['shipping-rates-validation']['children']
+                );
+        }
 
         if (isset($jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']
             ['children']['shippingAddress']['children']['shipping-address-fieldset']['children']
@@ -161,6 +185,26 @@ class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcesso
             );
         }
         return $jsLayout;
+    }
+
+    /**
+     * Process shipping configuration to exclude inactive carriers.
+     *
+     * @param array $shippingRatesLayout
+     * @return array
+     */
+    private function processShippingChildrenComponents($shippingRatesLayout)
+    {
+        $activeCarriers = $this->getShippingConfig()->getActiveCarriers(
+            $this->getStoreResolver()->getCurrentStoreId()
+        );
+        foreach (array_keys($shippingRatesLayout) as $carrierName) {
+            $carrierKey = str_replace('-rates-validation', '', $carrierName);
+            if (!array_key_exists($carrierKey, $activeCarriers)) {
+                unset($shippingRatesLayout[$carrierName]);
+            }
+        }
+        return $shippingRatesLayout;
     }
 
     /**
@@ -325,5 +369,35 @@ class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcesso
         }
 
         return $this->checkoutDataHelper;
+    }
+
+    /**
+     * Get active carriers list.
+     *
+     * @return array
+     * @deprecated
+     */
+    private function getShippingConfig()
+    {
+        if (!$this->shippingConfig) {
+            $this->shippingConfig = ObjectManager::getInstance()->get(\Magento\Shipping\Model\Config::class);
+        }
+
+        return $this->shippingConfig;
+    }
+
+    /**
+     * Get store resolver.
+     *
+     * @return StoreResolverInterface
+     * @deprecated
+     */
+    private function getStoreResolver()
+    {
+        if (!$this->storeResolver) {
+            $this->storeResolver = ObjectManager::getInstance()->get(StoreResolverInterface::class);
+        }
+
+        return $this->storeResolver;
     }
 }

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/LayoutProcessorTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/LayoutProcessorTest.php
@@ -69,7 +69,7 @@ class LayoutProcessorTest extends \PHPUnit_Framework_TestCase
         $this->countryCollection->expects($this->once())->method('loadByStore')->willReturnSelf();
         $this->countryCollection->expects($this->once())->method('toOptionArray')->willReturn($countries);
 
-        $this->regionCollection->expects($this->once())->method('load')->willReturnSelf();
+        $this->regionCollection->expects($this->once())->method('addAllowedCountriesFilter')->willReturnSelf();
         $this->regionCollection->expects($this->once())->method('toOptionArray')->willReturn($regions);
 
         $layoutMerged = $layout;
@@ -77,7 +77,12 @@ class LayoutProcessorTest extends \PHPUnit_Framework_TestCase
         ['address-fieldsets']['children']['fieldThree'] = ['param' => 'value'];
         $layoutMergedPointer = &$layoutMerged['components']['block-summary']['children']['block-shipping']
         ['children']['address-fieldsets']['children'];
-
+        $layoutMerged['components']['checkoutProvider'] = [
+            'dictionaries' => [
+                'country_id' => [],
+                'region_id' => [],
+            ]
+        ];
         $elements = [
             'city' => [
                 'visible' => false,

--- a/app/code/Magento/Checkout/Test/Unit/Block/Checkout/DirectoryDataProcessorTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Checkout/DirectoryDataProcessorTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Checkout\Test\Unit\Block\Checkout;
+
+class DirectoryDataProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Magento\Checkout\Block\Checkout\DirectoryDataProcessor
+     */
+    protected $model;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $countryCollectionFactoryMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $countryCollectionMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $regionCollectionFactoryMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $regionCollectionMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $storeResolverMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $directoryDataHelperMock;
+
+    protected function setUp()
+    {
+        $this->countryCollectionFactoryMock = $this->getMock(
+            \Magento\Directory\Model\ResourceModel\Country\CollectionFactory::class,
+            ['create'],
+            [],
+            '',
+            false
+        );
+        $this->countryCollectionMock = $this->getMock(
+            \Magento\Directory\Model\ResourceModel\Country\Collection::class,
+            [],
+            [],
+            '',
+            false
+        );
+        $this->regionCollectionFactoryMock = $this->getMock(
+            \Magento\Directory\Model\ResourceModel\Region\CollectionFactory::class,
+            ['create'],
+            [],
+            '',
+            false
+        );
+        $this->regionCollectionMock = $this->getMock(
+            \Magento\Directory\Model\ResourceModel\Region\Collection::class,
+            [],
+            [],
+            '',
+            false
+        );
+        $this->storeResolverMock = $this->getMock(
+            \Magento\Store\Api\StoreResolverInterface::class
+        );
+        $this->directoryDataHelperMock = $this->getMock(
+            \Magento\Directory\Helper\Data::class,
+            [],
+            [],
+            '',
+            false
+        );
+
+        $this->model = new \Magento\Checkout\Block\Checkout\DirectoryDataProcessor(
+            $this->countryCollectionFactoryMock,
+            $this->regionCollectionFactoryMock,
+            $this->storeResolverMock,
+            $this->directoryDataHelperMock
+        );
+    }
+
+    public function testProcess()
+    {
+        $expectedResult['components']['checkoutProvider']['dictionaries'] = [
+            'country_id' => [],
+            'region_id' => [],
+        ];
+
+        $this->countryCollectionFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($this->countryCollectionMock);
+        $this->countryCollectionMock->expects($this->once())->method('loadByStore')->willReturnSelf();
+        $this->countryCollectionMock->expects($this->once())->method('toOptionArray')->willReturn([]);
+        $this->regionCollectionFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($this->regionCollectionMock);
+        $this->regionCollectionMock->expects($this->once())->method('addAllowedCountriesFilter')->willReturnSelf();
+        $this->regionCollectionMock->expects($this->once())->method('toOptionArray')->willReturn([]);
+
+        $this->assertEquals($expectedResult, $this->model->process([]));
+    }
+}

--- a/app/code/Magento/Checkout/Test/Unit/Block/Checkout/LayoutProcessorTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Checkout/LayoutProcessorTest.php
@@ -17,6 +17,8 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
 /**
  * LayoutProcessorTest covers a list of variations for
  * checkout layout processor
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class LayoutProcessorTest extends \PHPUnit_Framework_TestCase
 {
@@ -44,6 +46,11 @@ class LayoutProcessorTest extends \PHPUnit_Framework_TestCase
      * @var LayoutProcessor
      */
     private $layoutProcessor;
+
+    /**
+     * @var MockObject
+     */
+    private $storeResolver;
 
     protected function setUp()
     {
@@ -79,8 +86,11 @@ class LayoutProcessorTest extends \PHPUnit_Framework_TestCase
             $this->attributeMerger
         );
 
+        $this->storeResolver = $this->getMock(\Magento\Store\Api\StoreResolverInterface::class);
+
         $objectManager->setBackwardCompatibleProperty($this->layoutProcessor, 'checkoutDataHelper', $this->dataHelper);
         $objectManager->setBackwardCompatibleProperty($this->layoutProcessor, 'options', $options);
+        $objectManager->setBackwardCompatibleProperty($this->layoutProcessor, 'storeResolver', $this->storeResolver);
     }
 
     /**

--- a/app/code/Magento/Checkout/etc/frontend/di.xml
+++ b/app/code/Magento/Checkout/etc/frontend/di.xml
@@ -55,6 +55,7 @@
             <argument name="layoutProcessors" xsi:type="array">
                 <item name="addressFormAttributes" xsi:type="object">Magento\Checkout\Block\Checkout\LayoutProcessor</item>
                 <item name="totalsSortOrder" xsi:type="object">Magento\Checkout\Block\Checkout\TotalsProcessor</item>
+                <item name="directoryData" xsi:type="object">Magento\Checkout\Block\Checkout\DirectoryDataProcessor</item>
             </argument>
         </arguments>
     </type>

--- a/app/code/Magento/Directory/Model/ResourceModel/Region/Collection.php
+++ b/app/code/Magento/Directory/Model/ResourceModel/Region/Collection.php
@@ -9,6 +9,14 @@
  */
 namespace Magento\Directory\Model\ResourceModel\Region;
 
+use Magento\Directory\Model\AllowedCountries;
+use Magento\Framework\App\ObjectManager;
+use Magento\Store\Model\ScopeInterface;
+
+/**
+ * Class Collection
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
 {
     /**
@@ -29,6 +37,11 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      * @var \Magento\Framework\Locale\ResolverInterface
      */
     protected $_localeResolver;
+
+    /**
+     * @var AllowedCountries
+     */
+    private $allowedCountriesReader;
 
     /**
      * @param \Magento\Framework\Data\Collection\EntityFactory $entityFactory
@@ -85,6 +98,40 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
             'main_table.region_id = rname.region_id AND rname.locale = :region_locale',
             ['name']
         );
+
+        return $this;
+    }
+
+    /**
+     * Return Allowed Countries reader
+     *
+     * @return \Magento\Directory\Model\AllowedCountries
+     * @deprecated
+     */
+    private function getAllowedCountriesReader()
+    {
+        if (!$this->allowedCountriesReader) {
+            $this->allowedCountriesReader = ObjectManager::getInstance()->get(AllowedCountries::class);
+        }
+
+        return $this->allowedCountriesReader;
+    }
+
+    /**
+     * Set allowed countries filter based on the given store.
+     * This is a convenience method for collection filtering based on store configuration settings.
+     *
+     * @param null|int|string|\Magento\Store\Model\Store $store
+     * @return \Magento\Directory\Model\ResourceModel\Region\Collection
+     */
+    public function addAllowedCountriesFilter($store = null)
+    {
+        $allowedCountries = $this->getAllowedCountriesReader()
+            ->getAllowedCountries(ScopeInterface::SCOPE_STORE, $store);
+
+        if (!empty($allowedCountries)) {
+            $this->addFieldToFilter('main_table.country_id', ['in' => $allowedCountries]);
+        }
 
         return $this;
     }

--- a/app/code/Magento/Directory/Test/Unit/Model/ResourceModel/Region/CollectionTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/ResourceModel/Region/CollectionTest.php
@@ -6,6 +6,7 @@
 namespace Magento\Directory\Test\Unit\Model\ResourceModel\Region;
 
 use Magento\Directory\Model\ResourceModel\Region\Collection;
+use Magento\Directory\Model\AllowedCountries;
 use Magento\Framework\DB\Adapter\Pdo\Mysql;
 use Magento\Framework\DB\Select;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
@@ -15,7 +16,14 @@ use Magento\Framework\Data\Collection\EntityFactory;
 use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\DataObject;
 use Psr\Log\LoggerInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
+/**
+ * Class CollectionTest
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class CollectionTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -23,15 +31,22 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
      */
     private $collection;
 
+    /**
+     * @var MockObject
+     */
+    private $allowedCountries;
+
     protected function setUp()
     {
+        $objectManager = new ObjectManager($this);
         $entityFactoryMock = $this->getMock(EntityFactory::class, [], [], '', false);
         $loggerMock = $this->getMock(LoggerInterface::class);
         $fetchStrategyMock = $this->getMock(FetchStrategyInterface::class);
         $eventManagerMock = $this->getMock(ManagerInterface::class);
         $localeResolverMock = $this->getMock(ResolverInterface::class);
         $connectionMock = $this->getMock(Mysql::class, [], [], '', false);
-        $resourceMock = $this->getMockForAbstractClass(AbstractDb::class,
+        $resourceMock = $this->getMockForAbstractClass(
+            AbstractDb::class,
             [],
             '',
             false,
@@ -39,6 +54,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
             true,
             ['getConnection', 'getMainTable', 'getTable', '__wakeup']
         );
+        $this->allowedCountries = $this->getMock(AllowedCountries::class, [], [], '', false);
 
         $selectMock = $this->getMock(Select::class, [], [], '', false);
         $connectionMock->expects($this->any())->method('select')->will($this->returnValue($selectMock));
@@ -53,6 +69,12 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
             $localeResolverMock,
             $connectionMock,
             $resourceMock
+        );
+
+        $objectManager->setBackwardCompatibleProperty(
+            $this->collection,
+            'allowedCountriesReader',
+            $this->allowedCountries
         );
     }
 
@@ -97,5 +119,15 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->assertEquals($expectedResult, $this->collection->toOptionArray());
+    }
+
+    public function testAddAllowedCountriesFilter()
+    {
+        $allowedCountries = [1, 2, 3];
+        $this->allowedCountries->expects($this->once())->method('getAllowedCountries')->with(
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            null
+        )->willReturn($allowedCountries);
+        $this->assertEquals($this->collection->addAllowedCountriesFilter(), $this->collection);
     }
 }

--- a/app/code/Magento/Ui/view/base/web/js/form/element/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/select.js
@@ -105,7 +105,9 @@ define([
     return Abstract.extend({
         defaults: {
             customName: '${ $.parentName }.${ $.index }_input',
-            elementTmpl: 'ui/form/element/select'
+            elementTmpl: 'ui/form/element/select',
+            caption: '',
+            options: []
         },
 
         /**
@@ -128,28 +130,6 @@ define([
         },
 
         /**
-         * Parses options and merges the result with instance
-         *
-         * @param  {Object} config
-         * @returns {Object} Chainable.
-         */
-        initConfig: function (config) {
-            var options = config.options,
-                captionValue = config.captionValue || '',
-                result = parseOptions(options, captionValue);
-
-            if (config.caption) {
-                delete result.caption;
-            }
-
-            _.extend(config, result);
-
-            this._super();
-
-            return this;
-        },
-
-        /**
          * Calls 'initObservable' of parent, initializes 'options' and 'initialOptions'
          *     properties, calls 'setOptions' passing options to it
          *
@@ -160,7 +140,7 @@ define([
 
             this.initialOptions = this.options;
 
-            this.observe('options')
+            this.observe('options caption')
                 .setOptions(this.options());
 
             return this;
@@ -209,7 +189,7 @@ define([
                 return option && option.value;
             }
 
-            if (!this.caption) {
+            if (!this.caption()) {
                 return findFirst(this.options);
             }
         },
@@ -254,14 +234,20 @@ define([
          * @returns {Object} Chainable
          */
         setOptions: function (data) {
-            var isVisible;
+            var captionValue = this.captionValue || '',
+                result = parseOptions(data, captionValue),
+                isVisible;
 
-            this.indexedOptions = indexOptions(data);
+            this.indexedOptions = indexOptions(result.options);
 
-            this.options(data);
+            this.options(result.options);
+
+            if (!this.caption()) {
+                this.caption(result.caption);
+            }
 
             if (this.customEntry) {
-                isVisible = !!data.length;
+                isVisible = !!result.options.length;
 
                 this.setVisible(isVisible);
                 this.toggleInput(!isVisible);
@@ -296,7 +282,7 @@ define([
          * @returns {Object} Chainable.
          */
         clear: function () {
-            var value = this.caption ? '' : findFirst(this.options);
+            var value = this.caption() ? '' : findFirst(this.options);
 
             this.value(value);
 

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/form/element/select.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/form/element/select.test.js
@@ -179,7 +179,7 @@ define([
                     {
                         value: 'valLast'
                     }];
-                model.caption = false;
+                model.caption('');
                 expect(model.normalizeData('')).toEqual('valFirst');
             });
         });


### PR DESCRIPTION
…due to pulling in JSON config, remove unneeded region definitions from the checkout page. #6997 #4868

### Description
This is a backport of issue MAGETWO-59685 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/6997: Remove unneeded region definitions from the /checkout page.
2. Partly https://github.com/magento/magento2/issues/4868: Checkout page very large and quite slow.

Reference to commit on the develop branch: https://github.com/magento/magento2/commit/6a5ece2f27934b2ddf7a939617c12507d264ee90


### Discussion
Together with the [backport of MAGETWO-60351](https://github.com/magento/magento2/pull/9365), this significantly speeds up the checkout process, even up to multiple seconds. This is due to the json data structure being outputted on the checkout containing way too many elements then necessary, which makes the client side processing of this json take a very long time (sometimes up to 10 seconds). In a concrete example of one of our webshops, this reduced the json structure from 175867 lines to 4003 lines.

MAGETWO-59685 in particular fixes not outputting country and region data for countries to which the webshop isn't selling.

