### PR TITLE
Can't delete last item in cart if Minimum Order is Enable #6151

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -140,7 +140,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
     /**
      * @var \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage
      */
-    private $minimumAmountErrorMessage;
+    private $minimumAmountMessage;
 
     /**
      * @param EventManager $eventManager
@@ -163,7 +163,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Customer\Api\AccountManagementInterface $accountManagement
      * @param QuoteFactory $quoteFactory
-     * @param Quote\Validator\MinimumOrderAmount\ValidationMessage $minimumAmountErrorMessage
+     * @param Quote\Validator\MinimumOrderAmount\ValidationMessage $minimumAmountMessage
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -187,7 +187,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         \Magento\Customer\Model\Session $customerSession,
         \Magento\Customer\Api\AccountManagementInterface $accountManagement,
         \Magento\Quote\Model\QuoteFactory $quoteFactory,
-        \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage $minimumAmountErrorMessage
+        \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage $minimumAmountMessage = null
     ) {
         $this->eventManager = $eventManager;
         $this->quoteValidator = $quoteValidator;
@@ -209,7 +209,8 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         $this->accountManagement = $accountManagement;
         $this->customerSession = $customerSession;
         $this->quoteFactory = $quoteFactory;
-        $this->minimumAmountErrorMessage = $minimumAmountErrorMessage;
+        $this->minimumAmountMessage = $minimumAmountMessage ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage::class);
     }
 
     /**
@@ -330,7 +331,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
     {
         $quote = $this->quoteRepository->getActive($cartId);
         if (!$quote->validateMinimumAmount($quote->getIsMultiShipping())) {
-            throw new InputException($this->minimumAmountErrorMessage->getMessage());
+            throw new InputException($this->minimumAmountMessage->getMessage());
         }
 
         if ($paymentMethod) {

--- a/app/code/Magento/Quote/Model/ShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingAddressManagement.php
@@ -117,10 +117,6 @@ class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressM
         $address->setSaveInAddressBook($saveInAddressBook);
         $address->setCollectShippingRates(true);
 
-        if (!$quote->validateMinimumAmount($quote->getIsMultiShipping())) {
-            throw new InputException($this->getMinimumAmountErrorMessage()->getMessage());
-        }
-
         try {
             $address->save();
         } catch (\Exception $e) {

--- a/app/code/Magento/Quote/Model/ShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingAddressManagement.php
@@ -53,11 +53,6 @@ class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressM
     protected $totalsCollector;
 
     /**
-     * @var \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage
-     */
-    private $minimumAmountErrorMessage;
-
-    /**
      * @param \Magento\Quote\Api\CartRepositoryInterface $quoteRepository
      * @param QuoteAddressValidator $addressValidator
      * @param Logger $logger
@@ -140,20 +135,5 @@ class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressM
         }
         /** @var \Magento\Quote\Model\Quote\Address $address */
         return $quote->getShippingAddress();
-    }
-
-    /**
-     * @return \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage
-     * @deprecated
-     */
-    private function getMinimumAmountErrorMessage()
-    {
-        if ($this->minimumAmountErrorMessage === null) {
-            $objectManager = ObjectManager::getInstance();
-            $this->minimumAmountErrorMessage = $objectManager->get(
-                \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage::class
-            );
-        }
-        return $this->minimumAmountErrorMessage;
     }
 }

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
@@ -124,7 +124,7 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
     /**
      * @var \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage
      */
-    protected $minimumAmountErrorMessage;
+    private $minimumAmountMessage;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -256,7 +256,7 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
             false
         );
 
-        $this->minimumAmountErrorMessage = $this->getMock(
+        $this->minimumAmountMessage = $this->getMock(
             \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage::class,
             ['getMessage'],
             [],
@@ -288,7 +288,7 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
                 'customerSession' => $this->customerSessionMock,
                 'accountManagement' => $this->accountManagementMock,
                 'quoteFactory' => $this->quoteFactoryMock,
-                'minimumAmountErrorMessage' => $this->minimumAmountErrorMessage
+                'minimumAmountMessage' => $this->minimumAmountMessage
             ]
         );
 
@@ -724,7 +724,7 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
         $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(false);
         $this->quoteMock->expects($this->once())->method('validateMinimumAmount')->with(false)->willReturn(true);
 
-        $this->minimumAmountErrorMessage->expects($this->never())->method('getMessage');
+        $this->minimumAmountMessage->expects($this->never())->method('getMessage');
 
         $addressMock = $this->getMock(\Magento\Quote\Model\Quote\Address::class, ['getEmail'], [], '', false);
         $addressMock->expects($this->once())->method('getEmail')->willReturn($email);
