### PR TITLE
Fix breadcrumbs extra space

### DIFF
--- a/app/code/Magento/Theme/view/frontend/templates/html/breadcrumbs.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/breadcrumbs.phtml
@@ -13,9 +13,7 @@
         <?php foreach ($crumbs as $crumbName => $crumbInfo) : ?>
             <li class="item <?php /* @escapeNotVerified */ echo $crumbName ?>">
             <?php if ($crumbInfo['link']) : ?>
-                <a href="<?php /* @escapeNotVerified */ echo $crumbInfo['link'] ?>" title="<?php echo $block->escapeHtml($crumbInfo['title']) ?>">
-                    <?php echo $block->escapeHtml($crumbInfo['label']) ?>
-                </a>
+                <a href="<?php /* @escapeNotVerified */ echo $crumbInfo['link'] ?>" title="<?php echo $block->escapeHtml($crumbInfo['title']) ?>"><?php echo $block->escapeHtml($crumbInfo['label']) ?></a>
             <?php elseif ($crumbInfo['last']) : ?>
                 <strong><?php echo $block->escapeHtml($crumbInfo['label']) ?></strong>
             <?php else: ?>


### PR DESCRIPTION
Fix an extra space on the breadcrumbs links.

Before: 
<img width="201" alt="breadcrumbsextraspace" src="https://cloud.githubusercontent.com/assets/1949412/25710578/f1c8cede-30ec-11e7-9f8f-0e7a136d5c67.png">

After:
<img width="191" alt="breadcrumbsextraspaceok" src="https://cloud.githubusercontent.com/assets/1949412/25710613/0cd7e61a-30ed-11e7-803e-98b934f1bf50.png">

