### PR TITLE
Fix for javascript "mixins" when 'urlArgs' is set in requirejs-config.js - issue 8221

### DIFF
--- a/lib/web/mage/requirejs/mixins.js
+++ b/lib/web/mage/requirejs/mixins.js
@@ -117,7 +117,7 @@ define('mixins', [
 			
             // fix for when urlArgs is set
             if (path.indexOf('?')!=-1) {
-			    path=path.substring(0,path.indexOf('?'));
+                path=path.substring(0,path.indexOf('?'));
             }			
 			
             var config = module.config() || {},

--- a/lib/web/mage/requirejs/mixins.js
+++ b/lib/web/mage/requirejs/mixins.js
@@ -114,6 +114,12 @@ define('mixins', [
          * @returns {Array} An array of paths to mixins.
          */
         getMixins: function (path) {
+			
+			// fix for when urlArgs is set
+			if (path.indexOf('?')!=-1) {
+				path=path.substring(0,path.indexOf('?'));
+			}			
+			
             var config = module.config() || {},
                 mixins = config[path] || {};
 

--- a/lib/web/mage/requirejs/mixins.js
+++ b/lib/web/mage/requirejs/mixins.js
@@ -115,10 +115,10 @@ define('mixins', [
          */
         getMixins: function (path) {
 			
-			// fix for when urlArgs is set
-			if (path.indexOf('?')!=-1) {
-				path=path.substring(0,path.indexOf('?'));
-			}			
+            // fix for when urlArgs is set
+            if (path.indexOf('?')!=-1) {
+			    path=path.substring(0,path.indexOf('?'));
+            }			
 			
             var config = module.config() || {},
                 mixins = config[path] || {};


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
This fixes the problem where if you add a "urlArgs" argument to a requirejs-config.js file, javascript mixins will stop working. For example if you add the line : 
`urlArgs:urlArgs: "bust=2017-04-21" `
to Magento_Theme/templates/page/js/require_js.phtml - this will stop mixins.js from working. 
See issue #8221
### Description
The problem is due to 'urlArgs' adding a query string to the path variable. The function getMixins in mixins.js tries to reference config using the path variable, but as this includes the query string, it fails.
This change removes the query string from the path variable, allowing config to be referenced correctly.
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8221: Javascript "mixins" doesn't works if 'urlArgs' is in requirejs-config.js
### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add urlArgs:urlArgs: "bust=2017-04-21" to any require-js config file on your site.
2. Test a module that uses javascript mixins or a plugin such as "Fooman GoogleAnalyticsPlus" that uses them.
3. They will now work.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
