### PR TITLE
Fix getSubject encoding

### DIFF
--- a/app/code/Magento/Email/Model/Template.php
+++ b/app/code/Magento/Email/Model/Template.php
@@ -386,7 +386,8 @@ class Template extends AbstractTemplate implements \Magento\Framework\Mail\Templ
      */
     public function getSubject()
     {
-        return $this->getProcessedTemplateSubject($this->_getVars());
+        $subject = $this->getProcessedTemplateSubject($this->_getVars());
+        return htmlspecialchars_decode((string)$subject, ENT_QUOTES);
     }
 
     /**


### PR DESCRIPTION
Fix for issues #6597 & #8094. Short description: If your store name has a special character in it, such as an apostrophe, it will be converted to a numerical character reference in any email subject. This will fix that problem.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
