### PR TITLE
Backport of MAGETWO-59512 for Magento 2.1: Products in wishlist show $0.00 price #6866

### DIFF
--- a/app/code/Magento/Wishlist/Pricing/ConfiguredPrice/ConfigurableProduct.php
+++ b/app/code/Magento/Wishlist/Pricing/ConfiguredPrice/ConfigurableProduct.php
@@ -21,15 +21,12 @@ class ConfigurableProduct extends FinalPrice implements ConfiguredPriceInterface
      */
     public function getValue()
     {
-        $result = 0.;
         /** @var \Magento\Wishlist\Model\Item\Option $customOption */
         $customOption = $this->getProduct()->getCustomOption('simple_product');
-        if ($customOption) {
-            /** @var \Magento\Framework\Pricing\PriceInfoInterface $priceInfo */
-            $priceInfo = $customOption->getProduct()->getPriceInfo();
-            $result = $priceInfo->getPrice(self::PRICE_CODE)->getValue();
-        }
-        return max(0, $result);
+        $product = $customOption ? $customOption->getProduct() : $this->getProduct();
+        $price = $product->getPriceInfo()->getPrice(self::PRICE_CODE)->getValue();
+
+        return max(0, $price);
     }
 
     /**

--- a/app/code/Magento/Wishlist/Test/Unit/Pricing/ConfiguredPrice/ConfigurableProductTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Pricing/ConfiguredPrice/ConfigurableProductTest.php
@@ -5,36 +5,30 @@
  */
 namespace Magento\Wishlist\Test\Unit\Pricing\ConfiguredPrice;
 
-use Magento\Framework\Pricing\Adjustment\CalculatorInterface;
-use Magento\Framework\Pricing\PriceCurrencyInterface;
-use Magento\Framework\Pricing\PriceInfoInterface;
-use Magento\Framework\Pricing\SaleableInterface;
-use Magento\Wishlist\Pricing\ConfiguredPrice\ConfigurableProduct;
-
 class ConfigurableProductTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var SaleableInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Pricing\SaleableInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $saleableItem;
 
     /**
-     * @var CalculatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Pricing\Adjustment\CalculatorInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $calculator;
 
     /**
-     * @var PriceCurrencyInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Pricing\PriceCurrencyInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $priceCurrency;
 
     /**
-     * @var ConfigurableProduct
+     * @var \Magento\Wishlist\Pricing\ConfiguredPrice\ConfigurableProduct
      */
     private $model;
 
     /**
-     * @var PriceInfoInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Pricing\PriceInfoInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $priceInfoMock;
 
@@ -49,9 +43,6 @@ class ConfigurableProductTest extends \PHPUnit_Framework_TestCase
                 'getCustomOption',
             ])
             ->getMockForAbstractClass();
-        $this->saleableItem->expects($this->once())
-            ->method('getPriceInfo')
-            ->willReturn($this->priceInfoMock);
 
         $this->calculator = $this->getMockBuilder('Magento\Framework\Pricing\Adjustment\CalculatorInterface')
             ->getMockForAbstractClass();
@@ -59,7 +50,7 @@ class ConfigurableProductTest extends \PHPUnit_Framework_TestCase
         $this->priceCurrency = $this->getMockBuilder('Magento\Framework\Pricing\PriceCurrencyInterface')
             ->getMockForAbstractClass();
 
-        $this->model = new ConfigurableProduct(
+        $this->model = new \Magento\Wishlist\Pricing\ConfiguredPrice\ConfigurableProduct(
             $this->saleableItem,
             null,
             $this->calculator,
@@ -82,7 +73,7 @@ class ConfigurableProductTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $this->priceInfoMock->expects($this->once())
             ->method('getPrice')
-            ->with(ConfigurableProduct::PRICE_CODE)
+            ->with(\Magento\Wishlist\Pricing\ConfiguredPrice\ConfigurableProduct::PRICE_CODE)
             ->willReturn($priceMock);
 
         $productMock = $this->getMockBuilder('Magento\Catalog\Model\Product')
@@ -109,11 +100,28 @@ class ConfigurableProductTest extends \PHPUnit_Framework_TestCase
 
     public function testGetValueWithNoCustomOption()
     {
+        $priceValue = 100;
+
+        $priceMock = $this->getMockBuilder(\Magento\Framework\Pricing\Price\PriceInterface::class)
+            ->getMockForAbstractClass();
+        $priceMock->expects($this->once())
+            ->method('getValue')
+            ->willReturn($priceValue);
+
         $this->saleableItem->expects($this->once())
             ->method('getCustomOption')
             ->with('simple_product')
             ->willReturn(null);
 
-        $this->assertEquals(0, $this->model->getValue());
+        $this->saleableItem->expects($this->once())
+            ->method('getPriceInfo')
+            ->willReturn($this->priceInfoMock);
+
+        $this->priceInfoMock->expects($this->once())
+            ->method('getPrice')
+            ->with(\Magento\Wishlist\Pricing\ConfiguredPrice\ConfigurableProduct::PRICE_CODE)
+            ->willReturn($priceMock);
+
+        $this->assertEquals(100, $this->model->getValue());
     }
 }

--- a/dev/tests/functional/tests/app/Magento/Wishlist/Test/Constraint/AssertProductPriceIsNotZero.php
+++ b/dev/tests/functional/tests/app/Magento/Wishlist/Test/Constraint/AssertProductPriceIsNotZero.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Wishlist\Test\Constraint;
+
+class AssertProductPriceIsNotZero extends \Magento\Mtf\Constraint\AbstractConstraint
+{
+    /**
+     * Assert that product price is not zero in default wishlist.
+     *
+     * @param \Magento\Cms\Test\Page\CmsIndex $cmsIndex
+     * @param \Magento\Customer\Test\Page\CustomerAccountIndex $customerAccountIndex
+     * @param \Magento\Wishlist\Test\Page\WishlistIndex $wishlistIndex
+     * @param \Magento\Mtf\Fixture\InjectableFixture $product
+     *
+     * @return void
+     */
+    public function processAssert(
+        \Magento\Cms\Test\Page\CmsIndex $cmsIndex,
+        \Magento\Customer\Test\Page\CustomerAccountIndex $customerAccountIndex,
+        \Magento\Wishlist\Test\Page\WishlistIndex $wishlistIndex,
+        \Magento\Mtf\Fixture\InjectableFixture $product
+    ) {
+        $cmsIndex->getLinksBlock()->openLink('My Account');
+        $customerAccountIndex->getAccountMenuBlock()->openMenuItem('My Wish List');
+        $wishlistItem = $wishlistIndex->getWishlistBlock()->getProductItemsBlock()->getItemProduct($product);
+
+        \PHPUnit_Framework_Assert::assertNotEquals(
+            '0.00',
+            $wishlistItem->getPrice(),
+            $product->getName() . ' has zero price on Wish List page.'
+        );
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'Product price is not zero in default Wish List.';
+    }
+}

