### PR TITLE
Backport of MAGETWO-53010 for Magento 2.1: Saving a custom transactional email logo, failed.

### DIFF
--- a/app/code/Magento/Config/Model/Config/Backend/Email/Logo.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Email/Logo.php
@@ -11,6 +11,9 @@
  */
 namespace Magento\Config\Model\Config\Backend\Email;
 
+/**
+ * @deprecated
+ */
 class Logo extends \Magento\Config\Model\Config\Backend\Image
 {
     /**

--- a/app/code/Magento/Email/Model/AbstractTemplate.php
+++ b/app/code/Magento/Email/Model/AbstractTemplate.php
@@ -389,7 +389,7 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
             $store
         );
         if ($fileName) {
-            $uploadDir = \Magento\Config\Model\Config\Backend\Email\Logo::UPLOAD_DIR;
+            $uploadDir = \Magento\Email\Model\Design\Backend\Logo::UPLOAD_DIR;
             $mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
             if ($mediaDirectory->isFile($uploadDir . '/' . $fileName)) {
                 return $this->storeManager->getStore()->getBaseUrl(

--- a/app/code/Magento/Email/Model/Design/Backend/Logo.php
+++ b/app/code/Magento/Email/Model/Design/Backend/Logo.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Email\Model\Design\Backend;
+
+use Magento\Theme\Model\Design\Backend\Logo as DesignLogo;
+
+class Logo extends DesignLogo
+{
+    /**
+     * The tail part of directory path for uploading
+     */
+    const UPLOAD_DIR = 'email/logo';
+
+    /**
+     * Upload max file size in kilobytes
+     *
+     * @var int
+     */
+    protected $maxFileSize = 2048;
+
+    /**
+     * Getter for allowed extensions of uploaded files
+     *
+     * @return string[]
+     */
+    public function getAllowedExtensions()
+    {
+        return ['jpg', 'jpeg', 'gif', 'png'];
+    }
+}

--- a/app/code/Magento/Email/composer.json
+++ b/app/code/Magento/Email/composer.json
@@ -3,6 +3,7 @@
     "description": "N/A",
     "require": {
         "php": "~5.6.5|7.0.2|7.0.4|~7.0.6",
+        "magento/module-theme": "100.1.*",
         "magento/module-config": "100.1.*",
         "magento/module-store": "100.1.*",
         "magento/module-cms": "101.0.*",

--- a/app/code/Magento/Email/etc/di.xml
+++ b/app/code/Magento/Email/etc/di.xml
@@ -27,7 +27,7 @@
                 <item name="email_logo" xsi:type="array">
                     <item name="path" xsi:type="string">design/email/logo</item>
                     <item name="fieldset" xsi:type="string">other_settings/email</item>
-                    <item name="backend_model" xsi:type="string">Magento\Theme\Model\Design\Backend\Logo</item>
+                    <item name="backend_model" xsi:type="string">Magento\Email\Model\Design\Backend\Logo</item>
                     <item name="base_url" xsi:type="array">
                         <item name="type" xsi:type="string">media</item>
                         <item name="scope_info" xsi:type="string">1</item>

--- a/app/code/Magento/Theme/Model/Design/Backend/Logo.php
+++ b/app/code/Magento/Theme/Model/Design/Backend/Logo.php
@@ -21,7 +21,7 @@ class Logo extends Image
      */
     protected function _getUploadDir()
     {
-        return $this->_mediaDirectory->getRelativePath($this->_appendScopeInfo(self::UPLOAD_DIR));
+        return $this->_mediaDirectory->getRelativePath($this->_appendScopeInfo(static::UPLOAD_DIR));
     }
 
     /**


### PR DESCRIPTION
### Description

This is a backport of issue MAGETWO-53010 for Magento 2.1

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/5352: Magento 2.1 email logo image function does not work
2. https://github.com/magento/magento2/issues/5633: Magento 2.1 fails to load email_logo.png
3. https://github.com/magento/magento2/issues/5916: Magento 2.1 transactional email uploaded logo not showing in admin.
4. https://github.com/magento/magento2/issues/6275: Transactional Email Logo Not Getting Updated
5. https://github.com/magento/magento2/issues/6420: New order email header logo not showing correctly v2.1
6. https://github.com/magento/magento2/issues/6502: Can't save Logo Image to Transactional Emails
7. https://github.com/magento/magento2/issues/7853: Transactional email logo wrong location
8. https://github.com/magento/magento2/issues/7985: Logo email
9. https://github.com/magento/magento2/issues/8489: Magento 2.1.4 - Asking Why Email Logo Never been fixed on all Magento releases
10. https://github.com/magento/magento2/issues/8728: Transactional Emails Logo
11. https://github.com/magento/magento2/issues/8961: email logo error
12. https://github.com/magento/magento2/issues/9118: transactional email
13. https://github.com/magento/magento2/issues/8626: Magento 2.1.2 - 2.1.4 email logo image function does not work

Wow, it took me longer to compile a list of all the issues then to actually create the backport :p
And I probably even forgot some...

Reference to the commits on the develop branch:
- 23103c03c527fe1ed3e1a3be691436818b7963fe
- cb603ff3d9af3c1fc4375c588a6593e8f8dc40d3