@@ -760,7 +760,7 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
                 'customerSession' => $this->customerSessionMock,
                 'accountManagement' => $this->accountManagementMock,
                 'quoteFactory' => $this->quoteFactoryMock,
-                'minimumAmountErrorMessage' => $this->minimumAmountErrorMessage
+                'minimumAmountMessage' => $this->minimumAmountMessage
             ]
         );
         $orderMock = $this->getMock(
@@ -819,7 +819,7 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
                 'customerSession' => $this->customerSessionMock,
                 'accountManagement' => $this->accountManagementMock,
                 'quoteFactory' => $this->quoteFactoryMock,
-                'minimumAmountErrorMessage' => $this->minimumAmountErrorMessage
+                'minimumAmountMessage' => $this->minimumAmountMessage
             ]
         );
         $orderMock = $this->getMock(
@@ -854,7 +854,7 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
         $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(false);
         $this->quoteMock->expects($this->once())->method('validateMinimumAmount')->with(false)->willReturn(true);
 
-        $this->minimumAmountErrorMessage->expects($this->never())->method('getMessage');
+        $this->minimumAmountMessage->expects($this->never())->method('getMessage');
 
         $service->expects($this->once())->method('submit')->willReturn($orderMock);
 
@@ -894,7 +894,7 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
         $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(false);
         $this->quoteMock->expects($this->once())->method('validateMinimumAmount')->with(false)->willReturn(false);
 
-        $this->minimumAmountErrorMessage->expects($this->once())
+        $this->minimumAmountMessage->expects($this->once())
             ->method('getMessage')
             ->willReturn(__('Incorrect amount'));
 
@@ -928,7 +928,7 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
                 'customerSession' => $this->customerSessionMock,
                 'accountManagement' => $this->accountManagementMock,
                 'quoteFactory' => $this->quoteFactoryMock,
-                'minimumAmountErrorMessage' => $this->minimumAmountErrorMessage
+                'minimumAmountMessage' => $this->minimumAmountMessage
             ]
         );
 

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
@@ -122,6 +122,11 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
     protected $quoteMock;
 
     /**
+     * @var \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage
+     */
+    protected $minimumAmountErrorMessage;
+
+    /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $quoteIdMock;
@@ -218,6 +223,8 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
                 'setCustomerGroupId',
                 'assignCustomer',
                 'getPayment',
+                'getIsMultiShipping',
+                'validateMinimumAmount'
             ],
             [],
             '',
@@ -249,6 +256,14 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
             false
         );
 
+        $this->minimumAmountErrorMessage = $this->getMock(
+            \Magento\Quote\Model\Quote\Validator\MinimumOrderAmount\ValidationMessage::class,
+            ['getMessage'],
+            [],
+            '',
+            false
+        );
+
         $this->quoteFactoryMock = $this->getMock(\Magento\Quote\Model\QuoteFactory::class, ['create'], [], '', false);
         $this->model = $objectManager->getObject(
             \Magento\Quote\Model\QuoteManagement::class,
@@ -272,7 +287,8 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
                 'checkoutSession' => $this->checkoutSessionMock,
                 'customerSession' => $this->customerSessionMock,
                 'accountManagement' => $this->accountManagementMock,
-                'quoteFactory' => $this->quoteFactoryMock
+                'quoteFactory' => $this->quoteFactoryMock,
+                'minimumAmountErrorMessage' => $this->minimumAmountErrorMessage
             ]
         );
 
@@ -705,6 +721,10 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
             ->willReturn(\Magento\Checkout\Model\Type\Onepage::METHOD_GUEST);
         $this->quoteMock->expects($this->once())->method('setCustomerId')->with(null)->willReturnSelf();
         $this->quoteMock->expects($this->once())->method('setCustomerEmail')->with($email)->willReturnSelf();
+        $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(false);
+        $this->quoteMock->expects($this->once())->method('validateMinimumAmount')->with(false)->willReturn(true);
+
+        $this->minimumAmountErrorMessage->expects($this->never())->method('getMessage');
 
         $addressMock = $this->getMock(\Magento\Quote\Model\Quote\Address::class, ['getEmail'], [], '', false);
         $addressMock->expects($this->once())->method('getEmail')->willReturn($email);
