### PR TITLE
Customer with unique attribute can't be saved #7844

### DIFF
--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Validate.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Validate.php
@@ -45,7 +45,7 @@ class Validate extends \Magento\Customer\Controller\Adminhtml\Index
                 \Magento\Customer\Api\Data\CustomerInterface::class
             );
             $submittedData = $this->getRequest()->getParam('customer');
-            if (array_key_exists('entity_id', $submittedData)) {
+            if (isset($submittedData['entity_id'])) {
                 $entity_id = $submittedData['entity_id'];
                 $customer->setId($entity_id);
             }

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Validate.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Validate.php
@@ -44,6 +44,11 @@ class Validate extends \Magento\Customer\Controller\Adminhtml\Index
                 $data,
                 \Magento\Customer\Api\Data\CustomerInterface::class
             );
+            $submittedData = $this->getRequest()->getParam('customer');
+            if (array_key_exists('entity_id', $submittedData)) {
+                $entity_id = $submittedData['entity_id'];
+                $customer->setId($entity_id);
+            }
             $errors = $this->customerAccountManagement->validate($customer)->getMessages();
         } catch (\Magento\Framework\Validator\Exception $exception) {
             /* @var $error Error */

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/ValidateTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/ValidateTest.php
@@ -101,7 +101,7 @@ class ValidateTest extends \PHPUnit_Framework_TestCase
             false,
             true,
             true,
-            ['getPost']
+            ['getPost', 'getParam']
         );
         $this->response = $this->getMockForAbstractClass(
             \Magento\Framework\App\ResponseInterface::class,
@@ -169,6 +169,17 @@ class ValidateTest extends \PHPUnit_Framework_TestCase
                 '_template_' => null,
                 'address_index' => null
             ]);
+        $customerEntityId = 2;
+        $this->request->expects($this->once())
+            ->method('getParam')
+            ->with('customer')
+            ->willReturn([
+                'entity_id' => $customerEntityId
+            ]);
+
+        $this->customer->expects($this->once())
+            ->method('setId')
+            ->with($customerEntityId);
 
         $this->form->expects($this->once())->method('setInvisibleIgnored');
         $this->form->expects($this->atLeastOnce())->method('extractData')->willReturn([]);
@@ -266,6 +277,49 @@ class ValidateTest extends \PHPUnit_Framework_TestCase
         $validationResult->expects($this->once())
             ->method('getMessages')
             ->willThrowException($exception);
+
+        $this->customerAccountManagement->expects($this->once())
+            ->method('validate')
+            ->willReturn($validationResult);
+
+        $this->controller->execute();
+    }
+
+    public function testExecuteWithNewCustomerAndNoEntityId()
+    {
+        $this->request->expects($this->once())
+            ->method('getPost')
+            ->willReturn([
+                '_template_' => null,
+                'address_index' => null
+            ]);
+        $this->request->expects($this->once())
+            ->method('getParam')
+            ->with('customer')
+            ->willReturn([]);
+
+        $this->customer->expects($this->never())
+            ->method('setId');
+
+        $this->form->expects($this->once())->method('setInvisibleIgnored');
+        $this->form->expects($this->atLeastOnce())->method('extractData')->willReturn([]);
+
+        $error = $this->getMock(\Magento\Framework\Message\Error::class, [], [], '', false);
+        $this->form->expects($this->once())
+            ->method('validateData')
+            ->willReturn([$error]);
+
+        $validationResult = $this->getMockForAbstractClass(
+            \Magento\Customer\Api\Data\ValidationResultsInterface::class,
+            [],
+            '',
+            false,
+            true,
+            true
+        );
+        $validationResult->expects($this->once())
+            ->method('getMessages')
+            ->willReturn(['Error message']);
 
         $this->customerAccountManagement->expects($this->once())
             ->method('validate')


### PR DESCRIPTION
### Description
Added the missing entity id of customer to validation process of customer (unique attribute) before saving it.

### Fixed Issues (if relevant)
1. magento/magento2#7844

### Manual testing scenarios
See "Steps to reproduce" of #7844
