### PR TITLE
Admin Grid Mass action Select / Unselect All issue #9610

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -274,7 +274,6 @@ abstract class AbstractMassaction extends \Magento\Backend\Block\Widget
         if (!$this->getUseSelectAll()) {
             return '';
         }
-
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
         $massActionIdField = $this->getParentBlock()->getMassactionIdField();

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -277,7 +277,7 @@ abstract class AbstractMassaction extends \Magento\Backend\Block\Widget
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
         $massActionIdField = $this->getParentBlock()->getMassactionIdField();
-        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);
+        $gridIds = $allIdsCollection->setPageSize(0)->getColumnValues($massActionIdField);
         if (!empty($gridIds)) {
             return join(",", $gridIds);
         }

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -277,9 +277,9 @@ abstract class AbstractMassaction extends \Magento\Backend\Block\Widget
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
         
-        if($this->getMassactionIdField()) {
+        if ($this->getMassactionIdField()) {
             $massActionIdField = $this->getMassactionIdField();
-        }else {
+        } else {
             $massActionIdField = $this->getParentBlock()->getMassactionIdField();
         }
         

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -277,7 +277,7 @@ abstract class AbstractMassaction extends \Magento\Backend\Block\Widget
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
         $massActionIdField = $this->getParentBlock()->getMassactionIdField();
-        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);        
+        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);
         if (!empty($gridIds)) {
             return join(",", $gridIds);
         }

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -276,7 +276,13 @@ abstract class AbstractMassaction extends \Magento\Backend\Block\Widget
         }
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
-        $massActionIdField = $this->getParentBlock()->getMassactionIdField();
+        
+        if($this->getMassactionIdField()) {
+            $massActionIdField = $this->getMassactionIdField();
+        }else {
+            $massActionIdField = $this->getParentBlock()->getMassactionIdField();
+        }
+        
         $gridIds = $allIdsCollection->setPageSize(0)->getColumnValues($massActionIdField);
         if (!empty($gridIds)) {
             return join(",", $gridIds);

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -277,7 +277,8 @@ abstract class AbstractMassaction extends \Magento\Backend\Block\Widget
 
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
-        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getAllIds();
+        $massActionIdField = $this->getParentBlock()->getMassactionIdField();
+        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);        
 
         if (!empty($gridIds)) {
             return join(",", $gridIds);

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -278,8 +278,8 @@ abstract class AbstractMassaction extends \Magento\Backend\Block\Widget
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
         $massActionIdField = $this->getParentBlock()->getMassactionIdField();
-        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);        
-
+        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);
+        
         if (!empty($gridIds)) {
             return join(",", $gridIds);
         }

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -277,8 +277,7 @@ abstract class AbstractMassaction extends \Magento\Backend\Block\Widget
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
         $massActionIdField = $this->getParentBlock()->getMassactionIdField();
-        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);
-        
+        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);        
         if (!empty($gridIds)) {
             return join(",", $gridIds);
         }

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
@@ -275,9 +275,9 @@ class Extended extends \Magento\Backend\Block\Widget
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
         
