### PR TITLE
Remove wrong '_setup' replace when getting DB connection (2)

### DIFF
--- a/lib/internal/Magento/Framework/App/ResourceConnection/Config.php
+++ b/lib/internal/Magento/Framework/App/ResourceConnection/Config.php
@@ -63,7 +63,7 @@ class Config extends \Magento\Framework\Config\Data\Scoped implements ConfigInte
     {
         $this->initConnections();
         $connectionName = \Magento\Framework\App\ResourceConnection::DEFAULT_CONNECTION;
-        
+ 
         if (!isset($this->_connectionNames[$resourceName])) {
             $resourcesConfig = $this->get();
             $pointerResourceName = $resourceName;

--- a/lib/internal/Magento/Framework/App/ResourceConnection/Config.php
+++ b/lib/internal/Magento/Framework/App/ResourceConnection/Config.php
@@ -63,9 +63,7 @@ class Config extends \Magento\Framework\Config\Data\Scoped implements ConfigInte
     {
         $this->initConnections();
         $connectionName = \Magento\Framework\App\ResourceConnection::DEFAULT_CONNECTION;
-
-        $resourceName = preg_replace("/_setup$/", '', $resourceName);
-
+        
         if (!isset($this->_connectionNames[$resourceName])) {
             $resourcesConfig = $this->get();
             $pointerResourceName = $resourceName;


### PR DESCRIPTION
### Description
I a second custom database into `etc/env.php` is added like that, it is not possible to get the database connection using `custom_setup` as `$resourceName`:

```php
array (
    'table_prefix' => '',
    'connection' => 
    array (
      'custom' => 
      array (
        'host' => 'localhost',
        'dbname' => '<db_custom>',
        'username' => '<user>',
        'password' => '<pass>',
        'engine' => 'innodb',
        'initStatements' => 'SET NAMES utf8;',
        'active' => '1',
      ),
      'default' => 
      array (
        'host' => 'localhost',
        'dbname' => '<db_default>',
        'username' => '<user>',
        'password' => '<pass>',
        'model' => 'mysql4',
        'engine' => 'innodb',
        'initStatements' => 'SET NAMES utf8;',
        'active' => '1',
      ),
    ),
  ),
  'resource' => 
  array (
    'custom_setup' => 
    array (
      'connection' => 'custom',
    ),
    'default_setup' => 
    array (
      'connection' => 'default',
    ),
  ),
```

After that I would expect to use the custom database by resource name `custom_setup`. However, as `_setup` is always replaced, the system does not find any resource with this name. Then, I need to use a different name without `_setup`. From my point of view, there is no need to replace that. In fact, the only reason why `default_setup` database works is because `default` connection is the fall back. When calling resource `default_setup` is also not found but it falls back to `default`.

What is exactly the purpose of replacing `_setup`? I checked the code and I do not see any need to have that.

### Fixed Issue
If a custom database resource contains '_setup', default is returned because `$resourceName` does not match after replacement

