### PR TITLE
Fix issue #6999: Configurable attribute cache was never hit

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -484,8 +484,7 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
      */
     protected function hasCacheData($configurableAttributes)
     {
-        if ($configurableAttributes)
-        {
+        if ($configurableAttributes) {
             $configurableAttributes = unserialize($configurableAttributes);
         }
         $isTraversable = (is_array($configurableAttributes) || $configurableAttributes instanceof \Traversable);

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -10,6 +10,7 @@ use Magento\Catalog\Api\Data\ProductInterfaceFactory;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Config;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Gallery\ReadHandler as GalleryReadHandler;
 use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\CatalogInventory\Model\Stock\Status;
 use Magento\ConfigurableProduct\Model\Product\Type\Collection\SalableProcessor;
@@ -18,7 +19,6 @@ use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable as
 use Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\EntityManager\MetadataPool;
-use Magento\Catalog\Model\Product\Gallery\ReadHandler as GalleryReadHandler;
 
 /**
  * Configurable product type implementation
@@ -484,8 +484,9 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
      */
     protected function hasCacheData($configurableAttributes)
     {
-	    $configurableAttributes = $configurableAttributes ? unserialize($configurableAttributes) : $configurableAttributes;
-        if ((is_array($configurableAttributes) || $configurableAttributes instanceof \Traversable) && count($configurableAttributes)) {
+        $configurableAttributes = $configurableAttributes ? unserialize( $configurableAttributes ) : $configurableAttributes;
+        $isTraversable = (is_array($configurableAttributes) || $configurableAttributes instanceof \Traversable);
+        if ($isTraversable && count($configurableAttributes)) {
             foreach ($configurableAttributes as $attribute) {
                 /** @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute $attribute */
                 if ($attribute->getData('options')) {

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -484,8 +484,8 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
      */
     protected function hasCacheData($configurableAttributes)
     {
-        $configurableAttributes = $configurableAttributes ?: unserialize($configurableAttributes);
-        if (is_array($configurableAttributes) && count($configurableAttributes)) {
+	    $configurableAttributes = $configurableAttributes ? unserialize($configurableAttributes) : $configurableAttributes;
+        if ((is_array($configurableAttributes) || $configurableAttributes instanceof \Traversable) && count($configurableAttributes)) {
             foreach ($configurableAttributes as $attribute) {
                 /** @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute $attribute */
                 if ($attribute->getData('options')) {

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -484,7 +484,10 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
      */
     protected function hasCacheData($configurableAttributes)
     {
-        $configurableAttributes = $configurableAttributes ? unserialize( $configurableAttributes ) : $configurableAttributes;
+        if ($configurableAttributes)
+        {
+            $configurableAttributes = unserialize($configurableAttributes);
+        }
         $isTraversable = (is_array($configurableAttributes) || $configurableAttributes instanceof \Traversable);
         if ($isTraversable && count($configurableAttributes)) {
             foreach ($configurableAttributes as $attribute) {


### PR DESCRIPTION

### Description
Changed the hasCache() method so that it now also works if a Traversable instead of an array is passed.

### Fixed Issues (if relevant)
1. magento/magento2#6999: Configurable attribute cache was never hit
