### PR TITLE
Alter Sitemap's items with results from new event

### DIFF
--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -277,6 +277,16 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel
                 self::CLOSE_TAG_KEY => '</urlset>',
             ],
         ];
+        
+        $eventData = new \Magento\Framework\DataObject(['items' => $this->_sitemapItems]);
+        $this->_eventManager->dispatch(
+            'sitemap_prepare_items',
+            [
+                'collection' => $eventData,
+                'store_id' => $this->getStoreId(),
+            ]
+        );
+        $this->_sitemapItems = $eventData->getData('items');
     }
 
     /**


### PR DESCRIPTION
### Description

Add an event "sitemap_prepare_items" that sends the items and the store id out, allowing customizations to add, modify, or remove items for the sitemap generation.

### Manual testing scenarios
1. Create an observer for sitemap_prepare_items
2. Add to the items an DataObject in the same format as the sitemap expects
3. Ensure the new item is in the generated sitemap.xml file

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
