### PR TITLE
Fix for #5897: getIdentities relies on uninitialized collection

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ProductList/Related.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Related.php
@@ -116,6 +116,13 @@ class Related extends \Magento\Catalog\Block\Product\AbstractProduct implements 
      */
     public function getItems()
     {
+        /**
+         * getIdentities() depends on _itemCollection populated, but it can be empty if the block is hidden
+         * @see https://github.com/magento/magento2/issues/5897
+         */
+        if (is_null($this->_itemCollection)) {
+            $this->_prepareData();
+        }
         return $this->_itemCollection;
     }
 

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Upsell.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Upsell.php
@@ -135,6 +135,13 @@ class Upsell extends \Magento\Catalog\Block\Product\AbstractProduct implements \
      */
     public function getItemCollection()
     {
+        /**
+         * getIdentities() depends on _itemCollection populated, but it can be empty if the block is hidden
+         * @see https://github.com/magento/magento2/issues/5897
+         */
+        if (is_null($this->_itemCollection)) {
+            $this->_prepareData();
+        }
         return $this->_itemCollection;
     }
 

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ProductList/UpsellTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/ProductList/UpsellTest.php
@@ -6,14 +6,14 @@
 namespace Magento\Catalog\Block\Product\ProductList;
 
 /**
- * Test class for \Magento\Catalog\Block\Product\List\Related.
+ * Test class for \Magento\Catalog\Block\Product\List\Upsell.
  *
- * @magentoDataFixture Magento/Catalog/_files/products_related.php
+ * @magentoDataFixture Magento/Catalog/_files/products_upsell.php
  */
-class RelatedTest extends \PHPUnit_Framework_TestCase
+class UpsellTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Magento\Catalog\Block\Product\ProductList\Related
+     * @var \Magento\Catalog\Block\Product\ProductList\Upsell
      */
     protected $block;
 
@@ -25,7 +25,7 @@ class RelatedTest extends \PHPUnit_Framework_TestCase
     /**
      * @var \Magento\Catalog\Api\Data\ProductInterface
      */
-    protected $relatedProduct;
+    protected $upsellProduct;
 
     protected function setUp()
     {
@@ -36,16 +36,16 @@ class RelatedTest extends \PHPUnit_Framework_TestCase
         /** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
         $productRepository = $objectManager->create(\Magento\Catalog\Api\ProductRepositoryInterface::class);
 
-        $this->relatedProduct = $productRepository->get('simple');
-        $this->product = $productRepository->get('simple_with_cross');
+        $this->upsellProduct = $productRepository->get('simple');
+        $this->product = $productRepository->get('simple_with_upsell');
         $objectManager->get(\Magento\Framework\Registry::class)->register('product', $this->product);
 
         $this->block = $objectManager->get(\Magento\Framework\View\LayoutInterface::class)
-            ->createBlock(\Magento\Catalog\Block\Product\ProductList\Related::class);
+            ->createBlock(\Magento\Catalog\Block\Product\ProductList\Upsell::class);
 
         $this->block->setLayout($objectManager->get(\Magento\Framework\View\LayoutInterface::class));
         $this->block->setTemplate('Magento_Catalog::product/list/items.phtml');
-        $this->block->setType('related');
+        $this->block->setType('upsell');
         $this->block->addChild('addto', \Magento\Catalog\Block\Product\ProductList\Item\Container::class);
         $this->block->getChildBlock(
             'addto'
@@ -63,14 +63,8 @@ class RelatedTest extends \PHPUnit_Framework_TestCase
     {
         $html = $this->block->toHtml();
         $this->assertNotEmpty($html);
-        $this->assertContains('Simple Related Product', $html);
-        /* name */
-        $this->assertContains('"product":"' . $this->relatedProduct->getId() . '"', $html);
-        /* part of url */
-        $this->assertInstanceOf(
-            \Magento\Catalog\Model\ResourceModel\Product\Link\Product\Collection::class,
-            $this->block->getItems()
-        );
+        $this->assertContains('Simple Up Sell', $html);
+        $this->assertCount(1, $this->block->getItems());
     }
 
     /**
@@ -78,7 +72,7 @@ class RelatedTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetIdentities()
     {
-        $expectedTags = ['cat_p_' . $this->relatedProduct->getId(), 'cat_p'];
+        $expectedTags = ['cat_p_' . $this->upsellProduct->getId(), 'cat_p'];
         $tags = $this->block->getIdentities();
         $this->assertEquals($expectedTags, $tags);
     }


### PR DESCRIPTION
### Fixed Issues

1. #5897
2. #7454

### Manual testing scenarios

See #5897