### PR TITLE
Fixed the Inconsistent Gift Options checkbox labels #9421

### DIFF
--- a/app/code/Magento/GiftMessage/i18n/en_US.csv
+++ b/app/code/Magento/GiftMessage/i18n/en_US.csv
@@ -22,7 +22,7 @@ OK,OK
 "Gift Options","Gift Options"
 "Gift Message","Gift Message"
 "Do you have any gift items in your order?","Do you have any gift items in your order?"
-"Add gift options","Add gift options"
+"Add Gift Options","Add Gift Options"
 "Gift Options for the Entire Order","Gift Options for the Entire Order"
 "Leave this box blank if you don\'t want to leave a gift message for the entire order.","Leave this box blank if you don\'t want to leave a gift message for the entire order."
 "Gift Options for Individual Items","Gift Options for Individual Items"
@@ -30,14 +30,14 @@ OK,OK
 "Leave a box blank if you don\'t want to add a gift message for that item.","Leave a box blank if you don\'t want to add a gift message for that item."
 "Add Gift Options for the Entire Order","Add Gift Options for the Entire Order"
 "You can leave this box blank if you don\'t want to add a gift message for this address.","You can leave this box blank if you don\'t want to add a gift message for this address."
-"Add gift options for Individual Items","Add gift options for Individual Items"
+"Add Gift Options for Individual Items","Add Gift Options for Individual Items"
 "You can leave this box blank if you don\'t want to add a gift message for the item.","You can leave this box blank if you don\'t want to add a gift message for the item."
 "Gift Message (optional)","Gift Message (optional)"
 To:,To:
 From:,From:
 Message:,Message:
 Update,Update
-"Gift options","Gift options"
+"Gift Options","Gift Options"
 Edit,Edit
 Delete,Delete
 "Allow Gift Messages on Order Level","Allow Gift Messages on Order Level"

--- a/app/code/Magento/GiftMessage/view/frontend/templates/inline.phtml
+++ b/app/code/Magento/GiftMessage/view/frontend/templates/inline.phtml
@@ -14,7 +14,7 @@
 
         <div class="field choice" id="add-gift-options-<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>">
             <input type="checkbox" name="allow_gift_options" id="allow_gift_options" data-mage-init='{"giftOptions":{}}' value="1" data-selector='{"id":"#allow-gift-options-container"}'<?php if ($block->getItemsHasMesssages() || $block->getEntityHasMessage()): ?> checked="checked"<?php endif; ?> class="checkbox" />
-            <label for="allow_gift_options" class="label"><span><?php /* @escapeNotVerified */ echo __('Add gift options') ?></span></label>
+            <label for="allow_gift_options" class="label"><span><?php /* @escapeNotVerified */ echo __('Add Gift Options') ?></span></label>
         </div>
 
         <dl class="options-items" id="allow-gift-options-container">
@@ -148,7 +148,7 @@
 
         <div class="field choice" id="add-gift-options-<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>">
             <input type="checkbox" name="allow_gift_options_<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>" id="allow_gift_options_<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>" data-mage-init='{"giftOptions":{}}' value="1" data-selector='{"id":"#allow-gift-options-container-<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>"}'<?php if ($block->getItemsHasMesssages() || $block->getEntityHasMessage()): ?> checked="checked"<?php endif; ?> class="checkbox" />
-            <label for="allow_gift_options_<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>" class="label"><span><?php /* @escapeNotVerified */ echo __('Add gift options') ?></span></label>
+            <label for="allow_gift_options_<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>" class="label"><span><?php /* @escapeNotVerified */ echo __('Add Gift Options') ?></span></label>
         </div>
 
         <dl class="options-items" id="allow-gift-options-container-<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>">
@@ -197,7 +197,7 @@
             <dt id="add-gift-options-for-items-<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>" class="order-title individual">
                 <div class="field choice">
                     <input type="checkbox" name="allow_gift_options_for_items_<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>" id="allow_gift_options_for_items_<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>" data-mage-init='{"giftOptions":{}}' value="1" data-selector='{"id":"#allow-gift-options-for-items-container-<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>"}'<?php if ($block->getItemsHasMesssages()): ?> checked="checked"<?php endif; ?> class="checkbox" />
-                    <label for="allow_gift_options_for_items_<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>" class="label"><span><?php /* @escapeNotVerified */ echo __('Add gift options for Individual Items') ?></span></label>
+                    <label for="allow_gift_options_for_items_<?php /* @escapeNotVerified */ echo $block->getEntity()->getId() ?>" class="label"><span><?php /* @escapeNotVerified */ echo __('Add Gift Options for Individual Items') ?></span></label>
                 </div>
             </dt>
 


### PR DESCRIPTION
Changed small "gift options"  to "Gift Options" for Multisipping
address.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Fixed the Inconsistent Gift Options checkbox labels #9421
Changed the labels "gift options" to "Gift Options" in both CSV file ("app\code\Magento\GiftMessage\i18n\en_US.csv") and phtml file ("app\code\Magento\GiftMessage\view\frontend\templates\inline.phtml")
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9421: Inconsistent Gift Options checkbox labels
![gift_options](https://cloud.githubusercontent.com/assets/11790408/25741424/72f8ad42-31a8-11e7-8e43-d1bbc0f17732.png)

2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add product to cart with gift options enabled.
2. Add Gift message in cart page.
3. Click "Multishipping Checkout" from cart page.
4. You can find all the Labels listed along with checkbox "Gift Options" all are consistent

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
