### PR TITLE
Fix save product images cache in windows servers

### DIFF
--- a/app/code/Magento/Catalog/Model/View/Asset/Image.php
+++ b/app/code/Magento/Catalog/Model/View/Asset/Image.php
@@ -201,7 +201,7 @@ class Image implements LocalInterface
         $result = $this->join($result, $this->getModule());
         $result = $this->join($result, $this->getMiscPath());
         $result = $this->join($result, $this->getFilePath());
-        if(1 !== strpos($result, ':')) {
+        if (1 !== strpos($result, ':')) {
             $result = DIRECTORY_SEPARATOR . $result;
         }
         return $result;

--- a/app/code/Magento/Catalog/Model/View/Asset/Image.php
+++ b/app/code/Magento/Catalog/Model/View/Asset/Image.php
@@ -201,6 +201,9 @@ class Image implements LocalInterface
         $result = $this->join($result, $this->getModule());
         $result = $this->join($result, $this->getMiscPath());
         $result = $this->join($result, $this->getFilePath());
-        return DIRECTORY_SEPARATOR . $result;
+        if(1 !== strpos($result, ':')) {
+            $result = DIRECTORY_SEPARATOR . $result;
+        }
+        return $result;
     }
 }


### PR DESCRIPTION
Result have "D:/something/..." value in the windows servers.
And after getRelativePath result equals "/D:/something/..."
It's bug,

Issue #8212
https://github.com/magento/magento2/issues/8212

1 exception(s):
Exception #0 (Exception): Unable to write file into directory \D:/Ampps/www/magento21.dev/pub/media/catalog/product\cache\0f831c1845fc143d00d6d1ebc49f446a\/m/j. Access forbidden.

