### PR TITLE
Bugfix > Adding Success Message > Recent Ordered

### DIFF
--- a/app/code/Magento/Checkout/Controller/Cart.php
+++ b/app/code/Magento/Checkout/Controller/Cart.php
@@ -7,6 +7,7 @@ namespace Magento\Checkout\Controller;
 
 use Magento\Catalog\Controller\Product\View\ViewInterface;
 use Magento\Checkout\Model\Cart as CustomerCart;
+use Magento\Framework\Escaper;
 
 /**
  * Shopping cart controller
@@ -39,6 +40,11 @@ abstract class Cart extends \Magento\Framework\App\Action\Action implements View
     protected $cart;
 
     /**
+    * @var \Magento\Framework\Escaper
+    */
+    protected $escaper;
+    
+    /**
      * @param \Magento\Framework\App\Action\Context $context
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Checkout\Model\Session $checkoutSession
@@ -53,13 +59,15 @@ abstract class Cart extends \Magento\Framework\App\Action\Action implements View
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator,
-        CustomerCart $cart
+        CustomerCart $cart,
+        Escaper $escaper
     ) {
         $this->_formKeyValidator = $formKeyValidator;
         $this->_scopeConfig = $scopeConfig;
         $this->_checkoutSession = $checkoutSession;
         $this->_storeManager = $storeManager;
-        $this->cart = $cart;
+        $this->cart = $cart;        
+        $this->escaper = $escaper;
         parent::__construct($context);
     }
 

--- a/app/code/Magento/Checkout/Controller/Cart.php
+++ b/app/code/Magento/Checkout/Controller/Cart.php
@@ -7,7 +7,6 @@ namespace Magento\Checkout\Controller;
 
 use Magento\Catalog\Controller\Product\View\ViewInterface;
 use Magento\Checkout\Model\Cart as CustomerCart;
-use Magento\Framework\Escaper;
 
 /**
  * Shopping cart controller
@@ -43,7 +42,7 @@ abstract class Cart extends \Magento\Framework\App\Action\Action implements View
     * @var \Magento\Framework\Escaper
     */
     protected $escaper;
-    
+
     /**
      * @param \Magento\Framework\App\Action\Context $context
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
@@ -51,6 +50,7 @@ abstract class Cart extends \Magento\Framework\App\Action\Action implements View
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator
      * @param CustomerCart $cart
+     * @param \Magento\Framework\Escaper $escaper
      * @codeCoverageIgnore
      */
     public function __construct(
@@ -60,14 +60,14 @@ abstract class Cart extends \Magento\Framework\App\Action\Action implements View
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator,
         CustomerCart $cart,
-        Escaper $escaper
+        \Magento\Framework\Escaper $escaper = null
     ) {
         $this->_formKeyValidator = $formKeyValidator;
         $this->_scopeConfig = $scopeConfig;
         $this->_checkoutSession = $checkoutSession;
         $this->_storeManager = $storeManager;
         $this->cart = $cart;        
-        $this->escaper = $escaper;
+        $this->escaper = $escaper ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Escaper::class);
         parent::__construct($context);
     }
 

--- a/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
@@ -24,7 +24,10 @@ class Addgroup extends \Magento\Checkout\Controller\Cart
                 try {
                     $this->cart->addOrderItem($item, 1);
                     if (!$this->cart->getQuote()->getHasError()) {
-                        $message = __('You added %1 to your shopping cart.', $item->getName());
+                        $message = __(
+                             'You added %1 to your shopping cart.',                             
+                             $this->escaper->escapeHtml($item->getName())
+                        );
                         $this->messageManager->addSuccessMessage($message);
                     }
                 } catch (\Magento\Framework\Exception\LocalizedException $e) {

--- a/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
@@ -23,6 +23,10 @@ class Addgroup extends \Magento\Checkout\Controller\Cart
             foreach ($itemsCollection as $item) {
                 try {
                     $this->cart->addOrderItem($item, 1);
+                    if (!$this->cart->getQuote()->getHasError()) {
+                        $message = __('You added %1 to your shopping cart.', $item->getName());
+                        $this->messageManager->addSuccessMessage($message);
+                    }
                 } catch (\Magento\Framework\Exception\LocalizedException $e) {
                     if ($this->_checkoutSession->getUseNotice(true)) {
                         $this->messageManager->addNotice($e->getMessage());

--- a/app/code/Magento/Checkout/Controller/Cart/Index.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Index.php
@@ -21,6 +21,7 @@ class Index extends \Magento\Checkout\Controller\Cart
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator
      * @param \Magento\Checkout\Model\Cart $cart
+     * @param \Magento\Framework\Escaper $escaper
      * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
      * @codeCoverageIgnore
      */
@@ -31,6 +32,7 @@ class Index extends \Magento\Checkout\Controller\Cart
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator,
         \Magento\Checkout\Model\Cart $cart,
+        \Magento\Framework\Escaper $escaper,
         \Magento\Framework\View\Result\PageFactory $resultPageFactory
     ) {
         parent::__construct(
@@ -39,7 +41,8 @@ class Index extends \Magento\Checkout\Controller\Cart
             $checkoutSession,
             $storeManager,
             $formKeyValidator,
-            $cart
+            $cart,            
+            $escaper
         );
         $this->resultPageFactory = $resultPageFactory;
     }


### PR DESCRIPTION
Adding a Success message

### Description

I've fixed the issue with success message when the customer adds a product to the cart using the sidebar "Recent Ordered" like that image:

![image](https://cloud.githubusercontent.com/assets/610598/26805190/338d92c6-4a21-11e7-8095-c6db8328b835.png)

### Manual testing scenarios

1. Buy some items.
2. Access your Customer Account page.
3. Select a product in **Recent Ordered** products listed.
4. Click **Add to Cart** button.
5. The success message not will show.

### Contribution checklist

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
