### PR TITLE
Fix broken Parallel deploy for redis users

### DIFF
--- a/app/code/Magento/Deploy/Console/DeployStaticOptions.php
+++ b/app/code/Magento/Deploy/Console/DeployStaticOptions.php
@@ -119,7 +119,7 @@ class DeployStaticOptions
     /**
      * Default jobs amount
      */
-    const DEFAULT_JOBS_AMOUNT = 0;
+    const DEFAULT_JOBS_AMOUNT = 1;
 
     /**
      * Key for languages parameter


### PR DESCRIPTION
Change default_job_amount to 1 - fixes setup:static-content:deploy redis issue

Redis and parallel deploy static content do not mix due to faulty implementation

### Description
Disable Parallel deploy for now until better fix can come along

### Fixed Issues (if relevant)
Fixes many redis errors since 2.1.6 during setup:static-content:deploy 

### Manual testing scenarios
1. php bin/magento setup:static-content:deploy en_US
2. find random redis errors such as closed connection 
3. website is now broken!

This is due to parallel deploy jobs not properly initializing a separate redis session when pcntl fork happens.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
