### PR TITLE
Update AttributeRepository.php

### DIFF
--- a/app/code/Magento/Customer/Ui/Component/Listing/AttributeRepository.php
+++ b/app/code/Magento/Customer/Ui/Component/Listing/AttributeRepository.php
@@ -95,12 +95,13 @@ class AttributeRepository
             if ($entityTypeCode == AddressMetadataInterface::ENTITY_TYPE_ADDRESS) {
                 $attributeCode = self::BILLING_ADDRESS_PREFIX . $attribute->getAttributeCode();
             }
+            $attributeOptions = $attribute->getOption();
             $attributes[$attributeCode] = [
                 AttributeMetadataInterface::ATTRIBUTE_CODE => $attributeCode,
                 AttributeMetadataInterface::FRONTEND_INPUT => $attribute->getFrontendInput(),
                 AttributeMetadataInterface::FRONTEND_LABEL => $attribute->getFrontendLabel(),
                 AttributeMetadataInterface::BACKEND_TYPE => $attribute->getBackendType(),
-                AttributeMetadataInterface::OPTIONS => $this->getOptionArray($attribute->getOptions()),
+                AttributeMetadataInterface::OPTIONS => is_array($attributeOptions) ? $this->getOptionArray($attributeOptions) : [],
                 AttributeMetadataInterface::IS_USED_IN_GRID => $attribute->getIsUsedInGrid(),
                 AttributeMetadataInterface::IS_VISIBLE_IN_GRID => $attribute->getIsVisibleInGrid(),
                 AttributeMetadataInterface::IS_FILTERABLE_IN_GRID => $management->canBeFilterableInGrid($attribute),

--- a/app/code/Magento/Customer/Ui/Component/Listing/AttributeRepository.php
+++ b/app/code/Magento/Customer/Ui/Component/Listing/AttributeRepository.php
@@ -95,13 +95,14 @@ class AttributeRepository
             if ($entityTypeCode == AddressMetadataInterface::ENTITY_TYPE_ADDRESS) {
                 $attributeCode = self::BILLING_ADDRESS_PREFIX . $attribute->getAttributeCode();
             }
-            $attributeOptions = $attribute->getOption();
+            $attributeOptions = $attribute->getOptions();
             $attributes[$attributeCode] = [
                 AttributeMetadataInterface::ATTRIBUTE_CODE => $attributeCode,
                 AttributeMetadataInterface::FRONTEND_INPUT => $attribute->getFrontendInput(),
                 AttributeMetadataInterface::FRONTEND_LABEL => $attribute->getFrontendLabel(),
                 AttributeMetadataInterface::BACKEND_TYPE => $attribute->getBackendType(),
-                AttributeMetadataInterface::OPTIONS => is_array($attributeOptions) ? $this->getOptionArray($attributeOptions) : [],
+                AttributeMetadataInterface::OPTIONS => is_array($attributeOptions)
+                    ? $this->getOptionArray($attributeOptions) : [],
                 AttributeMetadataInterface::IS_USED_IN_GRID => $attribute->getIsUsedInGrid(),
                 AttributeMetadataInterface::IS_VISIBLE_IN_GRID => $attribute->getIsVisibleInGrid(),
                 AttributeMetadataInterface::IS_FILTERABLE_IN_GRID => $management->canBeFilterableInGrid($attribute),


### PR DESCRIPTION
Fixes a bug in case `$attribute->getOption()` returns NULL when it does not have any options. When NULL is given to `AttributeRepository::getOptionArray`, PHP complains about a TypeError.