### PR TITLE
Replace Zend_Json in the configurable product block test

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -200,7 +200,7 @@ class ConfigurableTest extends \PHPUnit_Framework_TestCase
             ]);
 
         $expectedArray = $this->getExpectedArray($productId, $amount, $priceQty, $percentage);
-        $expectedJson = \Zend_Json::encode($expectedArray);
+        $expectedJson = json_encode($expectedArray);
 
         $this->jsonEncoder->expects($this->once())
             ->method('encode')


### PR DESCRIPTION
Replace Zend_Json with just a basic json_encode in the configurable product block view test

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Since Zend1 is at EOL we should replace any usage of it's elements. For this case we are removing Zend_Json #9236

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
