### PR TITLE
Allow reserved words in the namespace segment of a route

### DIFF
--- a/lib/internal/Magento/Framework/App/Router/ActionList.php
+++ b/lib/internal/Magento/Framework/App/Router/ActionList.php
@@ -94,6 +94,9 @@ class ActionList
         if (strpos($namespace, self::NOT_ALLOWED_IN_NAMESPACE_PATH) !== false) {
             return null;
         }
+        if (in_array(strtolower($namespace), $this->reservedWords)) {
+            $namespace .= 'action';
+        }
         if (in_array(strtolower($action), $this->reservedWords)) {
             $action .= 'action';
         }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Based on [Alan Storm's question about using reserved words in urls](https://magento.stackexchange.com/questions/177046/using-reserved-words-in-magento-2-urls/177081), this change searches for the directory of a namespace with a reserved word in the same manner Magento already searched for the class of an action with a reserved word.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
