### PR TITLE
Backport of MAGETWO-60351 for Magento 2.1 - Unnecessary disabled paym…

### DIFF
--- a/app/code/Magento/Payment/Plugin/PaymentConfigurationProcess.php
+++ b/app/code/Magento/Payment/Plugin/PaymentConfigurationProcess.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Payment\Plugin;
+
+/**
+ * Class PaymentConfigurationProcess
+ *
+ * Removes inactive payment methods and group from checkout configuration.
+ */
+class PaymentConfigurationProcess
+{
+    /**
+     * @var \Magento\Payment\Api\PaymentMethodListInterface
+     */
+    private $paymentMethodList;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @param \Magento\Payment\Api\PaymentMethodListInterface $paymentMethodList
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        \Magento\Payment\Api\PaymentMethodListInterface $paymentMethodList,
+        \Magento\Store\Model\StoreManagerInterface $storeManager
+    ) {
+        $this->paymentMethodList = $paymentMethodList;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * Checkout LayoutProcessor before process plugin.
+     *
+     * @param \Magento\Checkout\Block\Checkout\LayoutProcessor $processor
+     * @param array $jsLayout
+     * @return array
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function beforeProcess(\Magento\Checkout\Block\Checkout\LayoutProcessor $processor, $jsLayout)
+    {
+        $configuration = &$jsLayout['components']['checkout']['children']['steps']['children']['billing-step']
+        ['children']['payment']['children']['renders']['children'];
+
+        if (!isset($configuration)) {
+            return [$jsLayout];
+        }
+
+        $storeId = $this->storeManager->getStore()->getId();
+        $activePaymentMethodList = $this->paymentMethodList->getActiveList($storeId);
+        $getCodeFunc = function ($method) {
+            return $method->getCode();
+        };
+        $activePaymentMethodCodes = array_map($getCodeFunc, $activePaymentMethodList);
+
+        foreach ($configuration as $paymentGroup => $groupConfig) {
+            $notActivePaymentMethodCodes = array_diff(array_keys($groupConfig['methods']), $activePaymentMethodCodes);
+            foreach ($notActivePaymentMethodCodes as $notActivePaymentMethodCode) {
+                unset($configuration[$paymentGroup]['methods'][$notActivePaymentMethodCode]);
+            }
+            if (empty($configuration[$paymentGroup]['methods'])) {
+                unset($configuration[$paymentGroup]);
+            }
+        }
+
+        return [$jsLayout];
+    }
+}

