### PR TITLE
Update tax.js so that "Display Zero Tax Subtotal = No" works 

### DIFF
--- a/app/code/Magento/Tax/view/frontend/web/js/view/checkout/cart/totals/tax.js
+++ b/app/code/Magento/Tax/view/frontend/web/js/view/checkout/cart/totals/tax.js
@@ -21,7 +21,7 @@ define([
          * @override
          */
         ifShowValue: function () {
-            if (this.getPureValue() === 0) {
+            if (this.getPureValue() == 0) {
                 return isZeroTaxDisplayed;
             }
 


### PR DESCRIPTION
Making comparison less strict as tax value from this.getPureValue() when empty is 0.000 so that "Display Zero Tax Subtotal = No" works 

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Making comparison less strict as tax value from this.getPureValue() when empty is 0.000 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. Makes Display Zero Tax Subtotal = NO work

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
Tested manually:
1. Set Display Zero Tax Subtotal = NO
2. Open cart

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
