### PR TITLE
Remove zend json from form elements

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/Editablemultiselect.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editablemultiselect.php
@@ -29,6 +29,7 @@ class Editablemultiselect extends \Magento\Framework\Data\Form\Element\Multisele
      * @param Escaper $escaper
      * @param array $data
      * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         Factory $factoryElement,
@@ -53,6 +54,7 @@ class Editablemultiselect extends \Magento\Framework\Data\Form\Element\Multisele
      * Retrieve HTML markup of the element
      *
      * @return string
+     * @throws \InvalidArgumentException
      */
     public function getElementHtml()
     {

--- a/lib/internal/Magento/Framework/Data/Form/Element/Editablemultiselect.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editablemultiselect.php
@@ -13,8 +13,35 @@
  */
 namespace Magento\Framework\Data\Form\Element;
 
+use Magento\Framework\Escaper;
+
 class Editablemultiselect extends \Magento\Framework\Data\Form\Element\Multiselect
 {
+    /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
+     * Editablemultiselect constructor.
+     * @param Factory $factoryElement
+     * @param CollectionFactory $factoryCollection
+     * @param Escaper $escaper
+     * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     */
+    public function __construct(
+        Factory $factoryElement,
+        CollectionFactory $factoryCollection,
+        Escaper $escaper,
+        array $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+    ) {
+        parent::__construct($factoryElement, $factoryCollection, $escaper, $data);
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
+    }
+
     /**
      * Name of the default JavaScript class that is used to make multiselect editable
      *
@@ -41,7 +68,7 @@ class Editablemultiselect extends \Magento\Framework\Data\Form\Element\Multisele
             $elementJsClass = $this->getData('element_js_class');
         }
 
-        $selectConfigJson = \Zend_Json::encode($selectConfig);
+        $selectConfigJson = $this->serializer->serialize($selectConfig);
         $jsObjectName = $this->getJsObjectName();
 
         // TODO: TaxRateEditableMultiselect should be moved to a static .js module.

--- a/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
@@ -16,16 +16,25 @@ use Magento\Framework\Escaper;
 class Editor extends Textarea
 {
     /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
+     * Editor constructor.
      * @param Factory $factoryElement
      * @param CollectionFactory $factoryCollection
      * @param Escaper $escaper
      * @param array $data
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @throws \RuntimeException
      */
     public function __construct(
         Factory $factoryElement,
         CollectionFactory $factoryCollection,
         Escaper $escaper,
-        $data = []
+        $data = [],
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
     ) {
         parent::__construct($factoryElement, $factoryCollection, $escaper, $data);
 
@@ -36,6 +45,9 @@ class Editor extends Textarea
             $this->setType('textarea');
             $this->setExtType('textarea');
         }
+
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
 
     /**
@@ -55,6 +67,7 @@ class Editor extends Textarea
     /**
      * @return string
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @throws \InvalidArgumentException
      */
     public function getElementHtml()
     {
@@ -141,7 +154,7 @@ class Editor extends Textarea
                 ' = new tinyMceWysiwygSetup("' .
                 $this->getHtmlId() .
                 '", ' .
-                \Zend_Json::encode(
+                $this->serializer->serialize(
                     $this->getConfig()
                 ) .
                 ');' .
@@ -180,7 +193,7 @@ class Editor extends Textarea
                     //<![CDATA[
                     require(["jquery", "mage/translate", "mage/adminhtml/wysiwyg/widget"], function(jQuery){
                         (function($) {
-                            $.mage.translate.add(' . \Zend_Json::encode($this->getButtonTranslations()) . ')
+                            $.mage.translate.add(' . $this->serializer->serialize($this->getButtonTranslations()) . ')
                         })(jQuery);
                     });
                     //]]>
@@ -425,7 +438,7 @@ class Editor extends Textarea
      * Translate string using defined helper
      *
      * @param string $string String to be translated
-     * @return \Magento\Framework\Phrase
+     * @return string
      */
     public function translate($string)
     {

--- a/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
@@ -45,7 +45,6 @@ class Editor extends Textarea
             $this->setType('textarea');
             $this->setExtType('textarea');
         }
-
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Framework\Serialize\Serializer\Json::class);
     }
@@ -65,9 +64,23 @@ class Editor extends Textarea
     }
 
     /**
+     * @return bool|string
+     * @throws \InvalidArgumentException
+     */
+    private function getJsonConfig()
+    {
+        if (is_object($this->getConfig()) && method_exists($this->getConfig(), 'toJson')) {
+            return $this->getConfig()->toJson();
+        } else {
+            return $this->serializer->serialize(
+                $this->getConfig()
+            );
+        }
+    }
+
+    /**
      * @return string
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
-     * @throws \InvalidArgumentException
      */
     public function getElementHtml()
     {
@@ -145,7 +158,7 @@ class Editor extends Textarea
                 ], function(jQuery){' .
                 "\n" .
                 '  (function($) {$.mage.translate.add(' .
-                \Zend_Json::encode(
+                $this->serializer->serialize(
                     $this->getButtonTranslations()
                 ) .
                 ')})(jQuery);' .
@@ -154,9 +167,7 @@ class Editor extends Textarea
                 ' = new tinyMceWysiwygSetup("' .
                 $this->getHtmlId() .
                 '", ' .
-                $this->serializer->serialize(
-                    $this->getConfig()
-                ) .
+                $this->getJsonConfig() .
                 ');' .
                 $forceLoad .
                 '
@@ -438,7 +449,7 @@ class Editor extends Textarea
      * Translate string using defined helper
      *
      * @param string $string String to be translated
-     * @return string
+     * @return \Magento\Framework\Phrase
      */
     public function translate($string)
     {


### PR DESCRIPTION
Replace Zend_Json with just a basic json_encode in the configurable product block view test

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Since Zend1 is at EOL we should replace any usage of it's elements. For this case we are removing Zend_Json #9236

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9236: Upgrade ZF components. Zend_Json

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
