### PR TITLE
Fix to include an else to display a "static block" only

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/category/products.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/products.phtml
@@ -16,4 +16,6 @@
 ?>
 <?php if (!$block->isContentMode() || $block->isMixedMode()): ?>
     <?php echo $block->getProductListHtml() ?>
+<?php else: ?>
+    <?php echo $block->getCmsBlockHtml() ?>
 <?php endif; ?>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Whilst working, we noticed that when we set the category to show static block only nothing showed on the fronted. When taking a look at the view file we noticed this was not included.
