### PR TITLE
magento/magento2#9428: 2.1.6 Fixed 500 error while getting Low Stock Reports

### DIFF
--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_product_exportlowstockcsv.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_product_exportlowstockcsv.xml
@@ -8,6 +8,6 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="reports_report_product_lowstock_grid"/>
     <body>
-        <container name="adminhtml.block.report.product.lowstock.grid.container" label="Export CSV"/>
+        <block class="Magento\Backend\Block\Widget\Grid\Container" name="adminhtml.report.grid.container" template="Magento_Backend::widget/grid/container/empty.phtml"/>
     </body>
 </page>

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_product_exportlowstockexcel.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_product_exportlowstockexcel.xml
@@ -8,6 +8,6 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="reports_report_product_lowstock_grid"/>
     <body>
-        <container name="adminhtml.block.report.product.lowstock.grid.container" label="Excel XML"/>
+        <block class="Magento\Backend\Block\Widget\Grid\Container" name="adminhtml.report.grid.container" template="Magento_Backend::widget/grid/container/empty.phtml"/>
     </body>
 </page>


### PR DESCRIPTION
Fixed 500 error while getting Low Stock Reports

### Description
Fixed 500 error while getting Low Stock Reports. Now the reports can able to be downloaded. Fixed by creating the parent block which was referenced in grid xml

### Fixed Issues (if relevant)
1. magento/magento2#9428: Fixed 500 Internal Server Error
