### PR TITLE
Make imageAsset protected to allow extensions to access the original …

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Image.php
+++ b/app/code/Magento/Catalog/Model/Product/Image.php
@@ -183,7 +183,7 @@ class Image extends \Magento\Framework\Model\AbstractModel
     /**
      * @var \Magento\Framework\View\Asset\LocalInterface
      */
-    private $imageAsset;
+    protected $imageAsset;
 
     /**
      * @param \Magento\Framework\Model\Context $context


### PR DESCRIPTION
…file

I am a developer on a Magento 2 extension that optimizes images.

Since 2.1.6 there have been some changes to how product images are stored. I am trying to make the extension work with the latest changes, but the current implementation does not allow us to access the underlying `imageAsset` in order to retrieve/change the path of the images. This is required in order to make the extension work.

Please make `imageAsset` protected instead of private so we can update our extension and make it work with the latest Magento 2 versions again.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
