### PR TITLE
Exclude unnecessarily duplicated Travis CI build jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,12 @@ env:
     - TEST_SUITE=integration INTEGRATION_INDEX=3
     - TEST_SUITE=static
     - TEST_SUITE=js
+matrix:
+  exclude:
+    - php: 7.0
+      env: TEST_SUITE=static
+    - php: 7.0
+      env: TEST_SUITE=js
 cache:
   apt: true
   directories:


### PR DESCRIPTION
After removing PHP 5.6 (25c0a12ca85cad03675688cf17d1dc42e5b42b79) and adding PHP 7.1 (cf3865e1c6ef11cf84c277fe02c3e1fb7b76a2a6) in Travis configuration, some jobs are now unnecessarily duplicated, so I excluded them again to save some build time.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)