@@ -739,7 +759,8 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
                 'checkoutSession' => $this->checkoutSessionMock,
                 'customerSession' => $this->customerSessionMock,
                 'accountManagement' => $this->accountManagementMock,
-                'quoteFactory' => $this->quoteFactoryMock
+                'quoteFactory' => $this->quoteFactoryMock,
+                'minimumAmountErrorMessage' => $this->minimumAmountErrorMessage
             ]
         );
         $orderMock = $this->getMock(
@@ -797,7 +818,8 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
                 'checkoutSession' => $this->checkoutSessionMock,
                 'customerSession' => $this->customerSessionMock,
                 'accountManagement' => $this->accountManagementMock,
-                'quoteFactory' => $this->quoteFactoryMock
+                'quoteFactory' => $this->quoteFactoryMock,
+                'minimumAmountErrorMessage' => $this->minimumAmountErrorMessage
             ]
         );
         $orderMock = $this->getMock(
@@ -829,6 +851,11 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
             ->method('setCustomerIsGuest')
             ->with(true);
 
+        $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(false);
+        $this->quoteMock->expects($this->once())->method('validateMinimumAmount')->with(false)->willReturn(true);
+
+        $this->minimumAmountErrorMessage->expects($this->never())->method('getMessage');
+
         $service->expects($this->once())->method('submit')->willReturn($orderMock);
 
         $this->quoteMock->expects($this->atLeastOnce())->method('getId')->willReturn($cartId);
@@ -854,6 +881,67 @@ class QuoteManagementTest extends \PHPUnit_Framework_TestCase
         $paymentMethod->expects($this->once())->method('getData')->willReturn(['additional_data' => []]);
 
         $this->assertEquals($orderId, $service->placeOrder($cartId, $paymentMethod));
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\InputException
+     * @expectedExceptionMessage Incorrect amount
+     */
+    public function testPlaceOrderWithViolationOfMinimumAmount()
+    {
+        $cartId = 323;
+
+        $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(false);
+        $this->quoteMock->expects($this->once())->method('validateMinimumAmount')->with(false)->willReturn(false);
+
+        $this->minimumAmountErrorMessage->expects($this->once())
+            ->method('getMessage')
+            ->willReturn(__('Incorrect amount'));
+
+        $this->quoteRepositoryMock->expects($this->once())
+            ->method('getActive')
+            ->with($cartId)
+            ->willReturn($this->quoteMock);
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Quote\Model\QuoteManagement $service */
+        $service = $this->getMock(
+            \Magento\Quote\Model\QuoteManagement::class,
+            ['submit'],
+            [
+                'eventManager' => $this->eventManager,
+                'quoteValidator' => $this->quoteValidator,
+                'orderFactory' => $this->orderFactory,
+                'orderManagement' => $this->orderManagement,
+                'customerManagement' => $this->customerManagement,
+                'quoteAddressToOrder' => $this->quoteAddressToOrder,
+                'quoteAddressToOrderAddress' => $this->quoteAddressToOrderAddress,
+                'quoteItemToOrderItem' => $this->quoteItemToOrderItem,
+                'quotePaymentToOrderPayment' => $this->quotePaymentToOrderPayment,
+                'userContext' => $this->userContextMock,
+                'quoteRepository' => $this->quoteRepositoryMock,
+                'customerRepository' => $this->customerRepositoryMock,
+                'customerModelFactory' => $this->customerFactoryMock,
+                'quoteAddressFactory' => $this->quoteAddressFactory,
+                'dataObjectHelper' => $this->dataObjectHelperMock,
+                'storeManager' => $this->storeManagerMock,
+                'checkoutSession' => $this->checkoutSessionMock,
+                'customerSession' => $this->customerSessionMock,
+                'accountManagement' => $this->accountManagementMock,
+                'quoteFactory' => $this->quoteFactoryMock,
+                'minimumAmountErrorMessage' => $this->minimumAmountErrorMessage
+            ]
+        );
+
+        $service->expects($this->never())->method('submit');
+
+        $paymentMethod = $this->getMock(
+            \Magento\Quote\Model\Quote\Payment::class,
+            [],
+            [],
+            '',
+            false
+        );
+        $service->placeOrder($cartId, $paymentMethod);
     }
 
     /**

--- a/app/code/Magento/Quote/Test/Unit/Model/ShippingAddressManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/ShippingAddressManagementTest.php
@@ -116,11 +116,6 @@ class ShippingAddressManagementTest extends \PHPUnit_Framework_TestCase
                 'addressRepository' => $this->addressRepository
             ]
         );
-        $this->objectManager->setBackwardCompatibleProperty(
-            $this->service,
-            'minimumAmountErrorMessage',
-            $this->amountErrorMessageMock
-        );
     }
 
     /**
@@ -190,8 +185,6 @@ class ShippingAddressManagementTest extends \PHPUnit_Framework_TestCase
             ->method('setCollectShippingRates')
             ->with(true)
             ->willReturnSelf();
-        $quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(false);
-        $quoteMock->expects($this->once())->method('validateMinimumAmount')->with(false)->willReturn(true);
 
         $this->quoteAddressMock->expects($this->once())->method('save')->willReturnSelf();
         $this->quoteAddressMock->expects($this->once())->method('getId')->will($this->returnValue($addressId));
@@ -277,70 +270,6 @@ class ShippingAddressManagementTest extends \PHPUnit_Framework_TestCase
             ->method('setCollectShippingRates')
             ->with(true)
             ->willReturnSelf();
-        $quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(false);
-        $quoteMock->expects($this->once())->method('validateMinimumAmount')->with(false)->willReturn(true);
-
-        $this->service->assign('cart867', $this->quoteAddressMock);
-    }
-
-    /**
-     * @expectedException \Magento\Framework\Exception\InputException
-     * @expectedExceptionMessage Incorrect amount
-     */
-    public function testSetAddressWithViolationOfMinimumAmount()
-    {
-        $customerAddressId = 150;
-
-        $quoteMock = $this->getMock(
-            \Magento\Quote\Model\Quote::class,
-            ['getIsMultiShipping', 'isVirtual', 'validateMinimumAmount', 'setShippingAddress', 'getShippingAddress'],
-            [],
-            '',
-            false
-        );
-        $this->quoteRepositoryMock->expects($this->once())
-            ->method('getActive')
-            ->with('cart867')
-            ->willReturn($quoteMock);
-        $quoteMock->expects($this->once())->method('isVirtual')->will($this->returnValue(false));
-        $quoteMock->expects($this->once())
-            ->method('setShippingAddress')
-            ->with($this->quoteAddressMock)
-            ->willReturnSelf();
-
-        $customerAddressMock = $this->getMock(\Magento\Customer\Api\Data\AddressInterface::class);
-
-        $this->addressRepository->expects($this->once())
-            ->method('getById')
-            ->with($customerAddressId)
-            ->willReturn($customerAddressMock);
-
-        $this->validatorMock->expects($this->once())->method('validate')
-            ->with($this->quoteAddressMock)
-            ->willReturn(true);
-
-        $this->quoteAddressMock->expects($this->once())->method('getSaveInAddressBook')->willReturn(1);
-        $this->quoteAddressMock->expects($this->once())->method('getSameAsBilling')->willReturn(1);
-        $this->quoteAddressMock->expects($this->once())->method('getCustomerAddressId')->willReturn($customerAddressId);
-
-        $quoteMock->expects($this->exactly(2))->method('getShippingAddress')->willReturn($this->quoteAddressMock);
-        $this->quoteAddressMock->expects($this->once())
-            ->method('importCustomerAddressData')
-            ->with($customerAddressMock)
-            ->willReturnSelf();
-
-        $this->quoteAddressMock->expects($this->once())->method('setSameAsBilling')->with(1)->willReturnSelf();
-        $this->quoteAddressMock->expects($this->once())->method('setSaveInAddressBook')->with(1)->willReturnSelf();
-        $this->quoteAddressMock->expects($this->once())
-            ->method('setCollectShippingRates')
-            ->with(true)
-            ->willReturnSelf();
-
-        $this->amountErrorMessageMock->expects($this->once())
-            ->method('getMessage')
-            ->willReturn(__('Incorrect amount'));
-        $quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(false);
-        $quoteMock->expects($this->once())->method('validateMinimumAmount')->with(false)->willReturn(false);
 
         $this->service->assign('cart867', $this->quoteAddressMock);
     }


### PR DESCRIPTION
### Description
During editing the cart (adding or removing products from cart) the minimum order amount (mam) will be checked. This caused that the last product could not be removed from cart. In this fix the validation of the mam is removed during editing the cart. The mam will checked later during checkout.

### Fixed Issues (if relevant)
1. magento/magento2#6151

### Manual testing scenarios
See steps to reproduce #6151:
1. Put item in cart
2. Go to admin -> SALES -> sales
3. Enable -> Minimum Order Amount
4. Minimum Amount = 10 or something
5. Remove item from cart
6. Expected result: cart is empty
