### PR TITLE
#7959 - Fix for JS error on Swatch Renderer for undefined oldPrice

### DIFF
--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -711,7 +711,7 @@ define([
                 }
             );
 
-            if (result.oldPrice.amount !== result.finalPrice.amount) {
+            if (typeof result != 'undefined' && result.oldPrice.amount !== result.finalPrice.amount) {
                 $(this.options.slyOldPriceSelector).show();
             } else {
                 $(this.options.slyOldPriceSelector).hide();


### PR DESCRIPTION
This PR backports commit [269c215](https://github.com/magento/magento2/commit/269c2154db82e2c3a19f8ba9a36e9b249a745998) (originally for -develop) for 2.1-develop and issue #7959.

### Description
Check and verify if 'result' is defined or not before oldPrice is fetched from it.

### Fixed Issues (if relevant)

1. magento/magento2#7959: JS error on product page Cannot read property 'oldPrice' of undefined

### Manual testing scenarios
1. Follow the list of steps at the issue that is resolved here.
