### PR TITLE
Make Sales' emails $transport changeable from an observer

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Sender/EmailSender.php
@@ -7,6 +7,7 @@ namespace Magento\Sales\Model\Order\Creditmemo\Sender;
 
 use Magento\Sales\Model\Order\Email\Sender;
 use Magento\Sales\Model\Order\Creditmemo\SenderInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Email notification sender for Creditmemo.
@@ -106,13 +107,14 @@ class EmailSender extends Sender implements SenderInterface
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
             ];
+            $transport = new DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_creditmemo_set_template_vars_before',
                 ['sender' => $this, 'transport' => $transport]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transport->getData());
 
             if ($this->checkAndSend($order)) {
                 $creditmemo->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoCommentSender.php
@@ -71,13 +71,14 @@ class CreditmemoCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
+        $transport = new \Magento\Framework\DataObject($transport);
 
         $this->eventManager->dispatch(
             'email_creditmemo_comment_set_template_vars_before',
             ['sender' => $this, 'transport' => $transport]
         );
 
-        $this->templateContainer->setTemplateVars($transport);
+        $this->templateContainer->setTemplateVars($transport->getData());
 
         return $this->checkAndSend($order, $notify);
     }

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoCommentSender.php
@@ -12,6 +12,7 @@ use Magento\Sales\Model\Order\Email\Container\Template;
 use Magento\Sales\Model\Order\Email\NotifySender;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class CreditmemoCommentSender
@@ -71,7 +72,7 @@ class CreditmemoCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
-        $transport = new \Magento\Framework\DataObject($transport);
+        $transport = new DataObject($transport);
 
         $this->eventManager->dispatch(
             'email_creditmemo_comment_set_template_vars_before',

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoSender.php
@@ -14,6 +14,7 @@ use Magento\Sales\Model\Order\Email\Sender;
 use Magento\Sales\Model\ResourceModel\Order\Creditmemo as CreditmemoResource;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class CreditmemoSender
@@ -113,7 +114,7 @@ class CreditmemoSender extends Sender
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
             ];
-            $transport = new \Magento\Framework\DataObject($transport);
+            $transport = new DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_creditmemo_set_template_vars_before',

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoSender.php
@@ -113,13 +113,14 @@ class CreditmemoSender extends Sender
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_creditmemo_set_template_vars_before',
                 ['sender' => $this, 'transport' => $transport]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transport->getData());
 
             if ($this->checkAndSend($order)) {
                 $creditmemo->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceCommentSender.php
@@ -12,6 +12,7 @@ use Magento\Sales\Model\Order\Email\NotifySender;
 use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class InvoiceCommentSender
@@ -71,7 +72,7 @@ class InvoiceCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
-        $transport = new \Magento\Framework\DataObject($transport);
+        $transport = new DataObject($transport);
 
         $this->eventManager->dispatch(
             'email_invoice_comment_set_template_vars_before',

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceCommentSender.php
@@ -71,13 +71,14 @@ class InvoiceCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
+        $transport = new \Magento\Framework\DataObject($transport);
 
         $this->eventManager->dispatch(
             'email_invoice_comment_set_template_vars_before',
             ['sender' => $this, 'transport' => $transport]
         );
 
-        $this->templateContainer->setTemplateVars($transport);
+        $this->templateContainer->setTemplateVars($transport->getData());
 
         return $this->checkAndSend($order, $notify);
     }

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php
@@ -113,13 +113,14 @@ class InvoiceSender extends Sender
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order)
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_invoice_set_template_vars_before',
                 ['sender' => $this, 'transport' => $transport]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transport->getData());
 
             if ($this->checkAndSend($order)) {
                 $invoice->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php
@@ -14,6 +14,7 @@ use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\ResourceModel\Order\Invoice as InvoiceResource;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class InvoiceSender
@@ -113,7 +114,7 @@ class InvoiceSender extends Sender
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order)
             ];
