### PR TITLE
Use static:: to support late static bindings in Invoice and Creditmemo

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo.php
@@ -439,14 +439,14 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
      */
     public static function getStates()
     {
-        if (is_null(self::$_states)) {
-            self::$_states = [
+        if (is_null(static::$_states)) {
+            static::$_states = [
                 self::STATE_OPEN => __('Pending'),
                 self::STATE_REFUNDED => __('Refunded'),
                 self::STATE_CANCELED => __('Canceled'),
             ];
         }
-        return self::$_states;
+        return static::$_states;
     }
 
     /**
@@ -461,11 +461,11 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
             $stateId = $this->getState();
         }
 
-        if (is_null(self::$_states)) {
-            self::getStates();
+        if (is_null(static::$_states)) {
+            static::getStates();
         }
-        if (isset(self::$_states[$stateId])) {
-            return self::$_states[$stateId];
+        if (isset(static::$_states[$stateId])) {
+            return static::$_states[$stateId];
         }
         return __('Unknown State');
     }

--- a/app/code/Magento/Sales/Model/Order/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice.php
@@ -543,14 +543,14 @@ class Invoice extends AbstractModel implements EntityInterface, InvoiceInterface
      */
     public static function getStates()
     {
-        if (null === self::$_states) {
-            self::$_states = [
+        if (null === static::$_states) {
+            static::$_states = [
                 self::STATE_OPEN => __('Pending'),
                 self::STATE_PAID => __('Paid'),
                 self::STATE_CANCELED => __('Canceled'),
             ];
         }
-        return self::$_states;
+        return static::$_states;
     }
 
     /**
@@ -565,11 +565,11 @@ class Invoice extends AbstractModel implements EntityInterface, InvoiceInterface
             $stateId = $this->getState();
         }
 
-        if (null === self::$_states) {
-            self::getStates();
+        if (null === static::$_states) {
+            static::getStates();
         }
-        if (isset(self::$_states[$stateId])) {
-            return self::$_states[$stateId];
+        if (isset(static::$_states[$stateId])) {
+            return static::$_states[$stateId];
         }
         return __('Unknown State');
     }


### PR DESCRIPTION
### Description
When using self:: to call static properties and static methods late static binding (see http://php.net/manual/en/language.oop5.late-static-bindings.php) will not be supported. Instead static:: should be used.
When a class inherits from Magento\Sales\Model\Order\Invoice or Magento\Sales\Model\Order\Creditmemo and has its own implementation of the static method (or property) this implementation might not be called.

This is not a bug in the Magento code base but it would improve the code for customisation.

#### Example
I have class ExtendedInvoice which inherits from Invoice. It has its own implementation of getStates() because I want to add an extra state. 
``` php
<?php
class ExtendedInvoice extends \Magento\Sales\Model\Order\Invoice
{
    const STATE_EXTRA = 4;

    /**
     * This method will not be used when getStateName() is called
     */
    public static function getStates()
    {
        if (null === self::$_states) {
            self::$_states = [
                self::STATE_OPEN => __('Pending'),
                self::STATE_PAID => __('Paid'),
                self::STATE_CANCELED => __('Canceled'),
                self::STATE_EXTRA => __('Extra State'),
            ];
        }
        return self::$_states;
    }
}
```

Now when getStateName() is called on an instance of ExtendedInvoice, the getStates() method of the parent class will be used instead of my implementation and thus my extra state will be unknown.

When changing self:: to static:: as in my commit the correct implementation of getStates() will be called.

