### PR TITLE
Return array of pages as items instead of array of arrays

### DIFF
--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -157,25 +157,10 @@ class PageRepository implements PageRepositoryInterface
 
         $this->collectionProcessor->process($criteria, $collection);
 
-        $pages = [];
-        /** @var Page $pageModel */
-        foreach ($collection as $pageModel) {
-            $pageData = $this->dataPageFactory->create();
-            $this->dataObjectHelper->populateWithArray(
-                $pageData,
-                $pageModel->getData(),
-                \Magento\Cms\Api\Data\PageInterface::class
-            );
-            $pages[] = $this->dataObjectProcessor->buildOutputDataArray(
-                $pageData,
-                \Magento\Cms\Api\Data\PageInterface::class
-            );
-        }
-
         /** @var Data\PageSearchResultsInterface $searchResults */
         $searchResults = $this->searchResultsFactory->create();
         $searchResults->setSearchCriteria($criteria);
-        $searchResults->setItems($pages);
+        $searchResults->setItems($collection->getItems());
         $searchResults->setTotalCount($collection->getSize());
         return $searchResults;
     }


### PR DESCRIPTION
Based on `PageSearchResultsInterface` the getItems() should return `\Magento\Cms\Api\Data\PageInterface[]`. (basically the same problem as in the block repository https://github.com/magento/magento2/pull/9157 )