### PR TITLE
Removed unnecessary code and namespaces from import validators

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/AbstractPrice.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/AbstractPrice.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\CatalogImportExport\Model\Import\Product\Validator;
 
-use Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractImportValidator;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface;
 
 abstract class AbstractPrice extends AbstractImportValidator implements RowValidatorInterface

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Quantity.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Quantity.php
@@ -15,14 +15,6 @@ class Quantity extends AbstractImportValidator implements RowValidatorInterface
     /**
      * {@inheritdoc}
      */
-    public function init($context)
-    {
-        return parent::init($context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function isValid($value)
     {
         $this->_clearMessages();

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/SuperProductsSku.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/SuperProductsSku.php
@@ -26,14 +26,6 @@ class SuperProductsSku extends AbstractImportValidator implements RowValidatorIn
     /**
      * {@inheritdoc}
      */
-    public function init($context)
-    {
-        return parent::init($context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function isValid($value)
     {
         $this->_clearMessages();

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/TierPrice.php
@@ -30,14 +30,6 @@ class TierPrice extends AbstractPrice implements RowValidatorInterface
 
     /**
      * {@inheritdoc}
-     */
-    public function init($context)
-    {
-        return parent::init($context);
-    }
-
-    /**
-     * {@inheritdoc}
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function isValid($value)

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Website.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Website.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\CatalogImportExport\Model\Import\Product\Validator;
 
-use Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractImportValidator;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface;
 use Magento\CatalogImportExport\Model\Import\Product as ImportProduct;
 
@@ -22,14 +21,6 @@ class Website extends AbstractImportValidator implements RowValidatorInterface
     public function __construct(\Magento\CatalogImportExport\Model\Import\Product\StoreResolver $storeResolver)
     {
         $this->storeResolver = $storeResolver;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function init($context)
-    {
-        return parent::init($context);
     }
 
     /**

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Weight.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator/Weight.php
@@ -5,19 +5,10 @@
  */
 namespace Magento\CatalogImportExport\Model\Import\Product\Validator;
 
-use Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractImportValidator;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface;
 
 class Weight extends AbstractImportValidator implements RowValidatorInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function init($context)
-    {
-        return parent::init($context);
-    }
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Removed `init` method declaration from subclasses of `AbstractImportValidator` that simply calls `parent::init($context)` and removed unnecessary use of `Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractImportValidator` from some import validators