### PR TITLE
Add missing payment info template for PDF generation

### DIFF
--- a/app/code/Magento/Payment/view/frontend/templates/info/pdf/default.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/info/pdf/default.phtml
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// @codingStandardsIgnoreFile
+/**
+ * @see \Magento\Payment\Block\Info
+ * @var \Magento\Payment\Block\Info $block
+ */
+?>
+<?php echo $block->escapeHtml($block->getMethod()->getTitle()); ?>{{pdf_row_separator}}
+
+<?php if ($specificInfo = $block->getSpecificInformation()):?>
+    <?php foreach ($specificInfo as $label => $value):?>
+        <?php echo $block->escapeHtml($label) ?>:
+        <?php echo $block->escapeHtml(implode(' ', $block->getValueAsArray($value)));?>
+        {{pdf_row_separator}}
+    <?php endforeach; ?>
+<?php endif;?>
+
+<?php echo $block->escapeHtml(implode('{{pdf_row_separator}}', $block->getChildPdfAsArray())); ?>


### PR DESCRIPTION
### Description
The adminhtml area contains a default template for all payment methods
which comes without an own payment info template.
If you generate a PDF by clicking the "Print PDF" button i.e. the
invoice generation you will see correct payment informations.
If you generate a PDF in frontend you have an empty payment info because
of the missing template. The info block is returning an empty string
instead.

### Manual testing scenarios
1. Create an order with "banktransfer" payment.
2. Add an order and attach a PDF invoice (i.e. with an own module)
3. Download the invoice. 
4. Payment info is empty

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
