### PR TITLE
Fix depends per group in system.xml

### DIFF
--- a/lib/web/mage/adminhtml/form.js
+++ b/lib/web/mage/adminhtml/form.js
@@ -453,6 +453,9 @@ define([
             if (target) {
                 inputs = target.up(this._config['levels_up']).select('input', 'select', 'td');
                 isAnInputOrSelect = ['input', 'select'].indexOf(target.tagName.toLowerCase()) != -1; //eslint-disable-line
+                if (target.type === 'fieldset') {
+                    var inputs = target.select('input', 'select', 'td');
+                }
             } else {
                 inputs = false;
                 isAnInputOrSelect = false;
@@ -531,6 +534,9 @@ define([
 
             if (rowElement == undefined && target) { //eslint-disable-line eqeqeq
                 rowElement = target.up(this._config['levels_up']);
+                if (target.type === 'fieldset') {
+                    rowElement = target;
+                }
             }
 
             if (rowElement) {


### PR DESCRIPTION
Hide only inputs from fieldset (group) when depends it's leveled for group in system.xml

### Description

When you have a `<depends>` in group the result is that all inputs and groups are hidded, including a depends field.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. create a module
2. add system.xml
3. create a group general with field enable yes/no
4. create 2 groups test and test2
5. inside group test add depends to general/enable -> 1
6. go to admin and change value of general->enable

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
