### PR TITLE
Reset password failure count when flag is expired PR-BUGFIXES-4432

### DIFF
--- a/app/code/Magento/Integration/Model/Oauth/Token/RequestLog/ReaderInterface.php
+++ b/app/code/Magento/Integration/Model/Oauth/Token/RequestLog/ReaderInterface.php
@@ -19,4 +19,13 @@ interface ReaderInterface
      * @return int
      */
     public function getFailuresCount($userName, $userType);
+
+    /**
+     * Get the Datetime when the lock will expire.
+     *
+     * @param string $userName
+     * @param int $userType
+     * @return int
+     */
+    public function getLockExpiresAt($userName, $userType);
 }

--- a/app/code/Magento/Integration/Model/Oauth/Token/RequestThrottler.php
+++ b/app/code/Magento/Integration/Model/Oauth/Token/RequestThrottler.php
@@ -64,6 +64,14 @@ class RequestThrottler
      */
     public function throttle($userName, $userType)
     {
+        $lockExpiresAtString = $this->requestLogReader->getLockExpiresAt($userName, $userType);
+        $lockExpiresAt = new \Zend_Date($lockExpiresAtString);
+        $now = new \Zend_Date();
+
+        if ($lockExpiresAt < $now) {
+            $this->resetAuthenticationFailuresCount($userName, $userType);
+        }
+
         $count = $this->requestLogReader->getFailuresCount($userName, $userType);
         if ($count >= $this->requestLogConfig->getMaxFailuresCount()) {
             throw new AuthenticationException(

--- a/app/code/Magento/Integration/Model/Oauth/Token/RequestThrottler.php
+++ b/app/code/Magento/Integration/Model/Oauth/Token/RequestThrottler.php
@@ -65,11 +65,15 @@ class RequestThrottler
     public function throttle($userName, $userType)
     {
         $lockExpiresAtString = $this->requestLogReader->getLockExpiresAt($userName, $userType);
-        $lockExpiresAt = new \Zend_Date($lockExpiresAtString);
-        $now = new \Zend_Date();
 
-        if ($lockExpiresAt < $now) {
-            $this->resetAuthenticationFailuresCount($userName, $userType);
+        if ($lockExpiresAtString !== '') {
+
+            $lockExpiresAt = new \Zend_Date($lockExpiresAtString);
+            $now = new \Zend_Date();
+
+            if ($lockExpiresAt < $now) {
+                $this->resetAuthenticationFailuresCount($userName, $userType);
+            }
         }
 
         $count = $this->requestLogReader->getFailuresCount($userName, $userType);

--- a/app/code/Magento/Integration/Model/ResourceModel/Oauth/Token/RequestLog.php
+++ b/app/code/Magento/Integration/Model/ResourceModel/Oauth/Token/RequestLog.php
@@ -109,4 +109,16 @@ class RequestLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb im
         $dateTime = $date->format(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT);
         $this->getConnection()->delete($this->getMainTable(), ['lock_expires_at <= ?' => $dateTime]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLockExpiresAt($userName, $userType)
+    {
+        $select = $this->getConnection()->select();
+        $select->from($this->getMainTable(), 'lock_expires_at')
+            ->where('user_name = :user_name AND user_type = :user_type');
+
+        return $this->getConnection()->fetchOne($select, ['user_name' => $userName, 'user_type' => $userType]);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
If you try 6 or more times a customer password via webapi, the account gets locked and there is no way to unlock it.
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4432: Rest api getting customer token does not work

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Try an incorrect password more than 5 times using the endpoint `[POST] /integration/customer/token`.
2.Try the correct password 1 hour later (or whatever you set in the configuration) using the same endpoint. You will still not be able to login. Even if you reset your password, you will not be able to do so.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
