### PR TITLE
Fix addIdFilter method

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Flat/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Flat/Collection.php
@@ -119,7 +119,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
                 $condition = ['in' => $ids];
             }
         }
-        $this->addFieldToFilter('entity_id', $condition);
+        $this->addFieldToFilter('main_table.entity_id', $condition);
         return $this;
     }
 


### PR DESCRIPTION
### Description
Application breaks when \Magento\Catalog\Model\ResourceModel\Category\Flat::getCategories is called, with $toLoad == false (so collection is not loaded yet, as it is called indirectly at magento/module-catalog-event/Block/Event/Lister.php:108: $categories = $this->_categoryHelper->getStoreCategories('position', true, false);), then \Magento\Catalog\Model\ResourceModel\Category\Flat\Collection::addIdFilter is called for the unloaded collection (as in magento/module-catalog-event/Block/Event/Lister.php:125: $categories->addIdFilter($eventCollection->getColumnValues('category_id'));), and then it tries to load the collection.

It breaks due to ambiguous 'entity_id' field in where clause; field with such name is both found within catalog_category_flat_store_% and url_rewrite tables.

### Manual testing scenarios
- Category flat tables are enabled.
- Use \Magento\CatalogEvent\Block\Event\Lister or \Magento\CatalogEvent\Block\Widget\Lister, directly or via directive in cms page / block, or
- Create a new category collection, then call addUrlRewriteToResult() and addIdFilter($categoryIds) methods, and try to load the collection

### Issues related
https://github.com/magento/magento2/issues/7523