### PR TITLE
Improved error logging when trying to save a product

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
@@ -144,6 +144,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product
                     $this->messageManager->addSuccess(__('You duplicated the product.'));
                 }
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
+                $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
                 $this->messageManager->addError($e->getMessage());
                 $this->getDataPersistor()->set('catalog_product', $data);
                 $redirectBack = $productId ? true : 'new';

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -634,7 +634,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         } catch (LocalizedException $e) {
             throw $e;
         } catch (\Exception $e) {
-            throw new \Magento\Framework\Exception\CouldNotSaveException(__('Unable to save product'));
+            throw new \Magento\Framework\Exception\CouldNotSaveException(__('Unable to save product'), $e);
         }
         unset($this->instances[$product->getSku()]);
         unset($this->instancesById[$product->getId()]);


### PR DESCRIPTION
### Description
Improved error logging for 2 cases: 
- The original exception was not passed as $cause in the new exception, when 
- The original exception is not logged sometimes when trying to save a product
Now we can easily know the underlying exception.

### Fixed Issues (if relevant)
None. General improvement

### Manual testing scenarios
None. General improvement

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
