### PR TITLE
Replaced the page refresh from the gift option with a XHR request

### DIFF
--- a/app/code/Magento/GiftMessage/Api/CartRepositoryInterface.php
+++ b/app/code/Magento/GiftMessage/Api/CartRepositoryInterface.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\GiftMessage\Api;
 
+use Magento\GiftMessage\Api\Data\MessageInterface;
+
 /**
  * Interface CartRepositoryInterface
  * @api
@@ -31,5 +33,5 @@ interface CartRepositoryInterface
      * virtual products.
      * @throws \Magento\Framework\Exception\CouldNotSaveException The specified gift message could not be saved.
      */
-    public function save($cartId, \Magento\GiftMessage\Api\Data\MessageInterface $giftMessage);
+    public function save($cartId, MessageInterface $giftMessage);
 }

--- a/app/code/Magento/GiftMessage/Api/Data/MessageInterface.php
+++ b/app/code/Magento/GiftMessage/Api/Data/MessageInterface.php
@@ -5,11 +5,14 @@
  */
 namespace Magento\GiftMessage\Api\Data;
 
+use Magento\GiftMessage\Api\Data\MessageExtensionInterface;
+use Magento\Framework\Api\ExtensibleDataInterface;
+
 /**
  * Interface MessageInterface
  * @api
  */
-interface MessageInterface extends \Magento\Framework\Api\ExtensibleDataInterface
+interface MessageInterface extends ExtensibleDataInterface
 {
     /**#@+
      * Constants for keys of data array. Identical to the name of the getter in snake case
@@ -110,6 +113,6 @@ interface MessageInterface extends \Magento\Framework\Api\ExtensibleDataInterfac
      * @return $this
      */
     public function setExtensionAttributes(
-        \Magento\GiftMessage\Api\Data\MessageExtensionInterface $extensionAttributes
+        MessageExtensionInterface $extensionAttributes
     );
 }

--- a/app/code/Magento/GiftMessage/Api/GuestCartRepositoryInterface.php
+++ b/app/code/Magento/GiftMessage/Api/GuestCartRepositoryInterface.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\GiftMessage\Api;
 
+use Magento\GiftMessage\Api\Data\MessageInterface;
+
 /**
  * Interface GuestCartRepositoryInterface
  * @api
@@ -29,5 +31,5 @@ interface GuestCartRepositoryInterface
      * @throws \Magento\Framework\Exception\InputException You cannot add gift messages to empty carts.
      * @throws \Magento\Framework\Exception\CouldNotSaveException The specified gift message could not be saved.
      */
-    public function save($cartId, \Magento\GiftMessage\Api\Data\MessageInterface $giftMessage);
+    public function save($cartId, MessageInterface $giftMessage);
 }

--- a/app/code/Magento/GiftMessage/Api/GuestItemRepositoryInterface.php
+++ b/app/code/Magento/GiftMessage/Api/GuestItemRepositoryInterface.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\GiftMessage\Api;
 
+use Magento\GiftMessage\Api\Data\MessageInterface;
+
 /**
  * Interface GuestItemRepositoryInterface
  * @api
@@ -32,5 +34,5 @@ interface GuestItemRepositoryInterface
      * @throws \Magento\Framework\Exception\InputException You cannot add gift messages to empty carts.
      * @throws \Magento\Framework\Exception\CouldNotSaveException The specified gift message could not be saved.
      */
-    public function save($cartId, \Magento\GiftMessage\Api\Data\MessageInterface $giftMessage, $itemId);
+    public function save($cartId, MessageInterface $giftMessage, $itemId);
 }

--- a/app/code/Magento/GiftMessage/Api/ItemRepositoryInterface.php
+++ b/app/code/Magento/GiftMessage/Api/ItemRepositoryInterface.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\GiftMessage\Api;
 
+use Magento\GiftMessage\Api\Data\MessageInterface;
+
 /**
  * Interface ItemRepositoryInterface
  * @api
@@ -34,5 +36,5 @@ interface ItemRepositoryInterface
      * virtual products.
      * @throws \Magento\Framework\Exception\CouldNotSaveException The specified gift message could not be saved.
      */
-    public function save($cartId, \Magento\GiftMessage\Api\Data\MessageInterface $giftMessage, $itemId);
+    public function save($cartId, MessageInterface $giftMessage, $itemId);
 }

--- a/app/code/Magento/GiftMessage/Api/OrderItemRepositoryInterface.php
+++ b/app/code/Magento/GiftMessage/Api/OrderItemRepositoryInterface.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\GiftMessage\Api;
 
+use Magento\GiftMessage\Api\Data\MessageInterface;
+
 /**
  * Interface OrderItemRepositoryInterface
  * @api
@@ -32,5 +34,5 @@ interface OrderItemRepositoryInterface
      * @throws \Magento\Framework\Exception\State\InvalidTransitionException
      * @throws \Magento\Framework\Exception\CouldNotSaveException
      */
