### PR TITLE
magento/magento2#7279 bill-to name and ship-to name truncated to 20 chars

### DIFF
--- a/app/code/Magento/Quote/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Quote/Setup/UpgradeSchema.php
@@ -46,8 +46,16 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
         }
-
-        if (version_compare($context->getVersion(), '2.0.2', '<')) {
+        //drop foreign key for single DB case
+        if (version_compare($context->getVersion(), '2.0.3', '<')
+            && $setup->tableExists($setup->getTable('quote_item'))
+        ) {
+            $setup->getConnection()->dropForeignKey(
+                $setup->getTable('quote_item'),
+                $setup->getFkName('quote_item', 'product_id', 'catalog_product_entity', 'entity_id')
+            );
+        }
+        if (version_compare($context->getVersion(), '2.0.5', '<')) {
             $setup->getConnection(self::$connectionName)->changeColumn(
                 $setup->getTable('quote_address', self::$connectionName),
                 'firstname',
@@ -58,8 +66,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'comment' => 'Firstname'
                 ]
             );
-        }
-        if (version_compare($context->getVersion(), '2.0.2', '<')) {
             $setup->getConnection(self::$connectionName)->changeColumn(
                 $setup->getTable('quote_address', self::$connectionName),
                 'middlename',
@@ -70,8 +76,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'comment' => 'Middlename'
                 ]
             );
-        }
-        if (version_compare($context->getVersion(), '2.0.2', '<')) {
             $setup->getConnection(self::$connectionName)->changeColumn(
                 $setup->getTable('quote_address', self::$connectionName),
                 'lastname',
@@ -81,15 +85,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'length' => 255,
                     'comment' => 'Lastname'
                 ]
-            );
-        }
-        //drop foreign key for single DB case
-        if (version_compare($context->getVersion(), '2.0.3', '<')
-            && $setup->tableExists($setup->getTable('quote_item'))
-        ) {
-            $setup->getConnection()->dropForeignKey(
-                $setup->getTable('quote_item'),
-                $setup->getFkName('quote_item', 'product_id', 'catalog_product_entity', 'entity_id')
             );
         }
         $setup->endSetup();

--- a/app/code/Magento/Quote/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Quote/Setup/UpgradeSchema.php
@@ -46,6 +46,43 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
         }
+
+        if (version_compare($context->getVersion(), '2.0.2', '<')) {
+            $setup->getConnection(self::$connectionName)->changeColumn(
+                $setup->getTable('quote_address', self::$connectionName),
+                'firstname',
+                'firstname',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'length' => 255,
+                    'comment' => 'Firstname'
+                ]
+            );
+        }
+        if (version_compare($context->getVersion(), '2.0.2', '<')) {
+            $setup->getConnection(self::$connectionName)->changeColumn(
+                $setup->getTable('quote_address', self::$connectionName),
+                'middlename',
+                'middlename',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'length' => 40,
+                    'comment' => 'Middlename'
+                ]
+            );
+        }
+        if (version_compare($context->getVersion(), '2.0.2', '<')) {
+            $setup->getConnection(self::$connectionName)->changeColumn(
+                $setup->getTable('quote_address', self::$connectionName),
+                'lastname',
+                'lastname',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'length' => 255,
+                    'comment' => 'Lastname'
+                ]
+            );
+        }
         //drop foreign key for single DB case
         if (version_compare($context->getVersion(), '2.0.3', '<')
             && $setup->tableExists($setup->getTable('quote_item'))

--- a/app/code/Magento/Quote/etc/module.xml
+++ b/app/code/Magento/Quote/etc/module.xml
@@ -6,6 +6,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Quote" setup_version="2.0.4">
+    <module name="Magento_Quote" setup_version="2.0.5">
     </module>
 </config>


### PR DESCRIPTION
Bill-to Name and Ship-to Name truncated to 20 characters in backend

The firstname, middlename and lastname in table "quote_address" were set to a length of 20.
I compared the lengths of firstname, middlename and lastname of table "quote_address" with those of "quote" (255, 40 and 255 resp.) and of "sales_order_address" (255, 255 and 255) and with sales_order (128, 128 and 128) and choose to go with 255, 40 and 255 since these are used in "quote" as well and these are the values I know from Magento 1.9 as well. The other values seem a bit inconsistent.

### Description
In Magento\Quote\Setup\UpgradeSchema.php there was already a repair for street so I added the repairs for the lengths of firstname, lastname and middlename in the same way and tested.

### Fixed Issues (if relevant)
magento/magento2#7279 : bill-to name and ship-to name truncated to 20 chars

### Manual testing scenarios
Use composer install from the develop branch and after composer install, update the new Magento\Quote\Setup\UpgradeSchema.php. Go through the steps to install Magento further and when done, check the database table "quote_address". The columns firstname, middlename and lastname are now 255, 40 and 255 in length.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
