### PR TITLE
Shipping method radios become disabled when checkout page refreshed

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/new-customer-address.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/new-customer-address.js
@@ -22,9 +22,7 @@ define([], function () {
         return {
             email: addressData.email,
             countryId: addressData['country_id'] || addressData.countryId || window.checkoutConfig.defaultCountryId,
-            regionId: (addressData.region && addressData.region.region_id) ?
-                addressData.region.region_id
-                : window.checkoutConfig.defaultRegionId,
+            regionId: regionId || addressData.regionId,
             regionCode: (addressData.region) ? addressData.region.region_code : null,
             region: (addressData.region) ? addressData.region.region : null,
             customerId: addressData.customer_id || addressData.customerId,

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/new-customer-address.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/new-customer-address.js
@@ -10,7 +10,14 @@ define([], function () {
      * Returns new address object
      */
     return function (addressData) {
-        var identifier = Date.now();
+        var identifier = Date.now(),
+            regionId;
+
+        if (addressData.region && addressData.region.region_id) {
+            regionId = addressData.region.region_id;
+        } else if (addressData.country_id && addressData.country_id == window.checkoutConfig.defaultCountryId) {
+            regionId = window.checkoutConfig.defaultRegionId || undefined;
+        }
 
         return {
             email: addressData.email,
@@ -20,7 +27,7 @@ define([], function () {
                 : window.checkoutConfig.defaultRegionId,
             regionCode: (addressData.region) ? addressData.region.region_code : null,
             region: (addressData.region) ? addressData.region.region : null,
-            customerId: addressData.customer_id,
+            customerId: addressData.customer_id || addressData.customerId,
             street: addressData.street,
             company: addressData.company,
             telephone: addressData.telephone,

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
@@ -79,7 +79,6 @@ define(
                     fieldsetName = 'checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset';
 
                 this._super();
-                shippingRatesValidator.initFields(fieldsetName);
 
                 if (!quote.isVirtual()) {
                     stepNavigator.registerStep(
@@ -120,6 +119,7 @@ define(
                     checkoutProvider.on('shippingAddress', function (shippingAddressData) {
                         checkoutData.setShippingAddressFromData(shippingAddressData);
                     });
+                    shippingRatesValidator.initFields(fieldsetName);
                 });
 
                 return this;

--- a/app/code/Magento/Customer/view/frontend/web/js/model/customer/address.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/model/customer/address.js
@@ -10,11 +10,17 @@ define([], function() {
      * Returns new address object
      */
     return function (addressData) {
+        var regionId;
+
+        if (addressData.region['region_id'] && addressData.region['region_id'] !== '0') {
+            regionId = addressData.region['region_id'] + '';
+        }
+
         return {
             customerAddressId: addressData.id,
             email: addressData.email,
             countryId: addressData.country_id,
-            regionId: addressData.region_id,
+            regionId: regionId,
             regionCode: addressData.region.region_code,
             region: addressData.region.region,
             customerId: addressData.customer_id,


### PR DESCRIPTION
 - Backport fix MAGETWO-56073

<!--- Provide a general summary of the Pull Request in the Title above -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#7497: Shipping method radios become disabled when checkout page refreshed

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
For Guests
- Add product to the cart
- Proceed to checkout as a guest
- Enter valid address details
- Wait for shipping rates to be displayed
- Refresh page (Ctrl + R for example)

For Registred Users
- Sign into an existing (or create a new) customer account with an address in the address book
- Add one or more items to the shopping cart
- Click Checkout in the mini cart
- Click the New Address button on the shipping page
- Complete the new address form and submit

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
