### PR TITLE
Fix wrong store id filter

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/TermDropdownStrategy.php
+++ b/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/TermDropdownStrategy.php
@@ -101,7 +101,7 @@ class TermDropdownStrategy implements FilterStrategyInterface
             'search_index.entity_id = %1$s.entity_id AND %1$s.attribute_id = %2$d AND %1$s.store_id = %3$d',
             $alias,
             $attribute->getId(),
-            $this->storeManager->getWebsite()->getId()
+            $this->storeManager->getStore()->getId()
         );
         $select->joinLeft(
             [$alias => $this->frontendResource->getMainTable()],

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Search/FilterMapper/TermDropdownStrategyTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Search/FilterMapper/TermDropdownStrategyTest.php
@@ -11,7 +11,7 @@ use Magento\Indexer\Model\ResourceModel\FrontendResource;
 use Magento\Framework\Search\Request\FilterInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Store\Api\Data\WebsiteInterface;
+use Magento\Store\Api\Data\StoreInterface;
 use Magento\Framework\DB\Select;
 use Magento\Eav\Model\Config as EavConfig;
 use Magento\Catalog\Model\ResourceModel\Eav\Attribute;
@@ -85,7 +85,7 @@ class TermDropdownStrategyTest extends \PHPUnit_Framework_TestCase
         $attribute = $this->getMockBuilder(Attribute::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $website = $this->getMockBuilder(WebsiteInterface::class)
+        $store = $this->getMockBuilder(StoreInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -99,9 +99,9 @@ class TermDropdownStrategyTest extends \PHPUnit_Framework_TestCase
             ->method('getAttribute')
             ->willReturn($attribute);
         $this->storeManager->expects($this->once())
-            ->method('getWebsite')
-            ->willReturn($website);
-        $website->expects($this->once())
+            ->method('getStore')
+            ->willReturn($store);
+        $store->expects($this->once())
             ->method('getId')
             ->willReturn(1);
         $attribute->expects($this->once())


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
**Website id** is incorrectly used for **store filter** when retrieving products on category page. **Store id** should be used instead.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Having the following store structure:
![store_website](https://cloud.githubusercontent.com/assets/2362026/25487028/b4009f72-2b6b-11e7-840a-1571ba1b791d.png)
![store](https://cloud.githubusercontent.com/assets/2362026/25487068/d10c5822-2b6b-11e7-8e22-2b4339601b5f.png)

2. When i access a category page on store *Store View 2*, no products are displayed because of wrong filter.
Example: Go to  http://local-magento2/storeview2/test-some-category-path.html

3. When debugging the category page, at ```\Magento\Framework\Search\Adapter\Mysql\TemporaryStorage::storeDocumentsFromSelect```, the expression ```$select . ''``` is evaluated to:
```
SELECT `main_select`.`entity_id`, MAX(score) AS `relevance` FROM (SELECT `search_index`.`entity_id`, (((0) + (0)) * 1) AS `score` FROM `catalogsearch_fulltext_scope5` AS `search_index`
 INNER JOIN `catalog_category_product_index` AS `category_ids_index` ON search_index.entity_id = category_ids_index.product_id
 LEFT JOIN `catalog_product_index_eav` AS `visibility_filter` ON search_index.entity_id = visibility_filter.entity_id AND visibility_filter.attribute_id = 99 AND visibility_filter.store_id = 4
 LEFT JOIN `cataloginventory_stock_status` AS `visibility_filter_stock` ON visibility_filter_stock.product_id = visibility_filter.source_id
 INNER JOIN `cataloginventory_stock_status` AS `stock_index` ON search_index.entity_id = stock_index.product_id AND stock_index.website_id = 0 WHERE (stock_index.stock_status = 1) AND (category_ids_index.category_id = 3) AND (visibility_filter.value  IN ('2','4') AND visibility_filter_stock.stock_status = 1)) AS `main_select` GROUP BY `entity_id` ORDER BY `relevance` DESC
 LIMIT 10000
```
This query returns empty result. Changing ```visibility_filter.store_id = 4``` to ```visibility_filter.store_id = 5```, the query returns the expected products from category.
Note that the *Website 2* has id *4* and *Store View 2* has id *5*.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
