### PR TITLE
Fixed indexed product positions for anchor categories.

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
@@ -431,6 +431,10 @@ abstract class AbstractAction
             ['ccp' => $this->getTable('catalog_category_product')],
             'ccp.category_id = cc2.child_id',
             []
+        )->joinLeft(
+            ['ccp2' => $this->getTable('catalog_category_product')],
+            'ccp2.category_id = cc2.parent_id AND ccp.product_id = ccp2.product_id',
+            []
         )->joinInner(
             ['cpe' => $this->getTable('catalog_product_entity')],
             'ccp.product_id = cpe.entity_id',
@@ -493,7 +497,7 @@ abstract class AbstractAction
             [
                 'category_id' => 'cc.entity_id',
                 'product_id' => 'ccp.product_id',
-                'position' => new \Zend_Db_Expr('ccp.position + 10000'),
+                'position' => new \Zend_Db_Expr($this->connection->getIfNullSql('ccp2.position', 'ccp.position + 10000')),
                 'is_parent' => new \Zend_Db_Expr('0'),
                 'store_id' => new \Zend_Db_Expr($store->getId()),
                 'visibility' => new \Zend_Db_Expr($this->connection->getIfNullSql('cpvs.value', 'cpvd.value')),


### PR DESCRIPTION
### Description
Indexed product positions saved in `catalog_category_product_index ` table are incorrect for those products which could be found in child categories.

### Manual testing scenarios
**Initial data:** 
Category `2` (category with id == `2`)  is anchor. 
Category `37` (category with id == `37`)  is category's `2` child 

1.1. Append product to a category `2`. Set its position to 2.
1.2. Run `php bin/magento indexer:reindex catalog_product_category`
1.3. The result is _CORRECT_ (both `catalog_category_product` and  `catalog_category_product_index` tables shows a product position == 2)
![anchor_only](https://cloud.githubusercontent.com/assets/10599696/25384678/e7937b3c-29c9-11e7-861b-ef316396ea47.PNG)
1.4. Remove a product from a category `2`

2.1. Append a product to a category `37`. Set its position to 3.
2.2. Run `php bin/magento indexer:reindex catalog_product_category`
2.3. The result is _CORRECT_ (position == 3 for a category `37` and 10000 + 3 for an anchor category `2`)
![child_only](https://cloud.githubusercontent.com/assets/10599696/25384835/6fe4425a-29ca-11e7-8537-90548c35f2df.PNG)

3.1. Repeat a step#1.1 ( Append product to a category `2`. Set its position to 2.)
3.2. Run `php bin/magento indexer:reindex catalog_product_category`
3.3. The result is **_INCORRECT_** (position for a product in a category `2` in the table  `catalog_category_product_index` should be 2. But it is 10000 + 3 like in the second scenario)
![anchor_and_child](https://cloud.githubusercontent.com/assets/10599696/25384956/f4f2ac34-29ca-11e7-92ab-fbd0608b486f.PNG)


### Fixed Issues
Position for a product assigned to anchor categories is indexed currectly whether or not it has entries in child categories.
![anchor_and_child_fixed](https://cloud.githubusercontent.com/assets/10599696/25385121/a2da7c64-29cb-11e7-9145-f0bba6320fb4.PNG)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)