### PR TITLE
Fix coding standard in Magento AdminNotification module

### DIFF
--- a/app/code/Magento/AdminNotification/Block/Grid/Renderer/Actions.php
+++ b/app/code/Magento/AdminNotification/Block/Grid/Renderer/Actions.php
@@ -6,8 +6,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\AdminNotification\Block\Grid\Renderer;
 
 class Actions extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRenderer
@@ -39,9 +37,8 @@ class Actions extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstrac
      */
     public function render(\Magento\Framework\DataObject $row)
     {
-        $readDetailsHtml = $row->getUrl() ? '<a class="action-details" target="_blank" href="' . $row->getUrl() . '">' . __(
-            'Read Details'
-        ) . '</a>' : '';
+        $readDetailsHtml = $row->getUrl() ? '<a class="action-details" target="_blank" href="' . $row->getUrl() . '">' .
+            __('Read Details') . '</a>' : '';
 
         $markAsReadHtml = !$row->getIsRead() ? '<a class="action-mark" href="' . $this->getUrl(
             '*/*/markAsRead/',

--- a/app/code/Magento/AdminNotification/Block/ToolbarEntry.php
+++ b/app/code/Magento/AdminNotification/Block/ToolbarEntry.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\AdminNotification\Block;
 
 /**

--- a/app/code/Magento/AdminNotification/Model/ResourceModel/Grid/Collection.php
+++ b/app/code/Magento/AdminNotification/Model/ResourceModel/Grid/Collection.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * AdminNotification Inbox model
  *
@@ -18,7 +16,7 @@ class Collection extends \Magento\AdminNotification\Model\ResourceModel\Inbox\Co
     /**
      * Add remove filter
      *
-     * @return \Magento\AdminNotification\Model\ResourceModel\Grid\Collection|\Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+     * @return Collection|\Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
      */
     protected function _initSelect()
     {

--- a/app/code/Magento/AdminNotification/Test/Unit/Block/ToolbarEntryTest.php
+++ b/app/code/Magento/AdminNotification/Test/Unit/Block/ToolbarEntryTest.php
@@ -51,7 +51,8 @@ class ToolbarEntryTest extends \PHPUnit_Framework_TestCase
 
         // 1. Create mocks
         $notificationList = $this->getMockBuilder(
-            \Magento\AdminNotification\Model\ResourceModel\Inbox\Collection\Unread::class)
+            \Magento\AdminNotification\Model\ResourceModel\Inbox\Collection\Unread::class
+        )
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/app/code/Magento/AdminNotification/Test/Unit/Block/ToolbarEntryTest.php
+++ b/app/code/Magento/AdminNotification/Test/Unit/Block/ToolbarEntryTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Test class for \Magento\AdminNotification\Block\ToolbarEntry
  */


### PR DESCRIPTION
Fix coding standard in Magento AdminNotification module:
- Removed @codingStandardsIgnoreFile from head of the file.
- Fixed max line length
- Fixed closing parenthesis of a multi-line function call must be on a line by itself