### PR TITLE
#9439 Save region details in order address edit.

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -28,8 +28,8 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
     const ADMIN_RESOURCE = 'Magento_Sales::actions_edit';
 
     /** @var RegionFactory $regionFactory */
-    protected $regionFactory;
-    
+    private $regionFactory;
+
     /**
      * @param Action\Context $context
      * @param \Magento\Framework\Registry $coreRegistry
@@ -59,9 +59,8 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
         OrderManagementInterface $orderManagement,
         OrderRepositoryInterface $orderRepository,
         LoggerInterface $logger,
-        RegionFactory $regionFactory
+        RegionFactory $regionFactory = null
     ) {
-        $this->regionFactory = $regionFactory;
         parent::__construct(
             $context,
             $coreRegistry,
@@ -75,8 +74,9 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
             $orderRepository,
             $logger
         );
+        $this->regionFactory = $regionFactory ?: \Magento\Framework\App\ObjectManager::getInstance()->get('\Magento\Directory\Model\RegionFactory');
     }
-    
+
     /**
      * Save order address
      *

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -14,6 +14,10 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\InputException;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.NumberOfChildren)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
 {
     /**
@@ -59,10 +63,10 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
     ) {
         $this->regionFactory = $regionFactory;
         parent::__construct(
-            $context, 
+            $context,
             $coreRegistry,
             $fileFactory,
-            $translateInline,                            
+            $translateInline,
             $resultPageFactory,
             $resultJsonFactory,
             $resultLayoutFactory,
@@ -90,14 +94,14 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
         if ($data && $address->getId()) {
             $address->addData($data);
             try {
-                if($address->getRegion() == null) {
+                if ($address->getRegion() == null) {
                     $regionId = $address->getRegionId();
                     /** @var \Magento\Directory\Model\Region $region */
                     $region = $this->regionFactory->create();
                     $region->getResource()->load($region, $regionId);
                     $address->setRegion($region->getName());
                     $address->setRegionCode($region->getCode());
-                }                
+                }
                 $address->save();
                 $this->_eventManager->dispatch(
                     'admin_sales_order_address_update',

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -74,8 +74,9 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
             $orderRepository,
             $logger
         );
-        $this->regionFactory = 
-            $regionFactory ?: \Magento\Framework\App\ObjectManager::getInstance()->get('\Magento\Directory\Model\RegionFactory');
+        $this->regionFactory = $regionFactory ?:
+            \Magento\Framework\App\ObjectManager::getInstance()
+                ->get('\Magento\Directory\Model\RegionFactory');
     }
 
     /**

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -58,9 +58,19 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
         RegionFactory $regionFactory
     ) {
         $this->regionFactory = $regionFactory;
-        parent::__construct($context,$coreRegistry,$fileFactory,$translateInline,
-            $resultPageFactory,$resultJsonFactory,$resultLayoutFactory,$resultRawFactory,
-            $orderManagement,$orderRepository,$logger);
+        parent::__construct(
+            $context, 
+            $coreRegistry,
+            $fileFactory,
+            $translateInline,                            
+            $resultPageFactory,
+            $resultJsonFactory,
+            $resultLayoutFactory,
+            $resultRawFactory,
+            $orderManagement,
+            $orderRepository,
+            $logger
+        );
     }
     
     /**
@@ -80,11 +90,11 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
         if ($data && $address->getId()) {
             $address->addData($data);
             try {
-                if($address->getRegion() == null)   {
+                if($address->getRegion() == null) {
                     $regionId = $address->getRegionId();
                     /** @var \Magento\Directory\Model\Region $region */
                     $region = $this->regionFactory->create();
-                    $region->getResource()->load($region,$regionId);
+                    $region->getResource()->load($region, $regionId);
                     $address->setRegion($region->getName());
                     $address->setRegionCode($region->getCode());
                 }                

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/AddressSave.php
@@ -74,7 +74,8 @@ class AddressSave extends \Magento\Sales\Controller\Adminhtml\Order
             $orderRepository,
             $logger
         );
-        $this->regionFactory = $regionFactory ?: \Magento\Framework\App\ObjectManager::getInstance()->get('\Magento\Directory\Model\RegionFactory');
+        $this->regionFactory = 
+            $regionFactory ?: \Magento\Framework\App\ObjectManager::getInstance()->get('\Magento\Directory\Model\RegionFactory');
     }
 
     /**


### PR DESCRIPTION
Region is missing in admin order view after order edit.  The reason is that the address only save region ID.

This fixes AddressSave controller to save region code and name.

### Manual testing scenarios
1. View pending/processing order in the admin panel
2. Edit billing or shipping address of the order
3. Change State/Region field by selecting it from dropdown menu
4. Save

State/Region should now changed to new region or keep existing region if there is no change.