-    public function save($orderId, $orderItemId, \Magento\GiftMessage\Api\Data\MessageInterface $giftMessage);
+    public function save($orderId, $orderItemId, MessageInterface $giftMessage);
 }

--- a/app/code/Magento/GiftMessage/Api/OrderRepositoryInterface.php
+++ b/app/code/Magento/GiftMessage/Api/OrderRepositoryInterface.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\GiftMessage\Api;
 
+use Magento\GiftMessage\Api\Data\MessageInterface;
+
 /**
  * Interface OrderRepositoryInterface
  * @api

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Product/Helper/Form/Config.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Product/Helper/Form/Config.php
@@ -5,13 +5,21 @@
  */
 namespace Magento\GiftMessage\Block\Adminhtml\Product\Helper\Form;
 
+use Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Config as ConfigHelper;
+use Magento\Framework\Data\Form\Element\Factory;
+use Magento\Framework\Data\Form\Element\CollectionFactory;
+use Magento\Framework\Escaper;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\GiftMessage\Helper\Message;
+use Magento\Store\Model\ScopeInterface;
+
 /**
  * Adminhtml additional helper block for product configuration
  *
  * @author     Magento Core Team <core@magentocommerce.com>
  * @codeCoverageIgnore
  */
-class Config extends \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Config
+class Config extends ConfigHelper
 {
     /**
      * Core store config
@@ -28,10 +36,10 @@ class Config extends \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Config
      * @param array $data
      */
     public function __construct(
-        \Magento\Framework\Data\Form\Element\Factory $factoryElement,
-        \Magento\Framework\Data\Form\Element\CollectionFactory $factoryCollection,
-        \Magento\Framework\Escaper $escaper,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        Factory $factoryElement,
+        CollectionFactory $factoryCollection,
+        Escaper $escaper,
+        ScopeConfigInterface $scopeConfig,
         $data = []
     ) {
         $this->_scopeConfig = $scopeConfig;
@@ -46,8 +54,8 @@ class Config extends \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Config
     protected function _getValueFromConfig()
     {
         return $this->_scopeConfig->getValue(
-            \Magento\GiftMessage\Helper\Message::XPATH_CONFIG_GIFT_MESSAGE_ALLOW_ITEMS,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            Message::XPATH_CONFIG_GIFT_MESSAGE_ALLOW_ITEMS,
+            ScopeInterface::SCOPE_STORE
         );
     }
 }

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Form.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Form.php
@@ -5,13 +5,18 @@
  */
 namespace Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create;
 
+use Magento\Backend\Block\Template;
+use Magento\Backend\Block\Template\Context;
+use Magento\Backend\Model\Session\Quote;
+use Magento\GiftMessage\Helper\Message;
+
 /**
  * Adminhtml sales order create gift message form
  *
  * @api
  * @author     Magento Core Team <core@magentocommerce.com>
  */
-class Form extends \Magento\Backend\Block\Template
+class Form extends Template
 {
     /**
      * @var \Magento\Backend\Model\Session\Quote
@@ -30,9 +35,9 @@ class Form extends \Magento\Backend\Block\Template
      * @param array $data
      */
     public function __construct(
-        \Magento\Backend\Block\Template\Context $context,
-        \Magento\Backend\Model\Session\Quote $sessionQuote,
-        \Magento\GiftMessage\Helper\Message $messageHelper,
+        Context $context,
+        Quote $sessionQuote,
+        Message $messageHelper,
         array $data = []
     ) {
         $this->_messageHelper = $messageHelper;

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Giftoptions.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Giftoptions.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create;
 
+use Magento\Backend\Block\Template;
+
 /**
  * Adminhtml sales order create gift options block
  *
@@ -12,7 +14,7 @@ namespace Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create;
  * @author     Magento Core Team <core@magentocommerce.com>
  * @codeCoverageIgnore
  */
-class Giftoptions extends \Magento\Backend\Block\Template
+class Giftoptions extends Template
 {
     /**
      * Get order item object from parent block

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
@@ -5,13 +5,18 @@
  */
 namespace Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create;
 
+use Magento\Backend\Block\Template;
+use Magento\Backend\Block\Template\Context;
+use Magento\GiftMessage\Helper\Message;
+use Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage\Form;
+
 /**
  * Gift message adminhtml sales order create items
  *
  * @api
  * @author     Magento Core Team <core@magentocommerce.com>
  */
-class Items extends \Magento\Backend\Block\Template
+class Items extends Template
 {
     /**
      * @var \Magento\GiftMessage\Helper\Message
@@ -24,8 +29,8 @@ class Items extends \Magento\Backend\Block\Template
      * @param array $data
      */
     public function __construct(
-        \Magento\Backend\Block\Template\Context $context,
-        \Magento\GiftMessage\Helper\Message $messageHelper,
+        Context $context,
+        Message $messageHelper,
         array $data = []
     ) {
         $this->_messageHelper = $messageHelper;
@@ -66,7 +71,7 @@ class Items extends \Magento\Backend\Block\Template
     public function getFormHtml()
     {
         return $this->getLayout()->createBlock(
-            \Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage\Form::class
+            Form::class
         )->setEntity(
             $this->getItem()
         )->setEntityType(

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/Create/Items.php
@@ -8,7 +8,7 @@ namespace Magento\GiftMessage\Block\Adminhtml\Sales\Order\Create;
 use Magento\Backend\Block\Template;
 use Magento\Backend\Block\Template\Context;
 use Magento\GiftMessage\Helper\Message;
-use Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage\Form;
+use Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage\Form as GiftMessageForm;
 
 /**
  * Gift message adminhtml sales order create items
@@ -71,7 +71,7 @@ class Items extends Template
     public function getFormHtml()
     {
         return $this->getLayout()->createBlock(
-            Form::class
+            GiftMessageForm::class
         )->setEntity(
             $this->getItem()
         )->setEntityType(

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Form.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Form.php
@@ -5,13 +5,17 @@
  */
 namespace Magento\GiftMessage\Block\Adminhtml\Sales\Order\View;
 
+use Magento\Backend\Block\Template;
+use Magento\Backend\Block\Template\Context;
+use Magento\Framework\Registry;
+
 /**
  * Adminhtml sales order view gift message form
  *
  * @api
  * @author     Magento Core Team <core@magentocommerce.com>
  */
-class Form extends \Magento\Backend\Block\Template
+class Form extends Template
 {
     /**
      * Core registry
@@ -26,8 +30,8 @@ class Form extends \Magento\Backend\Block\Template
      * @param array $data
      */
     public function __construct(
-        \Magento\Backend\Block\Template\Context $context,
-        \Magento\Framework\Registry $registry,
+        Context $context,
+        Registry $registry,
         array $data = []
     ) {
         $this->_coreRegistry = $registry;

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Giftoptions.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Giftoptions.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\GiftMessage\Block\Adminhtml\Sales\Order\View;
 
+use Magento\Backend\Block\Template;
+
 /**
  * Adminhtml sales order view gift options block
  *
@@ -12,7 +14,7 @@ namespace Magento\GiftMessage\Block\Adminhtml\Sales\Order\View;
  * @author     Magento Core Team <core@magentocommerce.com>
  * @codeCoverageIgnore
  */
-class Giftoptions extends \Magento\Backend\Block\Template
+class Giftoptions extends Template
 {
     /**
      * Get order item object from parent block

--- a/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Items.php
+++ b/app/code/Magento/GiftMessage/Block/Adminhtml/Sales/Order/View/Items.php
@@ -5,13 +5,17 @@
  */
 namespace Magento\GiftMessage\Block\Adminhtml\Sales\Order\View;
 
+use Magento\Backend\Block\Template;
+use Magento\Backend\Block\Template\Context;
+use Magento\GiftMessage\Helper\Message;
+
 /**
  * Gift message adminhtml sales order view items
  *
  * @api
  * @author     Magento Core Team <core@magentocommerce.com>
  */
-class Items extends \Magento\Backend\Block\Template
+class Items extends Template
 {
     /**
      * Gift message array
@@ -31,8 +35,8 @@ class Items extends \Magento\Backend\Block\Template
      * @param array $data
      */
     public function __construct(
-        \Magento\Backend\Block\Template\Context $context,
-        \Magento\GiftMessage\Helper\Message $messageHelper,
+        Context $context,
+        Message $messageHelper,
         array $data = []
     ) {
         $this->_messageHelper = $messageHelper;

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -7,6 +7,12 @@ namespace Magento\GiftMessage\Block\Message;
 
 use Magento\Customer\Model\Context;
 use Magento\GiftMessage\Model\Message;
+use Magento\Framework\View\Element\Template\Context as TemplateContext;
+use Magento\Customer\Model\Session;
+use Magento\GiftMessage\Helper\Message as HelperMessage;
+use Magento\Catalog\Block\Product\ImageBuilder;
+use \Magento\Framework\App\Http\Context as HttpContext;
+
 
 /**
  * Gift message inline edit form
@@ -65,19 +71,20 @@ class Inline extends \Magento\Framework\View\Element\Template
     protected $checkoutType;
 
     /**
-     * @param \Magento\Framework\View\Element\Template\Context $context
-     * @param \Magento\Customer\Model\Session $customerSession
-     * @param \Magento\GiftMessage\Helper\Message $giftMessageMessage
-     * @param \Magento\Catalog\Block\Product\ImageBuilder $imageBuilder
-     * @param \Magento\Framework\App\Http\Context $httpContext
+     * Inline constructor.
+     * @param TemplateContext $context
+     * @param Session $customerSession
+     * @param HelperMessage $giftMessageMessage
+     * @param ImageBuilder $imageBuilder
+     * @param HttpContext $httpContext
      * @param array $data
      */
     public function __construct(
-        \Magento\Framework\View\Element\Template\Context $context,
-        \Magento\Customer\Model\Session $customerSession,
-        \Magento\GiftMessage\Helper\Message $giftMessageMessage,
-        \Magento\Catalog\Block\Product\ImageBuilder $imageBuilder,
-        \Magento\Framework\App\Http\Context $httpContext,
+        TemplateContext $context,
+        Session $customerSession,
+        HelperMessage $giftMessageMessage,
+        ImageBuilder $imageBuilder,
+        HttpContext $httpContext,
         array $data = []
     ) {
         $this->imageBuilder = $imageBuilder;

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -13,7 +13,6 @@ use Magento\GiftMessage\Helper\Message as HelperMessage;
 use Magento\Catalog\Block\Product\ImageBuilder;
 use Magento\Framework\App\Http\Context as HttpContext;
 
-
 /**
  * Gift message inline edit form
  *

--- a/app/code/Magento/GiftMessage/Block/Message/Inline.php
+++ b/app/code/Magento/GiftMessage/Block/Message/Inline.php
@@ -11,7 +11,7 @@ use Magento\Framework\View\Element\Template\Context as TemplateContext;
 use Magento\Customer\Model\Session;
 use Magento\GiftMessage\Helper\Message as HelperMessage;
 use Magento\Catalog\Block\Product\ImageBuilder;
-use \Magento\Framework\App\Http\Context as HttpContext;
+use Magento\Framework\App\Http\Context as HttpContext;
 
 
 /**

--- a/app/code/Magento/GiftMessage/view/frontend/web/js/action/gift-options.js
+++ b/app/code/Magento/GiftMessage/view/frontend/web/js/action/gift-options.js
@@ -59,7 +59,7 @@ define([
             }
         ).done(
             function (response) {
-                giftMessage.reset();
+                giftMessage.reset(remove);
                 _.each(giftMessage.getAfterSubmitCallbacks(), function (callback) {
                     if (_.isFunction(callback)) {
                         callback();

--- a/app/code/Magento/GiftMessage/view/frontend/web/js/action/gift-options.js
+++ b/app/code/Magento/GiftMessage/view/frontend/web/js/action/gift-options.js
@@ -46,20 +46,30 @@ define([
         }
         messageList.clear();
 
+        giftMessage.observables.isLoading(true);
+
         storage.post(
             serviceUrl,
             JSON.stringify({
-                'gift_message': giftMessage.getSubmitParams(remove)
+                gift_message: giftMessage.getSubmitParams(remove)
             })
-        ).done(function () {
-            giftMessage.reset();
-            _.each(giftMessage.getAfterSubmitCallbacks(), function (callback) {
-                if (_.isFunction(callback)) {
-                    callback();
-                }
-            });
-        }).fail(function (response) {
-            errorProcessor.process(response);
-        });
+        ).always(
+            function () {
+                giftMessage.observables.isLoading(false);
+            }
+        ).done(
+            function (response) {
+                giftMessage.reset();
+                _.each(giftMessage.getAfterSubmitCallbacks(), function (callback) {
+                    if (_.isFunction(callback)) {
+                        callback();
+                    }
+                });
+            }
+        ).fail(
+            function (response) {
+                errorProcessor.process(response);
+            }
+        );
     };
 });

--- a/app/code/Magento/GiftMessage/view/frontend/web/js/model/gift-message.js
+++ b/app/code/Magento/GiftMessage/view/frontend/web/js/model/gift-message.js
@@ -102,8 +102,13 @@ define([
             /**
              * Reset.
              */
-            reset: function () {
-                this.getObservable('isClear')(true);
+            reset: function (remove) {
+                if (remove) {
+                    this.getObservable('sender')(null);
+                    this.getObservable('recipient')(null);
+                    this.getObservable('message')(null);
+                }
+                this.getObservable('isClear')(true);;
             },
 
             /**

--- a/app/code/Magento/GiftMessage/view/frontend/web/js/model/gift-message.js
+++ b/app/code/Magento/GiftMessage/view/frontend/web/js/model/gift-message.js
@@ -126,9 +126,7 @@ define([
              * After submit.
              */
             afterSubmit: function () {
-                window.location.href = url.build('checkout/cart/updatePost') +
-                    '?form_key=' + window.checkoutConfig.formKey +
-                    '&cart[]';
+
             },
 
             /**

--- a/app/code/Magento/GiftMessage/view/frontend/web/js/view/gift-message.js
+++ b/app/code/Magento/GiftMessage/view/frontend/web/js/view/gift-message.js
@@ -40,7 +40,7 @@ define(
                 this.isResultBlockVisible();
             },
             /**
-             * Is reslt block visible
+             * Is result block visible
              */
             isResultBlockVisible: function () {
                 var self = this;

--- a/app/code/Magento/GiftMessage/view/frontend/web/js/view/gift-message.js
+++ b/app/code/Magento/GiftMessage/view/frontend/web/js/view/gift-message.js
@@ -13,6 +13,9 @@ define(
     function (Component, GiftMessage, giftOptions, giftOptionsService) {
         'use strict';
         return Component.extend({
+            defaults: {
+                isLoading: false
+            },
             formBlockVisibility: null,
             resultBlockVisibility: null,
             model: {},
@@ -24,11 +27,15 @@ define(
                     model;
                 this._super()
                     .observe('formBlockVisibility')
+                    .observe('isLoading')
                     .observe({
                         'resultBlockVisibility': false
                     });
                 this.itemId = this.itemId || 'orderLevel';
                 model = new GiftMessage(this.itemId);
+                model.observables = {
+                    isLoading: this.isLoading
+                };
                 giftOptions.addOption(model);
                 this.model = model;
                 this.model.getObservable('isClear').subscribe(function (value) {

--- a/app/code/Magento/GiftMessage/view/frontend/web/js/view/gift-message.js
+++ b/app/code/Magento/GiftMessage/view/frontend/web/js/view/gift-message.js
@@ -40,8 +40,13 @@ define(
                 this.model = model;
                 this.model.getObservable('isClear').subscribe(function (value) {
                     if (value == true) {
-                        self.resultBlockVisibility(true);
-                        self.formBlockVisibility(false);
+                        if (self.model.getObservable('message')() === null) {
+                            self.resultBlockVisibility(false);
+                            self.formBlockVisibility(true);
+                        } else {
+                            self.resultBlockVisibility(true);
+                            self.formBlockVisibility(false);
+                        }
                         self.model.getObservable('alreadyAdded')(true);
                     }
                     self.model.getObservable('isClear')(false)

--- a/app/code/Magento/GiftMessage/view/frontend/web/js/view/gift-message.js
+++ b/app/code/Magento/GiftMessage/view/frontend/web/js/view/gift-message.js
@@ -33,12 +33,16 @@ define(
                 this.model = model;
                 this.model.getObservable('isClear').subscribe(function (value) {
                     if (value == true) {
+                        self.resultBlockVisibility(true);
                         self.formBlockVisibility(false);
                         self.model.getObservable('alreadyAdded')(true);
                     }
+                    self.model.getObservable('isClear')(false)
                 });
+
                 this.isResultBlockVisible();
             },
+
             /**
              * Is result block visible
              */

--- a/app/code/Magento/GiftMessage/view/frontend/web/js/view/gift-message.js
+++ b/app/code/Magento/GiftMessage/view/frontend/web/js/view/gift-message.js
@@ -1,139 +1,127 @@
 /**
- * Copyright © Magento, Inc. All rights reserved.
+ * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
-
-define([
-    'uiComponent',
-    'Magento_GiftMessage/js/model/gift-message',
-    'Magento_GiftMessage/js/model/gift-options',
-    'Magento_GiftMessage/js/action/gift-options'
-], function (Component, GiftMessage, giftOptions, giftOptionsService) {
-    'use strict';
-
-    return Component.extend({
-        formBlockVisibility: null,
-        resultBlockVisibility: null,
-        model: {},
-
-        /**
-         * Component init
-         */
-        initialize: function () {
-            var self = this,
-                model;
-
-            this._super()
-                .observe('formBlockVisibility')
-                .observe({
-                    'resultBlockVisibility': false
+/*global define*/
+define(
+    [
+        'uiComponent',
+        'Magento_GiftMessage/js/model/gift-message',
+        'Magento_GiftMessage/js/model/gift-options',
+        'Magento_GiftMessage/js/action/gift-options'
+    ],
+    function (Component, GiftMessage, giftOptions, giftOptionsService) {
+        'use strict';
+        return Component.extend({
+            formBlockVisibility: null,
+            resultBlockVisibility: null,
+            model: {},
+            /**
+             * Component init
+             */
+            initialize: function () {
+                var self = this,
+                    model;
+                this._super()
+                    .observe('formBlockVisibility')
+                    .observe({
+                        'resultBlockVisibility': false
+                    });
+                this.itemId = this.itemId || 'orderLevel';
+                model = new GiftMessage(this.itemId);
+                giftOptions.addOption(model);
+                this.model = model;
+                this.model.getObservable('isClear').subscribe(function (value) {
+                    if (value == true) {
+                        self.formBlockVisibility(false);
+                        self.model.getObservable('alreadyAdded')(true);
+                    }
                 });
-
-            this.itemId = this.itemId || 'orderLevel';
-            model = new GiftMessage(this.itemId);
-            giftOptions.addOption(model);
-            this.model = model;
-
-            this.model.getObservable('isClear').subscribe(function (value) {
-                if (value == true) { //eslint-disable-line eqeqeq
-                    self.formBlockVisibility(false);
-                    self.model.getObservable('alreadyAdded')(true);
+                this.isResultBlockVisible();
+            },
+            /**
+             * Is reslt block visible
+             */
+            isResultBlockVisible: function () {
+                var self = this;
+                if (this.model.getObservable('alreadyAdded')()) {
+                    this.resultBlockVisibility(true);
                 }
-            });
-
-            this.isResultBlockVisible();
-        },
-
-        /**
-         * Is reslt block visible
-         */
-        isResultBlockVisible: function () {
-            var self = this;
-
-            if (this.model.getObservable('alreadyAdded')()) {
-                this.resultBlockVisibility(true);
-            }
-            this.model.getObservable('additionalOptionsApplied').subscribe(function (value) {
-                if (value == true) { //eslint-disable-line eqeqeq
-                    self.resultBlockVisibility(true);
+                this.model.getObservable('additionalOptionsApplied').subscribe(function (value) {
+                    if (value == true) {
+                        self.resultBlockVisibility(true);
+                    }
+                });
+            },
+            /**
+             * @param {String} key
+             * @return {*}
+             */
+            getObservable: function (key) {
+                return this.model.getObservable(key);
+            },
+            /**
+             * Hide\Show form block
+             */
+            toggleFormBlockVisibility: function () {
+                if (this.formBlockVisibility() || this.resultBlockVisibility()) {
+                    this.formBlockVisibility(false);
+                    this.resultBlockVisibility(false);
+                } else {
+                    if (!this.model.getObservable('alreadyAdded')()) {
+                        this.formBlockVisibility(!this.formBlockVisibility());
+                    } else {
+                        this.resultBlockVisibility(!this.resultBlockVisibility());
+                    }
                 }
-            });
-        },
-
-        /**
-         * @param {String} key
-         * @return {*}
-         */
-        getObservable: function (key) {
-            return this.model.getObservable(key);
-        },
-
-        /**
-         * Hide\Show form block
-         */
-        toggleFormBlockVisibility: function () {
-            if (!this.model.getObservable('alreadyAdded')()) {
-                this.formBlockVisibility(!this.formBlockVisibility());
-            } else {
-                this.resultBlockVisibility(!this.resultBlockVisibility());
-            }
-        },
-
-        /**
-         * Edit options
-         */
-        editOptions: function () {
-            this.resultBlockVisibility(false);
-            this.formBlockVisibility(true);
-        },
-
-        /**
-         * Delete options
-         */
-        deleteOptions: function () {
-            giftOptionsService(this.model, true);
-        },
-
-        /**
-         * Hide form block
-         */
-        hideFormBlock: function () {
-            this.formBlockVisibility(false);
-
-            if (this.model.getObservable('alreadyAdded')()) {
-                this.resultBlockVisibility(true);
-            }
-        },
-
-        /**
-         * @return {Boolean}
-         */
-        hasActiveOptions: function () {
-            var regionData = this.getRegion('additionalOptions'),
-                options = regionData(),
-                i;
-
-            for (i = 0; i < options.length; i++) {
-                if (options[i].isActive()) {
-                    return true;
+            },
+            /**
+             * Edit options
+             */
+            editOptions: function () {
+                this.resultBlockVisibility(false);
+                this.formBlockVisibility(true);
+            },
+            /**
+             * Delete options
+             */
+            deleteOptions: function () {
+                giftOptionsService(this.model, true);
+            },
+            /**
+             * Hide form block
+             */
+            hideFormBlock: function () {
+                this.formBlockVisibility(false);
+                if (this.model.getObservable('alreadyAdded')()) {
+                    this.resultBlockVisibility(true);
                 }
+            },
+            /**
+             * @return {Boolean}
+             */
+            hasActiveOptions: function () {
+                var regionData = this.getRegion('additionalOptions'),
+                    options = regionData();
+                for (var i = 0; i < options.length; i++) {
+                    if (options[i].isActive()) {
+                        return true;
+                    }
+                }
+                return false;
+            },
+            /**
+             * @return {Boolean}
+             */
+            isActive: function () {
+                return this.model.isGiftMessageAvailable();
+            },
+            /**
+             * Submit options
+             */
+            submitOptions: function () {
+                giftOptionsService(this.model);
             }
-
-            return false;
-        },
-
-        /**
-         * @return {Boolean}
-         */
-        isActive: function () {
-            return this.model.isGiftMessageAvailable();
-        },
-
-        /**
-         * Submit options
-         */
-        submitOptions: function () {
-            giftOptionsService(this.model);
-        }
-    });
-});
+        });
+    }
+);

--- a/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message-form.html
+++ b/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message-form.html
@@ -46,9 +46,9 @@
                 </div>
             </div>
         </fieldset>
-
     </div>
 </div>
+
 <!-- /ko -->
 <div class="actions-toolbar">
     <div class="secondary">

--- a/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message-form.html
+++ b/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message-form.html
@@ -9,7 +9,7 @@
     <div class="gift-options-title">
         <span data-bind="i18n: 'Gift Message (optional)'"></span>
     </div>
-    <div class="gift-options-content">
+    <div class="gift-options-content" data-bind="blockLoader: isLoading">
         <fieldset class="fieldset">
             <div class="field field-to">
                 <label for="gift-message-whole-to" class="label">

--- a/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message-item-level.html
+++ b/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message-item-level.html
@@ -23,7 +23,7 @@
     </div>
     <!-- /ko -->
     <!-- ko if: resultBlockVisibility() -->
-    <div class="gift-summary">
+    <div class="gift-summary" data-bind="blockLoader: isLoading">
         <!-- ko foreach: getRegion('additionalOptions') -->
         <!--ko template: appliedTemplate --><!-- /ko -->
         <!-- /ko -->

--- a/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message-item-level.html
+++ b/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message-item-level.html
@@ -1,54 +1,67 @@
 <!--
 /**
- * Copyright © Magento, Inc. All rights reserved.
+ * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
  -->
 <!-- ko if: isActive() || hasActiveOptions() -->
-<button class="action action-gift"
-        data-bind="
-            click: $data.toggleFormBlockVisibility.bind($data),
-            css: {_active: formBlockVisibility() || resultBlockVisibility()}
-        ">
-    <span data-bind="i18n: 'Gift options'"></span>
-</button>
+<a href="#"
+   class="action action-gift"
+   data-bind="
+   click: $data.toggleFormBlockVisibility.bind($data),
+   css: {_active: formBlockVisibility() || resultBlockVisibility()}
+   ">
+    <span data-bind="i18n: 'Gift message'"></span>
+</a>
 <div class="gift-content" data-bind="css: {_active: formBlockVisibility() || resultBlockVisibility()}"> <!-- add class "active" to display the content -->
     <!-- ko ifnot: resultBlockVisibility() -->
-        <div class="gift-options">
-            <!-- ko foreach: getRegion('additionalOptions') -->
-                <!-- ko template: getTemplate() --><!-- /ko -->
-            <!-- /ko -->
-            <!-- ko template: formTemplate --><!--/ko-->
-        </div>
+    <div class="gift-options">
+        <!-- ko foreach: getRegion('additionalOptions') -->
+        <!-- ko template: getTemplate() --><!-- /ko -->
+        <!-- /ko -->
+        <!-- ko template: formTemplate --><!--/ko-->
+    </div>
     <!-- /ko -->
     <!-- ko if: resultBlockVisibility() -->
-        <div class="gift-summary">
-            <!-- ko foreach: getRegion('additionalOptions') -->
-                <!--ko template: appliedTemplate --><!-- /ko -->
-            <!-- /ko -->
+    <div class="gift-summary">
+        <!-- ko foreach: getRegion('additionalOptions') -->
+        <!--ko template: appliedTemplate --><!-- /ko -->
+        <!-- /ko -->
 
-            <!-- ko if: getObservable('message') -->
-                <div class="gift-message-summary">
-                    <span data-bind="i18n: 'Message' + ':'"></span>
-                    <!-- ko text: getObservable('message') --><!-- /ko -->
-                </div>
-            <!-- /ko -->
-            
-            <div class="actions-toolbar">
-                <div class="secondary">
-                    <button type="submit" class="action action-edit" data-bind="
+        <!-- ko if: getObservable('sender') -->
+        <div class="gift-message-summary">
+            <strong data-bind="i18n: 'From' + ':'"></strong>
+            <!-- ko text: getObservable('sender') --><!-- /ko -->
+        </div>
+        <!-- /ko -->
+        <!-- ko if: getObservable('recipient') -->
+        <div class="gift-message-summary">
+            <strong data-bind="i18n: 'To' + ':'"></strong>
+            <!-- ko text: getObservable('recipient') --><!-- /ko -->
+        </div>
+        <!-- /ko -->
+        <!-- ko if: getObservable('message') -->
+        <div class="gift-message-summary">
+            <strong data-bind="i18n: 'Message:'"></strong>
+            <!-- ko text: getObservable('message') --><!-- /ko -->
+        </div>
+        <!-- /ko -->
+
+        <div class="actions-toolbar">
+            <div class="secondary">
+                <button type="submit" class="action action-edit" data-bind="
                             click: $data.editOptions.bind($data),
                             attr: {title: $t('Edit')">
-                        <span data-bind="i18n: 'Edit'"></span>
-                    </button>
-                    <button class="action action-delete" data-bind="
+                    <span data-bind="i18n: 'Edit'"></span>
+                </button>
+                <button class="action action-delete" data-bind="
                             click: $data.deleteOptions.bind($data),
                             attr: {title: $t('Delete')">
-                        <span data-bind="i18n: 'Delete'"></span>
-                    </button>
-                </div>
+                    <span data-bind="i18n: 'Delete'"></span>
+                </button>
             </div>
         </div>
+    </div>
     <!-- /ko -->
 </div>
 <!-- /ko -->

--- a/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message.html
+++ b/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message.html
@@ -1,6 +1,6 @@
 <!--
 /**
- * Copyright © Magento, Inc. All rights reserved.
+ * Copyright © 2016 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
 -->
@@ -16,36 +16,47 @@
             <!-- ko ifnot: resultBlockVisibility() -->
             <div class="gift-options">
                 <!-- ko foreach: getRegion('additionalOptions') -->
-                    <!-- ko template: getTemplate() --><!-- /ko -->
+                <!-- ko template: getTemplate() --><!-- /ko -->
                 <!-- /ko -->
                 <!-- ko template: formTemplate --><!--/ko-->
             </div>
             <!-- /ko -->
             <div class="gift-summary">
                 <!-- ko if: resultBlockVisibility() -->
-                    <!-- ko foreach: getRegion('additionalOptions') -->
-                         <!--ko template: appliedTemplate --><!-- /ko -->
-                    <!-- /ko -->
-
-                    <!-- ko if: getObservable('message') -->
-                        <div class="gift-message-summary">
-                            <span data-bind="i18n: 'Message:'"></span>
-                            <!-- ko text: getObservable('message') --><!-- /ko -->
-                        </div>
-                    <!-- /ko -->
-                    <div class="actions-toolbar">
-                        <div class="secondary">
-                            <button type="submit"
-                                    class="action action-edit"
-                                    data-bind="attr: {title: $t('Edit')}, click: $data.editOptions.bind($data)">
-                                <span data-bind="i18n: 'Edit'"></span>
-                            </button>
-                            <button class="action action-delete"
-                                    data-bind="attr: {title: $t('Delete')}, click: $data.deleteOptions.bind($data)">
-                                <span data-bind="i18n: 'Delete'"></span>
-                            </button>
-                        </div>
+                <!-- ko foreach: getRegion('additionalOptions') -->
+                <!--ko template: appliedTemplate --><!-- /ko -->
+                <!-- /ko -->
+                <!-- ko if: getObservable('sender') -->
+                <div class="gift-message-summary">
+                    <strong data-bind="i18n: 'From' + ':'"></strong>
+                    <!-- ko text: getObservable('sender') --><!-- /ko -->
+                </div>
+                <!-- /ko -->
+                <!-- ko if: getObservable('recipient') -->
+                <div class="gift-message-summary">
+                    <strong data-bind="i18n: 'To' + ':'"></strong>
+                    <!-- ko text: getObservable('recipient') --><!-- /ko -->
+                </div>
+                <!-- /ko -->
+                <!-- ko if: getObservable('message') -->
+                <div class="gift-message-summary">
+                    <strong data-bind="i18n: 'Message:'"></strong>
+                    <!-- ko text: getObservable('message') --><!-- /ko -->
+                </div>
+                <!-- /ko -->
+                <div class="actions-toolbar">
+                    <div class="secondary">
+                        <button type="submit"
+                                class="action action-edit"
+                                data-bind="attr: {title: $t('Edit')}, click: $data.editOptions.bind($data)">
+                            <span data-bind="i18n: 'Edit'"></span>
+                        </button>
+                        <button class="action action-delete"
+                                data-bind="attr: {title: $t('Delete')}, click: $data.deleteOptions.bind($data)">
+                            <span data-bind="i18n: 'Delete'"></span>
+                        </button>
                     </div>
+                </div>
                 <!-- /ko -->
             </div>
         </div>

--- a/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message.html
+++ b/app/code/Magento/GiftMessage/view/frontend/web/template/gift-message.html
@@ -21,8 +21,8 @@
                 <!-- ko template: formTemplate --><!--/ko-->
             </div>
             <!-- /ko -->
-            <div class="gift-summary">
-                <!-- ko if: resultBlockVisibility() -->
+            <!-- ko if: resultBlockVisibility() -->
+            <div class="gift-summary" data-bind="blockLoader: isLoading">
                 <!-- ko foreach: getRegion('additionalOptions') -->
                 <!--ko template: appliedTemplate --><!-- /ko -->
                 <!-- /ko -->
@@ -57,8 +57,8 @@
                         </button>
                     </div>
                 </div>
-                <!-- /ko -->
             </div>
+            <!-- /ko -->
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Description
Replaced the page refresh with a XHR request. Also added blockloaders for usability purposes. Updating and deleting gift messages will go way smoother now. Also refactored some code with uses. 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9206: Apply Shopping Cart Gift Options without page reload

### Manual testing scenarios
1. Install Magento latest develop version
2. Activate Gift Option from the backend (Stores>Configuration>Sales>Sales>Gift Options)
3. add product to cart
4. add gift message to product
5. delete/update gift message
6. add gift option to cart
7. delete/update gift message

Expected result:
After editing or deleting the message or option, there should not be a page refresh but a block loader on the section, and then the edited content. 

### Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds on Travis CI are green)