### PR TITLE
Support controller src_type for head links

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config/Generator/Head.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Generator/Head.php
@@ -58,13 +58,22 @@ class Head implements Layout\GeneratorInterface
     protected $pageConfig;
 
     /**
+     * @var \Magento\Framework\UrlInterface
+     */
+    protected $url;
+
+    /**
      * Constructor
      *
      * @param \Magento\Framework\View\Page\Config $pageConfig
+     * @param \Magento\Framework\UrlInterface $url
      */
-    public function __construct(\Magento\Framework\View\Page\Config $pageConfig)
-    {
+    public function __construct(
+        \Magento\Framework\View\Page\Config $pageConfig,
+        \Magento\Framework\UrlInterface $url 
+    ) {
         $this->pageConfig = $pageConfig;
+        $this->url = $url;
     }
 
     /**
@@ -107,10 +116,15 @@ class Head implements Layout\GeneratorInterface
     {
         foreach ($pageStructure->getAssets() as $name => $data) {
             if (isset($data['src_type']) && in_array($data['src_type'], $this->remoteAssetTypes)) {
+                if ($data['src_type'] === self::SRC_TYPE_CONTROLLER) {
+                    $data['src'] = $this->url->getUrl($data['src']);
+                }
+
                 $this->pageConfig->addRemotePageAsset(
-                    $name,
+                    $data['src'],
                     isset($data['content_type']) ? $data['content_type'] : self::VIRTUAL_CONTENT_TYPE_LINK,
-                    $this->getAssetProperties($data)
+                    $this->getAssetProperties($data),
+                    $name
                 );
             } else {
                 $this->pageConfig->addPageAsset($name, $this->getAssetProperties($data));

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
@@ -83,10 +83,29 @@ class HeadTest extends \PHPUnit_Framework_TestCase
             ->willReturn('http://magento.dev/customcss/render/css');
 
         $assets = [
-            'remoteCss' => ['src' => 'file-url-css', 'src_type' => 'url', 'media' => "all", 'content_type' => 'css'],
-            'remoteLink' => ['src' => 'file-url-link', 'src_type' => 'url', 'media' => "all"],
-            'controllerCss' => ['src' => 'customcss/render/css', 'src_type' => 'controller', 'content_type' => 'css', 'media' => 'all'],
-            'name' => ['src' => 'file-path', 'ie_condition' => 'lt IE 7', 'media' => "print", 'content_type' => 'css'],
+            'remoteCss' => [
+                'src' => 'file-url-css',
+                'src_type' => 'url',
+                'content_type' => 'css',
+                'media' => 'all',
+            ],
+            'remoteLink' => [
+                'src' => 'file-url-link',
+                'src_type' => 'url',
+                'media' => 'all',
+            ],
+            'controllerCss' => [
+                'src' => 'customcss/render/css',
+                'src_type' => 'controller',
+                'content_type' => 'css',
+                'media' => 'all',
+            ],
+            'name' => [
+                'src' => 'file-path',
+                'ie_condition' => 'lt IE 7',
+                'content_type' => 'css',
+                'media' => 'print',
+            ],
         ];
 
         $this->pageConfigMock->expects($this->at(0))

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
@@ -27,6 +27,11 @@ class HeadTest extends \PHPUnit_Framework_TestCase
     protected $pageConfigMock;
 
     /**
+     * @var \Magento\Framework\UrlInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $urlMock;
+
+    /**
      * @var \Magento\Framework\View\Page\Title|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $title;
@@ -39,12 +44,16 @@ class HeadTest extends \PHPUnit_Framework_TestCase
         $this->title = $this->getMockBuilder(\Magento\Framework\View\Page\Title::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->urlMock = $this->getMockBuilder(\Magento\Framework\UrlInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $objectManagerHelper = new ObjectManagerHelper($this);
         $this->headGenerator = $objectManagerHelper->getObject(
             \Magento\Framework\View\Page\Config\Generator\Head::class,
             [
                 'pageConfig' => $this->pageConfigMock,
+                'url' => $this->urlMock,
             ]
         );
     }
@@ -68,18 +77,27 @@ class HeadTest extends \PHPUnit_Framework_TestCase
 
         $structureMock->expects($this->once())->method('processRemoveAssets');
         $structureMock->expects($this->once())->method('processRemoveElementAttributes');
+        $this->urlMock->expects($this->once())
+            ->method('getUrl')
+            ->with('customcss/render/css')
+            ->willReturn('http://magento.dev/customcss/render/css');
 
         $assets = [
-            'remoteCss' => ['src' => 'file-url', 'src_type' => 'url', 'media' => "all", 'content_type' => 'css'],
-            'remoteLink' => ['src' => 'file-url', 'src_type' => 'url', 'media' => "all"],
+            'remoteCss' => ['src' => 'file-url-css', 'src_type' => 'url', 'media' => "all", 'content_type' => 'css'],
+            'remoteLink' => ['src' => 'file-url-link', 'src_type' => 'url', 'media' => "all"],
+            'controllerCss' => ['src' => 'customcss/render/css', 'src_type' => 'controller', 'content_type' => 'css', 'media' => 'all'],
             'name' => ['src' => 'file-path', 'ie_condition' => 'lt IE 7', 'media' => "print", 'content_type' => 'css'],
         ];
+
         $this->pageConfigMock->expects($this->at(0))
             ->method('addRemotePageAsset')
-            ->with('remoteCss', 'css', ['attributes' => ['media' => 'all']]);
+            ->with('file-url-css', 'css', ['attributes' => ['media' => 'all']]);
         $this->pageConfigMock->expects($this->at(1))
             ->method('addRemotePageAsset')
-            ->with('remoteLink', Head::VIRTUAL_CONTENT_TYPE_LINK, ['attributes' => ['media' => 'all']]);
+            ->with('file-url-link', Head::VIRTUAL_CONTENT_TYPE_LINK, ['attributes' => ['media' => 'all']]);
+        $this->pageConfigMock->expects($this->at(2))
+            ->method('addRemotePageAsset')
+            ->with('http://magento.dev/customcss/render/css', 'css', ['attributes' => ['media' => 'all']]);
         $this->pageConfigMock->expects($this->once())
             ->method('addPageAsset')
             ->with('name', ['attributes' => ['media' => 'print'], 'ie_condition' => 'lt IE 7']);


### PR DESCRIPTION
`\Magento\Framework\View\Page\Config\Generator\Head::SRC_TYPE_CONTROLLER` was foreseen but never implemented. This small PR allows to define `<link>` tags with dynamic URLs linking back to the current store. 

## Example

```
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
    <head>
        <css src="customcss/render/css" src_type="controller" />
    </head>
</page>
```

This will render:

    <link  rel="stylesheet" type="text/css"  media="all" href="http://magento.dev/customcss/render/" />

Given that `http://magento.dev/` is the Base URL.