### PR TITLE
Flip the property assignments for _logger and _fetchStrategy in __wakeup

### DIFF
--- a/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
@@ -902,8 +902,8 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
     {
         parent::__wakeup();
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        $this->_fetchStrategy = $objectManager->get(Logger::class);
-        $this->_logger = $objectManager->get(FetchStrategyInterface::class);
+        $this->_logger = $objectManager->get(Logger::class);
+        $this->_fetchStrategy = $objectManager->get(FetchStrategyInterface::class);
         $this->_conn = $objectManager->get(ResourceConnection::class)->getConnection();
     }
 }


### PR DESCRIPTION
The code changes here are self-explanatory. Just an obvious oversight when setting a couple class properties during `__wakeup`. I found this while digging deep into a different bug, but I admit I have not taken the time to figure out what needs to be done to test this fix.

<!---
### Manual testing scenarios
 Provide a set of unambiguous steps to test the proposed code change 
1. ...
2. ...
-->
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
