### PR TITLE
Enable filter type extension in search request

### DIFF
--- a/lib/internal/Magento/Framework/Search/Request/Cleaner.php
+++ b/lib/internal/Magento/Framework/Search/Request/Cleaner.php
@@ -14,7 +14,7 @@ class Cleaner
     /**
      * @var array
      */
-    private $requestData;
+    protected $requestData;
 
     /**
      * @var array
@@ -24,7 +24,7 @@ class Cleaner
     /**
      * @var array
      */
-    private $mappedFilters;
+    protected $mappedFilters;
 
     /**
      * @var AggregationStatus
@@ -220,7 +220,7 @@ class Cleaner
      * @param array $filterReference
      * @return array
      */
-    private function processFilterReference($filterReference)
+    protected function processFilterReference($filterReference)
     {
         foreach ($filterReference as $key => $value) {
             $this->cleanFilter($value['ref']);

--- a/lib/internal/Magento/Framework/Search/Request/Cleaner.php
+++ b/lib/internal/Magento/Framework/Search/Request/Cleaner.php
@@ -154,7 +154,7 @@ class Cleaner
      * @throws \Exception
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    private function cleanFilter($filterName)
+    protected function cleanFilter($filterName)
     {
         if (!isset($this->requestData['filters'][$filterName])) {
             throw new \Exception('Filter ' . $filterName . ' does not exist');

--- a/lib/internal/Magento/Framework/Search/Request/Mapper.php
+++ b/lib/internal/Magento/Framework/Search/Request/Mapper.php
@@ -27,7 +27,7 @@ class Mapper
     /**
      * @var array
      */
-    private $filters;
+    protected $filters;
 
     /**
      * @var string[]
@@ -37,7 +37,7 @@ class Mapper
     /**
      * @var string[]
      */
-    private $mappedFilters;
+    protected $mappedFilters;
 
     /**
      * @var array
@@ -47,7 +47,7 @@ class Mapper
     /**
      * @var \Magento\Framework\ObjectManagerInterface
      */
-    private $objectManager;
+    protected $objectManager;
 
     /**
      * @var string
@@ -241,7 +241,7 @@ class Mapper
      * @param array $data
      * @return array
      */
-    private function aggregateFiltersByType($data)
+    protected function aggregateFiltersByType($data)
     {
         $list = [];
         foreach ($data as $value) {

--- a/lib/internal/Magento/Framework/Search/Request/Mapper.php
+++ b/lib/internal/Magento/Framework/Search/Request/Mapper.php
@@ -176,7 +176,7 @@ class Mapper
      * @throws \InvalidArgumentException
      * @throws StateException
      */
-    private function mapFilter($filterName)
+    protected function mapFilter($filterName)
     {
         if (!isset($this->filters[$filterName])) {
             throw new \Exception('Filter ' . $filterName . ' does not exist');


### PR DESCRIPTION
Extending the filter type is not possible due to strict fields and methods restriction. Also would be better to use builders for creating the new filter instances with possibility to define filter types through dependency injection.