### PR TITLE
Add a name to the Composite\Fieldset\Options block directive

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/layout/CATALOG_PRODUCT_COMPOSITE_CONFIGURE.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/layout/CATALOG_PRODUCT_COMPOSITE_CONFIGURE.xml
@@ -8,7 +8,7 @@
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root">
         <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset" name="product.composite.fieldset">
-            <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options" template="Magento_Catalog::catalog/product/composite/fieldset/options.phtml">
+            <block class="Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options" name="product.composite.fieldset.options" template="Magento_Catalog::catalog/product/composite/fieldset/options.phtml">
                 <block class="Magento\Catalog\Block\Product\View\Options\Type\DefaultType" as="default" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/default.phtml"/>
                 <block class="Magento\Catalog\Block\Product\View\Options\Type\Text" as="text" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/text.phtml"/>
                 <block class="Magento\Catalog\Block\Product\View\Options\Type\File" as="file" template="Magento_Catalog::catalog/product/composite/fieldset/options/type/file.phtml"/>


### PR DESCRIPTION
Add the name "product.composite.fieldset.options" to Composite\Fieldset\Options block so that third party custom options can add their own values without re-declaring the product.composite.fieldset directive.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
The block modified in this PR needs to have a name so that it can be referenced from third party modules wishing to create their own custom options.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