--- a/dev/tests/functional/tests/app/Magento/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.php
+++ b/dev/tests/functional/tests/app/Magento/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.php
@@ -49,15 +49,16 @@ class AddProductToWishlistEntityTest extends AbstractWishlistTest
      *
      * @param Customer $customer
      * @param string $product
+     * @param bool $configure
      * @return array
      */
-    public function test(Customer $customer, $product)
+    public function test(Customer $customer, $product, $configure = true)
     {
         $product = $this->createProducts($product)[0];
 
         // Steps:
         $this->loginCustomer($customer);
-        $this->addToWishlist([$product], true);
+        $this->addToWishlist([$product], $configure);
 
         return ['product' => $product];
     }

--- a/dev/tests/functional/tests/app/Magento/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Wishlist/Test/TestCase/AddProductToWishlistEntityTest.xml
@@ -50,5 +50,12 @@
             <constraint name="Magento\Wishlist\Test\Constraint\AssertProductDetailsInWishlist" />
             <constraint name="Magento\Wishlist\Test\Constraint\AssertProductIsPresentInCustomerBackendWishlist" />
         </variation>
+        <variation name="AddProductToWishlistEntityTestVariation8">
+            <data name="product/0" xsi:type="string">configurableProduct::default</data>
+            <data name="configure" xsi:type="boolean">false</data>
+            <constraint name="Magento\Wishlist\Test\Constraint\AssertAddProductToWishlistSuccessMessage" />
+            <constraint name="Magento\Wishlist\Test\Constraint\AssertProductIsPresentInWishlist" />
+            <constraint name="Magento\Wishlist\Test\Constraint\AssertProductPriceIsNotZero" />
+        </variation>
     </testCase>
 </config>


### PR DESCRIPTION
### Description
This is a backport of issue MAGETWO-59512 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/6866: Products in wishlist show $0.00 price

Reference to the commits on the develop branch:
- c7d18bdfc6efb5ba8b5f1e362027ed8a1e962966
- 42dbe3f6d38df400da843231c7986b872b3f6584
- 199456abdea4c98f616092a44810b8b3e201d31e
- c0ec13410e582acbf5680048cca67c98615372cd

### Discussion
I first cherry-picked the 4 commits above and then rebased and squashed them (this is the first time I've used rebasing, so if something isn't right, please let me know!)