### PR TITLE
Add froogaloop library as a dependency to load-player module

### DIFF
--- a/app/code/Magento/ProductVideo/view/frontend/requirejs-config.js
+++ b/app/code/Magento/ProductVideo/view/frontend/requirejs-config.js
@@ -7,7 +7,11 @@ var config = {
     map: {
         '*': {
             loadPlayer: 'Magento_ProductVideo/js/load-player',
-            fotoramaVideoEvents: 'Magento_ProductVideo/js/fotorama-add-video-events'
+            fotoramaVideoEvents: 'Magento_ProductVideo/js/fotorama-add-video-events',
+			vimeoAPI: 'https://secure-a.vimeocdn.com/js/froogaloop2.min.js'
         }
-    }
+    },
+	shim: {
+		vimeoAPI: {}
+	}
 };

--- a/app/code/Magento/ProductVideo/view/frontend/requirejs-config.js
+++ b/app/code/Magento/ProductVideo/view/frontend/requirejs-config.js
@@ -8,10 +8,10 @@ var config = {
         '*': {
             loadPlayer: 'Magento_ProductVideo/js/load-player',
             fotoramaVideoEvents: 'Magento_ProductVideo/js/fotorama-add-video-events',
-			vimeoAPI: 'https://secure-a.vimeocdn.com/js/froogaloop2.min.js'
+            vimeoAPI: 'https://secure-a.vimeocdn.com/js/froogaloop2.min.js'
         }
     },
-	shim: {
-		vimeoAPI: {}
-	}
+    shim: {
+        vimeoAPI: {}
+    }
 };

--- a/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
@@ -7,7 +7,7 @@
  @version 0.0.1
  @requires jQuery & jQuery UI
  */
-define(['jquery', 'jquery/ui'], function ($) {
+define(['jquery', 'jquery/ui', 'vimeoAPI'], function ($) {
     'use strict';
 
     var videoRegister = {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
On line 336 of load-player.js the object window.$f is used
```js
this._player = window.$f(this.element.children(':first')[0]);
```

This object is defined in the froogaloop library. The load-player module is the only place where this object is used. The froogaloop library is  dependency for the load-player module but it is not declared as a dependency. Under certain network conditions this could lead to the window.$f object being undefined.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. To simulate a network condition that would cause the froogaloop library to load after line 336 is run, make the following change in `Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js`:

```js
_checkForVimeo: function () {
    var allVideoData = this.options.videoData,
        videoItem;

    for (videoItem in allVideoData) {
        if (allVideoData[videoItem].provider === this.VI) {
            setTimeout(function () {                                           // Added line
                this._loadVimeoJSFramework();
            }, 30000);                                                                  // Added line
        }
    }
},
```
2. Now add a vimeo video to a product and load that product on the frontend. When the video loads you will see a console message saying `window.$f` is undefined.

### Contribution checklist
[x] Pull request has a meaningful description of its purpose
[x] All commits are accompanied by meaningful commit messages
**N/A** All new or changed code is covered with unit/integration tests (if applicable)
**N/A** All automated tests passed successfully (all builds on Travis CI are green)
