### PR TITLE
magento/magento2#8607: Interface constructor if present will break Magento compilation

### DIFF
--- a/lib/internal/Magento/Framework/Code/Reader/ArgumentsReader.php
+++ b/lib/internal/Magento/Framework/Code/Reader/ArgumentsReader.php
@@ -25,7 +25,7 @@ class ArgumentsReader
         /**
          * Skip native PHP types, classes without constructor
          */
-        if (!$class->getFileName() || false == $class->hasMethod(
+        if ($class->isInterface() || !$class->getFileName() || false == $class->hasMethod(
             '__construct'
         ) || !$inherited && $class->getConstructor()->class != $class->getName()
         ) {


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->
 $class->isInterface() method of an php reflection class will implement the getConstructor() function not to pull any dependencies from the interface constructor. 
So we must have to add this condition  in order to call getConstructor(). This solves the issue
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8607: Interface constructor if present will break Magento compilation
### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Will be covered with unit test
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
