### PR TITLE
Adding logo in media folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ atlassian*
 /pub/media/favicon/*
 /pub/media/import/*
 !/pub/media/import/.htaccess
+/pub/media/logo/*
 /pub/media/theme/*
 /pub/media/theme_customization/*
 !/pub/media/theme_customization/.htaccess


### PR DESCRIPTION
When I've added a logo to email and to PDF, the Magento creates the folder **pub/media/logo** that needs to be ignored.