### PR TITLE
Fix data deletion using the multiple delete command

### DIFF
--- a/setup/src/Magento/Setup/Model/UninstallCollector.php
+++ b/setup/src/Magento/Setup/Model/UninstallCollector.php
@@ -56,7 +56,7 @@ class UninstallCollector
         $setup = $this->dataSetupFactory->create();
         $result = $setup->getConnection()->select()->from($setup->getTable('setup_module'), ['module']);
         if (isset($filterModules) && sizeof($filterModules) > 0) {
-            $result->where('module in( ? )', implode(',', $filterModules));
+            $result->where('module in( ? )', $filterModules);
         }
         // go through modules
         foreach ($setup->getConnection()->fetchAll($result) as $row) {


### PR DESCRIPTION
### Description
Use command
```
$ magento module:uninstall Prefix_Module1 Prefix_Module2
```
Deletion scripts do not work

### Manual testing scenarios
1. Install modules containing scripts for deletion (Setup/Uninstall.php file)
2. Uninstall module use command ``` magento module:uninstall Prefix_Module1 Prefix_Module2 ```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
