### PR TITLE
Feature/9201 cli command info system

### DIFF
--- a/app/code/Magento/Developer/Console/Command/SystemInfoCommand.php
+++ b/app/code/Magento/Developer/Console/Command/SystemInfoCommand.php
@@ -7,23 +7,132 @@ namespace Magento\Developer\Console\Command;
 
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Magento\Framework\App\State as AppState;
 
 class SystemInfoCommand extends \Symfony\Component\Console\Command\Command
 {
+    /**
+     * Constructor
+     */
+    public function __construct(
+        \Magento\Framework\App\ProductMetadataInterface $productMetadataInterface,
+        \Magento\Framework\App\DeploymentConfig $deploymentConfig,
+        \Magento\Framework\Module\ModuleListInterface $moduleList,
+        \Magento\Customer\Model\CustomerFactory $customerFactory,
+        \Magento\Catalog\Model\ProductFactory $productFactory,
+        \Magento\Catalog\Model\CategoryFactory $categoryFactory,
+        \Magento\Eav\Model\Entity\AttributeFactory $attributeFactory
+    ) {
+        parent::__construct('info:system');
+        $this->productMetadataInterface = $productMetadataInterface;
+        $this->deploymentConfig = $deploymentConfig;
+        $this->moduleList = $moduleList;
+        $this->customerFactory = $customerFactory;
+        $this->productFactory = $productFactory;
+        $this->categoryFactory = $categoryFactory;
+        $this->attributeFactory = $attributeFactory;
+    }
 
     protected function configure()
     {
-        $this->setName('info:system')
-            ->setDescription('')
-        ;
         parent::configure();
+        $this->setDescription('Get information about Magento setup and installation');
     }
 
     /**
-     * {@inheritdoc}
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->writeln("<info>helo</info>");
+        $table = new Table($output);
+
+        $table
+            ->setHeaders(array('Name', 'Value'))
+            ->setRows(array(
+                array('Application', $this->productMetadataInterface->getName() . ' ' . $this->productMetadataInterface->getEdition()),
+                array('Version', $this->productMetadataInterface->getVersion()),
+                new TableSeparator(),
+
+                array('Application Mode', $this->deploymentConfig->get(AppState::PARAM_MODE)),
+                array('Session', $this->deploymentConfig->get('session/save')),
+                array('Crypt Key', $this->deploymentConfig->get('crypt/key')),
+                array('Install Date', $this->deploymentConfig->get('install/date')),
+                array('Module Vendors', $this->getModuleVendors()),
+                new TableSeparator(),
+
+                array('Total Products', $this->getProductCount()),
+                array('Total Categories', $this->getProductCount()),
+                array('Total Attributes', $this->getAttributeCount()),
+                array('Total Customers', $this->getCustomerCount()),
+            ))
+        ;
+        $table->render();
+
+    }
+
+    /**
+     * @return string
+     */
+    protected function getModuleVendors()
+    {
+        $vendors = [];
+        $moduleList = $this->moduleList->getAll();
+
+        foreach ($moduleList as $moduleName => $info) {
+            $moduleNameData = explode('_', $moduleName);
+
+            if (isset($moduleNameData[0])) {
+                $vendors[] = $moduleNameData[0];
+            }
+        }
+
+        return implode(', ', array_unique($vendors));
+    }
+
+    /**
+     * @return number
+     */
+    protected function getProductCount()
+    {
+        return $this->productFactory
+            ->create()
+            ->getCollection()
+            ->getSize();
+    }
+
+    /**
+     * @return number
+     */
+    protected function getCategoryCount()
+    {
+        return $this->categoryFactory
+            ->create()
+            ->getCollection()
+            ->getSize();
+    }
+
+    /**
+     * @return number
+     */
+    protected function getAttributeCount()
+    {
+        return $this->attributeFactory
+            ->create()
+            ->getCollection()
+            ->getSize();
+    }
+
+    /**
+     * @return number
+     */
+    protected function getCustomerCount()
+    {
+        return $this->customerFactory->create()
+            ->getCollection()
+            ->getSize();
     }
 }