-            $transport = new \Magento\Framework\DataObject($transport);
+            $transport = new DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_invoice_set_template_vars_before',

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderCommentSender.php
@@ -68,13 +68,14 @@ class OrderCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
+        $transport = new \Magento\Framework\DataObject($transport);
 
         $this->eventManager->dispatch(
             'email_order_comment_set_template_vars_before',
             ['sender' => $this, 'transport' => $transport]
         );
 
-        $this->templateContainer->setTemplateVars($transport);
+        $this->templateContainer->setTemplateVars($transport->getData());
 
         return $this->checkAndSend($order, $notify);
     }

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderCommentSender.php
@@ -11,6 +11,7 @@ use Magento\Sales\Model\Order\Email\Container\Template;
 use Magento\Sales\Model\Order\Email\NotifySender;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class OrderCommentSender
@@ -68,7 +69,7 @@ class OrderCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
-        $transport = new \Magento\Framework\DataObject($transport);
+        $transport = new DataObject($transport);
 
         $this->eventManager->dispatch(
             'email_order_comment_set_template_vars_before',

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
@@ -13,6 +13,7 @@ use Magento\Sales\Model\Order\Email\Sender;
 use Magento\Sales\Model\ResourceModel\Order as OrderResource;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class OrderSender
@@ -130,7 +131,7 @@ class OrderSender extends Sender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
-        $transport = new \Magento\Framework\DataObject($transport);
+        $transport = new DataObject($transport);
 
         $this->eventManager->dispatch(
             'email_order_set_template_vars_before',

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentCommentSender.php
@@ -12,6 +12,7 @@ use Magento\Sales\Model\Order\Email\NotifySender;
 use Magento\Sales\Model\Order\Shipment;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class ShipmentCommentSender
@@ -71,7 +72,7 @@ class ShipmentCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
-        $transport = new \Magento\Framework\DataObject($transport);
+        $transport = new DataObject($transport);
 
         $this->eventManager->dispatch(
             'email_shipment_comment_set_template_vars_before',

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentCommentSender.php
@@ -71,13 +71,14 @@ class ShipmentCommentSender extends NotifySender
             'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
             'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
         ];
+        $transport = new \Magento\Framework\DataObject($transport);
 
         $this->eventManager->dispatch(
             'email_shipment_comment_set_template_vars_before',
             ['sender' => $this, 'transport' => $transport]
         );
 
-        $this->templateContainer->setTemplateVars($transport);
+        $this->templateContainer->setTemplateVars($transport->getData());
 
         return $this->checkAndSend($order, $notify);
     }

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentSender.php
@@ -113,13 +113,14 @@ class ShipmentSender extends Sender
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order)
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_shipment_set_template_vars_before',
                 ['sender' => $this, 'transport' => $transport]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transport->getData());
 
             if ($this->checkAndSend($order)) {
                 $shipment->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentSender.php
@@ -14,6 +14,7 @@ use Magento\Sales\Model\Order\Shipment;
 use Magento\Sales\Model\ResourceModel\Order\Shipment as ShipmentResource;
 use Magento\Sales\Model\Order\Address\Renderer;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Class ShipmentSender
@@ -113,7 +114,7 @@ class ShipmentSender extends Sender
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order)
             ];
-            $transport = new \Magento\Framework\DataObject($transport);
+            $transport = new DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_shipment_set_template_vars_before',

--- a/app/code/Magento/Sales/Model/Order/Invoice/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Sender/EmailSender.php
@@ -106,13 +106,14 @@ class EmailSender extends Sender implements SenderInterface
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_invoice_set_template_vars_before',
                 ['sender' => $this, 'transport' => $transport]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transport->getData());
 
             if ($this->checkAndSend($order)) {
                 $invoice->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Invoice/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Sender/EmailSender.php
@@ -7,6 +7,7 @@ namespace Magento\Sales\Model\Order\Invoice\Sender;
 
 use Magento\Sales\Model\Order\Email\Sender;
 use Magento\Sales\Model\Order\Invoice\SenderInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Email notification sender for Invoice.
@@ -106,7 +107,7 @@ class EmailSender extends Sender implements SenderInterface
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order),
             ];
