### PR TITLE
Fix not detecting current store using store code in url using $storeResolver->getCurrentStoreId()

### DIFF
--- a/app/code/Magento/Checkout/Block/Checkout/DirectoryDataProcessor.php
+++ b/app/code/Magento/Checkout/Block/Checkout/DirectoryDataProcessor.php
@@ -6,6 +6,7 @@
 namespace Magento\Checkout\Block\Checkout;
 
 use Magento\Directory\Helper\Data as DirectoryHelper;
+use Magento\Store\Api\StoreResolverInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 /**
@@ -49,19 +50,21 @@ class DirectoryDataProcessor implements \Magento\Checkout\Block\Checkout\LayoutP
     /**
      * @param \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollection
      * @param \Magento\Directory\Model\ResourceModel\Region\CollectionFactory $regionCollection
-     * @param StoreManagerInterface $storeManager
+     * @param StoreResolverInterface $storeResolver
      * @param DirectoryHelper $directoryHelper
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollection,
         \Magento\Directory\Model\ResourceModel\Region\CollectionFactory $regionCollection,
-        StoreManagerInterface $storeManager,
-        DirectoryHelper $directoryHelper
+        StoreResolverInterface $storeResolver,
+        DirectoryHelper $directoryHelper,
+        StoreManagerInterface $storeManager = null
     ) {
         $this->countryCollectionFactory = $countryCollection;
         $this->regionCollectionFactory = $regionCollection;
-        $this->storeManager = $storeManager;
         $this->directoryHelper = $directoryHelper;
+        $this->storeManager = $storeManager ?: \Magento\Framework\App\ObjectManager::getInstance()->get(StoreManagerInterface::class);
     }
 
     /**

--- a/app/code/Magento/Checkout/Block/Checkout/DirectoryDataProcessor.php
+++ b/app/code/Magento/Checkout/Block/Checkout/DirectoryDataProcessor.php
@@ -6,7 +6,7 @@
 namespace Magento\Checkout\Block\Checkout;
 
 use Magento\Directory\Helper\Data as DirectoryHelper;
-use Magento\Store\Api\StoreResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Directory data processor.
@@ -37,9 +37,9 @@ class DirectoryDataProcessor implements \Magento\Checkout\Block\Checkout\LayoutP
     private $countryCollectionFactory;
 
     /**
-     * @var StoreResolverInterface
+     * @var StoreManagerInterface
      */
-    private $storeResolver;
+    private $storeManager;
 
     /**
      * @var DirectoryHelper
@@ -49,18 +49,18 @@ class DirectoryDataProcessor implements \Magento\Checkout\Block\Checkout\LayoutP
     /**
      * @param \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollection
      * @param \Magento\Directory\Model\ResourceModel\Region\CollectionFactory $regionCollection
-     * @param StoreResolverInterface $storeResolver
+     * @param StoreManagerInterface $storeManager
      * @param DirectoryHelper $directoryHelper
      */
     public function __construct(
         \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollection,
         \Magento\Directory\Model\ResourceModel\Region\CollectionFactory $regionCollection,
-        StoreResolverInterface $storeResolver,
+        StoreManagerInterface $storeManager,
         DirectoryHelper $directoryHelper
     ) {
         $this->countryCollectionFactory = $countryCollection;
         $this->regionCollectionFactory = $regionCollection;
-        $this->storeResolver = $storeResolver;
+        $this->storeManager = $storeManager;
         $this->directoryHelper = $directoryHelper;
     }
 
