### PR TITLE
Cron uses the wrong timestamp method

### DIFF
--- a/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
@@ -64,9 +64,9 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     protected $_cronGroupConfig;
 
     /**
-     * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
+     * @var \Magento\Framework\Stdlib\DateTime\DateTime
      */
-    protected $timezone;
+    protected $dateTimeMock;
 
     /**
      * @var \Magento\Framework\Event\Observer
@@ -126,8 +126,10 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
 
         $this->observer = $this->getMock(\Magento\Framework\Event\Observer::class, [], [], '', false);
 
-        $this->timezone = $this->getMock(\Magento\Framework\Stdlib\DateTime\TimezoneInterface::class);
-        $this->timezone->expects($this->any())->method('scopeTimeStamp')->will($this->returnValue(time()));
+        $this->dateTimeMock = $this->getMockBuilder(\Magento\Framework\Stdlib\DateTime\DateTime::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->dateTimeMock->expects($this->any())->method('gmtTimestamp')->will($this->returnValue(time()));
 
         $phpExecutableFinder = $this->getMock(\Symfony\Component\Process\PhpExecutableFinder::class, [], [], '', false);
         $phpExecutableFinder->expects($this->any())->method('find')->willReturn('php');
@@ -148,7 +150,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             $this->_scopeConfig,
             $this->_request,
             $this->_shell,
-            $this->timezone,
+            $this->dateTimeMock,
             $phpExecutableFinderFactory,
             $this->loggerMock,
             $this->appStateMock


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->

Because the cron job uses a localized timestamp instead of a regular
timestamp, all times in the cron_schedule table are not the actual
times, but times with a double offset.

By using the regular timestamp, all times in cron_schedule are correct.
The cron job execution times are not affected by this change because
schedule generation and job execution depend on the same timestamp.
If both are in the same timezone all will go as intended.

Fixes #4237

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#4237: Cron times in the database are not UTC

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. truncate the cron_schedule table
2. flush the caches
3. execute `bin/magento cron:run`
4. verify that the earliest created_at time in the database is the current time
5. wait for one minute
6. execute `bin/magento cron:run` again
7. verify that the earliest executed_at time in the database is the current time
8. verify that only the jobs that are supposed to run based on their scheduled_at time, have run

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
