### PR TITLE
Correct comparison for case with no tax

### DIFF
--- a/app/code/Magento/Tax/view/frontend/web/js/view/checkout/cart/totals/tax.js
+++ b/app/code/Magento/Tax/view/frontend/web/js/view/checkout/cart/totals/tax.js
@@ -21,7 +21,7 @@ define([
          * @override
          */
         ifShowValue: function () {
-            if (this.getPureValue() === 0) {
+            if (this.getPureValue() === '0.0000') {
                 return isZeroTaxDisplayed;
             }
 

--- a/app/code/Magento/Tax/view/frontend/web/js/view/checkout/summary/tax.js
+++ b/app/code/Magento/Tax/view/frontend/web/js/view/checkout/summary/tax.js
@@ -32,7 +32,7 @@ define([
          * @return {Boolean}
          */
         ifShowValue: function () {
-            if (this.isFullMode() && this.getPureValue() == 0) { //eslint-disable-line eqeqeq
+            if (this.isFullMode() && this.getPureValue() === '0.0000') {
                 return isZeroTaxDisplayed;
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
In case of no tax return value of this.getPureValue() is string '0.0000'

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. "Display Zero Tax Subtotal = No" works

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Set "Display Zero Tax Subtotal = No"
2. Open cart and see that no tax entry is displayed

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
