### PR TITLE
Use CSS style instead of width and height attributes for logo image

### DIFF
--- a/app/code/Magento/Theme/view/frontend/templates/html/header/logo.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/header/logo.phtml
@@ -19,8 +19,8 @@
 <?php endif ?>
         <img src="<?php /* @escapeNotVerified */ echo $block->getLogoSrc() ?>"
              alt="<?php /* @escapeNotVerified */ echo $block->getLogoAlt() ?>"
-             <?php echo $block->getLogoWidth() ? 'width="' . $block->getLogoWidth() . '"' : '' ?>
-             <?php echo $block->getLogoHeight() ? 'height="' . $block->getLogoHeight() . '"' : '' ?>
+             style="<?php echo $block->getLogoWidth() ? 'width:' . $block->getLogoWidth() . 'px;' : '';
+                    echo $block->getLogoHeight() ? 'height:' . $block->getLogoHeight() . 'px;' : '' ?>"
         />
 <?php if ($block->isHomePage()):?>
     </strong>


### PR DESCRIPTION
### Description
width and height attributes does not override aspect ratio of logo image.
Using css styles does that.

### Manual testing scenarios
1. Upload a logo image with a different aspect ratio
2. user defined width and size are forcefully applied now

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
