### PR TITLE
[BUGFIX][6244] Fix Issue with code label display in cart checkout.

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/quote.js
@@ -11,6 +11,16 @@ define([
 ], function (ko, _) {
     'use strict';
 
+    var proceedTotalsData = function (data) {
+        if (_.isObject(data) && _.isObject(data['extension_attributes'])) {
+            _.each(data['extension_attributes'], function (element, index) {
+                data[index] = element;
+            });
+        }
+
+        return data;
+    };
+
     var billingAddress = ko.observable(null),
         shippingAddress = ko.observable(null),
         shippingMethod = ko.observable(null),
@@ -19,7 +29,7 @@ define([
         basePriceFormat = window.checkoutConfig.basePriceFormat,
         priceFormat = window.checkoutConfig.priceFormat,
         storeCode = window.checkoutConfig.storeCode,
-        totalsData = window.checkoutConfig.totalsData,
+        totalsData = proceedTotalsData(window.checkoutConfig.totalsData),
         totals = ko.observable(totalsData),
         collectedTotals = ko.observable({});
 
@@ -78,11 +88,7 @@ define([
          * @param {Object} data
          */
         setTotals: function (data) {
-            if (_.isObject(data) && _.isObject(data['extension_attributes'])) {
-                _.each(data['extension_attributes'], function (element, index) {
-                    data[index] = element;
-                });
-            }
+            data = proceedTotalsData(data);
             totals(data);
             this.setCollectedTotals('subtotal_with_discount', parseFloat(data['subtotal_with_discount']));
         },

--- a/app/code/Magento/Quote/etc/extension_attributes.xml
+++ b/app/code/Magento/Quote/etc/extension_attributes.xml
@@ -9,4 +9,8 @@
     <extension_attributes for="Magento\Quote\Api\Data\CartInterface">
         <attribute code="shipping_assignments" type="Magento\Quote\Api\Data\ShippingAssignmentInterface[]" />
     </extension_attributes>
+
+    <extension_attributes for="Magento\Quote\Api\Data\TotalsInterface">
+        <attribute code="coupon_label" type="string" />
+    </extension_attributes>
 </config>

--- a/app/code/Magento/SalesRule/Plugin/CartTotalRepository.php
+++ b/app/code/Magento/SalesRule/Plugin/CartTotalRepository.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\SalesRule\Plugin;
+
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Class CartTotalRepository
+ * @package Magento\SalesRule\Plugin
+ */
+class CartTotalRepository
+{
+    /**
+     * @var \Magento\Quote\Api\Data\TotalsExtensionFactory
+     */
+    private $extensionFactory;
+
+    /**
+     * @var \Magento\SalesRule\Api\RuleRepositoryInterface
+     */
+    private $ruleRepository;
+
+    /**
+     * @var \Magento\SalesRule\Model\Coupon
+     */
+    private $coupon;
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * CartTotalRepository constructor.
+     * @param \Magento\Quote\Api\Data\TotalsExtensionFactory $extensionFactory
+     * @param \Magento\SalesRule\Api\RuleRepositoryInterface $ruleRepository
+     * @param \Magento\SalesRule\Model\Coupon $coupon
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        \Magento\Quote\Api\Data\TotalsExtensionFactory $extensionFactory,
+        \Magento\SalesRule\Api\RuleRepositoryInterface $ruleRepository,
+        \Magento\SalesRule\Model\Coupon $coupon,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->extensionFactory = $extensionFactory;
+        $this->ruleRepository = $ruleRepository;
+        $this->coupon = $coupon;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @param \Magento\Quote\Model\Cart\CartTotalRepository $subject
+     * @param \Magento\Quote\Api\Data\TotalsInterface $result
+     * @return \Magento\Quote\Api\Data\TotalsInterface
+     */
+    public function afterGet(
+        \Magento\Quote\Model\Cart\CartTotalRepository $subject,
+        \Magento\Quote\Api\Data\TotalsInterface $result
+    ) {
+        if ($result->getExtensionAttributes() === null) {
+            $extensionAttributes = $this->extensionFactory->create();
+            $result->setExtensionAttributes($extensionAttributes);
+        }
+
+        $extensionAttributes = $result->getExtensionAttributes();
+        $couponCode = $result->getCouponCode();
+
+        if (empty($couponCode)) {
+            return $result;
+        }
+
+        $this->coupon->loadByCode($couponCode);
+        $ruleId = $this->coupon->getRuleId();
+
+        if (empty($ruleId)) {
+            return $result;
+        }
+
+        $storeId = $this->storeManager->getStore()->getId();
+        $rule = $this->ruleRepository->getById($ruleId);
+
+        $storeLabel = $storeLabelFallback = null;
+
+        /* @var $label \Magento\SalesRule\Model\Data\RuleLabel */
+        foreach ($rule->getStoreLabels() as $label) {
+
+            if ($label->getStoreId() === 0) {
+                $storeLabelFallback = $label->getStoreLabel();
+            }
+
+            if ($label->getStoreId() == $storeId) {
+                $storeLabel = $label->getStoreLabel();
+                break;
+            }
+        }
+
+        $extensionAttributes->setCouponLabel(($storeLabel) ? $storeLabel : $storeLabelFallback);
+
+        $result->setExtensionAttributes($extensionAttributes);
+
+        return $result;
+    }
+}

--- a/app/code/Magento/SalesRule/etc/di.xml
+++ b/app/code/Magento/SalesRule/etc/di.xml
@@ -178,4 +178,8 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="\Magento\Quote\Model\Cart\CartTotalRepository">
+        <plugin name="coupon_label_plugin" type="Magento\SalesRule\Plugin\CartTotalRepository" />
+    </type>
 </config>

--- a/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/view/summary/discount.js
@@ -34,6 +34,17 @@ define([
         },
 
         /**
+         * @return {*}
+         */
+        getCouponLabel: function () {
+            if (!this.totals()) {
+                return null;
+            }
+
+            return this.totals()['coupon_label'];
+        },
+
+        /**
          * @return {Number}
          */
         getPureValue: function () {

--- a/app/code/Magento/SalesRule/view/frontend/web/template/cart/totals/discount.html
+++ b/app/code/Magento/SalesRule/view/frontend/web/template/cart/totals/discount.html
@@ -8,7 +8,7 @@
 <tr class="totals">
     <th colspan="1" style="" class="mark" scope="row">
         <span class="title" data-bind="text: title"></span>
-        <span class="discount coupon" data-bind="text: getCouponCode()"></span>
+        <span class="discount coupon" data-bind="text: getCouponLabel()"></span>
     </th>
     <td class="amount" data-bind="attr: {'data-th': title}">
         <span><span class="price" data-bind="text: getValue()"></span></span>


### PR DESCRIPTION
### Description
Create a extension_attribute for the cart total repository object to not overwrite its interface and keep backward compatibility, set a plugin to get the correct coupon label of the current store view and change the js/html logic to display the coupon label correctly 

### Fixed Issues (if relevant)
1. magento/magento2#6244: Promo code label not used

### Manual testing scenarios
1. Set a sales rule code with a name : My Sales Rule
2. Set a coupon code for this Sales Rule: mycouponcode 
3. Setting a default label : "Enjoy 20% discount"
4. Add a product to the cart in frontend
5. Go the cart page
6. Enter the coupon code "mycouponcode" 
7. Check the total summary if the "Enjoy 20% discount" label is displayed instead of the coupon code value.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
