### PR TITLE
Fix _addUrlRewrite method for product collection

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -1403,6 +1403,11 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
                 ['cu' => $this->getTable('catalog_url_rewrite_product_category')],
                 'u.url_rewrite_id=cu.url_rewrite_id'
             )->where('cu.category_id IN (?)', $this->_urlRewriteCategory);
+        } else {
+            $select->joinLeft(
+                ['cu' => $this->getTable('catalog_url_rewrite_product_category')],
+                'u.url_rewrite_id=cu.url_rewrite_id'
+            )->where('cu.category_id IS NULL');
         }
 
         // more priority is data with category id


### PR DESCRIPTION
In general it looks strange that we have this functionality in catalog module, because we have separate module catalog url rewrites, that should work with url rewrites. Anyway, we're fixing getting URL rewrites for collection loading. 
**Reason**
We don't have filtration by missing category id for product URL and in some cases we were getting such url rewrite.

### Description
"Use Categories Path for Product URLs" configuration does not work.

### Fixed Issues (if relevant)
1. magento/magento2#9863: "Use Categories Path for Product URLs" configuration does not work correct

### Manual testing scenarios
1. Go to Admin >> Stores >> Configuration >> Catalog >> Catalog
2. Open "SEO" section
3. Change "Use Categories Path for Product URLs" to "No"
4. Flush all magento cache
5. Go to frontend >> category >> product page >> see generated product URL

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
  - [x] All automated tests passed successfully (all builds on Travis CI are green)
- [ ] All new or changed code is covered with unit/integration tests (if applicable)