--- a/app/code/Magento/Developer/Console/Command/SystemInfoCommand.php
+++ b/app/code/Magento/Developer/Console/Command/SystemInfoCommand.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Developer\Console\Command;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
+
+class SystemInfoCommand extends \Symfony\Component\Console\Command\Command
+{
+
+    protected function configure()
+    {
+        $this->setName('info:system')
+            ->setDescription('')
+        ;
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln("<info>helo</info>");
+    }
+}

--- a/app/code/Magento/Developer/Console/Command/SystemInfoCommand.php
+++ b/app/code/Magento/Developer/Console/Command/SystemInfoCommand.php
@@ -19,40 +19,40 @@ class SystemInfoCommand extends \Symfony\Component\Console\Command\Command
     const COMMAND = 'info:system';
 
     /**
-     * @param \Magento\Framework\App\ProductMetadataInterface $productMetadataInterface
+     * @param \Magento\Framework\App\ProductMetadataInterface $productMetadata
      * @param \Magento\Framework\App\DeploymentConfig $deploymentConfig
      * @param \Magento\Framework\Module\ModuleListInterface $moduleList
      * @param \Magento\Customer\Model\CustomerFactory $customerFactory
      * @param \Magento\Catalog\Model\ProductFactory $productFactory
      * @param \Magento\Catalog\Model\CategoryFactory $categoryFactory
      * @param \Magento\Eav\Model\Entity\AttributeFactory $attributeFactory
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfigInterface
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Payment\Model\Config $paymentConfig
      * @param AppState $appState
      */
     public function __construct(
-        \Magento\Framework\App\ProductMetadataInterface $productMetadataInterface,
+        \Magento\Framework\App\ProductMetadataInterface $productMetadata,
         \Magento\Framework\App\DeploymentConfig $deploymentConfig,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\App\State $appState,
         \Magento\Framework\Module\ModuleListInterface $moduleList,
         \Magento\Customer\Model\CustomerFactory $customerFactory,
         \Magento\Catalog\Model\ProductFactory $productFactory,
         \Magento\Catalog\Model\CategoryFactory $categoryFactory,
         \Magento\Eav\Model\Entity\AttributeFactory $attributeFactory,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfigInterface,
-        \Magento\Payment\Model\Config $paymentConfig,
-        \Magento\Framework\App\State $appState
+        \Magento\Payment\Model\Config $paymentConfig
     ) {
         parent::__construct(self::COMMAND);
-        $this->productMetadataInterface = $productMetadataInterface;
+        $this->productMetadata = $productMetadata;
         $this->deploymentConfig = $deploymentConfig;
+        $this->scopeConfig = $scopeConfig;
+        $this->appState = $appState;
         $this->moduleList = $moduleList;
         $this->customerFactory = $customerFactory;
         $this->productFactory = $productFactory;
         $this->categoryFactory = $categoryFactory;
         $this->attributeFactory = $attributeFactory;
-        $this->scopeConfigInterface = $scopeConfigInterface;
         $this->paymentConfig = $paymentConfig;
-        $this->appState = $appState;
     }
 
     protected function configure()
@@ -71,27 +71,27 @@ class SystemInfoCommand extends \Symfony\Component\Console\Command\Command
         $table = new Table($output);
 
         $table
