### PR TITLE
[MAGETWO-54158]:+ Corrected ACL rules for the sendfriend module and s…

### DIFF
--- a/app/code/Magento/Backend/etc/acl.xml
+++ b/app/code/Magento/Backend/etc/acl.xml
@@ -26,6 +26,13 @@
                 <resource id="Magento_Backend::stores" title="Stores" translate="title" sortOrder="80">
                     <resource id="Magento_Backend::stores_settings" title="Settings" translate="title" sortOrder="10">
                         <resource id="Magento_Backend::store" title="All Stores" translate="title" sortOrder="10"/>
+                        <resource id="Magento_Config::config" title="Configuration" translate="title" sortOrder="20">
+                            <resource id="Magento_Backend::advanced" title="Advanced Section" translate="title" sortOrder="90" />
+                            <resource id="Magento_Backend::currency" title="Currency Setup Section" translate="title" sortOrder="120" />
+                            <resource id="Magento_Backend::dev" title="Developer Section" translate="title" sortOrder="110" />
+                            <resource id="Magento_Backend::web" title="Web Section" translate="title" sortOrder="30" />
+                            <resource id="Magento_Backend::trans_email" title="Store Email Addresses Section" translate="title" sortOrder="100" />
+                        </resource>
                     </resource>
                     <resource id="Magento_Backend::stores_attributes" title="Attributes" translate="title" sortOrder="40" />
                     <resource id="Magento_Backend::stores_other_settings" title="Other Settings" translate="title" sortOrder="50" />

--- a/app/code/Magento/Config/Setup/UpgradeData.php
+++ b/app/code/Magento/Config/Setup/UpgradeData.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Config\Setup;
+
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\UpgradeDataInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class UpgradeData implements UpgradeDataInterface
+{
+
+    /**
+     * @param ModuleDataSetupInterface $setup
+     * @param ModuleContextInterface $context
+     */
+    public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    {
+        if (version_compare($context->getVersion(), '2.0.1', '<')) {
+            $this->upgradeAcl($setup);
+        }
+    }
+
+    /**
+     * @param ModuleDataSetupInterface $setup
+     */
+    protected function upgradeAcl(ModuleDataSetupInterface $setup) {
+
+        $aclUpdates = [
+            'Magento_Config::dev'           => 'Magento_Backend::dev',
+            'Magento_Config::web'           => 'Magento_Backend::web',
+            'Magento_Config::trans_email'   => 'Magento_Backend::trans_email',
+            'Magento_Config::currency'      => 'Magento_Backend::currency',
+            'Magento_Config::advanced'      => 'Magento_Backend::advanced',
+        ];
+
+        foreach($aclUpdates as $aclKey => $aclUpdate) {
+            $setup->getConnection()->update(
+                $setup->getTable('authorization_rule'),
+                ['resource_id' => $aclUpdate],
+                ['resource_id = ?' => $aclKey]
+            );
+        }
+
+    }
+
+}

