### PR TITLE
Update scripts.js

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
+++ b/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
@@ -1248,7 +1248,8 @@ define([
                 params.store_id = this.storeId;
             }
 
-            var currentCustomerGroupId = $(parameters.groupIdHtmlId).value;
+            var currentCustomerGroupId = $(parameters.groupIdHtmlId)
+                ? $(parameters.groupIdHtmlId).value : '';
 
             new Ajax.Request(parameters.validateUrl, {
                 parameters: params,


### PR DESCRIPTION
Got an error `Uncaught TypeError: Cannot read property 'value' of undefined` when the customer group setting was not present on the order create page in the admin.

### Description
Got an error `Uncaught TypeError: Cannot read property 'value' of undefined` when the customer group setting was not present on the order create page in the admin. This is the case when reordering an order for a guest. This fix checks whether the field can be found first.

### Manual testing scenarios
1. Open a guest's order
2. Reorder that order
3. Fill in a VAT number and click on Validate
4. The validation is now executed, while without this fix an error would be thrown in the console.
