### PR TITLE
Fixes layered navigation options being cached using the wrong store id.

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/AbstractFrontend.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Frontend/AbstractFrontend.php
@@ -13,7 +13,7 @@ namespace Magento\Eav\Model\Entity\Attribute\Frontend;
 
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\Serializer\Json as Serializer;
-use Magento\Store\Api\StoreResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Eav\Model\Cache\Type as CacheType;
 use Magento\Eav\Model\Entity\Attribute;
@@ -37,9 +37,9 @@ abstract class AbstractFrontend implements \Magento\Eav\Model\Entity\Attribute\F
     private $cache;
 
     /**
-     * @var StoreResolverInterface
+     * @var StoreManagerInterface
      */
-    private $storeResolver;
+    private $storeManager;
 
     /**
      * @var Serializer
@@ -66,22 +66,25 @@ abstract class AbstractFrontend implements \Magento\Eav\Model\Entity\Attribute\F
     /**
      * @param BooleanFactory $attrBooleanFactory
      * @param CacheInterface $cache
-     * @param StoreResolverInterface $storeResolver
+     * @param $storeResolver @deprecated
      * @param array $cacheTags
+     * @param StoreManagerInterface $storeManager
      * @param Serializer $serializer
      * @codeCoverageIgnore
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         BooleanFactory $attrBooleanFactory,
         CacheInterface $cache = null,
-        StoreResolverInterface $storeResolver = null,
+        $storeResolver = null,
         array $cacheTags = null,
+        StoreManagerInterface $storeManager = null,
         Serializer $serializer = null
     ) {
         $this->_attrBooleanFactory = $attrBooleanFactory;
         $this->cache = $cache ?: ObjectManager::getInstance()->get(CacheInterface::class);
-        $this->storeResolver = $storeResolver ?: ObjectManager::getInstance()->get(StoreResolverInterface::class);
         $this->cacheTags = $cacheTags ?: self::$defaultCacheTags;
+        $this->storeManager = $storeManager ?: ObjectManager::getInstance()->get(StoreManagerInterface::class);
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Serializer::class);
     }
 
@@ -299,7 +302,7 @@ abstract class AbstractFrontend implements \Magento\Eav\Model\Entity\Attribute\F
     {
         $cacheKey = 'attribute-navigation-option-' .
             $this->getAttribute()->getAttributeCode() . '-' .
-            $this->storeResolver->getCurrentStoreId();
+            $this->storeManager->getStore()->getId();
         $optionString = $this->cache->load($cacheKey);
         if (false === $optionString) {
             $options = $this->getAttribute()->getSource()->getAllOptions();

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Frontend/DefaultFrontendTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Frontend/DefaultFrontendTest.php
@@ -8,7 +8,8 @@ namespace Magento\Eav\Test\Unit\Model\Entity\Attribute\Frontend;
 use Magento\Eav\Model\Entity\Attribute\Frontend\DefaultFrontend;
 use Magento\Eav\Model\Entity\Attribute\Source\BooleanFactory;
 use Magento\Framework\Serialize\Serializer\Json as Serializer;
-use Magento\Store\Api\StoreResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Api\Data\StoreInterface;
 use Magento\Framework\App\CacheInterface;
 use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
 use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
@@ -31,9 +32,14 @@ class DefaultFrontendTest extends \PHPUnit_Framework_TestCase
     private $serializerMock;
 
     /**
-     * @var StoreResolverInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $storeResolverMock;
+    private $storeManagerMock;
+
+    /**
+     * @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeMock;
 
     /**
      * @var CacheInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -64,7 +70,9 @@ class DefaultFrontendTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $this->serializerMock = $this->getMockBuilder(Serializer::class)
             ->getMock();
-        $this->storeResolverMock = $this->getMockBuilder(StoreResolverInterface::class)
+        $this->storeManagerMock = $this->getMockBuilder(StoreManagerInterface::class)
+            ->getMockForAbstractClass();
+        $this->storeMock = $this->getMockBuilder(StoreInterface::class)
             ->getMockForAbstractClass();
         $this->cacheMock = $this->getMockBuilder(CacheInterface::class)
             ->getMockForAbstractClass();
@@ -83,7 +91,7 @@ class DefaultFrontendTest extends \PHPUnit_Framework_TestCase
             [
                 '_attrBooleanFactory' => $this->booleanFactory,
                 'cache' => $this->cacheMock,
-                'storeResolver' => $this->storeResolverMock,
+                'storeManager' => $this->storeManagerMock,
                 'serializer' => $this->serializerMock,
                 '_attribute' => $this->attributeMock,
                 'cacheTags' => $this->cacheTags
@@ -188,8 +196,11 @@ class DefaultFrontendTest extends \PHPUnit_Framework_TestCase
         $options = ['option1', 'option2'];
         $serializedOptions = "{['option1', 'option2']}";
 
-        $this->storeResolverMock->expects($this->once())
-            ->method('getCurrentStoreId')
+        $this->storeManagerMock->expects($this->once())
+            ->method('getStore')
+            ->willReturn($this->storeMock);
+        $this->storeMock->expects($this->once())
+            ->method('getId')
             ->willReturn($storeId);
         $this->attributeMock->expects($this->once())
             ->method('getAttributeCode')


### PR DESCRIPTION
### Description

This is a "forward" port of MAGETWO-69543.
See https://github.com/magento/magento2/pull/9704 for more details.

The reason why this was first fixed on the `2.1-develop` branch, is that the feature of caching the layered navigation options only landed on the `develop` branch a few days after https://github.com/magento/magento2/pull/9704 was created.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/9679: Translation for layered navigation attribute option not working

### Manual testing scenarios
See https://github.com/magento/magento2/pull/9704

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
