### PR TITLE
Fix memory leak for images resize command.

### DIFF
--- a/app/code/Magento/Catalog/Api/ProductRepositoryInterface.php
+++ b/app/code/Magento/Catalog/Api/ProductRepositoryInterface.php
@@ -72,4 +72,11 @@ interface ProductRepositoryInterface
      * @return \Magento\Catalog\Api\Data\ProductSearchResultsInterface
      */
     public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria);
+
+    /**
+     * Clean internal product cache
+     *
+     * @return void
+     */
+    public function cleanCache();
 }

--- a/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
+++ b/app/code/Magento/Catalog/Console/Command/ImagesResizeCommand.php
@@ -77,8 +77,7 @@ class ImagesResizeCommand extends Command
         $productCollection = $this->productCollectionFactory->create();
         $productIds = $productCollection->getAllIds();
         if (!count($productIds)) {
-            $output->writeln("<info>No product images to resize</info>");
-            // we must have an exit code higher than zero to indicate something was wrong
+            $output->writeln('<info>No product images to resize</info>');
             return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
         }
 
@@ -95,7 +94,9 @@ class ImagesResizeCommand extends Command
                 $imageCache = $this->imageCacheFactory->create();
                 $imageCache->generate($product);
 
-                $output->write(".");
+                $this->productRepository->cleanCache();
+
+                $output->write('.');
             }
         } catch (\Exception $e) {
             $output->writeln("<error>{$e->getMessage()}</error>");
@@ -103,7 +104,7 @@ class ImagesResizeCommand extends Command
             return \Magento\Framework\Console\Cli::RETURN_FAILURE;
         }
 
-        $output->write("\n");
-        $output->writeln("<info>Product images resized successfully</info>");
+        $output->writeln('');
+        $output->writeln('<info>Product images resized successfully</info>');
     }
 }

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -657,9 +657,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     }
 
     /**
-     * Clean internal product cache
-     *
-     * @return void
+     * {@inheritdoc}
      */
     public function cleanCache()
     {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
We have large catalog with many products and 2Gb memory limit is not enough to resize all of the images. I've removed storing loaded products inside identity map and it helps a lot.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
