### PR TITLE
#4272: v2.0.4 Credit memos with adjustment fees cannot be fully refunded with a second credit memo

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -618,7 +618,12 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
          * for this we have additional diapason for 0
          * TotalPaid - contains amount, that were not rounded.
          */
-        if (abs($this->priceCurrency->round($this->getTotalPaid()) - $this->getTotalRefunded()) < .0001) {
+        $totalRefunded = $this->priceCurrency->round($this->getTotalPaid()) - $this->getTotalRefunded();
+        if (abs($totalRefunded) < .0001) {
+            return false;
+        }
+        // Case when Adjustment Fee (adjustment_negative) has been used for first creditmemo
+        if (abs($totalRefunded - $this->getAdjustmentNegative()) < .0001) {
             return false;
         }
 

--- a/app/code/Magento/Sales/Test/Unit/Model/OrderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/OrderTest.php
@@ -357,6 +357,34 @@ class OrderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->order->canCreditmemo());
     }
 
+    public function testCanNotCreditMemoWithAdjustmentNegative()
+    {
+        $totalPaid = 100;
+        $adjustmentNegative = 10;
+        $totalRefunded = 90;
+
+        $this->order->setTotalPaid($totalPaid);
+        $this->order->setTotalRefunded($totalRefunded);
+        $this->order->setAdjustmentNegative($adjustmentNegative);
+        $this->priceCurrency->expects($this->once())->method('round')->with($totalPaid)->willReturnArgument(0);
+        
+        $this->assertFalse($this->order->canCreditmemo());
+    }
+
+    public function testCanCreditMemoWithAdjustmentNegativeLowerThanTotalPaid()
+    {
+        $totalPaid = 100;
+        $adjustmentNegative = 9;
+        $totalRefunded = 90;
+
+        $this->order->setTotalPaid($totalPaid);
+        $this->order->setTotalRefunded($totalRefunded);
+        $this->order->setAdjustmentNegative($adjustmentNegative);
+        $this->priceCurrency->expects($this->once())->method('round')->with($totalPaid)->willReturnArgument(0);
+
+        $this->assertTrue($this->order->canCreditmemo());
+    }
+
     /**
      * @param string $state
      *


### PR DESCRIPTION
This is a bug fix for #4272 open issue reported. The problem reported to creditmemo and inability to create second creditmemo for same order in case Adjustment Fee has been used during creation of first creditmemo.

### Description
The problem reported in #4272 issue highlights the fact of having 0 (ZERO) Subtotal during creating second creditmemo. However this is by design, neither Adjustment Refund nor Adjustment Fee should in any way reflect modifications in Subtotal, Shipping and Tax Totals. 

Magento 2 documentation should be updated in order to highlight purpose of Adjustment Fee/Refund.

Adjustment Fee is used to subtract amount from the total amount refund. It is not subtracted from specific Total e.g. Shipping, Subtotal or Tax, it is additional amount on its own.

Adjustment Refund is used to add additional amount for the refund amount.

### Fixed Issues
1. magento/magento2#4272: v2.0.4 Credit memos with adjustment fees cannot be fully refunded with a second credit memo

### Manual testing scenarios
Pre-Setup scenario:
1. Install Magento latest develop version
2. Go to Admin side
3. Click "Stores > All Stores"
4. Click "Add new store view"
5. Enter name and code, set status "Enabled" and click "Save"
6. Click "Stores > Configuration"
7. In header side choose created Store View
8. Click "General > Currency Setup"
9. "Default Display Currency" set "British Pound Sterling"
10. "Allowed Currencies" set "British Pound Sterling" then click "Save"
11. Click "Stores > Currency rates"
12. In row GPB enter 0.6 and click "Save"

**Scenario 1**
1. Place order on "GB" store view"
2. Go to Admin side "Sales > Orders"
3. Receive Invoice and after that click "Credit Memo"
4. Scroll page down and enter in field "Adjustment Fee" 1$ then click "Refund"

Expected Result:
* Order marked as "Complete", there is no Credit Memo button for the Order.

**Scenario 2**
1. Login as a customer
2. Place order on "GB" store view"
3. Go to Admin side "Sales > Orders"
4. Receive Invoice and after that click "Credit Memo"
5. Scroll page down and enter in field "Adjustment Fee" 1$ then click "Refund"
6. Navigate to customer account -> order view  and observer Refunds tab.

Expected result:
* Totals shows refunded amount and Adjustment Fee 0.6 GPB.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
