### PR TITLE
Update select.js

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js
@@ -27,7 +27,7 @@ define([
                 values = values.split(',');
             }
 
-            if (!Array.isArray(values)) {
+            if (!_.isArray(values)) {
                 values = [values];
             }
 

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js
@@ -55,7 +55,7 @@ define([
         flatOptions: function (options) {
             var self = this;
 
-            if (!Array.isArray(options)) {
+            if (!_.isArray(options)) {
                 options = _.values(options);
             }
 

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js
@@ -55,6 +55,10 @@ define([
         flatOptions: function (options) {
             var self = this;
 
+            if (!Array.isArray(options)) {
+                options = _.values(options);
+            }
+
             return options.reduce(function (opts, option) {
                 if (_.isArray(option.value)) {
                     opts = opts.concat(self.flatOptions(option.value));

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/select.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/select.test.js
@@ -10,7 +10,8 @@ define([
     'use strict';
 
     describe('Ui/js/grid/columns/select', function () {
-        var opts = [{
+        var fieldName = 'selectField',
+            opts = [{
                 label : 'a', value : 1
             }, {
                 label : 'b', value : 2
@@ -29,22 +30,27 @@ define([
             select;
 
         beforeEach(function () {
-            select = new Select();
+            select = new Select({index : fieldName});
         });
 
         describe('getLabel method', function () {
             it('get label while options empty', function () {
-                expect(select.getLabel(2)).toBe('');
+                expect(select.getLabel({selectField : '2'})).toBe('');
             });
 
             it('get label for existed value', function () {
                 select.options = opts;
-                expect(select.getLabel(2)).toBe('b');
+                expect(select.getLabel({selectField : '2'})).toBe('b');
             });
 
             it('get label for existed value in case the options are initialized as an object', function () {
                 select.options = optsAsObject;
-                expect(select.getLabel(3)).toBe('c');
+                expect(select.getLabel({selectField : '3'})).toBe('c');
+            });
+
+            it('get labels for existed values in case the options are initialized as an object', function () {
+                select.options = optsAsObject;
+                expect(select.getLabel({selectField : '1,3'})).toBe('a, c');
             });
         });
     });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/select.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/select.test.js
@@ -38,17 +38,17 @@ define([
                 expect(select.getLabel({selectField : '2'})).toBe('');
             });
 
-            it('get label for existed value', function () {
+            it('get label for existing value', function () {
                 select.options = opts;
                 expect(select.getLabel({selectField : '2'})).toBe('b');
             });
 
-            it('get label for existed value in case the options are initialized as an object', function () {
+            it('get label for existing value in case the options are initialized as an object', function () {
                 select.options = optsAsObject;
                 expect(select.getLabel({selectField : '3'})).toBe('c');
             });
 
-            it('get labels for existed values in case the options are initialized as an object', function () {
+            it('get labels for existing values in case the options are initialized as an object', function () {
                 select.options = optsAsObject;
                 expect(select.getLabel({selectField : '1,3'})).toBe('a, c');
             });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/select.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/select.test.js
@@ -10,7 +10,23 @@ define([
     'use strict';
 
     describe('Ui/js/grid/columns/select', function () {
-        var select;
+        var opts = [{
+                label : 'a', value : 1
+            }, {
+                label : 'b', value : 2
+            }],
+            optsAsObject = {
+                1 : {
+                    label : 'a', value : 1
+                },
+                2 : {
+                    label : 'b', value : 2
+                },
+                4 : {
+                    label : 'c', value : 3
+                }
+            },
+            select;
 
         beforeEach(function () {
             select = new Select();
@@ -19,6 +35,16 @@ define([
         describe('getLabel method', function () {
             it('get label while options empty', function () {
                 expect(select.getLabel(2)).toBe('');
+            });
+
+            it('get label for existed value', function () {
+                select.options = opts;
+                expect(select.getLabel(2)).toBe('b');
+            });
+
+            it('get label for existed value in case the options are initialized as an object', function () {
+                select.options = optsAsObject;
+                expect(select.getLabel(3)).toBe('c');
             });
         });
     });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/select.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/select.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © Magento, Inc. All rights reserved.
+ * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
 /*eslint max-nested-callbacks: 0*/
@@ -10,47 +10,57 @@ define([
     'use strict';
 
     describe('Ui/js/grid/columns/select', function () {
-        var fieldName = 'selectField',
-            opts = [{
-                label : 'a', value : 1
+        var fieldName    = 'selectField',
+            opts         = [{
+                label: 'a', value: 1
             }, {
-                label : 'b', value : 2
+                label: 'b', value: 2
             }],
             optsAsObject = {
-                1 : {
-                    label : 'a', value : 1
+                1: {
+                    label: 'a', value: 1
                 },
-                2 : {
-                    label : 'b', value : 2
+                2: {
+                    label: 'b', value: 2
                 },
-                4 : {
-                    label : 'c', value : 3
+                4: {
+                    label: 'c', value: 3
                 }
             },
             select;
 
         beforeEach(function () {
-            select = new Select({index : fieldName});
+            select = new Select({
+                index: fieldName
+            });
         });
 
         describe('getLabel method', function () {
             it('get label while options empty', function () {
-                expect(select.getLabel({selectField : '2'})).toBe('');
+                expect(select.getLabel({
+                    selectField: '2'
+                })).toBe('');
             });
 
-            it('get label for existing value', function () {
+            it('get label for existed value', function () {
                 select.options = opts;
-                expect(select.getLabel({selectField : '2'})).toBe('b');
+                expect(select.getLabel({
+                    selectField: '2'
+                })).toBe('b');
             });
 
-            it('get label for existing value in case the options are initialized as an object', function () {
+            it('get label for existed value in case the options are initialized as an object', function () {
                 select.options = optsAsObject;
-                expect(select.getLabel({selectField : '3'})).toBe('c');
+                expect(select.getLabel({
+                    selectField: '3'
+                })).toBe('c');
             });
 
-            it('get labels for existing values in case the options are initialized as an object', function () {
+            it('get labels for existed values in case the options are initialized as an object', function () {
                 select.options = optsAsObject;
-                expect(select.getLabel({selectField : '1,3'})).toBe('a, c');
+                expect(select.getLabel({
+                    selectField: '1,3'
+                })).toBe('a, c');
             });
         });
     });


### PR DESCRIPTION
### Description
Fixed a bug where `options.reduce` was not available in case options was generated by an array with non-numeric or missing numeric keys in PHP. In that case a TypeError get thrown, because `options.reduce` is not a function of an object.

Uncaught TypeError: Unable to process binding "text: function (){return $col.getLabel($row()) }"
Message: options.reduce is not a function



### Manual testing scenarios
1. Have a select attribute where the options are being generated from an option array in PHP, where that array have non-numeric keys or missing numeric keys. For example:
```
$options = [
    1 => ['label' => 'Option A', 'value' => 1],
    3 => ['label' => 'Option C', 'value' => 3],
    4 => ['label' => 'Option D', 'value' => 4],
];
```
2. Load a grid where that attribute has an active column
3. The grid won't fully load (it loads until the first cell where that attribute is used) and JS throws an error:
```
Uncaught TypeError: Unable to process binding "text: function (){return $col.getLabel($row()) }"
Message: options.reduce is not a function
    at UiClass.flatOptions (select.js:58)
    at UiClass.getLabel (select.js:38)
    at UiClass.getLabel (wrapper.js:109)
    at text (eval at createBindingsStringEvaluator (knockout.js:2624), <anonymous>:3:69)
    at update (knockout.js:4260)
    at ko.dependentObservable.disposeWhenNodeIsRemoved (knockout.js:3004)
    at evaluateImmediate (knockout.js:1737)
    at Object.ko.computed.ko.dependentObservable (knockout.js:1946)
    at knockout.js:3002
    at Object.arrayForEach (knockout.js:151)
```