### PR TITLE
Backport of MAGETWO-57675 for Magento 2.1: WYSIWYG editor does not show. #6222 #4828 #6815

### DIFF
--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/setup.js
@@ -53,6 +53,10 @@ define([
                 });
             }
 
+            if (jQuery.isReady) {
+                tinyMCE.dom.Event.domLoaded = true;
+            }
+
             tinyMCE.init(this.getSettings(mode));
         },
 


### PR DESCRIPTION
### Description

This is a backport of issue MAGETWO-57675 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/4828: Show/hide Editor not working sometimes
2. https://github.com/magento/magento2/issues/6222: [2.1.0] Sometimes WYSIWYG editor does not show.
3. https://github.com/magento/magento2/issues/6815: wysiwyg Editor problem

Reference to commit on the develop branch: https://github.com/magento/magento2/commit/3524943ac6544ee969480536ef6f0cd1a29b0b56
