### PR TITLE
stringify cookie value to fix Google Analyitcs Tracking and Cookie Overlay #5596

### DIFF
--- a/app/code/Magento/Cookie/view/frontend/web/js/notices.js
+++ b/app/code/Magento/Cookie/view/frontend/web/js/notices.js
@@ -24,7 +24,7 @@ define([
             $(this.options.cookieAllowButtonSelector).on('click', $.proxy(function () {
                 var cookieExpires = new Date(new Date().getTime() + this.options.cookieLifetime * 1000);
 
-                $.mage.cookies.set(this.options.cookieName, this.options.cookieValue, {
+                $.mage.cookies.set(this.options.cookieName, JSON.stringify(this.options.cookieValue), {
                     expires: cookieExpires
                 });
 


### PR DESCRIPTION
### Description

There seems to be a problem  in `module-cookie/view/frontend/web/js/notices.js`. After confirming the cookie restriction dialog, the value "[object Object]" gets saved, which cannot be evaluated anymore in  `_getAcceptedSaveCookiesWebsites` in `module-cookie/Helper/Cookie.php`

### Fixed Issues (if relevant)
1. magento/magento2#5596: Google Universal Analytics does not track when Cookie Restriction is enabled
2. magento/magento2#6441: Cookie Restriction Mode Overlay should not be cached by Varnish

### Manual testing scenarios
![auswahl_052](https://cloud.githubusercontent.com/assets/584644/18165703/18d794ae-7047-11e6-99f1-fa2d0f27c035.png)
![auswahl_053](https://cloud.githubusercontent.com/assets/584644/18165705/1e683af4-7047-11e6-8ca9-7a2b83d1f8d6.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
