### PR TITLE
Fixed pointless exception in logs every time a category with image is saved

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -134,11 +134,14 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     {
         $value = $object->getData($this->additionalData . $this->getAttribute()->getName());
 
-        if ($imageName = $this->getUploadedImageName($value)) {
-            try {
-                $this->getImageUploader()->moveFileFromTmp($imageName);
-            } catch (\Exception $e) {
-                $this->_logger->critical($e);
+        if(isset($value[0]['tmp_name'])) {
+            // A file was just uploaded, so process it
+            if ($imageName = $this->getUploadedImageName($value)) {
+                try {
+                    $this->getImageUploader()->moveFileFromTmp($imageName);
+                } catch (\Exception $e) {
+                    $this->_logger->critical($e);
+                }
             }
         }
 


### PR DESCRIPTION
Fixed a pointless exception in the logs every time a category is saved that has an image, even when nothing was changed.
When no image is uploaded, there is no need to try to process it.

Currently there is a try catch which writes an error to the log, but this is also triggered when no image is changed or uploaded. The log thus contains errors that aren't problematic.

### Description
Fixed superflous exception from logs every time a category (with image) is saved, even when no changes were made to the category,

### Fixed Issues (if relevant)
1. Fixed a superflous error message from getting in the logs. This alarms the developer/shopkeeper when there is actually no problem at all.

### Manual testing scenarios
1. Save a category that has an image. No need to change anything really.
2. The exception log should not contain a "critical" exception about a problem writing the file.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
