### PR TITLE
Backport of MAGETWO-59089 for Magento 2.1: Magento 2.1.1 Problem with change currency

### DIFF
--- a/lib/internal/Magento/Framework/Pricing/Render/PriceBox.php
+++ b/lib/internal/Magento/Framework/Pricing/Render/PriceBox.php
@@ -86,7 +86,7 @@ class PriceBox extends Template implements PriceBoxRenderInterface, IdentityInte
      */
     protected function getCacheLifetime()
     {
-        return parent::hasCacheLifetime() ? parent::getCacheLifetime() : self::DEFAULT_LIFETIME;
+        return parent::hasCacheLifetime() ? parent::getCacheLifetime() : null;
     }
     
     /**

--- a/lib/internal/Magento/Framework/Pricing/Test/Unit/Render/PriceBoxTest.php
+++ b/lib/internal/Magento/Framework/Pricing/Test/Unit/Render/PriceBoxTest.php
@@ -233,4 +233,17 @@ class PriceBoxTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($this->rendererPool, $this->model->getRendererPool());
     }
+
+    /**
+     * This tests ensures that protected method getCacheLifetime() returns a null value when cacheLifeTime is not
+     * explicitly set in the parent block
+     */
+    public function testCacheLifetime()
+    {
+        $reflectionClass = new \ReflectionClass(get_class($this->model));
+        $methodReflection = $reflectionClass->getMethod('getCacheLifetime');
+        $methodReflection->setAccessible(true);
+        $cacheLifeTime = $methodReflection->invoke($this->model);
+        $this->assertNull($cacheLifeTime, 'Expected null cache lifetime');
+    }
 }


### PR DESCRIPTION
### Description
This problem was discovered in scope of issue https://github.com/magento/magento2/issues/9562
But the fix was already on develop and was fixing another issue: https://github.com/magento/magento2/issues/6746

See the steps below to reproduce the issue we were having which lead me to create this PR.

Since this PR fixes multiple non-related issues, I think you should test this very well. It might even fix other reported issues as well, but it's really hard to tell...

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/9562: ItemZone on product detail is not set correctly when chaning products via related/upsell products list
2. Fixes https://github.com/magento/magento2/issues/6746: Magento 2.1.1 Problem with change currency

Reference to the commit on the develop branch: a9510d3166e4016d2cc2977d7b785f0676d52afd

### Manual testing scenarios
1. Setup a new Magento 2.1.7 installation
2. Create 2 products: Product1 and Product2, make sure they have a different price and that they are visible on the frontend
3. Edit Product2 and assign Product1 as an upsell product to it
4. Reindex and flush caches
5. Visit Product2 on the frontend and save the generated html: `curl --insecure https://mydomain/product2.html > correct.html`
6. Flush the cache again
7. Visit Product1 on the frontend using a browser, or curl or wget, or whatever, so its data gets cached
8. Visit Product2 on the frontend and save the generated html: `curl --insecure https://mydomain/product2.html > wrong.html`
9. Compare the `correct.html` against the `wrong.html`:
```diff
$ diff -u correct.html wrong.html
--- correct.html	2017-06-03 13:51:02.000000000 +0200
+++ wrong.html	2017-06-03 13:51:38.000000000 +0200
@@ -622,13 +622,14 @@


 <span class="price-container price-final_price tax weee"
-        >
+         itemprop="offers" itemscope itemtype="http://schema.org/Offer">
         <span  id="product-price-1"                data-price-amount="123"
         data-price-type="finalPrice"
         class="price-wrapper "
-        >
+         itemprop="price">
         <span class="price">€123.00</span>    </span>
-        </span>
+                <meta itemprop="priceCurrency" content="EUR" />
+    </span>

 </div>
```

The html files should be identical, but they aren't, because price data of Product1 is cached and then being used in the upsell list when visiting Product2.

In our case, this problem is causing some of the Google indexing services to pick the wrong price for Product2, instead it displays the price from Product1 for Product2 in some of its services (like Google adwords), which makes our client and marketeers really nervous as you can imagine :)
