### PR TITLE
Issue 9680: Use parent name for variations

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/summary.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/summary.js
@@ -91,6 +91,7 @@ define([
             var productSku = this.variationsComponent().getProductValue('sku'),
                 productPrice = this.variationsComponent().getProductPrice(),
                 productWeight = this.variationsComponent().getProductValue('weight'),
+                productName = this.variationsComponent().getProductValue('name'),
                 variationsKeys = [],
                 gridExisting = [],
                 gridNew = [],
@@ -98,7 +99,7 @@ define([
 
             this.variations = [];
             _.each(variations, function (options) {
-                var product, images, sku, quantity, price, variation,
+                var product, images, sku, name, quantity, price, variation,
                     productId = this.variationsComponent().getProductIdByOptions(options);
 
                 if (productId) {
@@ -110,6 +111,9 @@ define([
                 sku = productSku + _.reduce(options, function (memo, option) {
                     return memo + '-' + option.label;
                 }, '');
+                name = productName + _.reduce(options, function (memo, option) {
+                        return memo + '-' + option.label;
+                    }, '');
                 quantity = getSectionValue('quantity', options);
 
                 if (!quantity && productId) {
@@ -128,7 +132,7 @@ define([
                     options: options,
                     images: images,
                     sku: sku,
-                    name: sku,
+                    name: name,
                     quantity: quantity,
                     price: price,
                     productId: productId,


### PR DESCRIPTION
### Description
Use parent name for variations when creating configurables

### Fixed Issues (if relevant)
1. magento/magento2#9680: Adding product configurations uses sku based name

### Manual testing scenarios
1. Create a configurable product with some configurations (simple products)
2. Use name 'NAME'
3. Use sku 'SKU'
4. Create configurations and Generate products
5. Confirm that name of the configurations (simple products) are based on the name of the parent product

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
