### PR TITLE
use payment method name to make checkbox of agreements more unique #6207

### DIFF
--- a/app/code/Magento/CheckoutAgreements/view/frontend/web/js/view/checkout-agreements.js
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/web/js/view/checkout-agreements.js
@@ -48,20 +48,21 @@ define([
         /**
          * build a unique id for the term checkbox
          *
-         * @param {Object} ko context
-         * @param {Int} agreementId
+         * @param {Object} context - the ko context
+         * @param {Number} agreementId
          */
-        getCheckboxId: function(context, agreementId) {
-          var paymentMethodName = '';
-          // fetch corresponding payment method from parent context
-          var paymentMethodRenderer = context.$parents[1];
+        getCheckboxId: function (context, agreementId) {
+            var paymentMethodName = '',
+                paymentMethodRenderer = context.$parents[1];
 
-          if (paymentMethodRenderer) {
-            // item looks like this: {title: "Check / Money order", method: "checkmo"}
-            paymentMethodName = (paymentMethodRenderer.item) ?
-              paymentMethodRenderer.item.method : '';
-          }
-          return 'agreement_' + paymentMethodName + '_' + agreementId;
+            // corresponding payment method fetched from parent context
+            if (paymentMethodRenderer) {
+                // item looks like this: {title: "Check / Money order", method: "checkmo"}
+                paymentMethodName = paymentMethodRenderer.item ?
+                  paymentMethodRenderer.item.method : '';
+            }
+
+            return 'agreement_' + paymentMethodName + '_' + agreementId;
         },
 
         /**

--- a/app/code/Magento/CheckoutAgreements/view/frontend/web/js/view/checkout-agreements.js
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/web/js/view/checkout-agreements.js
@@ -46,6 +46,25 @@ define([
         },
 
         /**
+         * build a unique id for the term checkbox
+         *
+         * @param {Object} ko context
+         * @param {Int} agreementId
+         */
+        getCheckboxId: function(context, agreementId) {
+          var paymentMethodName = '';
+          // fetch corresponding payment method from parent context
+          var paymentMethodRenderer = context.$parents[1];
+
+          if (paymentMethodRenderer) {
+            // item looks like this: {title: "Check / Money order", method: "checkmo"}
+            paymentMethodName = (paymentMethodRenderer.item) ?
+              paymentMethodRenderer.item.method : '';
+          }
+          return 'agreement_' + paymentMethodName + '_' + agreementId;
+        },
+
+        /**
          * Init modal window for rendered element
          *
          * @param {Object} element

--- a/app/code/Magento/CheckoutAgreements/view/frontend/web/template/checkout/checkout-agreements.html
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/web/template/checkout/checkout-agreements.html
@@ -11,11 +11,11 @@
             <div class="checkout-agreement required">
                 <input type="checkbox" class="required-entry"
                        data-bind="attr: {
-                                    'id': 'agreement_' + agreementId,
+                                    'id': $parent.getCheckboxId($parentContext, agreementId),
                                     'name': 'agreement[' + agreementId + ']',
                                     'value': agreementId
                                     }"/>
-                <label data-bind="attr: {'for': 'agreement_' + agreementId}">
+                <label data-bind="attr: {'for': $parent.getCheckboxId($parentContext, agreementId)}">
                     <button type="button"
                             class="action action-show"
                             data-bind="click: function(data, event) { return $parent.showContent(data, event) }"


### PR DESCRIPTION
### Description
Currently, html id for agreement checkboxes are built using  

> 'id': 'agreement_' + agreementId,

But if you have more than one payment method enabled, these checkbox items appear multiple times and html id appears multiple times and is not unique anymore, which introduces some issues for css styling. 

![auswahl_103](https://cloud.githubusercontent.com/assets/584644/26282658/f0282512-3e15-11e7-8f07-8144f7411003.png)


Suggested fix is to use the method name of the current payment method for making this id more unique. However, the way of accessing the parent payment method through ko context parent seems ugly, any other idea, on how to do it?

### Fixed Issues (if relevant)
1. magento/magento2#6207

### Manual testing scenarios
See steps to reproduce in #6207

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