--- a/app/code/Magento/Payment/Test/Unit/Plugin/PaymentConfigurationProcessTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Plugin/PaymentConfigurationProcessTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Payment\Test\Unit\Plugin;
+
+/**
+ * Class PaymentConfigurationProcessTest.
+ */
+class PaymentConfigurationProcessTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManager;
+
+    /**
+     * @var \Magento\Store\Api\Data\StoreInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $store;
+
+    /**
+     * @var \Magento\Payment\Api\PaymentMethodListInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $paymentMethodList;
+
+    /**
+     * @var \Magento\Checkout\Block\Checkout\LayoutProcessor|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $layoutProcessor;
+
+    /**
+     * @var \Magento\Payment\Plugin\PaymentConfigurationProcess
+     */
+    private $plugin;
+
+    /**
+     * Set up
+     */
+    protected function setUp()
+    {
+        $this->storeManager = $this
+            ->getMockBuilder(\Magento\Store\Model\StoreManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getStore'])
+            ->getMockForAbstractClass();
+        $this->store = $this
+            ->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getId'])
+            ->getMockForAbstractClass();
+        $this->paymentMethodList = $this
+            ->getMockBuilder(\Magento\Payment\Api\PaymentMethodListInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getActiveList'])
+            ->getMockForAbstractClass();
+        $this->layoutProcessor =  $this
+            ->getMockBuilder(\Magento\Checkout\Block\Checkout\LayoutProcessor::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['process'])
+            ->getMockForAbstractClass();
+
+        $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->plugin = $objectManagerHelper->getObject(
+            \Magento\Payment\Plugin\PaymentConfigurationProcess::class,
+            [
+                'paymentMethodList' => $this->paymentMethodList,
+                'storeManager' => $this->storeManager
+            ]
+        );
+    }
+
+    /**
+     * @param array $jsLayout
+     * @param array $activePaymentList
+     * @param array $expectedResult
+     * @dataProvider beforeProcessDataProvider
+     */
+    public function testBeforeProcess($jsLayout, $activePaymentList, $expectedResult)
+    {
+        $this->store->expects($this->once())->method('getId')->willReturn(1);
+        $this->storeManager->expects($this->once())->method('getStore')->willReturn($this->store);
+        $this->paymentMethodList->expects($this->once())
+            ->method('getActiveList')
+            ->with(1)
+            ->willReturn($activePaymentList);
+
+        $result = $this->plugin->beforeProcess($this->layoutProcessor, $jsLayout);
+        $this->assertEquals($result[0], $expectedResult);
+    }
+
+    /**
+     * Data provider for BeforeProcess.
+     *
+     * @return array
+     */
+    public function beforeProcessDataProvider()
+    {
+        $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']
+        ['children']['payment']['children']['renders']['children'] = [
+            'braintree' => [
+                'methods' => [
+                    'braintree_paypal' => [],
+                    'braintree' => []
+                ]
+            ],
+            'paypal-payments' => [
+                'methods' => [
+                    'payflowpro' => [],
+                    'payflow_link' => []
+                ]
+            ]
+        ];
+        $result1['components']['checkout']['children']['steps']['children']['billing-step']
+        ['children']['payment']['children']['renders']['children'] = [];
+        $result2['components']['checkout']['children']['steps']['children']['billing-step']
+        ['children']['payment']['children']['renders']['children'] = [
+            'braintree' => [
+                'methods' => [
+                    'braintree' => [],
+                    'braintree_paypal' => []
+                ]
+            ]
+        ];
+
+        $braintreePaymentMethod = $this
+            ->getMockBuilder(\Magento\Payment\Api\Data\PaymentMethodInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCode'])
+            ->getMockForAbstractClass();
+        $braintreePaypalPaymentMethod = $this
+            ->getMockBuilder(\Magento\Payment\Api\Data\PaymentMethodInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCode'])
+            ->getMockForAbstractClass();
+
+        $braintreePaymentMethod->expects($this->any())->method('getCode')->willReturn('braintree');
+        $braintreePaypalPaymentMethod->expects($this->any())->method('getCode')->willReturn('braintree_paypal');
+
+        return [
+            [$jsLayout, [], $result1],
+            [$jsLayout, [$braintreePaymentMethod, $braintreePaypalPaymentMethod], $result2]
+        ];
+    }
+}

--- a/app/code/Magento/Payment/etc/frontend/di.xml
+++ b/app/code/Magento/Payment/etc/frontend/di.xml
@@ -19,4 +19,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Checkout\Block\Checkout\LayoutProcessor">
+        <plugin name="ProcessPaymentConfiguration" type="Magento\Payment\Plugin\PaymentConfigurationProcess"/>
+    </type>
 </config>

--- a/app/code/Magento/Vault/Plugin/PaymentVaultConfigurationProcess.php
+++ b/app/code/Magento/Vault/Plugin/PaymentVaultConfigurationProcess.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Vault\Plugin;
+
+/**
+ * Class PaymentVaultConfigurationProcess
+ *
+ * Checks if vault group have active vaults.
+ */
+class PaymentVaultConfigurationProcess
+{
+    /**
+     * @var \Magento\Vault\Api\PaymentMethodListInterface
+     */
+    private $vaultPaymentList;
+
+    /**
+     * @var \Magento\Vault\Api\PaymentMethodListInterface
+     */
+    private $paymentMethodList;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @param \Magento\Vault\Api\PaymentMethodListInterface $vaultPaymentList
+     * @param \Magento\Payment\Api\PaymentMethodListInterface $paymentMethodList
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        \Magento\Vault\Api\PaymentMethodListInterface $vaultPaymentList,
+        \Magento\Payment\Api\PaymentMethodListInterface $paymentMethodList,
+        \Magento\Store\Model\StoreManagerInterface $storeManager
+    ) {
+        $this->vaultPaymentList = $vaultPaymentList;
+        $this->paymentMethodList = $paymentMethodList;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * Checkout LayoutProcessor before process plugin.
+     *
+     * @param \Magento\Checkout\Block\Checkout\LayoutProcessor $processor
+     * @param array $jsLayout
+     * @return array
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function beforeProcess(\Magento\Checkout\Block\Checkout\LayoutProcessor $processor, $jsLayout)
+    {
+        $configuration = &$jsLayout['components']['checkout']['children']['steps']['children']['billing-step']
+        ['children']['payment']['children']['renders']['children'];
+
+        if (!isset($configuration)) {
+            return [$jsLayout];
+        }
+
+        $storeId = $this->storeManager->getStore()->getId();
+        $activePaymentMethodList = $this->paymentMethodList->getActiveList($storeId);
+        $activeVaultList = $this->vaultPaymentList->getActiveList($storeId);
+        $getCodeFunc = function ($method) {
+            return $method->getCode();
+        };
+        $getProviderCodeFunc = function ($method) {
+            return $method->getProviderCode();
+        };
+        $activePaymentMethodCodes = array_map($getCodeFunc, $activePaymentMethodList);
+        $activeVaultProviderCodes = array_map($getProviderCodeFunc, $activeVaultList);
+        $activePaymentMethodCodes = array_merge(
+            $activePaymentMethodCodes,
+            $activeVaultProviderCodes
+        );
+
+        foreach ($configuration as $paymentGroup => $groupConfig) {
+            $notActivePaymentMethodCodes = array_diff(array_keys($groupConfig['methods']), $activePaymentMethodCodes);
+            foreach ($notActivePaymentMethodCodes as $notActivePaymentMethodCode) {
+                unset($configuration[$paymentGroup]['methods'][$notActivePaymentMethodCode]);
+            }
+            if ($paymentGroup === 'vault' && !empty($activeVaultProviderCodes)) {
+                continue;
+            }
+            if (empty($configuration[$paymentGroup]['methods'])) {
+                unset($configuration[$paymentGroup]);
+            }
+        }
+
+        return [$jsLayout];
+    }
+}

--- a/app/code/Magento/Vault/Test/Unit/Plugin/PaymentVaultConfigurationProcessTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Plugin/PaymentVaultConfigurationProcessTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Vault\Test\Unit\Plugin;
+
+/**
+ * Class PaymentVaultConfigurationProcessTest.
+ */
+class PaymentVaultConfigurationProcessTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManager;
+
+    /**
+     * @var \Magento\Store\Api\Data\StoreInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $store;
+
+    /**
+     * @var \Magento\Vault\Api\PaymentMethodListInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $vaultList;
+
+    /**
+     * @var \Magento\Payment\Api\PaymentMethodListInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $paymentMethodList;
+
+    /**
+     * @var \Magento\Checkout\Block\Checkout\LayoutProcessor|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $layoutProcessor;
+
+    /**
+     * @var \Magento\Vault\Plugin\PaymentVaultConfigurationProcess
+     */
+    private $plugin;
+
+    /**
+     * Set up
+     */
+    protected function setUp()
+    {
+        $this->storeManager = $this
+            ->getMockBuilder(\Magento\Store\Model\StoreManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getStore'])
+            ->getMockForAbstractClass();
+        $this->store = $this
+            ->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getId'])
+            ->getMockForAbstractClass();
+        $this->vaultList = $this
+            ->getMockBuilder(\Magento\Vault\Api\PaymentMethodListInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getActiveList'])
+            ->getMockForAbstractClass();
+        $this->paymentMethodList = $this
+            ->getMockBuilder(\Magento\Payment\Api\PaymentMethodListInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getActiveList'])
+            ->getMockForAbstractClass();
+        $this->layoutProcessor =  $this
+            ->getMockBuilder(\Magento\Checkout\Block\Checkout\LayoutProcessor::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['process'])
+            ->getMockForAbstractClass();
+
+        $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->plugin = $objectManagerHelper->getObject(
+            \Magento\Vault\Plugin\PaymentVaultConfigurationProcess::class,
+            [
+                'vaultPaymentList' => $this->vaultList,
+                'paymentMethodList' => $this->paymentMethodList,
+                'storeManager' => $this->storeManager
+            ]
+        );
+    }
+
+    /**
+     * @param array $jsLayout
+     * @param array $activeVaultList
+     * @param array $activePaymentList
+     * @param array $expectedResult
+     * @dataProvider beforeProcessDataProvider
+     */
+    public function testBeforeProcess($jsLayout, $activeVaultList, $activePaymentList, $expectedResult)
+    {
+        $this->store->expects($this->once())->method('getId')->willReturn(1);
+        $this->storeManager->expects($this->once())->method('getStore')->willReturn($this->store);
+        $this->vaultList->expects($this->once())->method('getActiveList')->with(1)->willReturn($activeVaultList);
+        $this->paymentMethodList->expects($this->once())
+            ->method('getActiveList')
+            ->with(1)
+            ->willReturn($activePaymentList);
+        $result = $this->plugin->beforeProcess($this->layoutProcessor, $jsLayout);
+        $this->assertEquals($result[0], $expectedResult);
+    }
+
+    /**
+     * Data provider for BeforeProcess.
+     *
+     * @return array
+     */
+    public function beforeProcessDataProvider()
+    {
+        $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']
+        ['children']['payment']['children']['renders']['children'] = [
+            'vault' => [
+                'methods' => []
+            ],
+            'braintree' => [
+                'methods' => [
+                    'braintree_paypal' => [],
+                    'braintree' => []
+                ]
+            ],
+            'paypal-payments' => [
+                'methods' => [
+                    'payflowpro' => [],
+                    'payflow_link' => []
+                ]
+            ]
+        ];
+        $result1['components']['checkout']['children']['steps']['children']['billing-step']
+        ['children']['payment']['children']['renders']['children'] = [];
+        $result2['components']['checkout']['children']['steps']['children']['billing-step']
+        ['children']['payment']['children']['renders']['children'] = [
+            'vault' => [
+                'methods' => []
+            ],
+            'braintree' => [
+                'methods' => [
+                    'braintree_paypal' => []
+                ]
+            ]
+        ];
+
+        $vaultPaymentMethod = $this
+            ->getMockBuilder(\Magento\Vault\Api\PaymentMethodListInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCode', 'getProviderCode'])
+            ->getMockForAbstractClass();
+
+        $vaultPaymentMethod->expects($this->any())->method('getCode')->willReturn('braintree_paypal_vault');
+        $vaultPaymentMethod->expects($this->any())->method('getProviderCode')->willReturn('braintree_paypal');
+
+        return [
+            [$jsLayout, [], [], $result1],
+            [$jsLayout, [$vaultPaymentMethod], [$vaultPaymentMethod], $result2]
+        ];
+    }
+}

--- a/app/code/Magento/Vault/etc/frontend/di.xml
+++ b/app/code/Magento/Vault/etc/frontend/di.xml
@@ -19,4 +19,8 @@
             <argument name="session" xsi:type="object">Magento\Customer\Model\Session</argument>
         </arguments>
     </type>
+    <type name="Magento\Checkout\Block\Checkout\LayoutProcessor">
+        <plugin name="ProcessPaymentVaultConfiguration" type="Magento\Vault\Plugin\PaymentVaultConfigurationProcess"/>
+        <plugin name="ProcessPaymentConfiguration" disabled="true"/>
+    </type>
 </config>


### PR DESCRIPTION
…ent methods on checkout page #4868

### Description
This is a backport of issue MAGETWO-60351 for Magento 2.1

### Fixed Issues (if relevant)
1. Partly https://github.com/magento/magento2/issues/4868: Checkout page very large and quite slow.

Reference to commits on the develop branch: https://github.com/magento/magento2/commit/398b91532a3abdfd29c9d02749e41ac40b20a611 & https://github.com/magento/magento2/commit/79f392c4f1cf43675acc09fcc80ac248a40e1635 & https://github.com/magento/magento2/commit/0644f24c7d658a23733c51f670c1f6931be39a6f

### Discussion
Together with the [backport of MAGETWO-59685](https://github.com/magento/magento2/pull/9364), this significantly speeds up the checkout process, even up to multiple seconds. This is due to the json data structure being outputted on the checkout containing way too many elements then necessary, which makes the client side processing of this json take a very long time (sometimes up to 10 seconds). In a concrete example of one of our webshops, this reduced the json structure from 175867 lines to 4003 lines.

MAGETWO-60351 in particular fixes not outputting payment methods which your webshop isn't using.

