### PR TITLE
Fixes regression bug introduced in Magento 2.1.6 where the layered navigation options are sometimes being cached using the wrong store id.

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/AbstractFrontend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/AbstractFrontend.php
@@ -13,6 +13,7 @@ namespace Magento\Eav\Model\Entity\Attribute\Frontend;
 
 use Magento\Framework\App\CacheInterface;
 use Magento\Store\Api\StoreResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Eav\Model\Cache\Type as CacheType;
 use Magento\Eav\Model\Entity\Attribute;
@@ -20,14 +21,21 @@ use Magento\Eav\Model\Entity\Attribute;
 abstract class AbstractFrontend implements \Magento\Eav\Model\Entity\Attribute\Frontend\FrontendInterface
 {
     /**
+     * Default cache tags values
+     * will be used if no values in the constructor provided
+     * @var array
+     */
+    private static $defaultCacheTags = [CacheType::CACHE_TAG, Attribute::CACHE_TAG];
+
+    /**
      * @var CacheInterface
      */
     private $cache;
 
     /**
-     * @var StoreResolverInterface
+     * @var StoreManagerInterface
      */
-    private $storeResolver;
+    private $storeManager;
 
     /**
      * @var array
@@ -51,21 +59,21 @@ abstract class AbstractFrontend implements \Magento\Eav\Model\Entity\Attribute\F
      * @param CacheInterface $cache
      * @param StoreResolverInterface $storeResolver
      * @param array $cacheTags
+     * @param StoreManagerInterface $storeManager
      * @codeCoverageIgnore
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         \Magento\Eav\Model\Entity\Attribute\Source\BooleanFactory $attrBooleanFactory,
         CacheInterface $cache = null,
         StoreResolverInterface $storeResolver = null,
-        array $cacheTags = [
-        CacheType::CACHE_TAG,
-        Attribute::CACHE_TAG,
-        ]
+        array $cacheTags = null,
+        StoreManagerInterface $storeManager = null
     ) {
         $this->_attrBooleanFactory = $attrBooleanFactory;
         $this->cache = $cache ?: ObjectManager::getInstance()->get(CacheInterface::class);
-        $this->storeResolver = $storeResolver ?: ObjectManager::getInstance()->get(StoreResolverInterface::class);
-        $this->cacheTags = $cacheTags;
+        $this->cacheTags = $cacheTags ?: self::$defaultCacheTags;
+        $this->storeManager = $storeManager ?: ObjectManager::getInstance()->get(StoreManagerInterface::class);
     }
 
     /**
@@ -252,7 +260,7 @@ abstract class AbstractFrontend implements \Magento\Eav\Model\Entity\Attribute\F
     {
         $cacheKey = 'attribute-navigation-option-' .
             $this->getAttribute()->getAttributeCode() . '-' .
-            $this->storeResolver->getCurrentStoreId();
+            $this->storeManager->getStore()->getId();
         $optionString = $this->cache->load($cacheKey);
         if (false === $optionString) {
             $options = $this->getAttribute()->getSource()->getAllOptions();


### PR DESCRIPTION
### Description
Fixes problem with layered navigation options being cached using the wrong store id.

This problem only exists on Magento 2.1.6, not on the develop branch.
The problem was introduced in https://github.com/magento/magento2/commit/67b5ff743a11449fe97d0fcf711be30df6ec878b

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/9679: Translation for layered navigation attribute option not working

### Manual testing scenarios
1. Set up a new Magento 2.1.6
2. Make sure you have 2 storeviews, I used the codes: 'en' and 'nl' (English and Dutch)
3. Go to Stores => Configuration => Web => Url Options and set 'Add Store Code to Urls' to 'Yes'
4. Create a new category, I used 'Test'
5. Open the 'Color' attribute and add 2 options:

| Admin | English | Dutch |
| ------ | ------- | ------ |
| Red | Red | Rood |
| Black | Black | Zwart |

6. Add the 'Color' attribute to the 'Default' attributeset
7. Create 2 products, assign them to the 'Test' category, make sure the first one has color 'Red' and the second one has color 'Black'
8. Reindex
9. Flush cache
10. **VERY IMPORTANT**: Do **NOT** use the storeswitcher on the frontend in the next steps
11. In the frontend, go the the test category in English: http(s)://mydomain/en/test.html
12. Check the color options, it will say: 'Red' and 'Black', good!
13. Now go to the test category in Dutch, directly using the url, not the storeswitcher: http(s)://mydomain/nl/test.html
14. Check the color options, it will say: 'Red' and 'Black', **not** good!
15. Flush the cache
16. Refresh the Dutch page
17. Check the color options, it will say: 'Rood' and 'Zwart', good!
18. Again, go to the English page using the url
19. Check the color options, it will say: 'Rood' and 'Zwart', **not** good!

### Discussion
This problem exists because the `$cacheKey` is using the default store id every time if you don't use the storeswitcher. So the wrong info is cached and being used from the cache in the above cases.

The bug happens, because the original code calls `$this->storeResolver->getCurrentStoreId()`, this function checks if either the url has a '___store=xxx' param or if a cookie named 'store' exists. If neither of these things exist, it will return the default store view id.
When you use the storeswitcher, it will set a cookie and the functionality will work. But what about visitors going to the url directly just after the cache was flushed? They will put the wrong info into the cache.

This PR targets the `2.1-develop` branch, as the `develop` branch hasn't gotten this MAGETWO-65484 feature yet, which is strange...

Inspiration of this PR came from this other PR, which fixes some similar issues: https://github.com/magento/magento2/pull/9429

Would be really great if this could get included in the next minor release, as this is a pretty important bug which should get fixed ASAP.

It might be a good idea if this functionality is covered by some kind of test.
I have almost 0 experience with writing tests, so I won't do this for now, if somebody else is willing to do this, be my guest :)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
