### PR TITLE
Cookie Restriction Mode Overlay should not be cached by Varnish #6455

### DIFF
--- a/app/code/Magento/Cookie/Helper/Cookie.php
+++ b/app/code/Magento/Cookie/Helper/Cookie.php
@@ -70,11 +70,22 @@ class Cookie extends \Magento\Framework\App\Helper\AbstractHelper
     public function isUserNotAllowSaveCookie()
     {
         $acceptedSaveCookiesWebsites = $this->_getAcceptedSaveCookiesWebsites();
+        return $this->isCookieRestrictionModeEnabled() &&
+            empty($acceptedSaveCookiesWebsites[$this->_website->getId()]);
+    }
+
+    /**
+     * Check if cookie restriction mode is enabled for this store
+     *
+     * @return bool
+     */
+    public function isCookieRestrictionModeEnabled()
+    {
         return $this->scopeConfig->getValue(
             self::XML_PATH_COOKIE_RESTRICTION,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $this->_currentStore
-        ) && empty($acceptedSaveCookiesWebsites[$this->_website->getId()]);
+        );
     }
 
     /**

--- a/app/code/Magento/Cookie/view/frontend/templates/html/notices.phtml
+++ b/app/code/Magento/Cookie/view/frontend/templates/html/notices.phtml
@@ -8,7 +8,7 @@
 
 /** @var \Magento\Cookie\Block\Html\Notices $block */
 ?>
-<?php if ($this->helper(\Magento\Cookie\Helper\Cookie::class)->isUserNotAllowSaveCookie()): ?>
+<?php if ($this->helper(\Magento\Cookie\Helper\Cookie::class)->isCookieRestrictionModeEnabled()): ?>
     <div role="alertdialog"
          tabindex="-1"
          class="message global cookie"


### PR DESCRIPTION
### Description
Changed user-dependend `isUserNotAllowSaveCookie` condition in notice.ptml to fix varnish caching issue #6455

The proposed solution for this problem is that alertinfo container is always present in dom, no matter what cookie data the user has set, it should only depend on the setting if cookie restriction mode is enabled.

### Fixed Issues (if relevant)
1. magento/magento2#6455

### Manual testing scenarios
Follow steps in issue #6455 