### PR TITLE
Fixes Mage.Cookies poor performance

### DIFF
--- a/lib/web/mage/cookies.js
+++ b/lib/web/mage/cookies.js
@@ -91,17 +91,18 @@
         this.get = function (name) {
             var arg = name + '=',
                 aLength = arg.length,
-                cLength = document.cookie.length,
+                cookie = document.cookie,
+                cLength = cookie.length,
                 i = 0,
                 j = 0;
 
             while (i < cLength) {
                 j = i + aLength;
 
-                if (document.cookie.substring(i, j) === arg) {
+                if (cookie.substring(i, j) === arg) {
                     return this.getCookieVal(j);
                 }
-                i = document.cookie.indexOf(' ', i) + 1;
+                i = cookie.indexOf(' ', i) + 1;
 
                 if (i === 0) {
                     break;
@@ -130,13 +131,14 @@
          * @return {String}
          */
         this.getCookieVal = function (offset) {
-            var endstr = document.cookie.indexOf(';', offset);
+            var cookie = document.cookie,
+                endstr = cookie.indexOf(';', offset);
 
             if (endstr === -1) {
-                endstr = document.cookie.length;
+                endstr = cookie.length;
             }
 
-            return decodeURIComponent(document.cookie.substring(offset, endstr));
+            return decodeURIComponent(cookie.substring(offset, endstr));
         };
 
         return this;


### PR DESCRIPTION
While reviewing performance of Magento 1 and Magento 2 websites I was surprised by the time of Mage.Cookies.get calls execution being around 5-10 ms based on number of cookies stored.

This is how it looks on Land Rover website:

<img width="2116" alt="cookies-time-on-magento2" src="https://cloud.githubusercontent.com/assets/677017/26729482/0ceb59c0-47ae-11e7-8d09-0e77d9e060f6.png">

What I've found is that the Cookies class uses document.cookie property in extremely not effective way.

Document.cookie call is not just a string property retrieving - 
Quote from [w3c documentation on document.cookie]( https://www.w3schools.com/js/js_cookies.asp: )

> The document.cookie property looks like a normal text string. But it is not.

Single call can take from 0,03 to 10 milliseconds on various browsers/devices.

Simple test to reproduce in different browsers/devices : https://jsfiddle.net/rtxee657/1/.

### Description

This pull request reduce the time for a Mage.Cookies.get call around 10 times without any side effects, and that gives average Magento 2 based website 1-2% faster page load.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
