### PR TITLE
Fix for #9646

### DIFF
--- a/app/code/Magento/Quote/Model/Cart/CartTotalRepository.php
+++ b/app/code/Magento/Quote/Model/Cart/CartTotalRepository.php
@@ -12,6 +12,7 @@ use Magento\Catalog\Helper\Product\ConfigurationPool;
 use Magento\Framework\Api\DataObjectHelper;
 use Magento\Quote\Model\Cart\Totals\ItemConverter;
 use Magento\Quote\Api\CouponManagementInterface;
+use Magento\Framework\Api\ExtensibleDataInterface;
 
 /**
  * Cart totals data object.
@@ -94,6 +95,7 @@ class CartTotalRepository implements CartTotalRepositoryInterface
             $addressTotalsData = $quote->getShippingAddress()->getData();
             $addressTotals = $quote->getShippingAddress()->getTotals();
         }
+        unset($addressTotalsData[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]);
 
         /** @var \Magento\Quote\Api\Data\TotalsInterface $quoteTotals */
         $quoteTotals = $this->totalsFactory->create();


### PR DESCRIPTION
Allow extension attributes for quote addresses. See a fix for a similar issue here: https://github.com/magento/magento2/commit/8e0c8a67653cbd92df3c65f1cc3d96c8313df72e

### Description
Unset the address extension attributes before trying to create the quote totals.

### Fixed Issues (if relevant)
1. magento/magento2#9646

### Manual testing scenarios
From the linked issue:

1. define extension attributes for the quote billing address
2. login as a user who has at least two addresses in his address book
3. add a virtual product to card and proceed to checkout
4. choose or change the billing address, click update, note no errors.