### PR TITLE
suggestion from #9338: add some command/option to the deploy command to refresh the version

### DIFF
--- a/app/code/Magento/Deploy/Console/DeployStaticOptions.php
+++ b/app/code/Magento/Deploy/Console/DeployStaticOptions.php
@@ -132,6 +132,11 @@ class DeployStaticOptions
     const CONTENT_VERSION = 'content-version';
 
     /**
+     * Key for refresh content version only mode
+     */
+    const REFRESH_CONTENT_VERSION_ONLY = 'refresh-content-version-only';
+
+    /**
      * Deploy static command options list
      *
      * @return array
@@ -224,6 +229,13 @@ class DeployStaticOptions
                 InputArgument::OPTIONAL,
                 'Custom version of static content can be used if running deployment on multiple nodes '
                 . 'to ensure that static content version is identical and caching works properly.'
+            ),
+            new InputOption(
+                self::REFRESH_CONTENT_VERSION_ONLY,
+                null,
+                InputOption::VALUE_NONE,
+                'Refreshing the version of static content only can be used to refresh static content '
+                . 'in browser cache and CDN cache.'
             ),
             new InputArgument(
                 self::LANGUAGES_ARGUMENT,

--- a/app/code/Magento/Deploy/Service/DeployStaticContent.php
+++ b/app/code/Magento/Deploy/Service/DeployStaticContent.php
@@ -81,7 +81,7 @@ class DeployStaticContent
         $this->versionStorage->save($version);
 
         if ($this->getRefreshContentVersionOnly($options)) {
-            $this->logger->warning(PHP_EOL . "New content version: " . $version);
+            $this->logger->warning("New content version: " . $version);
             return;
         }
 
@@ -148,7 +148,6 @@ class DeployStaticContent
     private function getRefreshContentVersionOnly(array $options)
     {
         return isset($options[Options::REFRESH_CONTENT_VERSION_ONLY])
-            ? (bool)$options[Options::REFRESH_CONTENT_VERSION_ONLY]
-            : false;
+            && $options[Options::REFRESH_CONTENT_VERSION_ONLY];
     }
 }

--- a/app/code/Magento/Deploy/Service/DeployStaticContent.php
+++ b/app/code/Magento/Deploy/Service/DeployStaticContent.php
@@ -75,6 +75,16 @@ class DeployStaticContent
      */
     public function deploy(array $options)
     {
+        $version = !empty($options[Options::CONTENT_VERSION]) && is_string($options[Options::CONTENT_VERSION])
+            ? $options[Options::CONTENT_VERSION]
+            : (new \DateTime())->getTimestamp();
+        $this->versionStorage->save($version);
+
+        if ($options[Options::REFRESH_CONTENT_VERSION_ONLY]) {
+            $this->logger->warning(PHP_EOL . "New content version: " . $version);
+            return;
+        }
+
         $queue = $this->queueFactory->create(
             [
                 'logger' => $this->logger,
@@ -95,11 +105,6 @@ class DeployStaticContent
                 'queue' => $queue
             ]
         );
-
-        $version = !empty($options[Options::CONTENT_VERSION]) && is_string($options[Options::CONTENT_VERSION])
-            ? $options[Options::CONTENT_VERSION]
-            : (new \DateTime())->getTimestamp();
-        $this->versionStorage->save($version);
 
         $packages = $deployStrategy->deploy($options);
 

--- a/app/code/Magento/Deploy/Service/DeployStaticContent.php
+++ b/app/code/Magento/Deploy/Service/DeployStaticContent.php
@@ -80,7 +80,7 @@ class DeployStaticContent
             : (new \DateTime())->getTimestamp();
         $this->versionStorage->save($version);
 
-        if ($options[Options::REFRESH_CONTENT_VERSION_ONLY]) {
+        if ($this->getRefreshContentVersionOnly($options)) {
             $this->logger->warning(PHP_EOL . "New content version: " . $version);
             return;
         }
@@ -139,5 +139,16 @@ class DeployStaticContent
     private function getProcessesAmount(array $options)
     {
         return isset($options[Options::JOBS_AMOUNT]) ? (int)$options[Options::JOBS_AMOUNT] : 0;
+    }
+
+    /**
+     * @param array $options
+     * @return bool
+     */
+    private function getRefreshContentVersionOnly(array $options)
+    {
+        return isset($options[Options::REFRESH_CONTENT_VERSION_ONLY])
+            ? (bool)$options[Options::REFRESH_CONTENT_VERSION_ONLY]
+            : false;
     }
 }

--- a/app/code/Magento/Deploy/Service/DeployStaticContent.php
+++ b/app/code/Magento/Deploy/Service/DeployStaticContent.php
@@ -80,7 +80,7 @@ class DeployStaticContent
             : (new \DateTime())->getTimestamp();
         $this->versionStorage->save($version);
 
-        if ($this->getRefreshContentVersionOnly($options)) {
+        if ($this->isRefreshContentVersionOnly($options)) {
             $this->logger->warning("New content version: " . $version);
             return;
         }
@@ -145,7 +145,7 @@ class DeployStaticContent
      * @param array $options
      * @return bool
      */
-    private function getRefreshContentVersionOnly(array $options)
+    private function isRefreshContentVersionOnly(array $options)
     {
         return isset($options[Options::REFRESH_CONTENT_VERSION_ONLY])
             && $options[Options::REFRESH_CONTENT_VERSION_ONLY];

--- a/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
@@ -125,9 +125,7 @@ class DeployStaticContentTest extends \PHPUnit_Framework_TestCase
             $package->expects($this->exactly(3))->method('getTheme')->willReturn('theme');
             $package->expects($this->exactly(2))->method('getLocale')->willReturn('locale');
         }
-        $packages = [
-            'package' => $package
-        ];
+        $packages = ['package' => $package];
 
         if ($expectedContentVersion) {
             $this->versionStorage->expects($this->once())->method('save')->with($expectedContentVersion);
@@ -150,7 +148,6 @@ class DeployStaticContentTest extends \PHPUnit_Framework_TestCase
             ->getMockForAbstractClass();
         if ($options['refresh-content-version-only']) {
             $strategy->expects($this->never())->method('deploy');
-            $this->deployStrategyFactory->expects($this->never())->method('create');
         } else {
             $strategy->expects($this->once())->method('deploy')
                 ->with($options)
@@ -201,18 +198,11 @@ class DeployStaticContentTest extends \PHPUnit_Framework_TestCase
 
             $this->objectManager->expects($this->exactly(1))
                 ->method('get')
-                ->withConsecutive(
-                    [MinifyTemplates::class]
-                )
-                ->willReturnOnConsecutiveCalls(
-                    $minifyTemplates
-                );
+                ->withConsecutive([MinifyTemplates::class])
+                ->willReturnOnConsecutiveCalls($minifyTemplates);
         }
 
-        $this->assertEquals(
-            null,
-            $this->service->deploy($options)
-        );
+        $this->assertEquals(null, $this->service->deploy($options));
     }
 
     public function deployDataProvider()

--- a/lib/internal/Magento/Framework/App/View/Deployment/Version/Storage/File.php
+++ b/lib/internal/Magento/Framework/App/View/Deployment/Version/Storage/File.php
@@ -41,7 +41,7 @@ class File implements \Magento\Framework\App\View\Deployment\Version\StorageInte
     public function load()
     {
         if ($this->directory->isReadable($this->fileName)) {
-            return $this->directory->readFile($this->fileName);
+            return trim($this->directory->readFile($this->fileName));
         }
         return false;
     }

--- a/lib/internal/Magento/Framework/App/View/Deployment/Version/Storage/File.php
+++ b/lib/internal/Magento/Framework/App/View/Deployment/Version/Storage/File.php
@@ -41,7 +41,7 @@ class File implements \Magento\Framework\App\View\Deployment\Version\StorageInte
     public function load()
     {
         if ($this->directory->isReadable($this->fileName)) {
-            return trim($this->directory->readFile($this->fileName));
+            return $this->directory->readFile($this->fileName);
         }
         return false;
     }

--- a/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
@@ -120,11 +120,15 @@ class DeployStaticContentCommand extends Command
 
         $options = $input->getOptions();
         $options[Options::LANGUAGE] = $input->getArgument(Options::LANGUAGES_ARGUMENT) ?: ['all'];
+        $refreshOnly = isset($options[Options::REFRESH_CONTENT_VERSION_ONLY])
+            && $options[Options::REFRESH_CONTENT_VERSION_ONLY];
 
         $verbose = $output->getVerbosity() > 1 ? $output->getVerbosity() : OutputInterface::VERBOSITY_VERBOSE;
 
         $logger = $this->consoleLoggerFactory->getLogger($output, $verbose);
-        $logger->alert(PHP_EOL . "Deploy using {$options[Options::STRATEGY]} strategy");
+        if (!$refreshOnly) {
+            $logger->alert(PHP_EOL . "Deploy using {$options[Options::STRATEGY]} strategy");
+        }
 
         $this->mockCache();
 
@@ -135,7 +139,9 @@ class DeployStaticContentCommand extends Command
 
         $deployService->deploy($options);
 
-        $logger->alert(PHP_EOL . "Execution time: " . (microtime(true) - $time));
+        if (!$refreshOnly) {
+            $logger->alert(PHP_EOL . "Execution time: " . (microtime(true) - $time));
+        }
 
         return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
     }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
@ishakhsuvarov suggested to replace PR #9338 with an option to the `bin/magento setup:static-content:deploy` command that only updates the version of the generated files.
This is in favour of editing the `pub/static/deployed_version.txt` manually.

This comes in handy when a CDN server is out-of-sync or when you want to hotfix a file in deployed code and you want to force a browser cache refresh. This buys you time to deploy the hotfix in a proper way at a moment that is better suited for downtime.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#9338

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. `bin/magento setup:static-content:deploy -f --content-version="123456" --refresh-content-version-only`
2. No deployment will take place, but the version is now 123456

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
