### PR TITLE
Backport of MAGETWO-59256 for 2.1: Custom composer modules break Component Manager #6718

### DIFF
--- a/setup/src/Magento/Setup/Model/PackagesData.php
+++ b/setup/src/Magento/Setup/Model/PackagesData.php
@@ -326,6 +326,32 @@ class PackagesData
     }
 
     /**
+     * Filter packages by allowed types
+     *
+     * @param array $packages
+     * @return array
+     */
+    private function filterPackagesList(array $packages)
+    {
+        return array_filter(
+            $packages,
+            function ($item) {
+                return in_array(
+                    $item['package_type'],
+                    [
+                        \Magento\Setup\Model\Grid\TypeMapper::LANGUAGE_PACKAGE_TYPE,
+                        \Magento\Setup\Model\Grid\TypeMapper::MODULE_PACKAGE_TYPE,
+                        \Magento\Setup\Model\Grid\TypeMapper::EXTENSION_PACKAGE_TYPE,
+                        \Magento\Setup\Model\Grid\TypeMapper::THEME_PACKAGE_TYPE,
+                        \Magento\Setup\Model\Grid\TypeMapper::METAPACKAGE_PACKAGE_TYPE
+                    ]
+                );
+            }
+        );
+    }
+
+    /**
+     * Get MetaPackage for package
      *
      * @param array $packages
      * @return array
@@ -377,26 +403,38 @@ class PackagesData
 
                 return array_keys($packageVersions);
             }
-        } else {
-            $versionsPattern = '/^versions\s*\:\s(.+)$/m';
+        }
 
-            $commandParams = [
-                self::PARAM_COMMAND => self::COMPOSER_SHOW,
-                self::PARAM_PACKAGE => $package,
-                self::PARAM_AVAILABLE => true
-            ];
+        return $this->getAvailableVersionsFromAllRepositories($package);
+    }
 
-            $applicationFactory = $this->objectManagerProvider->get()
-                ->get('Magento\Framework\Composer\MagentoComposerApplicationFactory');
-            /** @var \Magento\Composer\MagentoComposerApplication $application */
-            $application = $applicationFactory->create();
+    /**
+     * Get available versions of package by "composer show" command
+     *
+     * @param string $package
+     * @return array
+     * @exception \RuntimeException
+     */
+    private function getAvailableVersionsFromAllRepositories($package)
+    {
+        $versionsPattern = '/^versions\s*\:\s(.+)$/m';
 
-            $result = $application->runComposerCommand($commandParams);
-            $matches = [];
-            preg_match($versionsPattern, $result, $matches);
-            if (isset($matches[1])) {
-                return explode(', ', $matches[1]);
-            }
+        $commandParams = [
+            self::PARAM_COMMAND => self::COMPOSER_SHOW,
+            self::PARAM_PACKAGE => $package,
+            self::PARAM_AVAILABLE => true
+        ];
+
+        $applicationFactory = $this->objectManagerProvider->get()
+            ->get(\Magento\Framework\Composer\MagentoComposerApplicationFactory::class);
+        /** @var \Magento\Composer\MagentoComposerApplication $application */
+        $application = $applicationFactory->create();
+
+        $result = $application->runComposerCommand($commandParams);
+        $matches = [];
+        preg_match($versionsPattern, $result, $matches);
+        if (isset($matches[1])) {
+            return explode(', ', $matches[1]);
         }
 
         throw new \RuntimeException(

--- a/setup/src/Magento/Setup/Model/PackagesData.php
+++ b/setup/src/Magento/Setup/Model/PackagesData.php
@@ -326,31 +326,6 @@ class PackagesData
     }
 
     /**
-     * Filter packages by allowed types
-     *
-     * @param array $packages
-     * @return array
-     */
-    private function filterPackagesList(array $packages)
-    {
-        return array_filter(
-            $packages,
-            function ($item) {
-                return in_array(
-                    $item['package_type'],
-                    [
-                        \Magento\Setup\Model\Grid\TypeMapper::LANGUAGE_PACKAGE_TYPE,
-                        \Magento\Setup\Model\Grid\TypeMapper::MODULE_PACKAGE_TYPE,
-                        \Magento\Setup\Model\Grid\TypeMapper::EXTENSION_PACKAGE_TYPE,
-                        \Magento\Setup\Model\Grid\TypeMapper::THEME_PACKAGE_TYPE,
-                        \Magento\Setup\Model\Grid\TypeMapper::METAPACKAGE_PACKAGE_TYPE
-                    ]
-                );
-            }
-        );
-    }
-
-    /**
      * Get MetaPackage for package
      *
      * @param array $packages

--- a/setup/src/Magento/Setup/Test/Unit/Model/PackagesDataTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/PackagesDataTest.php
@@ -5,8 +5,10 @@
  */
 
 namespace Magento\Setup\Test\Unit\Model;
-
-use \Magento\Setup\Model\PackagesData;
+use Composer\Package\RootPackage;
+use Magento\Framework\Composer\ComposerInformation;
+use Magento\Setup\Model\PackagesData;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Tests Magento\Setup\Model\PackagesData

--- a/setup/src/Magento/Setup/Test/Unit/Model/PackagesDataTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/PackagesDataTest.php
@@ -18,47 +18,96 @@ class PackagesDataTest extends \PHPUnit_Framework_TestCase
      */
     private $packagesData;
 
+    /**
+     * @var ComposerInformation|MockObject
+     */
+    private $composerInformation;
+
+    /**
+     * @var \Magento\Setup\Model\DateTime\TimeZoneProvider|MockObject
+     */
+    private $timeZoneProvider;
+
+    /**
+     * @var \Magento\Setup\Model\PackagesAuth|MockObject
+     */
+    private $packagesAuth;
+
+    /**
+     * @var \Magento\Framework\Filesystem|MockObject
+     */
+    private $filesystem;
+
+    /**
+     * @var \Magento\Setup\Model\ObjectManagerProvider|MockObject
+     */
+    private $objectManagerProvider;
+
+    /**
+     * @var \Magento\Setup\Model\Grid\TypeMapper|MockObject
+     */
+    private $typeMapper;
+
     public function setUp()
     {
-        $composerInformation = $this->getMock('\Magento\Framework\Composer\ComposerInformation', [], [], '', false);
-        $composerInformation->expects($this->any())->method('getInstalledMagentoPackages')->willReturn(
-            [
-                ['name' => 'magento/package-1', 'type' => 'magento2-module', 'version'=> '1.0.0'],
-                ['name' => 'magento/package-2', 'type' => 'magento2-module', 'version'=> '1.0.1']
-            ]
-        );
-
-        $composerInformation->expects($this->any())->method('getRootRepositories')->willReturn(['repo1', 'repo2']);
-        $composerInformation->expects($this->any())->method('getPackagesTypes')->willReturn(['magento2-module']);
-        $timeZoneProvider = $this->getMock('\Magento\Setup\Model\DateTime\TimeZoneProvider', [], [], '', false);
-        $timeZone = $this->getMock('\Magento\Framework\Stdlib\DateTime\Timezone', [], [], '', false);
-        $timeZoneProvider->expects($this->any())->method('get')->willReturn($timeZone);
-        $packagesAuth = $this->getMock('\Magento\Setup\Model\PackagesAuth', [], [], '', false);
-        $filesystem = $this->getMock('\Magento\Framework\Filesystem', [], [], '', false);
-        $objectManagerProvider = $this->getMock('\Magento\Setup\Model\ObjectManagerProvider', [], [], '', false);
-        $objectManager = $this->getMockForAbstractClass('\Magento\Framework\ObjectManagerInterface');
-        $applicationFactory = $this->getMock(
-            '\Magento\Framework\Composer\MagentoComposerApplicationFactory',
-            [],
-            [],
-            '',
-            false
-        );
-        $application = $this->getMock('\Magento\Composer\MagentoComposerApplication', [], [], '', false);
+        $this->composerInformation = $this->getComposerInformation();
+        $this->timeZoneProvider = $this->getMockBuilder(\Magento\Setup\Model\DateTime\TimeZoneProvider::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $timeZone = $this->getMock(\Magento\Framework\Stdlib\DateTime\Timezone::class, [], [], '', false);
+        $this->timeZoneProvider->expects($this->any())->method('get')->willReturn($timeZone);
+        $this->packagesAuth = $this->getMock(\Magento\Setup\Model\PackagesAuth::class, [], [], '', false);
+        $this->filesystem = $this->getMock(\Magento\Framework\Filesystem::class, [], [], '', false);
+        $this->objectManagerProvider = $this->getMockBuilder(\Magento\Setup\Model\ObjectManagerProvider::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $objectManager = $this->getMockForAbstractClass(\Magento\Framework\ObjectManagerInterface::class);
+        $appFactory = $this->getMockBuilder(\Magento\Framework\Composer\MagentoComposerApplicationFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $application = $this->getMock(\Magento\Composer\MagentoComposerApplication::class, [], [], '', false);
         $application->expects($this->any())
             ->method('runComposerCommand')
-            ->willReturn('versions: 2.0.1');
-        $applicationFactory->expects($this->any())->method('create')->willReturn($application);
+            ->willReturnMap([
+                [
+                    [
+                        PackagesData::PARAM_COMMAND => PackagesData::COMPOSER_SHOW,
+                        PackagesData::PARAM_PACKAGE => 'magento/package-1',
+                        PackagesData::PARAM_AVAILABLE => true,
+                    ],
+                    null,
+                    'versions: 2.0.1'
+                ],
+                [
+                    [
+                        PackagesData::PARAM_COMMAND => PackagesData::COMPOSER_SHOW,
+                        PackagesData::PARAM_PACKAGE => 'magento/package-2',
+                        PackagesData::PARAM_AVAILABLE => true,
+                    ],
+                    null,
+                    'versions: 2.0.1'
+                ],
+                [
+                    [
+                        PackagesData::PARAM_COMMAND => PackagesData::COMPOSER_SHOW,
+                        PackagesData::PARAM_PACKAGE => 'partner/package-3',
+                        PackagesData::PARAM_AVAILABLE => true,
+                    ],
+                    null,
+                    'versions: 3.0.1'
+                ],
+            ]);
+        $appFactory->expects($this->any())->method('create')->willReturn($application);
         $objectManager->expects($this->any())
             ->method('get')
-            ->with('Magento\Framework\Composer\MagentoComposerApplicationFactory')
-            ->willReturn($applicationFactory);
-        $objectManagerProvider->expects($this->any())->method('get')->willReturn($objectManager);
+            ->with(\Magento\Framework\Composer\MagentoComposerApplicationFactory::class)
+            ->willReturn($appFactory);
+        $this->objectManagerProvider->expects($this->any())->method('get')->willReturn($objectManager);
 
-        $directoryWrite = $this->getMockForAbstractClass('\Magento\Framework\Filesystem\Directory\WriteInterface');
-        $directoryRead = $this->getMockForAbstractClass('\Magento\Framework\Filesystem\Directory\ReadInterface');
-        $filesystem->expects($this->any())->method('getDirectoryRead')->will($this->returnValue($directoryRead));
-        $filesystem->expects($this->any())
+        $directoryWrite = $this->getMockForAbstractClass(\Magento\Framework\Filesystem\Directory\WriteInterface::class);
+        $directoryRead = $this->getMockForAbstractClass(\Magento\Framework\Filesystem\Directory\ReadInterface::class);
+        $this->filesystem->expects($this->any())->method('getDirectoryRead')->will($this->returnValue($directoryRead));
+        $this->filesystem->expects($this->any())
             ->method('getDirectoryWrite')
             ->will($this->returnValue($directoryWrite));
         $directoryWrite->expects($this->any())->method('isExist')->willReturn(true);
@@ -84,13 +133,80 @@ class PackagesDataTest extends \PHPUnit_Framework_TestCase
                 . '}}}'
             );
 
+        $this->typeMapper = $this->getMockBuilder(\Magento\Setup\Model\Grid\TypeMapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->typeMapper->expects(static::any())
+            ->method('map')
+            ->willReturnMap([
+                [ComposerInformation::MODULE_PACKAGE_TYPE, \Magento\Setup\Model\Grid\TypeMapper::MODULE_PACKAGE_TYPE],
+            ]);
+
+        $this->createPackagesData();
+    }
+
+    private function createPackagesData()
+    {
         $this->packagesData = new PackagesData(
-            $composerInformation,
-            $timeZoneProvider,
-            $packagesAuth,
-            $filesystem,
-            $objectManagerProvider
+            $this->composerInformation,
+            $this->timeZoneProvider,
+            $this->packagesAuth,
+            $this->filesystem,
+            $this->objectManagerProvider,
+            $this->typeMapper
         );
+    }
+
+    /**
+     * @param array $requiredPackages
+     * @param array $installedPackages
+     * @param array $repo
+     * @return ComposerInformation|MockObject
+     */
+    private function getComposerInformation($requiredPackages = [], $installedPackages = [], $repo = [])
+    {
+        $composerInformation = $this->getMock(ComposerInformation::class, [], [], '', false);
+        $composerInformation->expects($this->any())->method('getInstalledMagentoPackages')->willReturn(
+            $installedPackages ?:
+            [
+                'magento/package-1' => [
+                    'name' => 'magento/package-1',
+                    'type' => 'magento2-module',
+                    'version'=> '1.0.0'
+                ],
+                'magento/package-2' => [
+                    'name' => 'magento/package-2',
+                    'type' => 'magento2-module',
+                    'version'=> '1.0.1'
+                ],
+                'partner/package-3' => [
+                    'name' => 'partner/package-3',
+                    'type' => 'magento2-module',
+                    'version'=> '3.0.0'
+                ],
+            ]
+        );
+
+        $composerInformation->expects($this->any())->method('getRootRepositories')
+            ->willReturn($repo ?: ['repo1', 'repo2']);
+        $composerInformation->expects($this->any())->method('getPackagesTypes')
+            ->willReturn(['magento2-module']);
+        $rootPackage = $this->getMock(RootPackage::class, [], ['magento/project', '2.1.0', '2']);
+        $rootPackage->expects($this->any())
+            ->method('getRequires')
+            ->willReturn(
+                $requiredPackages ?:
+                [
+                    'magento/package-1' => '1.0.0',
+                    'magento/package-2' => '1.0.1',
+                    'partner/package-3' => '3.0.0',
+                ]
+            );
+        $composerInformation->expects($this->any())
+            ->method('getRootPackage')
+            ->willReturn($rootPackage);
+
+        return $composerInformation;
     }
 
     public function testSyncPackagesData()
@@ -100,11 +216,69 @@ class PackagesDataTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $latestData['lastSyncDate']);
         $this->assertArrayHasKey('time', $latestData['lastSyncDate']);
         $this->assertArrayHasKey('packages', $latestData);
-        $this->assertSame(2, count($latestData['packages']));
-        $this->assertSame(2, $latestData['countOfUpdate']);
+        $this->assertSame(3, count($latestData['packages']));
+        $this->assertSame(3, $latestData['countOfUpdate']);
         $this->assertArrayHasKey('installPackages', $latestData);
         $this->assertSame(1, count($latestData['installPackages']));
         $this->assertSame(1, $latestData['countOfInstall']);
-
     }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Couldn't get available versions for package partner/package-4
+     */
+    public function testGetPackagesForUpdateWithException()
+    {
+        $requiredPackages = [
+            'partner/package-4' => '4.0.4',
+        ];
+        $installedPackages = [
+            'partner/package-4' => [
+                'name' => 'partner/package-4',
+                'type' => 'magento2-module',
+                'version'=> '4.0.4'
+            ],
+        ];
+        $this->composerInformation = $this->getComposerInformation($requiredPackages, $installedPackages);
+        $this->createPackagesData();
+        $this->packagesData->getPackagesForUpdate();
+    }
+
+    public function testPackagesForUpdateFromJson()
+    {
+        $this->composerInformation = $this->getComposerInformation([], [], ['https://repo1']);
+        $this->packagesAuth->expects($this->atLeastOnce())
+            ->method('getCredentialBaseUrl')
+            ->willReturn('repo1');
+        $this->createPackagesData();
+        $packages = $this->packagesData->getPackagesForUpdate();
+        $this->assertEquals(2, count($packages));
+        $this->assertArrayHasKey('magento/package-1', $packages);
+        $this->assertArrayHasKey('partner/package-3', $packages);
+        $firstPackage = array_values($packages)[0];
+        $this->assertArrayHasKey('latestVersion', $firstPackage);
+        $this->assertArrayHasKey('versions', $firstPackage);
+    }
+
+    public function testGetPackagesForUpdate()
+    {
+        $packages = $this->packagesData->getPackagesForUpdate();
+        $this->assertEquals(3, count($packages));
+        $this->assertArrayHasKey('magento/package-1', $packages);
+        $this->assertArrayHasKey('magento/package-2', $packages);
+        $this->assertArrayHasKey('partner/package-3', $packages);
+        $firstPackage = array_values($packages)[0];
+        $this->assertArrayHasKey('latestVersion', $firstPackage);
+        $this->assertArrayHasKey('versions', $firstPackage);
+    }
+
+    public function testGetInstalledPackages()
+    {
+        $installedPackages = $this->packagesData->getInstalledPackages();
+        $this->assertEquals(3, count($installedPackages));
+        $this->assertArrayHasKey('magento/package-1', $installedPackages);
+        $this->assertArrayHasKey('magento/package-2', $installedPackages);
+        $this->assertArrayHasKey('partner/package-3', $installedPackages);
+    }
+
 }

--- a/setup/src/Magento/Setup/Test/Unit/Model/PackagesDataTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/PackagesDataTest.php
@@ -5,10 +5,8 @@
  */
 
 namespace Magento\Setup\Test\Unit\Model;
-use Composer\Package\RootPackage;
-use Magento\Framework\Composer\ComposerInformation;
-use Magento\Setup\Model\PackagesData;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+use \Magento\Setup\Model\PackagesData;
 
 /**
  * Tests Magento\Setup\Model\PackagesData
@@ -20,96 +18,47 @@ class PackagesDataTest extends \PHPUnit_Framework_TestCase
      */
     private $packagesData;
 
-    /**
-     * @var ComposerInformation|MockObject
-     */
-    private $composerInformation;
-
-    /**
-     * @var \Magento\Setup\Model\DateTime\TimeZoneProvider|MockObject
-     */
-    private $timeZoneProvider;
-
-    /**
-     * @var \Magento\Setup\Model\PackagesAuth|MockObject
-     */
-    private $packagesAuth;
-
-    /**
-     * @var \Magento\Framework\Filesystem|MockObject
-     */
-    private $filesystem;
-
-    /**
-     * @var \Magento\Setup\Model\ObjectManagerProvider|MockObject
-     */
-    private $objectManagerProvider;
-
-    /**
-     * @var \Magento\Setup\Model\Grid\TypeMapper|MockObject
-     */
-    private $typeMapper;
-
     public function setUp()
     {
-        $this->composerInformation = $this->getComposerInformation();
-        $this->timeZoneProvider = $this->getMockBuilder(\Magento\Setup\Model\DateTime\TimeZoneProvider::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $timeZone = $this->getMock(\Magento\Framework\Stdlib\DateTime\Timezone::class, [], [], '', false);
-        $this->timeZoneProvider->expects($this->any())->method('get')->willReturn($timeZone);
-        $this->packagesAuth = $this->getMock(\Magento\Setup\Model\PackagesAuth::class, [], [], '', false);
-        $this->filesystem = $this->getMock(\Magento\Framework\Filesystem::class, [], [], '', false);
-        $this->objectManagerProvider = $this->getMockBuilder(\Magento\Setup\Model\ObjectManagerProvider::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $objectManager = $this->getMockForAbstractClass(\Magento\Framework\ObjectManagerInterface::class);
-        $appFactory = $this->getMockBuilder(\Magento\Framework\Composer\MagentoComposerApplicationFactory::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $application = $this->getMock(\Magento\Composer\MagentoComposerApplication::class, [], [], '', false);
+        $composerInformation = $this->getMock('\Magento\Framework\Composer\ComposerInformation', [], [], '', false);
+        $composerInformation->expects($this->any())->method('getInstalledMagentoPackages')->willReturn(
+            [
+                ['name' => 'magento/package-1', 'type' => 'magento2-module', 'version'=> '1.0.0'],
+                ['name' => 'magento/package-2', 'type' => 'magento2-module', 'version'=> '1.0.1']
+            ]
+        );
+
+        $composerInformation->expects($this->any())->method('getRootRepositories')->willReturn(['repo1', 'repo2']);
+        $composerInformation->expects($this->any())->method('getPackagesTypes')->willReturn(['magento2-module']);
+        $timeZoneProvider = $this->getMock('\Magento\Setup\Model\DateTime\TimeZoneProvider', [], [], '', false);
+        $timeZone = $this->getMock('\Magento\Framework\Stdlib\DateTime\Timezone', [], [], '', false);
+        $timeZoneProvider->expects($this->any())->method('get')->willReturn($timeZone);
+        $packagesAuth = $this->getMock('\Magento\Setup\Model\PackagesAuth', [], [], '', false);
+        $filesystem = $this->getMock('\Magento\Framework\Filesystem', [], [], '', false);
+        $objectManagerProvider = $this->getMock('\Magento\Setup\Model\ObjectManagerProvider', [], [], '', false);
+        $objectManager = $this->getMockForAbstractClass('\Magento\Framework\ObjectManagerInterface');
+        $applicationFactory = $this->getMock(
+            '\Magento\Framework\Composer\MagentoComposerApplicationFactory',
+            [],
+            [],
+            '',
+            false
+        );
+        $application = $this->getMock('\Magento\Composer\MagentoComposerApplication', [], [], '', false);
         $application->expects($this->any())
             ->method('runComposerCommand')
-            ->willReturnMap([
-                [
-                    [
-                        PackagesData::PARAM_COMMAND => PackagesData::COMPOSER_SHOW,
-                        PackagesData::PARAM_PACKAGE => 'magento/package-1',
-                        PackagesData::PARAM_AVAILABLE => true,
-                    ],
-                    null,
-                    'versions: 2.0.1'
-                ],
-                [
-                    [
-                        PackagesData::PARAM_COMMAND => PackagesData::COMPOSER_SHOW,
-                        PackagesData::PARAM_PACKAGE => 'magento/package-2',
-                        PackagesData::PARAM_AVAILABLE => true,
-                    ],
-                    null,
-                    'versions: 2.0.1'
-                ],
-                [
-                    [
-                        PackagesData::PARAM_COMMAND => PackagesData::COMPOSER_SHOW,
-                        PackagesData::PARAM_PACKAGE => 'partner/package-3',
-                        PackagesData::PARAM_AVAILABLE => true,
-                    ],
-                    null,
-                    'versions: 3.0.1'
-                ],
-            ]);
-        $appFactory->expects($this->any())->method('create')->willReturn($application);
+            ->willReturn('versions: 2.0.1');
+        $applicationFactory->expects($this->any())->method('create')->willReturn($application);
         $objectManager->expects($this->any())
             ->method('get')
-            ->with(\Magento\Framework\Composer\MagentoComposerApplicationFactory::class)
-            ->willReturn($appFactory);
-        $this->objectManagerProvider->expects($this->any())->method('get')->willReturn($objectManager);
+            ->with('Magento\Framework\Composer\MagentoComposerApplicationFactory')
+            ->willReturn($applicationFactory);
+        $objectManagerProvider->expects($this->any())->method('get')->willReturn($objectManager);
 
-        $directoryWrite = $this->getMockForAbstractClass(\Magento\Framework\Filesystem\Directory\WriteInterface::class);
-        $directoryRead = $this->getMockForAbstractClass(\Magento\Framework\Filesystem\Directory\ReadInterface::class);
-        $this->filesystem->expects($this->any())->method('getDirectoryRead')->will($this->returnValue($directoryRead));
-        $this->filesystem->expects($this->any())
+        $directoryWrite = $this->getMockForAbstractClass('\Magento\Framework\Filesystem\Directory\WriteInterface');
+        $directoryRead = $this->getMockForAbstractClass('\Magento\Framework\Filesystem\Directory\ReadInterface');
+        $filesystem->expects($this->any())->method('getDirectoryRead')->will($this->returnValue($directoryRead));
+        $filesystem->expects($this->any())
             ->method('getDirectoryWrite')
             ->will($this->returnValue($directoryWrite));
         $directoryWrite->expects($this->any())->method('isExist')->willReturn(true);
@@ -135,80 +84,13 @@ class PackagesDataTest extends \PHPUnit_Framework_TestCase
                 . '}}}'
             );
 
-        $this->typeMapper = $this->getMockBuilder(\Magento\Setup\Model\Grid\TypeMapper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->typeMapper->expects(static::any())
-            ->method('map')
-            ->willReturnMap([
-                [ComposerInformation::MODULE_PACKAGE_TYPE, \Magento\Setup\Model\Grid\TypeMapper::MODULE_PACKAGE_TYPE],
-            ]);
-
-        $this->createPackagesData();
-    }
-
-    private function createPackagesData()
-    {
         $this->packagesData = new PackagesData(
-            $this->composerInformation,
-            $this->timeZoneProvider,
-            $this->packagesAuth,
-            $this->filesystem,
-            $this->objectManagerProvider,
-            $this->typeMapper
+            $composerInformation,
+            $timeZoneProvider,
+            $packagesAuth,
+            $filesystem,
+            $objectManagerProvider
         );
-    }
-
-    /**
-     * @param array $requiredPackages
-     * @param array $installedPackages
-     * @param array $repo
-     * @return ComposerInformation|MockObject
-     */
-    private function getComposerInformation($requiredPackages = [], $installedPackages = [], $repo = [])
-    {
-        $composerInformation = $this->getMock(ComposerInformation::class, [], [], '', false);
-        $composerInformation->expects($this->any())->method('getInstalledMagentoPackages')->willReturn(
-            $installedPackages ?:
-            [
-                'magento/package-1' => [
-                    'name' => 'magento/package-1',
-                    'type' => 'magento2-module',
-                    'version'=> '1.0.0'
-                ],
-                'magento/package-2' => [
-                    'name' => 'magento/package-2',
-                    'type' => 'magento2-module',
-                    'version'=> '1.0.1'
-                ],
-                'partner/package-3' => [
-                    'name' => 'partner/package-3',
-                    'type' => 'magento2-module',
-                    'version'=> '3.0.0'
-                ],
-            ]
-        );
-
-        $composerInformation->expects($this->any())->method('getRootRepositories')
-            ->willReturn($repo ?: ['repo1', 'repo2']);
-        $composerInformation->expects($this->any())->method('getPackagesTypes')
-            ->willReturn(['magento2-module']);
-        $rootPackage = $this->getMock(RootPackage::class, [], ['magento/project', '2.1.0', '2']);
-        $rootPackage->expects($this->any())
-            ->method('getRequires')
-            ->willReturn(
-                $requiredPackages ?:
-                [
-                    'magento/package-1' => '1.0.0',
-                    'magento/package-2' => '1.0.1',
-                    'partner/package-3' => '3.0.0',
-                ]
-            );
-        $composerInformation->expects($this->any())
-            ->method('getRootPackage')
-            ->willReturn($rootPackage);
-
-        return $composerInformation;
     }
 
     public function testSyncPackagesData()
@@ -218,69 +100,11 @@ class PackagesDataTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $latestData['lastSyncDate']);
         $this->assertArrayHasKey('time', $latestData['lastSyncDate']);
         $this->assertArrayHasKey('packages', $latestData);
-        $this->assertSame(3, count($latestData['packages']));
-        $this->assertSame(3, $latestData['countOfUpdate']);
+        $this->assertSame(2, count($latestData['packages']));
+        $this->assertSame(2, $latestData['countOfUpdate']);
         $this->assertArrayHasKey('installPackages', $latestData);
         $this->assertSame(1, count($latestData['installPackages']));
         $this->assertSame(1, $latestData['countOfInstall']);
-    }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Couldn't get available versions for package partner/package-4
-     */
-    public function testGetPackagesForUpdateWithException()
-    {
-        $requiredPackages = [
-            'partner/package-4' => '4.0.4',
-        ];
-        $installedPackages = [
-            'partner/package-4' => [
-                'name' => 'partner/package-4',
-                'type' => 'magento2-module',
-                'version'=> '4.0.4'
-            ],
-        ];
-        $this->composerInformation = $this->getComposerInformation($requiredPackages, $installedPackages);
-        $this->createPackagesData();
-        $this->packagesData->getPackagesForUpdate();
     }
-
-    public function testPackagesForUpdateFromJson()
-    {
-        $this->composerInformation = $this->getComposerInformation([], [], ['https://repo1']);
-        $this->packagesAuth->expects($this->atLeastOnce())
-            ->method('getCredentialBaseUrl')
-            ->willReturn('repo1');
-        $this->createPackagesData();
-        $packages = $this->packagesData->getPackagesForUpdate();
-        $this->assertEquals(2, count($packages));
-        $this->assertArrayHasKey('magento/package-1', $packages);
-        $this->assertArrayHasKey('partner/package-3', $packages);
-        $firstPackage = array_values($packages)[0];
-        $this->assertArrayHasKey('latestVersion', $firstPackage);
-        $this->assertArrayHasKey('versions', $firstPackage);
-    }
-
-    public function testGetPackagesForUpdate()
-    {
-        $packages = $this->packagesData->getPackagesForUpdate();
-        $this->assertEquals(3, count($packages));
-        $this->assertArrayHasKey('magento/package-1', $packages);
-        $this->assertArrayHasKey('magento/package-2', $packages);
-        $this->assertArrayHasKey('partner/package-3', $packages);
-        $firstPackage = array_values($packages)[0];
-        $this->assertArrayHasKey('latestVersion', $firstPackage);
-        $this->assertArrayHasKey('versions', $firstPackage);
-    }
-
-    public function testGetInstalledPackages()
-    {
-        $installedPackages = $this->packagesData->getInstalledPackages();
-        $this->assertEquals(3, count($installedPackages));
-        $this->assertArrayHasKey('magento/package-1', $installedPackages);
-        $this->assertArrayHasKey('magento/package-2', $installedPackages);
-        $this->assertArrayHasKey('partner/package-3', $installedPackages);
-    }
-
 }


### PR DESCRIPTION
### Description
Backport of issue MAGETWO-59256 for 2.1
Cherry picked commits from develop, rebased, and squashed. Then removed some code from farther up the branch to make compatible with 2.1
First time making a PR for this so if I need to make changes/fix let me know.

Commits from the develop branch:
- https://github.com/magento/magento2/commit/fc99447f6aa1abfc1003f4181cea916c1616ea9e
- https://github.com/magento/magento2/commit/a9697c672e371f4484bb6ab0307d59bc346e8625
- https://github.com/magento/magento2/commit/7352b7cc7616b4b0de0ee3109983ec64abb7ccd8
- https://github.com/magento/magento2/commit/e8712764a918c0814c789b57d892963ac63305c5
- https://github.com/magento/magento2/commit/01f1f42b2431c8ce0b23c260a1af0261c02cb81c
- https://github.com/magento/magento2/commit/e072d65045ce8a3063ce07a164a06f7d3c09b0ac

### Fixed Issues (if relevant)
1. magento/magento2#6718: Custom composer modules break Component Manager

### Manual testing scenarios
1. Ensure Magento Marketplace keys have been added to system manager
2. Require a module with composer (I used semaio/magento2-configimportexport)
3. Go to /setup/index.php#/component-grid
4. AJAX request to /setup/index.php/componentGrid/components no longer has an error

