### PR TITLE
Magento/Magento2#6992 - CatalogImportExport categoryProcessor is using default store id values #6992

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\CatalogImportExport\Model\Import\Product;
 
+use \Magento\Store\Model\Store;
+
 class CategoryProcessor
 {
     /**
@@ -65,7 +67,9 @@ class CategoryProcessor
     {
         if (empty($this->categories)) {
             $collection = $this->categoryColFactory->create();
-            $collection->addAttributeToSelect('name')
+            $collection
+                ->setStoreId(Store::DEFAULT_STORE_ID)
+                ->addAttributeToSelect('name')
                 ->addAttributeToSelect('url_key')
                 ->addAttributeToSelect('url_path');
             /* @var $collection \Magento\Catalog\Model\ResourceModel\Category\Collection */

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
@@ -118,7 +118,6 @@ class CategoryProcessor
         return $category->getId();
     }
 
-
     /**
      * Returns ID of category by string path creating nonexistent ones.
      *

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/CategoryProcessor.php
@@ -67,8 +67,8 @@ class CategoryProcessor
     {
         if (empty($this->categories)) {
             $collection = $this->categoryColFactory->create();
+            $collection->setStoreId(Store::DEFAULT_STORE_ID);
             $collection
-                ->setStoreId(Store::DEFAULT_STORE_ID)
                 ->addAttributeToSelect('name')
                 ->addAttributeToSelect('url_key')
                 ->addAttributeToSelect('url_path');


### PR DESCRIPTION
### Description
While importing the product with categories path showing error "1. Category "Default Category/Test" has not been created. URL key for specified store already exists. in row(s): 1"

issue fixed by setting the default store id with category collection.

For that, I am using the class Magento\Store\Model\Store in Magento\CatalogImportExport\Model\Import\Product\CategoryProcessor and added $collection->setStoreId(Store::DEFAULT_STORE_ID);

### Fixed Issues
1. magento/magento2#6992: CatalogImportExport categoryProcessor is using default store id values #6992

### Manual testing scenarios
1. Create a category 'Test'
2. Set the category name to something completely different on default storeview
3. Create a csv with catalogue product data
4. Set 'Default Category/Test' as the 'categories' value
5. Import

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
