### PR TITLE
ported fix from 237e54d - MAGETWO-55684: Fix XSD schema

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/layout_merged.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/layout_merged.xsd
@@ -7,6 +7,8 @@
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="urn:magento:framework:View/Layout/etc/elements.xsd"/>
+    <xs:include schemaLocation="urn:magento:framework:View/Layout/etc/head.xsd"/>
+    <xs:include schemaLocation="urn:magento:framework:View/Layout/etc/body.xsd"/>
 
     <xs:element name="layout">
         <xs:annotation>
@@ -20,29 +22,31 @@
             </xs:sequence>
         </xs:complexType>
         <xs:key name="handleName">
-            <xs:selector xpath="handle"></xs:selector>
-            <xs:field xpath="@id"></xs:field>
+            <xs:selector xpath="handle"/>
+            <xs:field xpath="@id"/>
         </xs:key>
     </xs:element>
 
-    <xs:element name="handle" type="handleType">
-        <xs:unique name="blockKey">
-            <xs:selector xpath=".//block"/>
-            <xs:field xpath="@name"/>
-        </xs:unique>
-        <xs:unique name="containerKey">
-            <xs:selector xpath=".//container"/>
-            <xs:field xpath="@name"/>
-        </xs:unique>
-        <xs:keyref name="blockReference" refer="blockKey">
-            <xs:selector xpath=".//referenceBlock"/>
-            <xs:field xpath="@name"/>
-        </xs:keyref>
-        <xs:keyref name="containerReference" refer="containerKey">
-            <xs:selector xpath=".//referenceContainer"/>
-            <xs:field xpath="@name"/>
-        </xs:keyref>
-    </xs:element>
+    <xs:element name="handle" type="handleType" />
+
+    <xs:complexType name="layoutType">
+        <xs:annotation>
+            <xs:documentation>
+                Layout Type definition
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="referenceContainer" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="container" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="update" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="remove" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="move" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="block" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="referenceBlock" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="body" type="bodyType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="head" type="headType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
+    </xs:complexType>
 
     <xs:complexType name="handleType">
         <xs:annotation>


### PR DESCRIPTION
Signed-off-by: Andre Flitsch <andre@pixelperfect.at>

Fixes the incorrect xsd in 2.1-develop which was fixed in develop

### Description
ported fix from 237e54d - MAGETWO-55684: Fix XSD schema

### Fixed Issues (if relevant)
1. magento/magento2#4731: developer mode throws an exception, but production mode is good
2. magento/magento2#7827: DOM schema validation error

### Manual testing scenarios
1. clear cache, reload home page, exception should not be generated in developer mode