-            ->setHeaders(array('Name', 'Value'))
-            ->setRows(array(
-                array('Application', $this->getApplicationName()),
-                array('Version', $this->productMetadataInterface->getVersion()),
+            ->setHeaders(['Item', 'Value'])
+            ->setRows([
+                ['Application', $this->getApplicationName()],
+                ['Version', $this->productMetadata->getVersion()],
                 new TableSeparator(),
 
-                array('Application Mode', $this->deploymentConfig->get(AppState::PARAM_MODE)),
-                array('Session', $this->deploymentConfig->get('session/save')),
-                array('Crypt Key', $this->deploymentConfig->get('crypt/key')),
-                array('Secure URLs at Storefront', $this->getSecurityInfo('frontend')),
-                array('Secure URLs in Admin', $this->getSecurityInfo('adminhtml')),
-                array('Install Date', $this->deploymentConfig->get('install/date')),
-                array('Module Vendors', $this->getModuleVendors()),
+                ['Application Mode', $this->deploymentConfig->get(AppState::PARAM_MODE)],
+                ['Session', $this->deploymentConfig->get('session/save')],
+                ['Crypt Key', $this->deploymentConfig->get('crypt/key')],
+                ['Secure URLs at Storefront', $this->getSecurityInfo('frontend')],
+                ['Secure URLs in Admin', $this->getSecurityInfo('adminhtml')],
+                ['Install Date', $this->deploymentConfig->get('install/date')],
+                ['Module Vendors', $this->getModuleVendors()],
                 new TableSeparator(),
 
-                array('Total Products', $this->getProductCount()),
-                array('Total Categories', $this->getProductCount()),
-                array('Total Attributes', $this->getAttributeCount()),
-                array('Total Customers', $this->getCustomerCount()),
-                array('Active Payment Methods', $this->getActivePaymentMethods()),
-            ));
+                ['Total Products', $this->getProductCount()],
+                ['Total Categories', $this->getProductCount()],
+                ['Total Attributes', $this->getAttributeCount()],
+                ['Total Customers', $this->getCustomerCount()],
+                ['Active Payment Methods', $this->getActivePaymentMethods()],
+            ]);
 
         $table->render();
     }
@@ -101,9 +101,9 @@ class SystemInfoCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function getApplicationName()
     {
-        return $this->productMetadataInterface->getName() . ' ' . $this->productMetadataInterface->getEdition();
+        return $this->productMetadata->getName() . ' ' . $this->productMetadata->getEdition();
     }
-    
+
     /**
      * @return string
      */
@@ -176,10 +176,10 @@ class SystemInfoCommand extends \Symfony\Component\Console\Command\Command
             'adminhtml',
             function() {
                 $payments = $this->paymentConfig->getActiveMethods();
-                $paymentTitles = array();
+                $paymentTitles = [];
 
                 foreach ($payments as $paymentCode => $paymentModel) {
-                    $paymentTitles[] = $this->scopeConfigInterface
+                    $paymentTitles[] = $this->scopeConfig
                         ->getValue('payment/'.$paymentCode.'/title');
                 }
 
@@ -193,6 +193,6 @@ class SystemInfoCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function getSecurityInfo($area)
     {
-        return $this->scopeConfigInterface->getValue('web/secure/use_in_' . $area) ? 'Yes' : 'No';
+        return $this->scopeConfig->getValue('web/secure/use_in_' . $area) ? 'Yes' : 'No';
     }
 }

--- a/app/code/Magento/Developer/etc/di.xml
+++ b/app/code/Magento/Developer/etc/di.xml
@@ -100,6 +100,7 @@
                 <item name="dev_di_info" xsi:type="object">Magento\Developer\Console\Command\DiInfoCommand</item>
                 <item name="dev_query_log_enable" xsi:type="object">Magento\Developer\Console\Command\QueryLogEnableCommand</item>
                 <item name="dev_query_log_disable" xsi:type="object">Magento\Developer\Console\Command\QueryLogDisableCommand</item>
+                <item name="info_system" xsi:type="object">Magento\Developer\Console\Command\SystemInfoCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
This PR introduces a basic CLI command for getting Magento installation and setup data. Currently, it displays the following:

![screenshot 2017-05-29 17 07 22](https://cloud.githubusercontent.com/assets/658281/26613358/f0d68ec4-457f-11e7-98ca-07b72c27be3c.png)

### Description
- Has a command called 'info:system'.
- The command resides at Magento_Developer module.

### Fixed Issues (if relevant)
1. magento/magento2#9201: Create New CLI command: Collect Magento Information

### Manual testing scenarios
1. Switch to dreamworkers:feature/9201-cli-command-info-system 
2. php bin/magento setup:upgrade
3. php bin/magento info:system

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)