-            $transport = new \Magento\Framework\DataObject($transport);
+            $transport = new DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_invoice_set_template_vars_before',

--- a/app/code/Magento/Sales/Model/Order/Shipment/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Sender/EmailSender.php
@@ -106,13 +106,14 @@ class EmailSender extends Sender implements SenderInterface
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order)
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_shipment_set_template_vars_before',
                 ['sender' => $this, 'transport' => $transport]
             );
 
-            $this->templateContainer->setTemplateVars($transport);
+            $this->templateContainer->setTemplateVars($transport->getData());
 
             if ($this->checkAndSend($order)) {
                 $shipment->setEmailSent(true);

--- a/app/code/Magento/Sales/Model/Order/Shipment/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Sender/EmailSender.php
@@ -7,6 +7,7 @@ namespace Magento\Sales\Model\Order\Shipment\Sender;
 
 use Magento\Sales\Model\Order\Email\Sender;
 use Magento\Sales\Model\Order\Shipment\SenderInterface;
+use Magento\Framework\DataObject;
 
 /**
  * Email notification sender for Shipment.
@@ -106,7 +107,7 @@ class EmailSender extends Sender implements SenderInterface
                 'formattedShippingAddress' => $this->getFormattedShippingAddress($order),
                 'formattedBillingAddress' => $this->getFormattedBillingAddress($order)
             ];
-            $transport = new \Magento\Framework\DataObject($transport);
+            $transport = new DataObject($transport);
 
             $this->eventManager->dispatch(
                 'email_shipment_set_template_vars_before',

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Sender/EmailSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Sender/EmailSenderTest.php
@@ -262,6 +262,7 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
                 'formattedShippingAddress' => 'Formatted address',
                 'formattedBillingAddress' => 'Formatted address',
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManagerMock->expects($this->once())
                 ->method('dispatch')
@@ -275,7 +276,7 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
 
             $this->templateContainerMock->expects($this->once())
                 ->method('setTemplateVars')
-                ->with($transport);
+                ->with($transport->getData());
 
             $this->identityContainerMock->expects($this->once())
                 ->method('isEnabled')

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Invoice/Sender/EmailSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Invoice/Sender/EmailSenderTest.php
@@ -260,6 +260,7 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
                 'formattedShippingAddress' => 'Formatted address',
                 'formattedBillingAddress' => 'Formatted address',
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManagerMock->expects($this->once())
                 ->method('dispatch')
@@ -273,7 +274,7 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
 
             $this->templateContainerMock->expects($this->once())
                 ->method('setTemplateVars')
-                ->with($transport);
+                ->with($transport->getData());
 
             $this->identityContainerMock->expects($this->once())
                 ->method('isEnabled')

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Shipment/Sender/EmailSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Shipment/Sender/EmailSenderTest.php
@@ -262,6 +262,7 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
                 'formattedShippingAddress' => 'Formatted address',
                 'formattedBillingAddress' => 'Formatted address',
             ];
+            $transport = new \Magento\Framework\DataObject($transport);
 
             $this->eventManagerMock->expects($this->once())
                 ->method('dispatch')
@@ -275,7 +276,7 @@ class EmailSenderTest extends \PHPUnit_Framework_TestCase
 
             $this->templateContainerMock->expects($this->once())
                 ->method('setTemplateVars')
-                ->with($transport);
+                ->with($transport->getData());
 
             $this->identityContainerMock->expects($this->once())
                 ->method('isEnabled')


### PR DESCRIPTION
In the commit 
https://github.com/magento/magento2/commit/44791d5a8e2b3fc2b0dacc72300030e2df4398ff#diff-f625923e436a1fdf17c94533d06a45fb
`$transport` variable type was changed from `array` to `\Magento\Framework\DataObject`. in the 
`Magento/Sales/Model/Order/Email/Sender/OrderSender` class

As the result `OrderSender`'s `$transport`  became changeable from an observer.
But `OrderCommentSender`, `InvoiceSender` and others had been missed.
This PR fixes it.

#### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)