### PR TITLE
Fix issue Import can't use add_update as behaviour #9310

### DIFF
--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
@@ -543,6 +543,7 @@ abstract class AbstractEntity
         if (!isset(
             $this->_parameters['behavior']
         ) ||
+            $this->_parameters['behavior'] != \Magento\ImportExport\Model\Import::BEHAVIOR_ADD_UPDATE &&
             $this->_parameters['behavior'] != \Magento\ImportExport\Model\Import::BEHAVIOR_APPEND &&
             $this->_parameters['behavior'] != \Magento\ImportExport\Model\Import::BEHAVIOR_REPLACE &&
             $this->_parameters['behavior'] != \Magento\ImportExport\Model\Import::BEHAVIOR_DELETE

--- a/app/code/Magento/ImportExport/Model/Source/Import/Behavior/Basic.php
+++ b/app/code/Magento/ImportExport/Model/Source/Import/Behavior/Basic.php
@@ -18,7 +18,8 @@ class Basic extends \Magento\ImportExport\Model\Source\Import\AbstractBehavior
     public function toArray()
     {
         return [
-            \Magento\ImportExport\Model\Import::BEHAVIOR_APPEND => __('Add/Update'),
+            \Magento\ImportExport\Model\Import::BEHAVIOR_ADD_UPDATE => __('Add/Update'),
+            \Magento\ImportExport\Model\Import::BEHAVIOR_APPEND => __('Append'),
             \Magento\ImportExport\Model\Import::BEHAVIOR_REPLACE => __('Replace'),
             \Magento\ImportExport\Model\Import::BEHAVIOR_DELETE => __('Delete')
         ];

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Source/Import/Behavior/BasicTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Source/Import/Behavior/BasicTest.php
@@ -24,6 +24,7 @@ class BasicTest extends \Magento\ImportExport\Test\Unit\Model\Source\Import\Abst
      * @var array
      */
     protected $_expectedBehaviors = [
+        \Magento\ImportExport\Model\Import::BEHAVIOR_ADD_UPDATE,
         \Magento\ImportExport\Model\Import::BEHAVIOR_APPEND,
         \Magento\ImportExport\Model\Import::BEHAVIOR_REPLACE,
         \Magento\ImportExport\Model\Import::BEHAVIOR_DELETE,


### PR DESCRIPTION
### Description
In product import the add/update behavior is not using correct behavior and append behavior is missing on the possible behaviors select field.

### Fixed Issues (if relevant)
1. magento/magento2#9310: Import can't use add_update as behaviour

### Manual testing scenarios
1. Create a csv file with existing product sku
2. Include only fields that needs to be updated (for example price)
3. Try Import with behavior Add/Update

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
