### PR TITLE
Use loadPlayer requirejs mapping

### DIFF
--- a/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
@@ -7,7 +7,7 @@ define([
     'jquery',
     'jquery/ui',
     'catalogGallery',
-    'Magento_ProductVideo/js/load-player'
+    'loadPlayer'
 ], function ($) {
     'use strict';
 


### PR DESCRIPTION
There is no reason for this module to use the path to the file when there exists a path mapping to the file within the requirejs-config.js file in this module.