-        if($this->getMassactionIdField()) {
+        if ($this->getMassactionIdField()) {
             $massActionIdField = $this->getMassactionIdField();
-        }else {
+        } else {
             $massActionIdField = $this->getParentBlock()->getMassactionIdField();
         }
         

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
@@ -274,7 +274,13 @@ class Extended extends \Magento\Backend\Block\Widget
 
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
-        $massActionIdField = $this->getParentBlock()->getMassactionIdField();
+        
+        if($this->getMassactionIdField()) {
+            $massActionIdField = $this->getMassactionIdField();
+        }else {
+            $massActionIdField = $this->getParentBlock()->getMassactionIdField();
+        }
+        
         $gridIds = $allIdsCollection->setPageSize(0)->getColumnValues($massActionIdField);
 
         if (!empty($gridIds)) {

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
@@ -275,7 +275,7 @@ class Extended extends \Magento\Backend\Block\Widget
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
         $massActionIdField = $this->getParentBlock()->getMassactionIdField();
-        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);
+        $gridIds = $allIdsCollection->setPageSize(0)->getColumnValues($massActionIdField);
 
         if (!empty($gridIds)) {
             return join(",", $gridIds);

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Extended.php
@@ -274,7 +274,8 @@ class Extended extends \Magento\Backend\Block\Widget
 
         /** @var \Magento\Framework\Data\Collection $allIdsCollection */
         $allIdsCollection = clone $this->getParentBlock()->getCollection();
-        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getAllIds();
+        $massActionIdField = $this->getParentBlock()->getMassactionIdField();
+        $gridIds = $allIdsCollection->clear()->setPageSize(0)->getColumnValues($massActionIdField);
 
         if (!empty($gridIds)) {
             return join(",", $gridIds);

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
@@ -133,10 +133,10 @@ class ExtendedTest extends \PHPUnit_Framework_TestCase
     {
         $this->_block->setUseSelectAll(true);
         
-        if($this->_block->getMassactionIdField()) {
+        if ($this->_block->getMassactionIdField()) {
             $massActionIdField = $this->_block->getMassactionIdField();
         } else {
-            $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();    
+            $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();
         }
         
         $collectionMock = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
@@ -131,10 +131,8 @@ class ExtendedTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetGridIdsJsonWithUseSelectAll(array $items, $result)
     {
-        $this->_block->setUseSelectAll(true);
-        
+        $this->_block->setUseSelectAll(true);        
         $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();
-
         $collectionMock = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
@@ -132,7 +132,13 @@ class ExtendedTest extends \PHPUnit_Framework_TestCase
     public function testGetGridIdsJsonWithUseSelectAll(array $items, $result)
     {
         $this->_block->setUseSelectAll(true);
-        $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();
+        
+        if($this->_block->getMassactionIdField()) {
+            $massActionIdField = $this->_block->getMassactionIdField();
+        } else {
+            $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();    
+        }
+        
         $collectionMock = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
@@ -131,7 +131,7 @@ class ExtendedTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetGridIdsJsonWithUseSelectAll(array $items, $result)
     {
-        $this->_block->setUseSelectAll(true);        
+        $this->_block->setUseSelectAll(true);
         $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();
         $collectionMock = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
@@ -142,9 +142,6 @@ class ExtendedTest extends \PHPUnit_Framework_TestCase
             ->willReturn($collectionMock);
 
         $collectionMock->expects($this->once())
-            ->method('clear')
-            ->willReturnSelf();
-        $collectionMock->expects($this->once())
             ->method('setPageSize')
             ->with(0)
             ->willReturnSelf();

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
@@ -133,7 +133,7 @@ class ExtendedTest extends \PHPUnit_Framework_TestCase
     {
         $this->_block->setUseSelectAll(true);
         
-        $massActionIdField = $this->_block->getMassactionIdField();
+        $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();
 
         $collectionMock = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Massaction/ExtendedTest.php
@@ -132,6 +132,8 @@ class ExtendedTest extends \PHPUnit_Framework_TestCase
     public function testGetGridIdsJsonWithUseSelectAll(array $items, $result)
     {
         $this->_block->setUseSelectAll(true);
+        
+        $massActionIdField = $this->_block->getMassactionIdField();
 
         $collectionMock = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)
             ->disableOriginalConstructor()
@@ -149,7 +151,8 @@ class ExtendedTest extends \PHPUnit_Framework_TestCase
             ->with(0)
             ->willReturnSelf();
         $collectionMock->expects($this->once())
-            ->method('getAllIds')
+            ->method('getColumnValues')
+            ->with($massActionIdField)
             ->willReturn($items);
 
         $this->assertEquals($result, $this->_block->getGridIdsJson());

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/MassactionTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/MassactionTest.php
@@ -246,10 +246,7 @@ class MassactionTest extends \PHPUnit_Framework_TestCase
         $this->_gridMock->expects($this->once())
             ->method('getCollection')
             ->willReturn($collectionMock);
-
-        $collectionMock->expects($this->once())
-            ->method('clear')
-            ->willReturnSelf();
+        
         $collectionMock->expects($this->once())
             ->method('setPageSize')
             ->with(0)

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/MassactionTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/MassactionTest.php
@@ -237,6 +237,7 @@ class MassactionTest extends \PHPUnit_Framework_TestCase
     public function testGetGridIdsJsonWithUseSelectAll(array $items, $result)
     {
         $this->_block->setUseSelectAll(true);
+        $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();
 
         $collectionMock = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)
             ->disableOriginalConstructor()
@@ -254,7 +255,8 @@ class MassactionTest extends \PHPUnit_Framework_TestCase
             ->with(0)
             ->willReturnSelf();
         $collectionMock->expects($this->once())
-            ->method('getAllIds')
+            ->method('getColumnValues')
+            ->with($massActionIdField)
             ->willReturn($items);
 
         $this->assertEquals($result, $this->_block->getGridIdsJson());

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/MassactionTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/MassactionTest.php
@@ -237,7 +237,12 @@ class MassactionTest extends \PHPUnit_Framework_TestCase
     public function testGetGridIdsJsonWithUseSelectAll(array $items, $result)
     {
         $this->_block->setUseSelectAll(true);
-        $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();
+        
+        if($this->_block->getMassactionIdField()) {
+            $massActionIdField = $this->_block->getMassactionIdField();
+        } else {
+            $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();    
+        }
 
         $collectionMock = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/MassactionTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/MassactionTest.php
@@ -246,7 +246,6 @@ class MassactionTest extends \PHPUnit_Framework_TestCase
         $this->_gridMock->expects($this->once())
             ->method('getCollection')
             ->willReturn($collectionMock);
-        
         $collectionMock->expects($this->once())
             ->method('setPageSize')
             ->with(0)

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/MassactionTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/MassactionTest.php
@@ -238,10 +238,10 @@ class MassactionTest extends \PHPUnit_Framework_TestCase
     {
         $this->_block->setUseSelectAll(true);
         
-        if($this->_block->getMassactionIdField()) {
+        if ($this->_block->getMassactionIdField()) {
             $massActionIdField = $this->_block->getMassactionIdField();
         } else {
-            $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();    
+            $massActionIdField = $this->_block->getParentBlock()->getMassactionIdField();
         }
 
         $collectionMock = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)


### PR DESCRIPTION
Admin Grid Mass Action `Select All ` and `Unselect All` work only on `primary_key` of collection object no matter if we set other field as mass action field using grid method `setMassactionIdField` other than `primary_key`

### Preconditions
1. Magento version 2.1.3


### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Found this issue while creating custom module where i need mass action id field other than `primary_key` of collection. 

### Expected result
<!--- Tell us what should happen -->
1. It should `Select All` and `Unselect All`  on click of option
2. It should post `MassactionIdField`  on submit

### Actual result

1. Checkbox `checked` and `unchecked` not working on click of option
2. Always post  `primary_key` value of collection on submit


