### PR TITLE
Change when item existence is checked in order to update / add new item, see #9445

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Item/CartItemPersister.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/CartItemPersister.php
@@ -58,8 +58,7 @@ class CartItemPersister
         $itemId = $item->getItemId();
         try {
             /** Update existing item */
-            if (isset($itemId)) {
-                $currentItem = $quote->getItemById($itemId);
+            if (isset($itemId) && $currentItem = $quote->getItemById($itemId)) {
                 if (!$currentItem) {
                     throw new NoSuchEntityException(
                         __('Cart %1 does not contain item %2', $cartId, $itemId)


### PR DESCRIPTION
### Description
This commit corrects a validation within a quote save method. Because this function checks whether `getItemById($itemId)` returns an item too late (while already being in the update part) the exception message `Cart %1 does not contain item %2` is shown. By doing this validation one line earlier, it can continue in the else part if this item is not known to the quote. In the else part, a new product is added to the cart as it should.

It's not easy to reproduce. In order to reproduce and verify this, i've setup a small module in a repository that can be used. The README file contains more in-depth explanation.

https://github.com/frosit/module-devpoc.git

### Fixed Issues (if relevant)
1. magento/magento2#9445: Cart % does not contain item %

### Manual testing scenarios
1. Follow the write-up and use the POC module at https://github.com/frosit/module-devpoc.git

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