--- a/app/code/Magento/Config/Setup/UpgradeData.php
+++ b/app/code/Magento/Config/Setup/UpgradeData.php
@@ -17,9 +17,7 @@ class UpgradeData implements UpgradeDataInterface
 {
 
     /**
-     * @param ModuleDataSetupInterface $setup
-     * @param ModuleContextInterface $context
-     * @return void
+     * {@inheritdoc}
      */
     public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {
@@ -29,10 +27,13 @@ class UpgradeData implements UpgradeDataInterface
     }
 
     /**
+     * ACL roles were moved to Magento_Backend
+     * for backward compatibility, roles that are already defined as Magento_Config should be updated to Magento_Backend
+     *
      * @param ModuleDataSetupInterface $setup
      * @return void
      */
-    protected function upgradeAcl(ModuleDataSetupInterface $setup)
+    private function upgradeAcl(ModuleDataSetupInterface $setup)
     {
 
         $aclUpdates = [

--- a/app/code/Magento/Config/Setup/UpgradeData.php
+++ b/app/code/Magento/Config/Setup/UpgradeData.php
@@ -19,6 +19,7 @@ class UpgradeData implements UpgradeDataInterface
     /**
      * @param ModuleDataSetupInterface $setup
      * @param ModuleContextInterface $context
+     * @return void
      */
     public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {
@@ -29,8 +30,10 @@ class UpgradeData implements UpgradeDataInterface
 
     /**
      * @param ModuleDataSetupInterface $setup
+     * @return void
      */
-    protected function upgradeAcl(ModuleDataSetupInterface $setup) {
+    protected function upgradeAcl(ModuleDataSetupInterface $setup)
+    {
 
         $aclUpdates = [
             'Magento_Config::dev'           => 'Magento_Backend::dev',
@@ -40,7 +43,7 @@ class UpgradeData implements UpgradeDataInterface
             'Magento_Config::advanced'      => 'Magento_Backend::advanced',
         ];
 
-        foreach($aclUpdates as $aclKey => $aclUpdate) {
+        foreach ($aclUpdates as $aclKey => $aclUpdate) {
             $setup->getConnection()->update(
                 $setup->getTable('authorization_rule'),
                 ['resource_id' => $aclUpdate],
@@ -49,5 +52,4 @@ class UpgradeData implements UpgradeDataInterface
         }
 
     }
-
 }

--- a/app/code/Magento/Config/etc/acl.xml
+++ b/app/code/Magento/Config/etc/acl.xml
@@ -12,15 +12,10 @@
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config" title="Configuration" translate="title" sortOrder="20">
-                            <resource id="Magento_Backend::advanced" title="Advanced Section" translate="title" sortOrder="90" />
                             <resource id="Magento_Config::config_admin" title="Advanced Admin Section" translate="title" sortOrder="100" />
                             <resource id="Magento_Config::config_design" title="Design Section" translate="title" sortOrder="40" />
                             <resource id="Magento_Config::config_general" title="General Section" translate="title" sortOrder="20" />
                             <resource id="Magento_Config::config_system" title="System Section" translate="title" sortOrder="80" />
-                            <resource id="Magento_Backend::currency" title="Currency Setup Section" translate="title" sortOrder="120" />
-                            <resource id="Magento_Backend::dev" title="Developer Section" translate="title" sortOrder="110" />
-                            <resource id="Magento_Backend::web" title="Web Section" translate="title" sortOrder="30" />
-                            <resource id="Magento_Backend::trans_email" title="Store Email Addresses Section" translate="title" sortOrder="100" />
                         </resource>
                     </resource>
                 </resource>

--- a/app/code/Magento/Config/etc/acl.xml
+++ b/app/code/Magento/Config/etc/acl.xml
@@ -12,16 +12,15 @@
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config" title="Configuration" translate="title" sortOrder="20">
-                            <resource id="Magento_Config::advanced" title="Advanced Section" translate="title" sortOrder="90" />
+                            <resource id="Magento_Backend::advanced" title="Advanced Section" translate="title" sortOrder="90" />
                             <resource id="Magento_Config::config_admin" title="Advanced Admin Section" translate="title" sortOrder="100" />
                             <resource id="Magento_Config::config_design" title="Design Section" translate="title" sortOrder="40" />
                             <resource id="Magento_Config::config_general" title="General Section" translate="title" sortOrder="20" />
                             <resource id="Magento_Config::config_system" title="System Section" translate="title" sortOrder="80" />
-                            <resource id="Magento_Config::currency" title="Currency Setup Section" translate="title" sortOrder="120" />
-                            <resource id="Magento_Config::dev" title="Developer Section" translate="title" sortOrder="110" />
-                            <resource id="Magento_Config::web" title="Web Section" translate="title" sortOrder="30" />
-                            <resource id="Magento_Config::trans_email" title="Store Email Addresses Section" translate="title" sortOrder="100" />
-                            <resource id="Magento_Config::sendfriend" title="Email to a Friend" translate="title" sortOrder="140" />
+                            <resource id="Magento_Backend::currency" title="Currency Setup Section" translate="title" sortOrder="120" />
+                            <resource id="Magento_Backend::dev" title="Developer Section" translate="title" sortOrder="110" />
+                            <resource id="Magento_Backend::web" title="Web Section" translate="title" sortOrder="30" />
+                            <resource id="Magento_Backend::trans_email" title="Store Email Addresses Section" translate="title" sortOrder="100" />
                         </resource>
                     </resource>
                 </resource>

--- a/app/code/Magento/Config/etc/module.xml
+++ b/app/code/Magento/Config/etc/module.xml
@@ -6,5 +6,5 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Config" setup_version="2.0.0"/>
+    <module name="Magento_Config" setup_version="2.0.1"/>
 </config>

--- a/app/code/Magento/SendFriend/Setup/UpgradeData.php
+++ b/app/code/Magento/SendFriend/Setup/UpgradeData.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\SendFriend\Setup;
+
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\UpgradeDataInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class UpgradeData implements UpgradeDataInterface
+{
+
+    /**
+     * @param ModuleDataSetupInterface $setup
+     * @param ModuleContextInterface $context
+     */
+    public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    {
+        if (version_compare($context->getVersion(), '2.0.1', '<')) {
+            $this->upgradeAcl($setup);
+        }
+    }
+
+    /**
+     * @param ModuleDataSetupInterface $setup
+     */
+    protected function upgradeAcl(ModuleDataSetupInterface $setup) {
+
+        $setup->getConnection()->update(
+            $setup->getTable('authorization_rule'),
+            ['resource_id' => 'Magento_Backend::sendfriend'],
+            ['resource_id = ?' => 'Magento_Config::sendfriend']
+        );
+
+    }
+
+}

--- a/app/code/Magento/SendFriend/Setup/UpgradeData.php
+++ b/app/code/Magento/SendFriend/Setup/UpgradeData.php
@@ -17,9 +17,7 @@ class UpgradeData implements UpgradeDataInterface
 {
 
     /**
-     * @param ModuleDataSetupInterface $setup
-     * @param ModuleContextInterface $context
-     * @return void
+     * {@inheritdoc}
      */
     public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {
@@ -29,10 +27,13 @@ class UpgradeData implements UpgradeDataInterface
     }
 
     /**
+     * ACL roles were moved to Magento_Backend
+     * for backward compatibility, roles that are already defined as Magento_Config should be updated to Magento_Backend
+     *
      * @param ModuleDataSetupInterface $setup
      * @return void
      */
-    protected function upgradeAcl(ModuleDataSetupInterface $setup)
+    private function upgradeAcl(ModuleDataSetupInterface $setup)
     {
 
         $setup->getConnection()->update(

--- a/app/code/Magento/SendFriend/Setup/UpgradeData.php
+++ b/app/code/Magento/SendFriend/Setup/UpgradeData.php
@@ -19,6 +19,7 @@ class UpgradeData implements UpgradeDataInterface
     /**
      * @param ModuleDataSetupInterface $setup
      * @param ModuleContextInterface $context
+     * @return void
      */
     public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {
@@ -29,8 +30,10 @@ class UpgradeData implements UpgradeDataInterface
 
     /**
      * @param ModuleDataSetupInterface $setup
+     * @return void
      */
-    protected function upgradeAcl(ModuleDataSetupInterface $setup) {
+    protected function upgradeAcl(ModuleDataSetupInterface $setup)
+    {
 
         $setup->getConnection()->update(
             $setup->getTable('authorization_rule'),
@@ -39,5 +42,4 @@ class UpgradeData implements UpgradeDataInterface
         );
 
     }
-
 }

--- a/app/code/Magento/SendFriend/etc/acl.xml
+++ b/app/code/Magento/SendFriend/etc/acl.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="Magento_Backend::sendfriend" title="Email to a Friend" translate="title" sortOrder="140" />
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/app/code/Magento/SendFriend/etc/module.xml
+++ b/app/code/Magento/SendFriend/etc/module.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_SendFriend" setup_version="2.0.0">
+    <module name="Magento_SendFriend" setup_version="2.0.1">
         <sequence>
             <module name="Magento_Catalog"/>
         </sequence>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Added an acl.xml to the send-friend module
Added upgrade data script for backward compatibility for ACL-roles that were already selected for users.

Changed the acl.xml for the backend module
Added upgrade data script for backward compatibility for ACL-roles that were already selected for users.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#MAGETWO-54158: ACL not defined for Magento_Backend::web

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Install Magento latest develop version
2. Go to Admin side
3. Click "System > User Roles"
4. Click "Add new Role" enter Role name
5. In left side choose Role Resources and check "Dashboard", "Web Section", "Email to a friend", "Currency Setup", "Store E-mail addresses"
6. Save Role
7. Click "System > All Users"
8. Click "Add new User"
9. Enter data in required fields
10. In left side click "User Role" and choose early created role.
11. Click "Save"
12. Sign out and Log in using credentials of new user
13. Click "Stores > Configuration"

Expected result:
All the tabs that were selected in the role should be visible

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)