### PR TITLE
Backport of MAGETWO-54798 For Magento 2.1: One page checkout - Street Address should highlight red when data is missing

### DIFF
--- a/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
+++ b/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
@@ -281,7 +281,7 @@ class AttributeMerger
                         $attributeConfig['validation']
                     )
                     : $attributeConfig['validation'],
-                'additionalClasses' => $isFirstLine ? : 'additional'
+                'additionalClasses' => $isFirstLine ? 'field' : 'additional'
 
             ];
             if ($isFirstLine && isset($attributeConfig['default']) && $attributeConfig['default'] != null) {


### PR DESCRIPTION
### Description
This is a backport of issue MAGETWO-54798 for Magento 2.1

### Fixed Issues (if relevant)
1. MAGETWO-54798

Reference to commit on the develop branch: https://github.com/magento/magento2/commit/6f7444ab62824bb002cff0686925c5dfa18ab146

