### PR TITLE
Redis sess: fix path for persistent_identifier & compression_threshold

### DIFF
--- a/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php
@@ -48,12 +48,12 @@ class Config implements \Cm\RedisSession\Handler\ConfigInterface
     /**
      * Configuration path for persistent identifier
      */
-    const PARAM_PERSISTENT_IDENTIFIER   = 'session/redis/param_persistent_identifier';
+    const PARAM_PERSISTENT_IDENTIFIER   = 'session/redis/persistent_identifier';
 
     /**
      * Configuration path for compression threshold
      */
-    const PARAM_COMPRESSION_THRESHOLD   = 'session/redis/param_compression_threshold';
+    const PARAM_COMPRESSION_THRESHOLD   = 'session/redis/compression_threshold';
 
     /**
      * Configuration path for compression library


### PR DESCRIPTION
Currently, the paths for both `persistent_identifier` & `compression_threshold` are prefixed with `param_`. This is against both the documentation and it does not follow the standard used throughout the configuration. This PR removes the prefix.

Docs:
https://github.com/magento/devdocs/blob/develop/guides/v2.0/config-guide/redis/redis-session.md#configure-magento-to-use-redis-for-session-storage

### Fixed Issues (if relevant)

Currently, `persistent_identifier` and `compression_threshold` are ignored in the Redis session configuration (the documented options for configuring).

### Manual testing scenarios

Change `compression_threshold` to 1 (to force compression) and the sessions will not be compressed. Changing the name to be `param_compression_threshold` results in compression.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
