### PR TITLE
Fix bug linked product position not updated if product link already exists

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1230,15 +1230,15 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                                         'linked_product_id' => $linkedId,
                                         'link_type_id' => $linkId,
                                     ];
-                                    if (!empty($linkPositions[$linkedKey])) {
-                                        $positionRows[] = [
-                                            'link_id' => $productLinkKeys[$linkKey],
-                                            'product_link_attribute_id' => $positionAttrId[$linkId],
-                                            'value' => $linkPositions[$linkedKey],
-                                        ];
-                                    }
-                                    $nextLinkId++;
                                 }
+                                if (!empty($linkPositions[$linkedKey])) {
+                                    $positionRows[] = [
+                                        'link_id' => $productLinkKeys[$linkKey],
+                                        'product_link_attribute_id' => $positionAttrId[$linkId],
+                                        'value' => $linkPositions[$linkedKey],
+                                    ];
+                                }
+                                $nextLinkId++;
                             }
                         }
                     }


### PR DESCRIPTION
Linked product position is not updated on product import if product link already exists. This pull requests fixes that issue by always updating the sorting position

## Steps to reproduce
Log into Magento Admin and do the following

0. Go to manage products and open a product
0. Go to `Related Products, Up-Sells, and Cross-Sells` section and add a couple of related products
0. Save product
0. Go to `System > Export` and export all products
0. Take the generated `.csv` file and edit the related products order on `related_position` column for that product.
0. Go to `System > Import` and import the edited `.csv` file
    * `Entity type = product`
    * `Import behaviour = add/update`

## Expected Result
Related products order is updated.

## Actual Result
Related products order is ignored during import as the related products are already existing.