### PR TITLE
new CLI command: Enable Template Hints

### DIFF
--- a/app/code/Magento/Developer/Console/Command/TemplateHintsDisableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/TemplateHintsDisableCommand.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Developer\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TemplateHintsDisableCommand extends Command
+{
+    /**
+     * command name
+     */
+    const COMMAND_NAME = 'dev:template-hints:disable';
+
+    /**
+     * Success message
+     */
+    const SUCCESS_MESSAGE = "Template hints disabled.";
+
+    /**
+     * TemplateHintsDisableCommand constructor.
+     * @param \Magento\Config\Model\ResourceModel\Config $resourceConfig
+     */
+    public function __construct(
+        \Magento\Config\Model\ResourceModel\Config $resourceConfig
+    ) {
+        parent::__construct($name);
+        $this->_resourceConfig = $resourceConfig;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName(self::COMMAND_NAME)
+            ->setDescription('Disable frontend template hints.');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \InvalidArgumentException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->_resourceConfig->saveConfig(
+                    'dev/debug/template_hints_storefront',
+                    0,
+                    'default',
+                    0
+                );
+
+        $output->writeln("<info>". self::SUCCESS_MESSAGE . "</info>");
+    }
+}

--- a/app/code/Magento/Developer/Console/Command/TemplateHintsDisableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/TemplateHintsDisableCommand.php
@@ -29,7 +29,7 @@ class TemplateHintsDisableCommand extends Command
     public function __construct(
         \Magento\Config\Model\ResourceModel\Config $resourceConfig
     ) {
-        parent::__construct($name);
+        parent::__construct();
         $this->_resourceConfig = $resourceConfig;
     }
 

--- a/app/code/Magento/Developer/Console/Command/TemplateHintsDisableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/TemplateHintsDisableCommand.php
@@ -20,7 +20,7 @@ class TemplateHintsDisableCommand extends Command
     /**
      * Success message
      */
-    const SUCCESS_MESSAGE = "Template hints disabled.";
+    const SUCCESS_MESSAGE = "Template hints disabled. Refresh cache types";
 
     /**
      * TemplateHintsDisableCommand constructor.
@@ -39,7 +39,7 @@ class TemplateHintsDisableCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME)
-            ->setDescription('Disable frontend template hints.');
+            ->setDescription('Disable frontend template hints. A cache flush might be required.');
 
         parent::configure();
     }

--- a/app/code/Magento/Developer/Console/Command/TemplateHintsEnableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/TemplateHintsEnableCommand.php
@@ -41,7 +41,7 @@ class TemplateHintsEnableCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME)
-            ->setDescription('Disable frontend template hints.');
+            ->setDescription('Disable frontend template hints. A cache flush might be required.');
 
         parent::configure();
     }

--- a/app/code/Magento/Developer/Console/Command/TemplateHintsEnableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/TemplateHintsEnableCommand.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Developer\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class TemplateHintsEnableCommand extends Command
+{
+
+    /**
+     * command name
+     */
+    const COMMAND_NAME = 'dev:template-hints:enable';
+
+    /**
+     * Success message
+     */
+    const SUCCESS_MESSAGE = "Template hints enabled.";
+
+    /**
+     * TemplateHintsDisableCommand constructor.
+     * @param \Magento\Config\Model\ResourceModel\Config $resourceConfig
+     */
+    public function __construct(
+        \Magento\Config\Model\ResourceModel\Config $resourceConfig
+    ) {
+        parent::__construct($name);
+        $this->_resourceConfig = $resourceConfig;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName(self::COMMAND_NAME)
+            ->setDescription('Enable DB query logging');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \InvalidArgumentException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->_resourceConfig->saveConfig(
+                    'dev/debug/template_hints_storefront',
+                    1,
+                    'default',
+                    0
+                );
+
+        $output->writeln("<info>". self::SUCCESS_MESSAGE . "</info>");
+    }
+}

--- a/app/code/Magento/Developer/Console/Command/TemplateHintsEnableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/TemplateHintsEnableCommand.php
@@ -31,7 +31,7 @@ class TemplateHintsEnableCommand extends Command
     public function __construct(
         \Magento\Config\Model\ResourceModel\Config $resourceConfig
     ) {
-        parent::__construct($name);
+        parent::__construct();
         $this->_resourceConfig = $resourceConfig;
     }
 
@@ -41,7 +41,7 @@ class TemplateHintsEnableCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME)
-            ->setDescription('Enable DB query logging');
+            ->setDescription('Disable frontend template hints.');
 
         parent::configure();
     }

--- a/app/code/Magento/Developer/etc/di.xml
+++ b/app/code/Magento/Developer/etc/di.xml
@@ -100,6 +100,8 @@
                 <item name="dev_di_info" xsi:type="object">Magento\Developer\Console\Command\DiInfoCommand</item>
                 <item name="dev_query_log_enable" xsi:type="object">Magento\Developer\Console\Command\QueryLogEnableCommand</item>
                 <item name="dev_query_log_disable" xsi:type="object">Magento\Developer\Console\Command\QueryLogDisableCommand</item>
+                <item name="dev_template_hints_disable" xsi:type="object">Magento\Developer\Console\Command\TemplateHintsDisableCommand</item>
+                <item name="dev_template_hints_enable" xsi:type="object">Magento\Developer\Console\Command\TemplateHintsEnableCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
In order to help developers to work with the Magento CLI, create new commands which will simplify the debugging of the application. Currently, enabling of these setting require doing that either with the UI or changing the configuration of the di.xml.

### Description
Added a CLI switch to enable/disable template hints.

### Fixed Issues (if relevant)
1. magento/magento2#9278 Create new CLI command: Enable Template Hints

### Manual testing scenarios
1. php bin/magento dev:template-hints:enable 
2. Check for dev/debug/template_hints_storefront to be 1
3. php bin/magento dev:template-hints:disable 
4. Check for dev/debug/template_hints_storefront to be 0

*. A cache flush is required both from the CLI and from the web UI after template paths are enabled/disabled in order for the hints to show. ~~_This should probably be in the success message, not really sure how to word it._~~

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

Submitted at #mm17se contribution day