Exception #0 (Exception): Unable to write file into directory \D:/Ampps/www/magento21.dev/pub/media/catalog/product\cache\0f831c1845fc143d00d6d1ebc49f446a\/m/j. Access forbidden.
#0 D:\Ampps\www\magento21.dev\vendor\magento\framework\Image\Adapter\Gd2.php(141): Magento\Framework\Image\Adapter\AbstractAdapter->_prepareDestination('\\D:/Ampps/www/m...', 'mj01-yellow_mai...')
#1 D:\Ampps\www\magento21.dev\vendor\magento\framework\Image.php(79): Magento\Framework\Image\Adapter\Gd2->save('\\D:/Ampps/www/m...', NULL)
#2 D:\Ampps\www\magento21.dev\vendor\magento\module-catalog\Model\Product\Image.php(677): Magento\Framework\Image->save('\\D:/Ampps/www/m...')
#3 D:\Ampps\www\magento21.dev\vendor\magento\module-catalog\Helper\Image.php(465): Magento\Catalog\Model\Product\Image->saveFile()
#4 D:\Ampps\www\magento21.dev\vendor\magento\module-catalog\Helper\Image.php(534): Magento\Catalog\Helper\Image->applyScheduledActions()
#5 D:\Ampps\www\magento21.dev\vendor\magento\module-catalog\Block\Product\ImageBuilder.php(132): Magento\Catalog\Helper\Image->getResizedImageInfo()
#6 D:\Ampps\www\magento21.dev\vendor\magento\module-catalog\Block\Product\AbstractProduct.php(517): Magento\Catalog\Block\Product\ImageBuilder->create()
#7 D:\Ampps\www\magento21.dev\vendor\magento\framework\Interception\Interceptor.php(146): Magento\Catalog\Block\Product\AbstractProduct->getImage(Object(Magento\Catalog\Model\Product\Interceptor), 'product_base_im...', Array)
#8 D:\Ampps\www\magento21.dev\var\generation\Magento\Catalog\Block\Product\View\Interceptor.php(455): Magento\Catalog\Block\Product\View\Interceptor->___callPlugins('getImage', Array, Array)
#9 D:\Ampps\www\magento21.dev\vendor\magento\module-catalog\view\frontend\templates\product\view\opengraph\general.phtml(14): Magento\Catalog\Block\Product\View\Interceptor->getImage(Object(Magento\Catalog\Model\Product\Interceptor), 'product_base_im...')
#10 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\TemplateEngine\Php.php(59): include('D:\\Ampps\\www\\ma...')
#11 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Element\Template.php(255): Magento\Framework\View\TemplateEngine\Php->render(Object(Magento\Catalog\Block\Product\View\Interceptor), 'D:/Ampps/www/ma...', Array)
#12 D:\Ampps\www\magento21.dev\var\generation\Magento\Catalog\Block\Product\View\Interceptor.php(544): Magento\Framework\View\Element\Template->fetchView('D:/Ampps/www/ma...')
#13 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Element\Template.php(279): Magento\Catalog\Block\Product\View\Interceptor->fetchView('D:/Ampps/www/ma...')
#14 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Element\AbstractBlock.php(659): Magento\Framework\View\Element\Template->_toHtml()
#15 D:\Ampps\www\magento21.dev\var\generation\Magento\Catalog\Block\Product\View\Interceptor.php(869): Magento\Framework\View\Element\AbstractBlock->toHtml()
#16 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Layout.php(542): Magento\Catalog\Block\Product\View\Interceptor->toHtml()
#17 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Layout.php(518): Magento\Framework\View\Layout->_renderBlock('opengraph.gener...')
#18 D:\Ampps\www\magento21.dev\var\generation\Magento\Framework\View\Layout\Interceptor.php(206): Magento\Framework\View\Layout->renderNonCachedElement('opengraph.gener...')
#19 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Layout.php(472): Magento\Framework\View\Layout\Interceptor->renderNonCachedElement('opengraph.gener...')
#20 D:\Ampps\www\magento21.dev\var\generation\Magento\Framework\View\Layout\Interceptor.php(193): Magento\Framework\View\Layout->renderElement('opengraph.gener...', true)
#21 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Element\AbstractBlock.php(503): Magento\Framework\View\Layout\Interceptor->renderElement('opengraph.gener...', true)
#22 D:\Ampps\www\magento21.dev\vendor\magento\module-theme\view\frontend\templates\html\container.phtml(10): Magento\Framework\View\Element\AbstractBlock->getChildHtml()
#23 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\TemplateEngine\Php.php(59): include('D:\\Ampps\\www\\ma...')
#24 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Element\Template.php(255): Magento\Framework\View\TemplateEngine\Php->render(Object(Magento\Framework\View\Element\Template), 'D:/Ampps/www/ma...', Array)
#25 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Element\Template.php(279): Magento\Framework\View\Element\Template->fetchView('D:/Ampps/www/ma...')
#26 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Element\AbstractBlock.php(659): Magento\Framework\View\Element\Template->_toHtml()
#27 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Result\Page.php(236): Magento\Framework\View\Element\AbstractBlock->toHtml()
#28 D:\Ampps\www\magento21.dev\vendor\magento\framework\View\Result\Layout.php(164): Magento\Framework\View\Result\Page->render(Object(Magento\Framework\App\Response\Http\Interceptor))
#29 D:\Ampps\www\magento21.dev\vendor\magento\framework\Interception\Interceptor.php(74): Magento\Framework\View\Result\Layout->renderResult(Object(Magento\Framework\App\Response\Http\Interceptor))
#30 D:\Ampps\www\magento21.dev\vendor\magento\framework\Interception\Chain\Chain.php(70): Magento\Framework\View\Result\Page\Interceptor->___callParent('renderResult', Array)
#31 D:\Ampps\www\magento21.dev\vendor\magento\framework\Interception\Chain\Chain.php(63): Magento\Framework\Interception\Chain\Chain->invokeNext('Magento\\Framewo...', 'renderResult', Object(Magento\Framework\View\Result\Page\Interceptor), Array, 'result-varnish-...')
#32 D:\Ampps\www\magento21.dev\vendor\magento\module-page-cache\Model\Controller\Result\VarnishPlugin.php(74): Magento\Framework\Interception\Chain\Chain->Magento\Framework\Interception\Chain\{closure}(Object(Magento\Framework\App\Response\Http\Interceptor))
#33 D:\Ampps\www\magento21.dev\vendor\magento\framework\Interception\Chain\Chain.php(67): Magento\PageCache\Model\Controller\Result\VarnishPlugin->aroundRenderResult(Object(Magento\Framework\View\Result\Page\Interceptor), Object(Closure), Object(Magento\Framework\App\Response\Http\Interceptor))
#34 D:\Ampps\www\magento21.dev\vendor\magento\framework\Interception\Interceptor.php(138): Magento\Framework\Interception\Chain\Chain->invokeNext('Magento\\Framewo...', 'renderResult', Object(Magento\Framework\View\Result\Page\Interceptor), Array, 'result-builtin-...')
#35 D:\Ampps\www\magento21.dev\vendor\magento\module-page-cache\Model\Controller\Result\BuiltinPlugin.php(67): Magento\Framework\View\Result\Page\Interceptor->Magento\Framework\Interception\{closure}(Object(Magento\Framework\App\Response\Http\Interceptor))
#36 D:\Ampps\www\magento21.dev\vendor\magento\framework\Interception\Interceptor.php(142): Magento\PageCache\Model\Controller\Result\BuiltinPlugin->aroundRenderResult(Object(Magento\Framework\View\Result\Page\Interceptor), Object(Closure), Object(Magento\Framework\App\Response\Http\Interceptor))
#37 D:\Ampps\www\magento21.dev\var\generation\Magento\Framework\View\Result\Page\Interceptor.php(130): Magento\Framework\View\Result\Page\Interceptor->___callPlugins('renderResult', Array, Array)
#38 D:\Ampps\www\magento21.dev\vendor\magento\framework\App\Http.php(139): Magento\Framework\View\Result\Page\Interceptor->renderResult(Object(Magento\Framework\App\Response\Http\Interceptor))
#39 D:\Ampps\www\magento21.dev\vendor\magento\framework\App\Bootstrap.php(258): Magento\Framework\App\Http->launch()
#40 D:\Ampps\www\magento21.dev\index.php(39): Magento\Framework\App\Bootstrap->run(Object(Magento\Framework\App\Http))
#41 {main}