### PR TITLE
Fix composer validation

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Integrity/ComposerTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/ComposerTest.php
@@ -103,7 +103,7 @@ class ComposerTest extends \PHPUnit_Framework_TestCase
         try {
             $app->runComposerCommand(['command' => 'validate'], $path);
         } catch (\RuntimeException $exception) {
-            $this->fail("Failed validation of {$path}");
+            $this->fail($exception->getMessage());
         }
     }
 

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/ComposerTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/ComposerTest.php
@@ -99,7 +99,12 @@ class ComposerTest extends \PHPUnit_Framework_TestCase
         /** @var \Magento\Framework\Composer\MagentoComposerApplicationFactory $appFactory */
         $appFactory = self::$objectManager->get(\Magento\Framework\Composer\MagentoComposerApplicationFactory::class);
         $app = $appFactory->create();
-        $app->runComposerCommand(['command' => 'validate'], $path);
+
+        try {
+            $app->runComposerCommand(['command' => 'validate'], $path);
+        } catch (\RuntimeException $exception) {
+            $this->fail("Failed validation of {$path}");
+        }
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Composer validate command returns an exit code >0 when the file being evaluated is considered invalid which translates to a RuntimeException being thrown, ending in an error result for the test. 
This fix catches the RuntimeException and treats it as a failure instead adding the evaluated path to the message to make it possible to trace the offending file.

### Manual testing scenarios
1. Edit any composer.json file and remove the description field
2. Run ComposerTest (cd dev\tests\static; php ..\..\..\vendor\phpunit\phpunit\phpunit --filter=ComposerTest)

## Output before fix:

```
PHPUnit 4.1.0 by Sebastian Bergmann.

Configuration read from C:\wamp64\www\magento2\dev\tests\static\phpunit.xml.dist

E.

Time: 2.3 minutes, Memory: 178.00MB

There was 1 error:

1) Magento\Test\Integrity\ComposerTest::testValidComposerJson
RuntimeException: Command "validate" failed: ./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
<warning>See https://getcomposer.org/doc/04-schema.md for details on the schema</warning>
description : The property description is required
<warning>The version field is present, it is recommended to leave it out if the package is published on Packagist.</warning>
<warning>Defining autoload.psr-0 with an empty namespace prefix is a bad idea for performance</warning>
<warning>require.colinmollenhour/credis : exact version constraints (1.6) should be avoided if the package follows semantic versioning</warning>
<warning>require.colinmollenhour/cache-backend-redis : exact version constraints (1.10.2) should be avoided if the package follows semantic versioning</warning>
<warning>require.colinmollenhour/cache-backend-file : exact version constraints (1.4) should be avoided if the package follows semantic versioning</warning>
<warning>require.composer/composer : exact version constraints (1.4.1) should be avoided if the package follows semantic versioning</warning>
<warning>require.tubalmartin/cssmin : exact version constraints (3.0.0) should be avoided if the package follows semantic versioning</warning>
<warning>require.magento/magento-composer-installer : unbound version constraints (>=0.1.11) should be avoided</warning>
<warning>require.braintree/braintree_php : exact version constraints (3.22.0) should be avoided if the package follows semantic versioning</warning>
<warning>require.ramsey/uuid : exact version constraints (3.6.1) should be avoided if the package follows semantic versioning</warning>


C:\wamp64\www\magento2\vendor\magento\composer\src\MagentoComposerApplication.php:119
C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:104
C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:57
C:\wamp64\www\magento2\lib\internal\Magento\Framework\App\Utility\AggregateInvoker.php:56
C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:63

FAILURES!
Tests: 2, Assertions: 2409, Errors: 1.
```

## Output after the fix

```
Configuration read from C:\wamp64\www\magento2\dev\tests\static\phpunit.xml.dist

F.

Time: 1.89 minutes, Memory: 178.00MB

There was 1 failure:

1) Magento\Test\Integrity\ComposerTest::testValidComposerJson
Passed: 120, Failed: 2, Incomplete: 0, Skipped: 0.
Data set: C:/wamp64/www/magento2/app/code/Magento/Backup
Command "validate" failed: ./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
<warning>See https://getcomposer.org/doc/04-schema.md for details on the schema</warning>
description : The property description is required
<warning>The version field is present, it is recommended to leave it out if the package is published on Packagist.</warning>

C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:106
C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:57
C:\wamp64\www\magento2\lib\internal\Magento\Framework\App\Utility\AggregateInvoker.php:56
C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:63

Data set: C:\wamp64\www\magento2
Following dependencies declared in the root composer.json do not exist: magento/module-backup
Failed asserting that an array is empty.
C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:412
C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:172
C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:61
C:\wamp64\www\magento2\lib\internal\Magento\Framework\App\Utility\AggregateInvoker.php:56
C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:63

C:\wamp64\www\magento2\lib\internal\Magento\Framework\App\Utility\AggregateInvoker.php:114
C:\wamp64\www\magento2\lib\internal\Magento\Framework\App\Utility\AggregateInvoker.php:70
C:\wamp64\www\magento2\dev\tests\static\testsuite\Magento\Test\Integrity\ComposerTest.php:63

FAILURES!
Tests: 2, Assertions: 2401, Failures: 1.
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
