### PR TITLE
Selects correct stores value option

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Indexer.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Indexer.php
@@ -137,7 +137,13 @@ class Indexer
                             ['t.option_id', 't.value']
                         )->where(
                             $this->_connection->quoteInto('t.option_id IN (?)', $valueIds)
-                        );
+                        )->where(
+                            $this->_connection->quoteInto('t.store_id IN(?)', [
+                                \Magento\Store\Model\Store::DEFAULT_STORE_ID,
+                                $storeId
+                            ])
+                        )
+                        ->order('t.store_id ASC');
                         $cursor = $this->_connection->query($select);
                         while ($row = $cursor->fetch(\Zend_Db::FETCH_ASSOC)) {
                             $valueColumnName = $valueColumns[$row['option_id']];


### PR DESCRIPTION
When saving the product and having indexers on live mode at least the value option for flat tabels gets a random stores value, this orders them and filters down to be either the selected store or the default stores value.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Filter of unwanted stores values, and makes sure that we pic the store value if it is present and we have to chose between store value and admin value (default value)

### Manual testing scenarios
To test before this patch
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Have multiple store instances on your Magento store.
2. Have a dropdown field set to be visible in flat tables, enter values across all stores in the options
3. Have product flat indexers set to update on save. 
4. Check database or FE to see the value is now from the wrong store in the _value field for some of the stores.