@@ -91,7 +91,7 @@ class DirectoryDataProcessor implements \Magento\Checkout\Block\Checkout\LayoutP
     {
         if (!isset($this->countryOptions)) {
             $this->countryOptions = $this->countryCollectionFactory->create()->loadByStore(
-                $this->storeResolver->getCurrentStoreId()
+                $this->storeManager->getStore()->getId()
             )->toOptionArray();
             $this->countryOptions = $this->orderCountryOptions($this->countryOptions);
         }
@@ -108,7 +108,7 @@ class DirectoryDataProcessor implements \Magento\Checkout\Block\Checkout\LayoutP
     {
         if (!isset($this->regionOptions)) {
             $this->regionOptions = $this->regionCollectionFactory->create()->addAllowedCountriesFilter(
-                $this->storeResolver->getCurrentStoreId()
+                $this->storeManager->getStore()->getId()
             )->toOptionArray();
         }
 

--- a/app/code/Magento/Checkout/Test/Unit/Block/Checkout/DirectoryDataProcessorTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Checkout/DirectoryDataProcessorTest.php
@@ -35,7 +35,7 @@ class DirectoryDataProcessorTest extends \PHPUnit_Framework_TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    protected $storeResolverMock;
+    protected $storeManagerMock;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -72,8 +72,8 @@ class DirectoryDataProcessorTest extends \PHPUnit_Framework_TestCase
             '',
             false
         );
-        $this->storeResolverMock = $this->getMock(
-            \Magento\Store\Api\StoreResolverInterface::class
+        $this->storeManagerMock = $this->getMock(
+            \Magento\Store\Model\StoreManagerInterface::class
         );
         $this->directoryDataHelperMock = $this->getMock(
             \Magento\Directory\Helper\Data::class,
@@ -86,7 +86,7 @@ class DirectoryDataProcessorTest extends \PHPUnit_Framework_TestCase
         $this->model = new \Magento\Checkout\Block\Checkout\DirectoryDataProcessor(
             $this->countryCollectionFactoryMock,
             $this->regionCollectionFactoryMock,
-            $this->storeResolverMock,
+            $this->storeManagerMock,
             $this->directoryDataHelperMock
         );
     }

--- a/app/code/Magento/Checkout/Test/Unit/Block/Checkout/DirectoryDataProcessorTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Checkout/DirectoryDataProcessorTest.php
@@ -35,6 +35,11 @@ class DirectoryDataProcessorTest extends \PHPUnit_Framework_TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
+    protected $storeResolverMock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
     protected $storeManagerMock;
 
     /**
@@ -72,6 +77,9 @@ class DirectoryDataProcessorTest extends \PHPUnit_Framework_TestCase
             '',
             false
         );
+        $this->storeResolverMock = $this->getMock(
+            \Magento\Store\Api\StoreResolverInterface::class
+        );
         $this->storeManagerMock = $this->getMock(
             \Magento\Store\Model\StoreManagerInterface::class
         );
@@ -86,8 +94,9 @@ class DirectoryDataProcessorTest extends \PHPUnit_Framework_TestCase
         $this->model = new \Magento\Checkout\Block\Checkout\DirectoryDataProcessor(
             $this->countryCollectionFactoryMock,
             $this->regionCollectionFactoryMock,
-            $this->storeManagerMock,
-            $this->directoryDataHelperMock
+            $this->storeResolverMock,
+            $this->directoryDataHelperMock,
+            $this->storeManagerMock
         );
     }
 

--- a/app/code/Magento/Customer/Model/ResourceModel/Address/Attribute/Source/Country.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/Address/Attribute/Source/Country.php
@@ -11,9 +11,7 @@
  */
 namespace Magento\Customer\Model\ResourceModel\Address\Attribute\Source;
 
-use Magento\Checkout\Model\Session;
 use Magento\Framework\App\ObjectManager;
-use Magento\Store\Api\StoreResolverInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 /**
@@ -28,9 +26,9 @@ class Country extends \Magento\Eav\Model\Entity\Attribute\Source\Table
     protected $_countriesFactory;
 
     /**
-     * @var StoreResolverInterface
+     * @var StoreManagerInterface
      */
-    private $storeResolver;
+    private $storeManager;
 
     /**
      * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory $attrOptionCollectionFactory
@@ -55,7 +53,7 @@ class Country extends \Magento\Eav\Model\Entity\Attribute\Source\Table
     {
         if (!$this->_options) {
             $this->_options = $this->_createCountriesCollection()->loadByStore(
-                $this->getStoreResolver()->getCurrentStoreId()
+                $this->getStoreManager()->getStore()->getId()
             )->toOptionArray();
         }
         return $this->_options;
@@ -70,16 +68,16 @@ class Country extends \Magento\Eav\Model\Entity\Attribute\Source\Table
     }
 
     /**
-     * Retrieve Store Resolver
+     * Retrieve Store Manager
      * @deprecated
-     * @return StoreResolverInterface
+     * @return StoreManagerInterface
      */
-    private function getStoreResolver()
+    private function getStoreManager()
     {
-        if (!$this->storeResolver) {
-            $this->storeResolver = ObjectManager::getInstance()->get(StoreResolverInterface::class);
+        if (!$this->storeManager) {
+            $this->storeManager = ObjectManager::getInstance()->get(StoreManagerInterface::class);
         }
 
-        return $this->storeResolver;
+        return $this->storeManager;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Current store id is not correctly identified when ```$storeResolver->getCurrentStoreId()``` is used.
```$storeManager->getStore()->getId()``` should be used instead.

### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8732: The country drop-down list display incorrect after upgrade to 2.1.4 in Admin

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
#### PRE-REQUISTIES:
1. Set *STORES -> Configuration -> GENERAL -> Web -> Url Options -> Add Store Codes to Urls* to *Yes*.
2. The system has at least two websites.
* The first website is set as default website
* The first website has a store view with code *default*
* The second website has a store view with code *storeview2*.
![stores___settings___stores___magento_admin_](https://cloud.githubusercontent.com/assets/2362026/25485733/9287a2cc-2b67-11e7-85d9-4ff6f7ec9232.png)
3. Set *STORES -> Configuration -> GENERAL -> General -> Country Options -> Allow Countries* to *Estonia* for first website.
4. Set *STORES -> Configuration -> GENERAL -> General -> Country Options -> Allow Countries* to *Romania* for second website.

#### STESP TO REPLICATE
1. Access the website **directly** using storeview2 store code, e.g. http://local-magento2/storeview2/
2. Add any product to cart
3. Go to checkout

#### EXPECTED
Available country for checkout: Romania

#### ACTUAL
Available country for checkout: Estonia
![Checkout Page](https://cloud.githubusercontent.com/assets/2362026/25485987/720a0e4e-2b68-11e7-99c7-5fa985054157.png)




### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
