### PR TITLE
Instantly apply configuration changes in the cron schedule

### DIFF
--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -469,8 +469,8 @@ class ProcessCronQueueObserver implements ObserverInterface
         $currentTime = $this->timezone->scopeTimeStamp();
         $timeAhead = $currentTime + $timeInterval;
         for ($time = $currentTime; $time < $timeAhead; $time += self::SECONDS_IN_MINUTE) {
-            $ts = strftime('%Y-%m-%d %H:%M:00', $time);
-            if (!empty($exists[$jobCode . '/' . $ts])) {
+            $timestamp = strftime('%Y-%m-%d %H:%M:00', $time);
+            if (!empty($exists[$jobCode . '/' . $timestamp])) {
                 // already scheduled
                 continue;
             }

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -176,6 +176,8 @@ class ProcessCronQueueObserver implements ObserverInterface
         $phpPath = $this->phpExecutableFinder->find() ?: 'php';
 
         foreach ($jobGroupsRoot as $groupId => $jobsRoot) {
+            $this->cleanup($groupId);
+            $this->generate($groupId);
             if ($this->request->getParam('group') !== null
                 && $this->request->getParam('group') !== '\'' . ($groupId) . '\''
                 && $this->request->getParam('group') !== $groupId) {
@@ -232,9 +234,6 @@ class ProcessCronQueueObserver implements ObserverInterface
                 }
                 $schedule->save();
             }
-
-            $this->generate($groupId);
-            $this->cleanup($groupId);
         }
     }
 

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -248,7 +248,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @return void
      * @throws \Exception
      */
-    protected function runJob($scheduledTime, $currentTime, $jobConfig, $schedule, $groupId)
+    public function runJob($scheduledTime, $currentTime, $jobConfig, $schedule, $groupId)
     {
         $scheduleLifetime = (int)$this->scopeConfig->getValue(
             'system/cron/' . $groupId . '/' . self::XML_PATH_SCHEDULE_LIFETIME,
@@ -293,7 +293,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      *
      * @return \Magento\Cron\Model\ResourceModel\Schedule\Collection
      */
-    protected function getPendingSchedules()
+    public function getPendingSchedules()
     {
         if (!$this->pendingSchedules) {
             $this->pendingSchedules = $this->scheduleFactory->create()->getCollection()->addFieldToFilter(
@@ -310,7 +310,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param string $groupId
      * @return $this
      */
-    protected function generate($groupId)
+    public function generate($groupId)
     {
         /**
          * check if schedule generation is needed
@@ -359,7 +359,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param   string $groupId
      * @return  $this
      */
-    protected function generateJobs($jobs, $exists, $groupId)
+    public function generateJobs($jobs, $exists, $groupId)
     {
         foreach ($jobs as $jobCode => $jobConfig) {
             $cronExpression = null;
@@ -389,7 +389,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param string $groupId
      * @return $this
      */
-    protected function cleanup($groupId)
+    public function cleanup($groupId)
     {
         // check if history cleanup is needed
         $lastCleanup = (int)$this->cache->load(self::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . $groupId);
@@ -455,7 +455,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param array $jobConfig
      * @return mixed
      */
-    protected function getConfigSchedule($jobConfig)
+    public function getConfigSchedule($jobConfig)
     {
         $cronExpr = $this->scopeConfig->getValue(
             $jobConfig['config_path'],
@@ -472,7 +472,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param array $exists
      * @return void
      */
-    protected function saveSchedule($jobCode, $cronExpression, $timeInterval, $exists)
+    public function saveSchedule($jobCode, $cronExpression, $timeInterval, $exists)
     {
         $currentTime = $this->timezone->scopeTimeStamp();
         $timeAhead = $currentTime + $timeInterval;
@@ -496,7 +496,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param int $time
      * @return Schedule
      */
-    protected function generateSchedule($jobCode, $cronExpression, $time)
+    public function generateSchedule($jobCode, $cronExpression, $time)
     {
         $schedule = $this->scheduleFactory->create()
             ->setCronExpr($cronExpression)
@@ -512,7 +512,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param string $groupId
      * @return int
      */
-    protected function getScheduleTimeInterval($groupId)
+    public function getScheduleTimeInterval($groupId)
     {
         $scheduleAheadFor = (int)$this->scopeConfig->getValue(
             'system/cron/' . $groupId . '/' . self::XML_PATH_SCHEDULE_AHEAD_FOR,

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -122,6 +122,11 @@ class ProcessCronQueueObserver implements ObserverInterface
     protected $invalid = [];
 
     /**
+     * @var array
+     */
+    protected $jobs;
+
+    /**
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Cron\Model\ScheduleFactory $scheduleFactory
      * @param \Magento\Framework\App\CacheInterface $cache
@@ -206,6 +211,7 @@ class ProcessCronQueueObserver implements ObserverInterface
                 continue;
             }
 
+            /** @var \Magento\Cron\Model\Schedule $schedule */
             foreach ($pendingJobs as $schedule) {
                 $jobConfig = isset($jobsRoot[$schedule->getJobCode()]) ? $jobsRoot[$schedule->getJobCode()] : null;
                 if (!$jobConfig) {
@@ -342,7 +348,7 @@ class ProcessCronQueueObserver implements ObserverInterface
         /**
          * generate global crontab jobs
          */
-        $jobs = $this->config->getJobs();
+        $jobs = $this->getJobs();
         $this->invalid = [];
         $this->generateJobs($jobs[$groupId], $exists, $groupId);
         $this->cleanupScheduleMismatches();
@@ -539,7 +545,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      */
     public function cleanupDisabledJobs($groupId)
     {
-        $jobs = $this->config->getJobs();
+        $jobs = $this->getJobs();
         foreach ($jobs[$groupId] as $jobCode => $jobConfig) {
             if (!$this->getCronExpression($jobConfig)) {
                 /** @var \Magento\Cron\Model\ResourceModel\Schedule $scheduleResource */
@@ -589,5 +595,16 @@ class ProcessCronQueueObserver implements ObserverInterface
             ]);
         }
         return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getJobs()
+    {
+        if (is_null($this->jobs)) {
+            $this->jobs = $this->config->getJobs();
+        }
+        return $this->jobs;
     }
 }

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -374,7 +374,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param   string $groupId
      * @return  $this
      */
-    public function generateJobs($jobs, $exists, $groupId)
+    private function generateJobs($jobs, $exists, $groupId)
     {
         foreach ($jobs as $jobCode => $jobConfig) {
             $cronExpression = $this->getCronExpression($jobConfig);
@@ -394,7 +394,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param string $groupId
      * @return $this
      */
-    public function cleanup($groupId)
+    private function cleanup($groupId)
     {
         $this->cleanupDisabledJobs($groupId);
 
@@ -462,7 +462,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param array $jobConfig
      * @return mixed
      */
-    public function getConfigSchedule($jobConfig)
+    private function getConfigSchedule($jobConfig)
     {
         $cronExpr = $this->scopeConfig->getValue(
             $jobConfig['config_path'],
@@ -479,7 +479,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param array $exists
      * @return void
      */
-    public function saveSchedule($jobCode, $cronExpression, $timeInterval, $exists)
+    private function saveSchedule($jobCode, $cronExpression, $timeInterval, $exists)
     {
         $currentTime = $this->timezone->scopeTimeStamp();
         $timeAhead = $currentTime + $timeInterval;
@@ -510,7 +510,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param int $time
      * @return Schedule
      */
-    public function generateSchedule($jobCode, $cronExpression, $time)
+    private function generateSchedule($jobCode, $cronExpression, $time)
     {
         $schedule = $this->scheduleFactory->create()
             ->setCronExpr($cronExpression)
@@ -526,7 +526,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param string $groupId
      * @return int
      */
-    public function getScheduleTimeInterval($groupId)
+    private function getScheduleTimeInterval($groupId)
     {
         $scheduleAheadFor = (int)$this->scopeConfig->getValue(
             'system/cron/' . $groupId . '/' . self::XML_PATH_SCHEDULE_AHEAD_FOR,
@@ -562,7 +562,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param $jobConfig
      * @return null|string
      */
-    public function getCronExpression($jobConfig)
+    private function getCronExpression($jobConfig)
     {
         $cronExpression = null;
         if (isset($jobConfig['config_path'])) {
@@ -600,7 +600,7 @@ class ProcessCronQueueObserver implements ObserverInterface
     /**
      * @return array
      */
-    public function getJobs()
+    private function getJobs()
     {
         if (is_null($this->jobs)) {
             $this->jobs = $this->config->getJobs();

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -59,7 +59,7 @@ class ProcessCronQueueObserver implements ObserverInterface
     /**
      * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection
      */
-    protected $pendingSchedules;
+    protected $_pendingSchedules;
 
     /**
      * @var \Magento\Cron\Model\ConfigInterface
@@ -109,7 +109,7 @@ class ProcessCronQueueObserver implements ObserverInterface
     /**
      * @var \Psr\Log\LoggerInterface
      */
-    protected $logger;
+    private $logger;
 
     /**
      * @var \Magento\Framework\App\State
@@ -308,13 +308,13 @@ class ProcessCronQueueObserver implements ObserverInterface
      */
     protected function _getPendingSchedules()
     {
-        if (!$this->pendingSchedules) {
-            $this->pendingSchedules = $this->_scheduleFactory->create()->getCollection()->addFieldToFilter(
+        if (!$this->_pendingSchedules) {
+            $this->_pendingSchedules = $this->_scheduleFactory->create()->getCollection()->addFieldToFilter(
                 'status',
                 Schedule::STATUS_PENDING
             )->load();
         }
-        return $this->pendingSchedules;
+        return $this->_pendingSchedules;
     }
 
     /**

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -59,72 +59,72 @@ class ProcessCronQueueObserver implements ObserverInterface
     /**
      * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection
      */
-    protected $pendingSchedules;
+    private $pendingSchedules;
 
     /**
      * @var \Magento\Cron\Model\ConfigInterface
      */
-    protected $config;
+    private $config;
 
     /**
      * @var \Magento\Framework\App\ObjectManager
      */
-    protected $objectManager;
+    private $objectManager;
 
     /**
      * @var \Magento\Framework\App\CacheInterface
      */
-    protected $cache;
+    private $cache;
 
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
-    protected $scopeConfig;
+    private $scopeConfig;
 
     /**
      * @var ScheduleFactory
      */
-    protected $scheduleFactory;
+    private $scheduleFactory;
 
     /**
      * @var \Magento\Framework\App\Console\Request
      */
-    protected $request;
+    private $request;
 
     /**
      * @var \Magento\Framework\ShellInterface
      */
-    protected $shell;
+    private $shell;
 
     /**
      * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
      */
-    protected $timezone;
+    private $timezone;
 
     /**
      * @var \Symfony\Component\Process\PhpExecutableFinder
      */
-    protected $phpExecutableFinder;
+    private $phpExecutableFinder;
 
     /**
      * @var \Psr\Log\LoggerInterface
      */
-    protected $logger;
+    private $logger;
 
     /**
      * @var \Magento\Framework\App\State
      */
-    protected $state;
+    private $state;
 
     /**
      * @var array
      */
-    protected $invalid = [];
+    private $invalid = [];
 
     /**
      * @var array
      */
-    protected $jobs;
+    private $jobs;
 
     /**
      * @param \Magento\Framework\ObjectManagerInterface $objectManager

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -541,7 +541,8 @@ class ProcessCronQueueObserver implements ObserverInterface
      * Clean up scheduled jobs that are disabled in the configuration
      * This can happen when you turn off a cron job in the config and flush the cache
      *
-     * @param $groupId
+     * @param string $groupId
+     * @return void
      */
     public function cleanupDisabledJobs($groupId)
     {
@@ -559,7 +560,7 @@ class ProcessCronQueueObserver implements ObserverInterface
     }
 
     /**
-     * @param $jobConfig
+     * @param array $jobConfig
      * @return null|string
      */
     private function getCronExpression($jobConfig)
@@ -602,7 +603,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      */
     private function getJobs()
     {
-        if (is_null($this->jobs)) {
+        if ($this->jobs === null) {
             $this->jobs = $this->config->getJobs();
         }
         return $this->jobs;

--- a/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
@@ -18,50 +18,52 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     /**
      * @var ProcessCronQueueObserver
      */
-    protected $_observer;
+    protected $cronQueueObserver;
 
     /**
      * @var \Magento\Framework\App\ObjectManager|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $_objectManager;
+    protected $objectManager;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    protected $_cache;
+    protected $cache;
 
     /**
      * @var \Magento\Cron\Model\Config|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $_config;
+    protected $config;
 
     /**
      * @var \Magento\Cron\Model\ScheduleFactory
      */
-    protected $_scheduleFactory;
+    protected $scheduleFactory;
 
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $_scopeConfig;
+    protected $scopeConfig;
 
     /**
      * @var \Magento\Framework\App\Console\Request|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $_request;
+    protected $request;
 
     /**
      * @var \Magento\Framework\ShellInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $_shell;
+    protected $shell;
 
-    /** @var \Magento\Cron\Model\ResourceModel\Schedule\Collection|\PHPUnit_Framework_MockObject_MockObject */
-    protected $_collection;
+    /**
+     * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $collection;
 
     /**
      * @var \Magento\Cron\Model\Groups\Config\Data
      */
-    protected $_cronGroupConfig;
+    protected $cronGroupConfig;
 
     /**
      * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
@@ -88,32 +90,32 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->_objectManager = $this->getMockBuilder(
+        $this->objectManager = $this->getMockBuilder(
             \Magento\Framework\App\ObjectManager::class
         )->disableOriginalConstructor()->getMock();
-        $this->_cache = $this->getMock(\Magento\Framework\App\CacheInterface::class);
-        $this->_config = $this->getMockBuilder(
+        $this->cache = $this->getMock(\Magento\Framework\App\CacheInterface::class);
+        $this->config = $this->getMockBuilder(
             \Magento\Cron\Model\Config::class
         )->disableOriginalConstructor()->getMock();
-        $this->_scopeConfig = $this->getMockBuilder(
+        $this->scopeConfig = $this->getMockBuilder(
             \Magento\Framework\App\Config\ScopeConfigInterface::class
         )->disableOriginalConstructor()->getMock();
-        $this->_collection = $this->getMockBuilder(
+        $this->collection = $this->getMockBuilder(
             \Magento\Cron\Model\ResourceModel\Schedule\Collection::class
         )->setMethods(
             ['addFieldToFilter', 'load', '__wakeup']
         )->disableOriginalConstructor()->getMock();
-        $this->_collection->expects($this->any())->method('addFieldToFilter')->will($this->returnSelf());
-        $this->_collection->expects($this->any())->method('load')->will($this->returnSelf());
-        $this->_scheduleFactory = $this->getMockBuilder(
+        $this->collection->expects($this->any())->method('addFieldToFilter')->will($this->returnSelf());
+        $this->collection->expects($this->any())->method('load')->will($this->returnSelf());
+        $this->scheduleFactory = $this->getMockBuilder(
             \Magento\Cron\Model\ScheduleFactory::class
         )->setMethods(
             ['create']
         )->disableOriginalConstructor()->getMock();
-        $this->_request = $this->getMockBuilder(
+        $this->request = $this->getMockBuilder(
             \Magento\Framework\App\Console\Request::class
         )->disableOriginalConstructor()->getMock();
-        $this->_shell = $this->getMockBuilder(
+        $this->shell = $this->getMockBuilder(
             \Magento\Framework\ShellInterface::class
         )->disableOriginalConstructor()->setMethods(
             ['execute']
@@ -140,14 +142,14 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         );
         $phpExecutableFinderFactory->expects($this->any())->method('create')->willReturn($phpExecutableFinder);
 
-        $this->_observer = new ProcessCronQueueObserver(
-            $this->_objectManager,
-            $this->_scheduleFactory,
-            $this->_cache,
-            $this->_config,
-            $this->_scopeConfig,
-            $this->_request,
-            $this->_shell,
+        $this->cronQueueObserver = new ProcessCronQueueObserver(
+            $this->objectManager,
+            $this->scheduleFactory,
+            $this->cache,
+            $this->config,
+            $this->scopeConfig,
+            $this->request,
+            $this->shell,
             $this->timezone,
             $phpExecutableFinderFactory,
             $this->loggerMock,
@@ -161,18 +163,18 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     public function testDispatchNoPendingJobs()
     {
         $lastRun = time() + 10000000;
-        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->_scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
+        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
 
-        $this->_config->expects($this->once())->method('getJobs')->will($this->returnValue([]));
+        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue([]));
 
         $scheduleMock = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
-        $this->_scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
@@ -181,10 +183,10 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     public function testDispatchNoJobConfig()
     {
         $lastRun = time() + 10000000;
-        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->_scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
+        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
 
-        $this->_config->expects(
+        $this->config->expects(
             $this->once()
         )->method(
             'getJobs'
@@ -195,17 +197,17 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule = $this->getMock(\Magento\Cron\Model\Schedule::class, ['getJobCode', '__wakeup'], [], '', false);
         $schedule->expects($this->once())->method('getJobCode')->will($this->returnValue('not_existed_job_code'));
 
-        $this->_collection->addItem($schedule);
+        $this->collection->addItem($schedule);
 
-        $this->_config->expects($this->once())->method('getJobs')->will($this->returnValue([]));
+        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue([]));
 
         $scheduleMock = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
-        $this->_scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
@@ -214,9 +216,9 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     public function testDispatchCanNotLock()
     {
         $lastRun = time() + 10000000;
-        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->_scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
-        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
+        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
         $schedule = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->setMethods(
@@ -227,9 +229,9 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->once())->method('tryLockJob')->will($this->returnValue(false));
         $abstractModel = $this->getMock(\Magento\Framework\Model\AbstractModel::class, [], [], '', false);
         $schedule->expects($this->any())->method('save')->will($this->returnValue($abstractModel));
-        $this->_collection->addItem($schedule);
+        $this->collection->addItem($schedule);
 
-        $this->_config->expects(
+        $this->config->expects(
             $this->once()
         )->method(
             'getJobs'
@@ -240,10 +242,10 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $scheduleMock = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
-        $this->_scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
@@ -257,9 +259,9 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $exception = $exceptionMessage . ' Schedule Id: ' . $scheduleId . ' Job Code: ' . $jobCode;
 
         $lastRun = time() + 10000000;
-        $this->_cache->expects($this->any())->method('load')->willReturn($lastRun);
-        $this->_scopeConfig->expects($this->any())->method('getValue')->willReturn(0);
-        $this->_request->expects($this->any())->method('getParam')->willReturn('test_group');
+        $this->cache->expects($this->any())->method('load')->willReturn($lastRun);
+        $this->scopeConfig->expects($this->any())->method('getValue')->willReturn(0);
+        $this->request->expects($this->any())->method('getParam')->willReturn('test_group');
         $schedule = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->setMethods(
@@ -296,9 +298,9 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
 
         $this->loggerMock->expects($this->once())->method('info')->with($exception);
 
-        $this->_collection->addItem($schedule);
+        $this->collection->addItem($schedule);
 
-        $this->_config->expects(
+        $this->config->expects(
             $this->once()
         )->method(
             'getJobs'
@@ -308,10 +310,10 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
 
         $scheduleMock = $this->getMockBuilder(\Magento\Cron\Model\Schedule::class)
             ->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->willReturn($this->_collection);
-        $this->_scheduleFactory->expects($this->once())->method('create')->willReturn($scheduleMock);
+        $scheduleMock->expects($this->any())->method('getCollection')->willReturn($this->collection);
+        $this->scheduleFactory->expects($this->once())->method('create')->willReturn($scheduleMock);
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
@@ -342,27 +344,27 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->once())->method('setMessages')->with($this->equalTo($exceptionMessage));
         $schedule->expects($this->any())->method('getStatus')->willReturn(Schedule::STATUS_ERROR);
         $schedule->expects($this->once())->method('save');
-        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
-        $this->_collection->addItem($schedule);
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
+        $this->collection->addItem($schedule);
 
         $this->loggerMock->expects($this->once())->method('critical')->with($exception);
 
         $jobConfig = ['test_group' => ['test_job1' => ['instance' => 'Some_Class']]];
 
-        $this->_config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
 
         $lastRun = time() + 10000000;
-        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
 
-        $this->_scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(strtotime('+1 day')));
+        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(strtotime('+1 day')));
 
         $scheduleMock = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
-        $this->_scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
@@ -389,7 +391,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
         $schedule = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->setMethods(
@@ -408,26 +410,26 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
 
         $this->loggerMock->expects($this->once())->method('critical')->with($exception);
 
-        $this->_collection->addItem($schedule);
+        $this->collection->addItem($schedule);
 
-        $this->_config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
 
         $lastRun = time() + 10000000;
-        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->_scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(strtotime('+1 day')));
+        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(strtotime('+1 day')));
 
         $scheduleMock = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
-        $this->_scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
-        $this->_objectManager
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $this->objectManager
             ->expects($this->once())
             ->method('create')
             ->with($this->equalTo($cronJobType))
             ->will($this->returnValue($cronJobObject));
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
@@ -461,7 +463,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $jobConfig = [
             'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
         ];
-        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
 
         $scheduleMethods = [
             'getJobCode',
@@ -501,24 +503,24 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
 
         $schedule->expects($this->at(8))->method('save');
 
-        $this->_collection->addItem($schedule);
+        $this->collection->addItem($schedule);
 
-        $this->_config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
 
         $lastRun = time() + 10000000;
-        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->_scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(strtotime('+1 day')));
+        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(strtotime('+1 day')));
 
         $scheduleMock = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
-        $this->_scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
 
         $testCronJob = $this->getMockBuilder('CronJob')->setMethods(['execute'])->getMock();
         $testCronJob->expects($this->atLeastOnce())->method('execute')->with($schedule);
 
-        $this->_objectManager->expects(
+        $this->objectManager->expects(
             $this->once()
         )->method(
             'create'
@@ -528,11 +530,11 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             $this->returnValue($testCronJob)
         );
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
-     * Testing _generate(), iterate over saved cron jobs
+     * Testing generate(), iterate over saved cron jobs
      */
     public function testDispatchNotGenerate()
     {
@@ -540,16 +542,16 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
         ];
 
-        $this->_config->expects($this->at(0))->method('getJobs')->will($this->returnValue($jobConfig));
-        $this->_config->expects(
+        $this->config->expects($this->at(0))->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->config->expects(
             $this->at(1)
         )->method(
             'getJobs'
         )->will(
             $this->returnValue(['test_group' => []])
         );
-        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
-        $this->_cache->expects(
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
+        $this->cache->expects(
             $this->at(0)
         )->method(
             'load'
@@ -558,7 +560,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         )->will(
             $this->returnValue(time() - 10000000)
         );
-        $this->_cache->expects(
+        $this->cache->expects(
             $this->at(2)
         )->method(
             'load'
@@ -568,7 +570,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             $this->returnValue(time() + 10000000)
         );
 
-        $this->_scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
+        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
 
         $schedule = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
@@ -578,24 +580,24 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('job_code1'));
         $schedule->expects($this->once())->method('getScheduledAt')->will($this->returnValue('* * * * *'));
 
-        $this->_collection->addItem(new \Magento\Framework\DataObject());
-        $this->_collection->addItem($schedule);
+        $this->collection->addItem(new \Magento\Framework\DataObject());
+        $this->collection->addItem($schedule);
 
-        $this->_cache->expects($this->any())->method('save');
+        $this->cache->expects($this->any())->method('save');
 
         $scheduleMock = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
-        $this->_scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $this->scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->_scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($schedule));
+        $this->scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($schedule));
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
-     * Testing _generate(), iterate over saved cron jobs and generate jobs
+     * Testing generate(), iterate over saved cron jobs and generate jobs
      */
     public function testDispatchGenerate()
     {
@@ -615,17 +617,17 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
                 'job3' => ['schedule' => '* * * * *'],
             ],
         ];
-        $this->_config->expects($this->at(0))->method('getJobs')->willReturn($jobConfig);
-        $this->_config->expects($this->at(1))->method('getJobs')->willReturn($jobs);
-        $this->_request->expects($this->any())->method('getParam')->willReturn('default');
-        $this->_cache->expects(
+        $this->config->expects($this->at(0))->method('getJobs')->willReturn($jobConfig);
+        $this->config->expects($this->at(1))->method('getJobs')->willReturn($jobs);
+        $this->request->expects($this->any())->method('getParam')->willReturn('default');
+        $this->cache->expects(
             $this->at(0)
         )->method(
             'load'
         )->with(
             $this->equalTo(ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'default')
         )->willReturn(time() - 10000000);
-        $this->_cache->expects(
+        $this->cache->expects(
             $this->at(2)
         )->method(
             'load'
@@ -633,7 +635,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             $this->equalTo(ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default')
         )->willReturn(time() + 10000000);
 
-        $this->_scopeConfig->expects($this->any())->method('getValue')->willReturnMap(
+        $this->scopeConfig->expects($this->any())->method('getValue')->willReturnMap(
             [
                 [
                     'system/cron/default/schedule_generate_every',
@@ -659,17 +661,17 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->once())->method('getScheduledAt')->willReturn('* * * * *');
         $schedule->expects($this->any())->method('unsScheduleId')->willReturnSelf();
         $schedule->expects($this->any())->method('trySchedule')->willReturnSelf();
-        $schedule->expects($this->any())->method('getCollection')->willReturn($this->_collection);
+        $schedule->expects($this->any())->method('getCollection')->willReturn($this->collection);
         $schedule->expects($this->atLeastOnce())->method('save')->willReturnSelf();
 
-        $this->_collection->addItem(new \Magento\Framework\DataObject());
-        $this->_collection->addItem($schedule);
+        $this->collection->addItem(new \Magento\Framework\DataObject());
+        $this->collection->addItem($schedule);
 
-        $this->_cache->expects($this->any())->method('save');
+        $this->cache->expects($this->any())->method('save');
 
-        $this->_scheduleFactory->expects($this->any())->method('create')->willReturn($schedule);
+        $this->scheduleFactory->expects($this->any())->method('create')->willReturn($schedule);
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
@@ -688,21 +690,21 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         )->getMock();
         $schedule->expects($this->any())->method('getExecutedAt')->will($this->returnValue('-1 day'));
         $schedule->expects($this->any())->method('getStatus')->will($this->returnValue('success'));
-        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
-        $this->_collection->addItem($schedule);
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
+        $this->collection->addItem($schedule);
 
-        $this->_config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
 
-        $this->_cache->expects($this->at(0))->method('load')->will($this->returnValue(time() + 10000000));
-        $this->_cache->expects($this->at(1))->method('load')->will($this->returnValue(time() - 10000000));
+        $this->cache->expects($this->at(0))->method('load')->will($this->returnValue(time() + 10000000));
+        $this->cache->expects($this->at(1))->method('load')->will($this->returnValue(time() - 10000000));
 
-        $this->_scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
+        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
 
         $scheduleMock = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
-        $this->_scheduleFactory->expects($this->at(0))->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $this->scheduleFactory->expects($this->at(0))->method('create')->will($this->returnValue($scheduleMock));
 
         $collection = $this->getMockBuilder(
             \Magento\Cron\Model\ResourceModel\Schedule\Collection::class
@@ -717,14 +719,14 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($collection));
-        $this->_scheduleFactory->expects($this->at(1))->method('create')->will($this->returnValue($scheduleMock));
+        $this->scheduleFactory->expects($this->at(1))->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 
     public function testMissedJobsCleanedInTime()
     {
-        /* 1. Initialize dependencies of _generate() method which is called first */
+        /* 1. Initialize dependencies of generate() method which is called first */
         $jobConfig = [
             'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
         ];
@@ -754,39 +756,39 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         //we don't expect this job be deleted from the list
         $schedule2->expects($this->never())->method('delete');
 
-        $this->_collection->addItem($schedule1);
-        $this->_config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->collection->addItem($schedule1);
+        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
 
         //get configuration value CACHE_KEY_LAST_HISTORY_CLEANUP_AT in the "_generate()"
-        $this->_cache->expects($this->at(0))->method('load')->will($this->returnValue(time() + 10000000));
+        $this->cache->expects($this->at(0))->method('load')->will($this->returnValue(time() + 10000000));
         //get configuration value CACHE_KEY_LAST_HISTORY_CLEANUP_AT in the "_cleanup()"
-        $this->_cache->expects($this->at(1))->method('load')->will($this->returnValue(time() - 10000000));
+        $this->cache->expects($this->at(1))->method('load')->will($this->returnValue(time() - 10000000));
 
-        $this->_scopeConfig->expects($this->at(0))->method('getValue')
+        $this->scopeConfig->expects($this->at(0))->method('getValue')
             ->with($this->equalTo('system/cron/test_group/use_separate_process'))
             ->will($this->returnValue(0));
-        $this->_scopeConfig->expects($this->at(1))->method('getValue')
+        $this->scopeConfig->expects($this->at(1))->method('getValue')
             ->with($this->equalTo('system/cron/test_group/schedule_generate_every'))
             ->will($this->returnValue(0));
-        $this->_scopeConfig->expects($this->at(2))->method('getValue')
+        $this->scopeConfig->expects($this->at(2))->method('getValue')
             ->with($this->equalTo('system/cron/test_group/history_cleanup_every'))
             ->will($this->returnValue(0));
-        $this->_scopeConfig->expects($this->at(3))->method('getValue')
+        $this->scopeConfig->expects($this->at(3))->method('getValue')
             ->with($this->equalTo('system/cron/test_group/schedule_lifetime'))
             ->will($this->returnValue(2*24*60));
-        $this->_scopeConfig->expects($this->at(4))->method('getValue')
+        $this->scopeConfig->expects($this->at(4))->method('getValue')
             ->with($this->equalTo('system/cron/test_group/history_success_lifetime'))
             ->will($this->returnValue(0));
-        $this->_scopeConfig->expects($this->at(5))->method('getValue')
+        $this->scopeConfig->expects($this->at(5))->method('getValue')
             ->with($this->equalTo('system/cron/test_group/history_failure_lifetime'))
             ->will($this->returnValue(0));
 
-        /* 2. Initialize dependencies of _cleanup() method which is called second */
+        /* 2. Initialize dependencies of cleanup() method which is called second */
         $scheduleMock = $this->getMockBuilder(
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
-        $this->_scheduleFactory->expects($this->at(0))->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $this->scheduleFactory->expects($this->at(0))->method('create')->will($this->returnValue($scheduleMock));
 
         $collection = $this->getMockBuilder(
             \Magento\Cron\Model\ResourceModel\Schedule\Collection::class
@@ -802,8 +804,8 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             \Magento\Cron\Model\Schedule::class
         )->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($collection));
-        $this->_scheduleFactory->expects($this->at(1))->method('create')->will($this->returnValue($scheduleMock));
+        $this->scheduleFactory->expects($this->at(1))->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->_observer->execute($this->observer);
+        $this->cronQueueObserver->execute($this->observer);
     }
 }

--- a/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
@@ -5,13 +5,17 @@
  */
 namespace Magento\Cron\Test\Unit\Observer;
 
+use Magento\Cron\Model\ResourceModel\Schedule as ScheduleResource;
 use Magento\Cron\Model\Schedule;
-use Magento\Cron\Observer\ProcessCronQueueObserver as ProcessCronQueueObserver;
+use Magento\Cron\Observer\ProcessCronQueueObserver;
 use Magento\Framework\App\State;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use PHPUnit_Framework_MockObject_MockObject as Mock;
 
 /**
  * Class \Magento\Cron\Test\Unit\Model\ObserverTest
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
  */
 class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,42 +25,42 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     protected $cronQueueObserver;
 
     /**
-     * @var \Magento\Framework\App\ObjectManager|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\ObjectManager | Mock
      */
     protected $objectManager;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var Mock
      */
     protected $cache;
 
     /**
-     * @var \Magento\Cron\Model\Config|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Cron\Model\Config | Mock
      */
     protected $config;
 
     /**
-     * @var \Magento\Cron\Model\ScheduleFactory
+     * @var \Magento\Cron\Model\ScheduleFactory | Mock
      */
     protected $scheduleFactory;
 
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface | Mock
      */
     protected $scopeConfig;
 
     /**
-     * @var \Magento\Framework\App\Console\Request|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\Console\Request | Mock
      */
     protected $request;
 
     /**
-     * @var \Magento\Framework\ShellInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\ShellInterface | Mock
      */
     protected $shell;
 
     /**
-     * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection | Mock
      */
     protected $collection;
 
@@ -76,14 +80,24 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     protected $observer;
 
     /**
-     * @var \Psr\Log\LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Psr\Log\LoggerInterface | Mock
      */
     protected $loggerMock;
 
     /**
-     * @var \Magento\Framework\App\State|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\State | Mock
      */
     protected $appStateMock;
+
+    /**
+     * @var ScheduleResource | Mock
+     */
+    protected $scheduleResource;
+
+    /**
+     * @var AdapterInterface | Mock
+     */
+    protected $connection;
 
     /**
      * Prepare parameters
@@ -100,6 +114,16 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $this->scopeConfig = $this->getMockBuilder(
             \Magento\Framework\App\Config\ScopeConfigInterface::class
         )->disableOriginalConstructor()->getMock();
+        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValueMap([
+            ['system/cron/default/schedule_generate_every', 'store', null, 1],
+            ['system/cron/default/schedule_ahead_for', 'store', null, 20],
+            ['system/cron/default/schedule_lifetime', 'store', null, 15],
+            ['system/cron/default/history_cleanup_every', 'store', null, 10],
+            ['system/cron/default/history_success_lifetime', 'store', null, 60],
+            ['system/cron/default/history_failure_lifetime', 'store', null, 600],
+            ['system/cron/default/use_separate_process', 'store', null, 0],
+        ]));
+
         $this->collection = $this->getMockBuilder(
             \Magento\Cron\Model\ResourceModel\Schedule\Collection::class
         )->setMethods(
@@ -107,19 +131,12 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         )->disableOriginalConstructor()->getMock();
         $this->collection->expects($this->any())->method('addFieldToFilter')->will($this->returnSelf());
         $this->collection->expects($this->any())->method('load')->will($this->returnSelf());
-        $this->scheduleFactory = $this->getMockBuilder(
-            \Magento\Cron\Model\ScheduleFactory::class
-        )->setMethods(
-            ['create']
-        )->disableOriginalConstructor()->getMock();
-        $this->request = $this->getMockBuilder(
-            \Magento\Framework\App\Console\Request::class
-        )->disableOriginalConstructor()->getMock();
-        $this->shell = $this->getMockBuilder(
-            \Magento\Framework\ShellInterface::class
-        )->disableOriginalConstructor()->setMethods(
-            ['execute']
-        )->getMock();
+        $this->scheduleFactory = $this->getMockBuilder(\Magento\Cron\Model\ScheduleFactory::class)
+            ->setMethods(['create'])->disableOriginalConstructor()->getMock();
+        $this->request = $this->getMockBuilder(\Magento\Framework\App\Console\Request::class)
+            ->disableOriginalConstructor()->getMock();
+        $this->shell = $this->getMockBuilder(\Magento\Framework\ShellInterface::class)
+            ->disableOriginalConstructor()->setMethods(['execute'])->getMock();
         $this->loggerMock = $this->getMock(\Psr\Log\LoggerInterface::class);
 
         $this->appStateMock = $this->getMockBuilder(\Magento\Framework\App\State::class)
@@ -142,6 +159,13 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         );
         $phpExecutableFinderFactory->expects($this->any())->method('create')->willReturn($phpExecutableFinder);
 
+        $this->scheduleResource = $this->getMockBuilder(ScheduleResource::class)
+            ->disableOriginalConstructor()->getMock();
+        $this->connection = $this->getMockBuilder(AdapterInterface::class)->disableOriginalConstructor()->getMock();
+
+        $this->scheduleResource->method('getConnection')->willReturn($this->connection);
+        $this->connection->method('delete')->willReturn(1);
+
         $this->cronQueueObserver = new ProcessCronQueueObserver(
             $this->objectManager,
             $this->scheduleFactory,
@@ -158,112 +182,101 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test case without saved cron jobs in data base
+     * Test case for an empty cron_schedule table and no job generation
      */
     public function testDispatchNoPendingJobs()
     {
-        $lastRun = time() + 10000000;
+        $lastRun = time() + 10000000; // skip cleanup and generation
         $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
 
-        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue([]));
+        $this->config->expects($this->exactly(2))->method('getJobs')
+            ->will($this->returnValue(['default' => ['test_job1' => ['test_data']]]));
 
-        $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->getMock();
+        $scheduleMock = $this->getMockBuilder(Schedule::class)->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
-        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
+        $scheduleMock->expects($this->never())->method('setStatus');
+        $scheduleMock->expects($this->never())->method('setExecutedAt');
+        $this->scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
 
         $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
-     * Test case for not existed cron jobs in files but in data base is presented
+     * Test case for a cron job in the database that is not found in the config
      */
     public function testDispatchNoJobConfig()
     {
-        $lastRun = time() + 10000000;
+        $lastRun = time() + 10000000; // skip cleanup and generation
         $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
 
-        $this->config->expects(
-            $this->once()
-        )->method(
-            'getJobs'
-        )->will(
-            $this->returnValue(['test_job1' => ['test_data']])
-        );
+        $this->config->expects($this->any())->method('getJobs')->will($this->returnValue(['default' => []]));
 
-        $schedule = $this->getMock(\Magento\Cron\Model\Schedule::class, ['getJobCode', '__wakeup'], [], '', false);
-        $schedule->expects($this->once())->method('getJobCode')->will($this->returnValue('not_existed_job_code'));
+        /** @var Schedule | Mock $schedule */
+        $schedule = $this->getMock(Schedule::class, ['getJobCode', '__wakeup'], [], '', false);
+        $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('not_existed_job_code'));
 
         $this->collection->addItem($schedule);
 
-        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue([]));
-
-        $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->getMock();
+        $scheduleMock = $this->getMockBuilder(Schedule::class)->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
+        $scheduleMock->expects($this->never())->method('getScheduledAt');
         $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
 
         $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
-     * Test case checks if some job can't be locked
+     * Test case when a job can't be locked
      */
     public function testDispatchCanNotLock()
     {
-        $lastRun = time() + 10000000;
+        $lastRun = time() + 10000000;  // skip cleanup and generation
         $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
-        $schedule = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->setMethods(
-            ['getJobCode', 'tryLockJob', 'getScheduledAt', '__wakeup', 'save']
-        )->disableOriginalConstructor()->getMock();
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        /** @var Schedule | Mock $schedule */
+        $schedule = $this->getMockBuilder(Schedule::class)
+            ->setMethods(['getJobCode', 'tryLockJob', 'getScheduledAt', '__wakeup', 'save'])
+            ->disableOriginalConstructor()->getMock();
         $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('test_job1'));
         $schedule->expects($this->once())->method('getScheduledAt')->will($this->returnValue('-1 day'));
         $schedule->expects($this->once())->method('tryLockJob')->will($this->returnValue(false));
+        $schedule->expects($this->never())->method('setStatus');
+        $schedule->expects($this->never())->method('setExecutedAt');
         $abstractModel = $this->getMock(\Magento\Framework\Model\AbstractModel::class, [], [], '', false);
         $schedule->expects($this->any())->method('save')->will($this->returnValue($abstractModel));
         $this->collection->addItem($schedule);
 
-        $this->config->expects(
-            $this->once()
-        )->method(
-            'getJobs'
-        )->will(
-            $this->returnValue(['test_group' => ['test_job1' => ['test_data']]])
-        );
+        $this->config->expects($this->exactly(2))->method('getJobs')
+            ->will($this->returnValue(['default' => ['test_job1' => ['test_data']]]));
 
-        $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->getMock();
+        $scheduleMock = $this->getMockBuilder(Schedule::class)->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
-        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
+        $this->scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
 
         $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
-     * Test case catch exception if to late for schedule
+     * Test case for catching the exception 'Too late for the schedule'
      */
     public function testDispatchExceptionTooLate()
     {
+        $lastRun = time() + 10000000;  // skip cleanup and generation
         $exceptionMessage = 'Too late for the schedule';
         $scheduleId = 42;
         $jobCode = 'test_job1';
         $exception = $exceptionMessage . ' Schedule Id: ' . $scheduleId . ' Job Code: ' . $jobCode;
 
-        $lastRun = time() + 10000000;
         $this->cache->expects($this->any())->method('load')->willReturn($lastRun);
-        $this->scopeConfig->expects($this->any())->method('getValue')->willReturn(0);
-        $this->request->expects($this->any())->method('getParam')->willReturn('test_group');
+        $this->request->expects($this->any())->method('getParam')->willReturn('default');
+        /** @var Schedule | Mock $schedule */
         $schedule = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
+            Schedule::class
         )->setMethods(
             [
                 'getJobCode',
@@ -279,90 +292,68 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             ]
         )->disableOriginalConstructor()->getMock();
         $schedule->expects($this->any())->method('getJobCode')->willReturn($jobCode);
-        $schedule->expects($this->once())->method('getScheduledAt')->willReturn('-1 day');
+        $schedule->expects($this->once())->method('getScheduledAt')->willReturn('-16 minutes');
         $schedule->expects($this->once())->method('tryLockJob')->willReturn(true);
-        $schedule->expects(
-            $this->once()
-        )->method(
-            'setStatus'
-        )->with(
-            $this->equalTo(\Magento\Cron\Model\Schedule::STATUS_MISSED)
-        )->willReturnSelf();
+        $schedule->expects($this->once())->method('setStatus')
+            ->with($this->equalTo(Schedule::STATUS_MISSED))->willReturnSelf();
         $schedule->expects($this->once())->method('setMessages')->with($this->equalTo($exceptionMessage));
+        $schedule->expects($this->once())->method('setStatus')->with(Schedule::STATUS_MISSED);
         $schedule->expects($this->any())->method('getStatus')->willReturn(Schedule::STATUS_MISSED);
         $schedule->expects($this->once())->method('getMessages')->willReturn($exceptionMessage);
         $schedule->expects($this->once())->method('getScheduleId')->willReturn($scheduleId);
         $schedule->expects($this->once())->method('save');
-
-        $this->appStateMock->expects($this->once())->method('getMode')->willReturn(State::MODE_DEVELOPER);
-
-        $this->loggerMock->expects($this->once())->method('info')->with($exception);
-
         $this->collection->addItem($schedule);
 
-        $this->config->expects(
-            $this->once()
-        )->method(
-            'getJobs'
-        )->willReturn(
-            ['test_group' => ['test_job1' => ['test_data']]]
-        );
+        $this->appStateMock->expects($this->once())->method('getMode')->willReturn(State::MODE_DEVELOPER);
+        $this->loggerMock->expects($this->once())->method('info')->with($exception);
+        $this->config->expects($this->exactly(2))->method('getJobs')
+            ->willReturn(['default' => ['test_job1' => ['test_data']]]);
 
-        $scheduleMock = $this->getMockBuilder(\Magento\Cron\Model\Schedule::class)
+        $scheduleMock = $this->getMockBuilder(Schedule::class)
             ->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->willReturn($this->collection);
-        $this->scheduleFactory->expects($this->once())->method('create')->willReturn($scheduleMock);
+        $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
+        $this->scheduleFactory->expects($this->exactly(2))->method('create')->willReturn($scheduleMock);
 
         $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
-     * Test case catch exception if callback not exist
+     * Test case catch exception if callback does not exist
      */
     public function testDispatchExceptionNoCallback()
     {
+        $lastRun = time() + 10000000;  // skip cleanup and generation
         $exceptionMessage = 'No callbacks found';
         $exception = new \Exception(__($exceptionMessage));
+        $jobConfig = ['default' => ['test_job1' => ['instance' => 'Some_Class', /* 'method' => 'not_set' */]]];
 
+        /** @var Schedule | Mock $schedule */
         $schedule = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
+            Schedule::class
         )->setMethods(
             ['getJobCode', 'tryLockJob', 'getScheduledAt', 'save', 'setStatus', 'setMessages', '__wakeup', 'getStatus']
         )->disableOriginalConstructor()->getMock();
         $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('test_job1'));
-        $schedule->expects($this->once())->method('getScheduledAt')->will($this->returnValue('-1 day'));
+        $schedule->expects($this->once())->method('getScheduledAt')->will($this->returnValue(date('Y-m-d H:i:00')));
         $schedule->expects($this->once())->method('tryLockJob')->will($this->returnValue(true));
-        $schedule->expects(
-            $this->once()
-        )->method(
-            'setStatus'
-        )->with(
-            $this->equalTo(\Magento\Cron\Model\Schedule::STATUS_ERROR)
-        )->will(
-            $this->returnSelf()
-        );
+        $schedule->expects($this->once())->method('setStatus')
+            ->with($this->equalTo(Schedule::STATUS_ERROR))->will($this->returnSelf());
         $schedule->expects($this->once())->method('setMessages')->with($this->equalTo($exceptionMessage));
         $schedule->expects($this->any())->method('getStatus')->willReturn(Schedule::STATUS_ERROR);
         $schedule->expects($this->once())->method('save');
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
         $this->collection->addItem($schedule);
-
         $this->loggerMock->expects($this->once())->method('critical')->with($exception);
-
-        $jobConfig = ['test_group' => ['test_job1' => ['instance' => 'Some_Class']]];
-
-        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
-
-        $lastRun = time() + 10000000;
+        $this->config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
         $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
 
-        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(strtotime('+1 day')));
-
         $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
+            Schedule::class
         )->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
-        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
+        $this->scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
 
         $this->cronQueueObserver->execute($this->observer);
     }
@@ -385,44 +376,36 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $saveCalls,
         $exception
     ) {
-        $jobConfig = [
-            'test_group' => [
-                'test_job1' => ['instance' => $cronJobType, 'method' => 'execute'],
-            ],
-        ];
+        $lastRun = time() + 10000000;  // skip cleanup and generation
+        $jobConfig = ['default' => ['test_job1' => ['instance' => $cronJobType, 'method' => 'execute']]];
 
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
-        $schedule = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->setMethods(
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        /** @var Schedule | Mock $schedule */
+        $schedule = $this->getMockBuilder(Schedule::class)->setMethods(
             ['getJobCode', 'tryLockJob', 'getScheduledAt', 'save', 'setStatus', 'setMessages', '__wakeup', 'getStatus']
         )->disableOriginalConstructor()->getMock();
         $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('test_job1'));
-        $schedule->expects($this->once())->method('getScheduledAt')->will($this->returnValue('-1 day'));
+        $schedule->expects($this->once())->method('getScheduledAt')->will($this->returnValue(date('Y-m-d H:i:00')));
         $schedule->expects($this->once())->method('tryLockJob')->will($this->returnValue(true));
         $schedule->expects($this->once())
             ->method('setStatus')
-            ->with($this->equalTo(\Magento\Cron\Model\Schedule::STATUS_ERROR))
+            ->with($this->equalTo(Schedule::STATUS_ERROR))
             ->will($this->returnSelf());
         $schedule->expects($this->once())->method('setMessages')->with($this->equalTo($exceptionMessage));
         $schedule->expects($this->any())->method('getStatus')->willReturn(Schedule::STATUS_ERROR);
         $schedule->expects($this->exactly($saveCalls))->method('save');
-
-        $this->loggerMock->expects($this->once())->method('critical')->with($exception);
-
         $this->collection->addItem($schedule);
 
-        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
-
-        $lastRun = time() + 10000000;
+        $this->loggerMock->expects($this->once())->method('critical')->with($exception);
+        $this->config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
         $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(strtotime('+1 day')));
 
         $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
+            Schedule::class
         )->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
-        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
+        $this->scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
         $this->objectManager
             ->expects($this->once())
             ->method('create')
@@ -460,10 +443,9 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
      */
     public function testDispatchRunJob()
     {
-        $jobConfig = [
-            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
-        ];
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
+        $lastRun = time() + 10000000;  // skip cleanup and generation
+        $jobConfig = ['default' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']]];
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
 
         $scheduleMethods = [
             'getJobCode',
@@ -476,14 +458,14 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             'setFinishedAt',
             '__wakeup',
         ];
-        /** @var \Magento\Cron\Model\Schedule|\PHPUnit_Framework_MockObject_MockObject $schedule */
+        /** @var Schedule | Mock $schedule */
         $schedule = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
+            Schedule::class
         )->setMethods(
             $scheduleMethods
         )->disableOriginalConstructor()->getMock();
         $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('test_job1'));
-        $schedule->expects($this->once())->method('getScheduledAt')->will($this->returnValue('-1 day'));
+        $schedule->expects($this->once())->method('getScheduledAt')->will($this->returnValue(date('Y-m-d H:i:00')));
         $schedule->expects($this->once())->method('tryLockJob')->will($this->returnValue(true));
 
         // cron start to execute some job
@@ -491,107 +473,83 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->at(5))->method('save');
 
         // cron end execute some job
-        $schedule->expects(
-            $this->at(6)
-        )->method(
-            'setStatus'
-        )->with(
-            $this->equalTo(\Magento\Cron\Model\Schedule::STATUS_SUCCESS)
-        )->will(
-            $this->returnSelf()
-        );
+        $schedule->expects($this->at(6))
+            ->method('setStatus')
+            ->with($this->equalTo(Schedule::STATUS_SUCCESS))
+            ->will($this->returnSelf());
 
         $schedule->expects($this->at(8))->method('save');
 
         $this->collection->addItem($schedule);
-
-        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
-
-        $lastRun = time() + 10000000;
+        $this->config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
         $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(strtotime('+1 day')));
 
         $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
+            Schedule::class
         )->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
-        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
+        $this->scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
 
         $testCronJob = $this->getMockBuilder('CronJob')->setMethods(['execute'])->getMock();
         $testCronJob->expects($this->atLeastOnce())->method('execute')->with($schedule);
 
-        $this->objectManager->expects(
-            $this->once()
-        )->method(
-            'create'
-        )->with(
-            $this->equalTo('CronJob')
-        )->will(
-            $this->returnValue($testCronJob)
-        );
+        $this->objectManager->expects($this->once())
+            ->method('create')
+            ->with($this->equalTo('CronJob'))
+            ->will($this->returnValue($testCronJob));
 
         $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
      * Testing generate(), iterate over saved cron jobs
+     * Generate should not generate any jobs, because they are already in the database
      */
     public function testDispatchNotGenerate()
     {
-        $jobConfig = [
-            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
+        $jobConfig = ['default' => [
+            'test_job1' => ['instance' => 'CronJob', 'method' => 'execute', 'schedule' => '* * * * *']]
         ];
 
-        $this->config->expects($this->at(0))->method('getJobs')->will($this->returnValue($jobConfig));
-        $this->config->expects(
-            $this->at(1)
-        )->method(
-            'getJobs'
-        )->will(
-            $this->returnValue(['test_group' => []])
-        );
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
-        $this->cache->expects(
-            $this->at(0)
-        )->method(
-            'load'
-        )->with(
-            $this->equalTo(ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'test_group')
-        )->will(
-            $this->returnValue(time() - 10000000)
-        );
-        $this->cache->expects(
-            $this->at(2)
-        )->method(
-            'load'
-        )->with(
-            $this->equalTo(ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'test_group')
-        )->will(
-            $this->returnValue(time() + 10000000)
-        );
+        $this->config->expects($this->any())->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        $this->cache->expects($this->any())->method('load')->willReturnMap([
+            [ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default', time() + 1000], // skip cleanup
+            [ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'default', time() - 1000], // do generation
+        ]);
 
-        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
-
-        $schedule = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->setMethods(
-            ['getJobCode', 'getScheduledAt', '__wakeup']
-        )->disableOriginalConstructor()->getMock();
-        $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('job_code1'));
-        $schedule->expects($this->once())->method('getScheduledAt')->will($this->returnValue('* * * * *'));
-
-        $this->collection->addItem(new \Magento\Framework\DataObject());
-        $this->collection->addItem($schedule);
+        /** @var Schedule | Mock $schedule */
+        $schedule = $this->getMockBuilder(Schedule::class)
+            ->setMethods(['getJobCode', 'getScheduledAt', '__wakeup', 'save'])
+            ->disableOriginalConstructor()->getMock();
+        $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('test_job1'));
+        for ($i=0; $i < 20 * 2; $i+=2) {
+            $minutes = 0.5 * $i;
+            $schedule->expects($this->at($i))->method('getScheduledAt')
+                ->will($this->returnValue(date('Y-m-d H:i:00', strtotime("+$minutes minutes"))));
+            $schedule->expects($this->at($i + 1))->method('getScheduledAt')
+                ->will($this->returnValue(date('Y-m-d H:i:00', strtotime("+$minutes minutes"))));
+            $schedule->expects($this->at($minutes))->method('getId')->willReturn($minutes + 1);
+            $this->collection->addItem($schedule);
+        }
 
         $this->cache->expects($this->any())->method('save');
 
-        $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->getMock();
+        $scheduleMock = $this->getMockBuilder(Schedule::class)
+            ->setMethods([
+                'getCollection',
+                'getResource',
+                'trySchedule',
+                'save',
+            ])
+            ->disableOriginalConstructor()
+            ->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
+        $scheduleMock->expects($this->exactly(20))->method('trySchedule')->willReturn(true);
+        $scheduleMock->expects($this->never())->method('save');
         $this->scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($scheduleMock));
-
-        $this->scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($schedule));
 
         $this->cronQueueObserver->execute($this->observer);
     }
@@ -603,7 +561,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     {
         $jobConfig = [
             'default' => [
-                'test_job1' => [
+                'job1' => [
                     'instance' => 'CronJob',
                     'method' => 'execute',
                 ],
@@ -620,191 +578,76 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $this->config->expects($this->at(0))->method('getJobs')->willReturn($jobConfig);
         $this->config->expects($this->at(1))->method('getJobs')->willReturn($jobs);
         $this->request->expects($this->any())->method('getParam')->willReturn('default');
-        $this->cache->expects(
-            $this->at(0)
-        )->method(
-            'load'
-        )->with(
-            $this->equalTo(ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'default')
-        )->willReturn(time() - 10000000);
-        $this->cache->expects(
-            $this->at(2)
-        )->method(
-            'load'
-        )->with(
-            $this->equalTo(ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default')
-        )->willReturn(time() + 10000000);
+        $this->cache->expects($this->any())->method('load')->willReturnMap([
+            [ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default', time() + 1000], // skip cleanup
+            [ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'default', time() - 1000], // do generation
+        ]);
 
-        $this->scopeConfig->expects($this->any())->method('getValue')->willReturnMap(
-            [
-                [
-                    'system/cron/default/schedule_generate_every',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                    null,
-                    0
-                ],
-                [
-                    'system/cron/default/schedule_ahead_for',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                    null,
-                    2
-                ]
-            ]
-        );
-
+        /** @var Schedule | Mock $schedule */
         $schedule = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
+            Schedule::class
         )->setMethods(
-            ['getJobCode', 'save', 'getScheduledAt', 'unsScheduleId', 'trySchedule', 'getCollection']
+            ['getJobCode', 'save', 'getScheduledAt', 'unsScheduleId', 'trySchedule', 'getCollection', 'getResource']
         )->disableOriginalConstructor()->getMock();
-        $schedule->expects($this->any())->method('getJobCode')->willReturn('job_code1');
-        $schedule->expects($this->once())->method('getScheduledAt')->willReturn('* * * * *');
+        $schedule->expects($this->any())->method('getJobCode')->willReturn('job1');
+        $schedule->expects($this->exactly(2))->method('getScheduledAt')->willReturn('* * * * *');
         $schedule->expects($this->any())->method('unsScheduleId')->willReturnSelf();
         $schedule->expects($this->any())->method('trySchedule')->willReturnSelf();
         $schedule->expects($this->any())->method('getCollection')->willReturn($this->collection);
         $schedule->expects($this->atLeastOnce())->method('save')->willReturnSelf();
+        $schedule->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
 
-        $this->collection->addItem(new \Magento\Framework\DataObject());
         $this->collection->addItem($schedule);
-
         $this->cache->expects($this->any())->method('save');
-
         $this->scheduleFactory->expects($this->any())->method('create')->willReturn($schedule);
-
         $this->cronQueueObserver->execute($this->observer);
     }
 
     /**
-     * Test case without saved cron jobs in data base
+     * Test case to test the cleanup process
      */
     public function testDispatchCleanup()
     {
-        $jobConfig = [
-            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
+        $jobConfig = ['default' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']]];
+        $this->config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+
+        $this->cache->expects($this->any())->method('load')->willReturnMap([
+            // do cleanup
+            [ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default', time() - 1000],
+            // skip generation
+            [ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'default', time() + 1000],
+        ]);
+
+        $jobs = [
+            ['status' => 'success', 'age' => '-61 minutes', 'delete' => true],
+            ['status' => 'success', 'age' => '-59 minutes', 'delete' => false],
+            ['status' => 'missed', 'age' => '-601 minutes', 'delete' => true],
+            ['status' => 'missed', 'age' => '-509 minutes', 'delete' => false],
+            ['status' => 'error', 'age' => '-601 minutes', 'delete' => true],
+            ['status' => 'error', 'age' => '-509 minutes', 'delete' => false],
         ];
 
-        $schedule = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->setMethods(
-            ['getExecutedAt', 'getStatus', 'delete', '__wakeup']
-        )->getMock();
-        $schedule->expects($this->any())->method('getExecutedAt')->will($this->returnValue('-1 day'));
-        $schedule->expects($this->any())->method('getStatus')->will($this->returnValue('success'));
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('test_group'));
-        $this->collection->addItem($schedule);
+        foreach ($jobs as $job) {
+            /** @var Schedule | Mock $schedule */
+            $schedule = $this->getMockBuilder(Schedule::class)
+                ->disableOriginalConstructor()
+                ->setMethods(['getExecutedAt', 'getStatus', 'delete', '__wakeup'])->getMock();
+            $schedule->expects($this->any())->method('getExecutedAt')->will($this->returnValue($job['age']));
+            $schedule->expects($this->any())->method('getStatus')->will($this->returnValue($job['status']));
+            if ($job['delete']) {
+                $schedule->expects($this->once())->method('delete');
+            } else {
+                $schedule->expects($this->never())->method('delete');
+            }
 
-        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
+            $this->collection->addItem($schedule);
+        }
 
-        $this->cache->expects($this->at(0))->method('load')->will($this->returnValue(time() + 10000000));
-        $this->cache->expects($this->at(1))->method('load')->will($this->returnValue(time() - 10000000));
-
-        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValue(0));
-
-        $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->getMock();
+        $scheduleMock = $this->getMockBuilder(Schedule::class)->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
-        $this->scheduleFactory->expects($this->at(0))->method('create')->will($this->returnValue($scheduleMock));
-
-        $collection = $this->getMockBuilder(
-            \Magento\Cron\Model\ResourceModel\Schedule\Collection::class
-        )->setMethods(
-            ['addFieldToFilter', 'load', '__wakeup']
-        )->disableOriginalConstructor()->getMock();
-        $collection->expects($this->any())->method('addFieldToFilter')->will($this->returnSelf());
-        $collection->expects($this->any())->method('load')->will($this->returnSelf());
-        $collection->addItem($schedule);
-
-        $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($collection));
-        $this->scheduleFactory->expects($this->at(1))->method('create')->will($this->returnValue($scheduleMock));
-
-        $this->cronQueueObserver->execute($this->observer);
-    }
-
-    public function testMissedJobsCleanedInTime()
-    {
-        /* 1. Initialize dependencies of generate() method which is called first */
-        $jobConfig = [
-            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
-        ];
-
-        // This item was scheduled 2 days ago
-        /** @var \Magento\Cron\Model\Schedule|\PHPUnit_Framework_MockObject_MockObject $schedule1 */
-        $schedule1 = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->setMethods(
-            ['getExecutedAt', 'getScheduledAt', 'getStatus', 'delete', '__wakeup']
-        )->getMock();
-        $schedule1->expects($this->any())->method('getExecutedAt')->will($this->returnValue(null));
-        $schedule1->expects($this->any())->method('getScheduledAt')->will($this->returnValue('-2 day -2 hour'));
-        $schedule1->expects($this->any())->method('getStatus')->will($this->returnValue(Schedule::STATUS_MISSED));
-        //we expect this job be deleted from the list
-        $schedule1->expects($this->once())->method('delete')->will($this->returnValue(true));
-
-        // This item was scheduled 1 day ago
-        $schedule2 = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->setMethods(
-            ['getExecutedAt', 'getScheduledAt', 'getStatus', 'delete', '__wakeup']
-        )->getMock();
-        $schedule2->expects($this->any())->method('getExecutedAt')->will($this->returnValue(null));
-        $schedule2->expects($this->any())->method('getScheduledAt')->will($this->returnValue('-1 day'));
-        $schedule2->expects($this->any())->method('getStatus')->will($this->returnValue(Schedule::STATUS_MISSED));
-        //we don't expect this job be deleted from the list
-        $schedule2->expects($this->never())->method('delete');
-
-        $this->collection->addItem($schedule1);
-        $this->config->expects($this->once())->method('getJobs')->will($this->returnValue($jobConfig));
-
-        //get configuration value CACHE_KEY_LAST_HISTORY_CLEANUP_AT in the "_generate()"
-        $this->cache->expects($this->at(0))->method('load')->will($this->returnValue(time() + 10000000));
-        //get configuration value CACHE_KEY_LAST_HISTORY_CLEANUP_AT in the "_cleanup()"
-        $this->cache->expects($this->at(1))->method('load')->will($this->returnValue(time() - 10000000));
-
-        $this->scopeConfig->expects($this->at(0))->method('getValue')
-            ->with($this->equalTo('system/cron/test_group/use_separate_process'))
-            ->will($this->returnValue(0));
-        $this->scopeConfig->expects($this->at(1))->method('getValue')
-            ->with($this->equalTo('system/cron/test_group/schedule_generate_every'))
-            ->will($this->returnValue(0));
-        $this->scopeConfig->expects($this->at(2))->method('getValue')
-            ->with($this->equalTo('system/cron/test_group/history_cleanup_every'))
-            ->will($this->returnValue(0));
-        $this->scopeConfig->expects($this->at(3))->method('getValue')
-            ->with($this->equalTo('system/cron/test_group/schedule_lifetime'))
-            ->will($this->returnValue(2*24*60));
-        $this->scopeConfig->expects($this->at(4))->method('getValue')
-            ->with($this->equalTo('system/cron/test_group/history_success_lifetime'))
-            ->will($this->returnValue(0));
-        $this->scopeConfig->expects($this->at(5))->method('getValue')
-            ->with($this->equalTo('system/cron/test_group/history_failure_lifetime'))
-            ->will($this->returnValue(0));
-
-        /* 2. Initialize dependencies of cleanup() method which is called second */
-        $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
-        $this->scheduleFactory->expects($this->at(0))->method('create')->will($this->returnValue($scheduleMock));
-
-        $collection = $this->getMockBuilder(
-            \Magento\Cron\Model\ResourceModel\Schedule\Collection::class
-        )->setMethods(
-            ['addFieldToFilter', 'load', '__wakeup']
-        )->disableOriginalConstructor()->getMock();
-        $collection->expects($this->any())->method('addFieldToFilter')->will($this->returnSelf());
-        $collection->expects($this->any())->method('load')->will($this->returnSelf());
-        $collection->addItem($schedule1);
-        $collection->addItem($schedule2);
-
-        $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
-        )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($collection));
-        $this->scheduleFactory->expects($this->at(1))->method('create')->will($this->returnValue($scheduleMock));
+        $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
+        $this->scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($scheduleMock));
 
         $this->cronQueueObserver->execute($this->observer);
     }

--- a/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
@@ -22,52 +22,52 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     /**
      * @var ProcessCronQueueObserver
      */
-    protected $cronQueueObserver;
+    protected $_observer;
 
     /**
      * @var \Magento\Framework\App\ObjectManager | Mock
      */
-    protected $objectManager;
+    protected $_objectManager;
 
     /**
      * @var Mock
      */
-    protected $cache;
+    protected $_cache;
 
     /**
      * @var \Magento\Cron\Model\Config | Mock
      */
-    protected $config;
+    protected $_config;
 
     /**
      * @var \Magento\Cron\Model\ScheduleFactory | Mock
      */
-    protected $scheduleFactory;
+    protected $_scheduleFactory;
 
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface | Mock
      */
-    protected $scopeConfig;
+    protected $_scopeConfig;
 
     /**
      * @var \Magento\Framework\App\Console\Request | Mock
      */
-    protected $request;
+    protected $_request;
 
     /**
      * @var \Magento\Framework\ShellInterface | Mock
      */
-    protected $shell;
+    protected $_shell;
 
     /**
      * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection | Mock
      */
-    protected $collection;
+    protected $_collection;
 
     /**
      * @var \Magento\Cron\Model\Groups\Config\Data
      */
-    protected $cronGroupConfig;
+    protected $_cronGroupConfig;
 
     /**
      * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
@@ -92,29 +92,29 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     /**
      * @var ScheduleResource | Mock
      */
-    protected $scheduleResource;
+    private $scheduleResource;
 
     /**
      * @var AdapterInterface | Mock
      */
-    protected $connection;
+    private $connection;
 
     /**
      * Prepare parameters
      */
     protected function setUp()
     {
-        $this->objectManager = $this->getMockBuilder(
+        $this->_objectManager = $this->getMockBuilder(
             \Magento\Framework\App\ObjectManager::class
         )->disableOriginalConstructor()->getMock();
-        $this->cache = $this->getMock(\Magento\Framework\App\CacheInterface::class);
-        $this->config = $this->getMockBuilder(
+        $this->_cache = $this->getMock(\Magento\Framework\App\CacheInterface::class);
+        $this->_config = $this->getMockBuilder(
             \Magento\Cron\Model\Config::class
         )->disableOriginalConstructor()->getMock();
-        $this->scopeConfig = $this->getMockBuilder(
+        $this->_scopeConfig = $this->getMockBuilder(
             \Magento\Framework\App\Config\ScopeConfigInterface::class
         )->disableOriginalConstructor()->getMock();
-        $this->scopeConfig->expects($this->any())->method('getValue')->will($this->returnValueMap([
+        $this->_scopeConfig->expects($this->any())->method('getValue')->will($this->returnValueMap([
             ['system/cron/default/schedule_generate_every', 'store', null, 1],
             ['system/cron/default/schedule_ahead_for', 'store', null, 20],
             ['system/cron/default/schedule_lifetime', 'store', null, 15],
@@ -124,18 +124,18 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             ['system/cron/default/use_separate_process', 'store', null, 0],
         ]));
 
-        $this->collection = $this->getMockBuilder(
+        $this->_collection = $this->getMockBuilder(
             \Magento\Cron\Model\ResourceModel\Schedule\Collection::class
         )->setMethods(
             ['addFieldToFilter', 'load', '__wakeup']
         )->disableOriginalConstructor()->getMock();
-        $this->collection->expects($this->any())->method('addFieldToFilter')->will($this->returnSelf());
-        $this->collection->expects($this->any())->method('load')->will($this->returnSelf());
-        $this->scheduleFactory = $this->getMockBuilder(\Magento\Cron\Model\ScheduleFactory::class)
+        $this->_collection->expects($this->any())->method('addFieldToFilter')->will($this->returnSelf());
+        $this->_collection->expects($this->any())->method('load')->will($this->returnSelf());
+        $this->_scheduleFactory = $this->getMockBuilder(\Magento\Cron\Model\ScheduleFactory::class)
             ->setMethods(['create'])->disableOriginalConstructor()->getMock();
-        $this->request = $this->getMockBuilder(\Magento\Framework\App\Console\Request::class)
+        $this->_request = $this->getMockBuilder(\Magento\Framework\App\Console\Request::class)
             ->disableOriginalConstructor()->getMock();
-        $this->shell = $this->getMockBuilder(\Magento\Framework\ShellInterface::class)
+        $this->_shell = $this->getMockBuilder(\Magento\Framework\ShellInterface::class)
             ->disableOriginalConstructor()->setMethods(['execute'])->getMock();
         $this->loggerMock = $this->getMock(\Psr\Log\LoggerInterface::class);
 
@@ -166,14 +166,14 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $this->scheduleResource->method('getConnection')->willReturn($this->connection);
         $this->connection->method('delete')->willReturn(1);
 
-        $this->cronQueueObserver = new ProcessCronQueueObserver(
-            $this->objectManager,
-            $this->scheduleFactory,
-            $this->cache,
-            $this->config,
-            $this->scopeConfig,
-            $this->request,
-            $this->shell,
+        $this->_observer = new ProcessCronQueueObserver(
+            $this->_objectManager,
+            $this->_scheduleFactory,
+            $this->_cache,
+            $this->_config,
+            $this->_scopeConfig,
+            $this->_request,
+            $this->_shell,
             $this->timezone,
             $phpExecutableFinderFactory,
             $this->loggerMock,
@@ -187,20 +187,20 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     public function testDispatchNoPendingJobs()
     {
         $lastRun = time() + 10000000; // skip cleanup and generation
-        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
 
-        $this->config->expects($this->exactly(2))->method('getJobs')
+        $this->_config->expects($this->exactly(2))->method('getJobs')
             ->will($this->returnValue(['default' => ['test_job1' => ['test_data']]]));
 
         $scheduleMock = $this->getMockBuilder(Schedule::class)->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
         $scheduleMock->expects($this->never())->method('setStatus');
         $scheduleMock->expects($this->never())->method('setExecutedAt');
-        $this->scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_observer->execute($this->observer);
     }
 
     /**
@@ -209,24 +209,24 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     public function testDispatchNoJobConfig()
     {
         $lastRun = time() + 10000000; // skip cleanup and generation
-        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
 
-        $this->config->expects($this->any())->method('getJobs')->will($this->returnValue(['default' => []]));
+        $this->_config->expects($this->any())->method('getJobs')->will($this->returnValue(['default' => []]));
 
         /** @var Schedule | Mock $schedule */
         $schedule = $this->getMock(Schedule::class, ['getJobCode', '__wakeup'], [], '', false);
         $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('not_existed_job_code'));
 
-        $this->collection->addItem($schedule);
+        $this->_collection->addItem($schedule);
 
         $scheduleMock = $this->getMockBuilder(Schedule::class)->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
         $scheduleMock->expects($this->never())->method('getScheduledAt');
-        $this->scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->once())->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_observer->execute($this->observer);
     }
 
     /**
@@ -235,8 +235,8 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     public function testDispatchCanNotLock()
     {
         $lastRun = time() + 10000000;  // skip cleanup and generation
-        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
         /** @var Schedule | Mock $schedule */
         $schedule = $this->getMockBuilder(Schedule::class)
             ->setMethods(['getJobCode', 'tryLockJob', 'getScheduledAt', '__wakeup', 'save'])
@@ -248,17 +248,17 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->never())->method('setExecutedAt');
         $abstractModel = $this->getMock(\Magento\Framework\Model\AbstractModel::class, [], [], '', false);
         $schedule->expects($this->any())->method('save')->will($this->returnValue($abstractModel));
-        $this->collection->addItem($schedule);
+        $this->_collection->addItem($schedule);
 
-        $this->config->expects($this->exactly(2))->method('getJobs')
+        $this->_config->expects($this->exactly(2))->method('getJobs')
             ->will($this->returnValue(['default' => ['test_job1' => ['test_data']]]));
 
         $scheduleMock = $this->getMockBuilder(Schedule::class)->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_observer->execute($this->observer);
     }
 
     /**
@@ -272,8 +272,8 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $jobCode = 'test_job1';
         $exception = $exceptionMessage . ' Schedule Id: ' . $scheduleId . ' Job Code: ' . $jobCode;
 
-        $this->cache->expects($this->any())->method('load')->willReturn($lastRun);
-        $this->request->expects($this->any())->method('getParam')->willReturn('default');
+        $this->_cache->expects($this->any())->method('load')->willReturn($lastRun);
+        $this->_request->expects($this->any())->method('getParam')->willReturn('default');
         /** @var Schedule | Mock $schedule */
         $schedule = $this->getMockBuilder(
             Schedule::class
@@ -302,20 +302,20 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->once())->method('getMessages')->willReturn($exceptionMessage);
         $schedule->expects($this->once())->method('getScheduleId')->willReturn($scheduleId);
         $schedule->expects($this->once())->method('save');
-        $this->collection->addItem($schedule);
+        $this->_collection->addItem($schedule);
 
         $this->appStateMock->expects($this->once())->method('getMode')->willReturn(State::MODE_DEVELOPER);
         $this->loggerMock->expects($this->once())->method('info')->with($exception);
-        $this->config->expects($this->exactly(2))->method('getJobs')
+        $this->_config->expects($this->exactly(2))->method('getJobs')
             ->willReturn(['default' => ['test_job1' => ['test_data']]]);
 
         $scheduleMock = $this->getMockBuilder(Schedule::class)
             ->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->willReturn($this->collection);
+        $scheduleMock->expects($this->any())->method('getCollection')->willReturn($this->_collection);
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->scheduleFactory->expects($this->exactly(2))->method('create')->willReturn($scheduleMock);
+        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->willReturn($scheduleMock);
 
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_observer->execute($this->observer);
     }
 
     /**
@@ -342,20 +342,20 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->once())->method('setMessages')->with($this->equalTo($exceptionMessage));
         $schedule->expects($this->any())->method('getStatus')->willReturn(Schedule::STATUS_ERROR);
         $schedule->expects($this->once())->method('save');
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
-        $this->collection->addItem($schedule);
+        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        $this->_collection->addItem($schedule);
         $this->loggerMock->expects($this->once())->method('critical')->with($exception);
-        $this->config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
-        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->_config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
 
         $scheduleMock = $this->getMockBuilder(
             Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_observer->execute($this->observer);
     }
 
     /**
@@ -379,7 +379,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $lastRun = time() + 10000000;  // skip cleanup and generation
         $jobConfig = ['default' => ['test_job1' => ['instance' => $cronJobType, 'method' => 'execute']]];
 
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
         /** @var Schedule | Mock $schedule */
         $schedule = $this->getMockBuilder(Schedule::class)->setMethods(
             ['getJobCode', 'tryLockJob', 'getScheduledAt', 'save', 'setStatus', 'setMessages', '__wakeup', 'getStatus']
@@ -394,25 +394,25 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->once())->method('setMessages')->with($this->equalTo($exceptionMessage));
         $schedule->expects($this->any())->method('getStatus')->willReturn(Schedule::STATUS_ERROR);
         $schedule->expects($this->exactly($saveCalls))->method('save');
-        $this->collection->addItem($schedule);
+        $this->_collection->addItem($schedule);
 
         $this->loggerMock->expects($this->once())->method('critical')->with($exception);
-        $this->config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
-        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->_config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
 
         $scheduleMock = $this->getMockBuilder(
             Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
-        $this->objectManager
+        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
+        $this->_objectManager
             ->expects($this->once())
             ->method('create')
             ->with($this->equalTo($cronJobType))
             ->will($this->returnValue($cronJobObject));
 
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_observer->execute($this->observer);
     }
 
     /**
@@ -445,7 +445,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     {
         $lastRun = time() + 10000000;  // skip cleanup and generation
         $jobConfig = ['default' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']]];
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
 
         $scheduleMethods = [
             'getJobCode',
@@ -480,26 +480,26 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
 
         $schedule->expects($this->at(8))->method('save');
 
-        $this->collection->addItem($schedule);
-        $this->config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
-        $this->cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
+        $this->_collection->addItem($schedule);
+        $this->_config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->_cache->expects($this->any())->method('load')->will($this->returnValue($lastRun));
 
         $scheduleMock = $this->getMockBuilder(
             Schedule::class
         )->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->exactly(2))->method('create')->will($this->returnValue($scheduleMock));
 
         $testCronJob = $this->getMockBuilder('CronJob')->setMethods(['execute'])->getMock();
         $testCronJob->expects($this->atLeastOnce())->method('execute')->with($schedule);
 
-        $this->objectManager->expects($this->once())
+        $this->_objectManager->expects($this->once())
             ->method('create')
             ->with($this->equalTo('CronJob'))
             ->will($this->returnValue($testCronJob));
 
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_observer->execute($this->observer);
     }
 
     /**
@@ -512,9 +512,9 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             'test_job1' => ['instance' => 'CronJob', 'method' => 'execute', 'schedule' => '* * * * *']]
         ];
 
-        $this->config->expects($this->any())->method('getJobs')->will($this->returnValue($jobConfig));
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
-        $this->cache->expects($this->any())->method('load')->willReturnMap([
+        $this->_config->expects($this->any())->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        $this->_cache->expects($this->any())->method('load')->willReturnMap([
             [ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default', time() + 1000], // skip cleanup
             [ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'default', time() - 1000], // do generation
         ]);
@@ -531,10 +531,10 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             $schedule->expects($this->at($i + 1))->method('getScheduledAt')
                 ->will($this->returnValue(date('Y-m-d H:i:00', strtotime("+$minutes minutes"))));
             $schedule->expects($this->at($minutes))->method('getId')->willReturn($minutes + 1);
-            $this->collection->addItem($schedule);
+            $this->_collection->addItem($schedule);
         }
 
-        $this->cache->expects($this->any())->method('save');
+        $this->_cache->expects($this->any())->method('save');
 
         $scheduleMock = $this->getMockBuilder(Schedule::class)
             ->setMethods([
@@ -545,13 +545,13 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             ])
             ->disableOriginalConstructor()
             ->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
         $scheduleMock->expects($this->exactly(20))->method('trySchedule')->willReturn(true);
         $scheduleMock->expects($this->never())->method('save');
-        $this->scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_observer->execute($this->observer);
     }
 
     /**
@@ -575,10 +575,10 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
                 'job3' => ['schedule' => '* * * * *'],
             ],
         ];
-        $this->config->expects($this->at(0))->method('getJobs')->willReturn($jobConfig);
-        $this->config->expects($this->at(1))->method('getJobs')->willReturn($jobs);
-        $this->request->expects($this->any())->method('getParam')->willReturn('default');
-        $this->cache->expects($this->any())->method('load')->willReturnMap([
+        $this->_config->expects($this->at(0))->method('getJobs')->willReturn($jobConfig);
+        $this->_config->expects($this->at(1))->method('getJobs')->willReturn($jobs);
+        $this->_request->expects($this->any())->method('getParam')->willReturn('default');
+        $this->_cache->expects($this->any())->method('load')->willReturnMap([
             [ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default', time() + 1000], // skip cleanup
             [ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'default', time() - 1000], // do generation
         ]);
@@ -593,14 +593,14 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->exactly(2))->method('getScheduledAt')->willReturn('* * * * *');
         $schedule->expects($this->any())->method('unsScheduleId')->willReturnSelf();
         $schedule->expects($this->any())->method('trySchedule')->willReturnSelf();
-        $schedule->expects($this->any())->method('getCollection')->willReturn($this->collection);
+        $schedule->expects($this->any())->method('getCollection')->willReturn($this->_collection);
         $schedule->expects($this->atLeastOnce())->method('save')->willReturnSelf();
         $schedule->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
 
-        $this->collection->addItem($schedule);
-        $this->cache->expects($this->any())->method('save');
-        $this->scheduleFactory->expects($this->any())->method('create')->willReturn($schedule);
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_collection->addItem($schedule);
+        $this->_cache->expects($this->any())->method('save');
+        $this->_scheduleFactory->expects($this->any())->method('create')->willReturn($schedule);
+        $this->_observer->execute($this->observer);
     }
 
     /**
@@ -609,10 +609,10 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
     public function testDispatchCleanup()
     {
         $jobConfig = ['default' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']]];
-        $this->config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        $this->_config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
 
-        $this->cache->expects($this->any())->method('load')->willReturnMap([
+        $this->_cache->expects($this->any())->method('load')->willReturnMap([
             // do cleanup
             [ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default', time() - 1000],
             // skip generation
@@ -641,15 +641,15 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
                 $schedule->expects($this->never())->method('delete');
             }
 
-            $this->collection->addItem($schedule);
+            $this->_collection->addItem($schedule);
         }
 
         $scheduleMock = $this->getMockBuilder(Schedule::class)->disableOriginalConstructor()->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($scheduleMock));
 
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_observer->execute($this->observer);
     }
 
     /**
@@ -662,10 +662,10 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             'test_job1' => ['instance' => 'CronJob', 'method' => 'execute', 'schedule' => '*/10 * * * *'],
             'test_job2' => ['instance' => 'CronJob', 'method' => 'execute', 'schedule' => null]
         ]];
-        $this->config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
+        $this->_config->expects($this->exactly(2))->method('getJobs')->will($this->returnValue($jobConfig));
+        $this->_request->expects($this->any())->method('getParam')->will($this->returnValue('default'));
 
-        $this->cache->expects($this->any())->method('load')->willReturnMap([
+        $this->_cache->expects($this->any())->method('load')->willReturnMap([
             // skip cleanup
             [ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default', time() + 1000],
             // do generation
@@ -689,7 +689,7 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
             $schedule->expects($this->any())->method('getStatus')->will($this->returnValue('pending'));
             $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('test_job1'));
             $schedule->expects($this->any())->method('getScheduledAt')->will($this->returnValue($job['age']));
-            $this->collection->addItem($schedule);
+            $this->_collection->addItem($schedule);
         }
 
         /** @var Schedule | Mock $schedule */
@@ -699,13 +699,13 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         $schedule->expects($this->any())->method('getStatus')->will($this->returnValue('pending'));
         $schedule->expects($this->any())->method('getJobCode')->will($this->returnValue('test_job2'));
         $schedule->expects($this->any())->method('getScheduledAt')->will($this->returnValue(date('Y-m-d H:i:00')));
-        $this->collection->addItem($schedule);
+        $this->_collection->addItem($schedule);
 
         $scheduleMock = $this->getMockBuilder(Schedule::class)->disableOriginalConstructor()
             ->setMethods(['save', 'getCollection', 'getResource'])->getMock();
-        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->collection));
+        $scheduleMock->expects($this->any())->method('getCollection')->will($this->returnValue($this->_collection));
         $scheduleMock->expects($this->any())->method('getResource')->will($this->returnValue($this->scheduleResource));
-        $this->scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($scheduleMock));
+        $this->_scheduleFactory->expects($this->any())->method('create')->will($this->returnValue($scheduleMock));
 
         $query = [
             'status=?' => Schedule::STATUS_PENDING,
@@ -726,6 +726,6 @@ class ProcessCronQueueObserverTest extends \PHPUnit_Framework_TestCase
         ];
         $this->connection->expects($this->at(1))->method('delete')->with(null, $query);
 
-        $this->cronQueueObserver->execute($this->observer);
+        $this->_observer->execute($this->observer);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This pull request:
1. fixes a number of errors in the unit tests that came with the cron process
2. deletes cron jobs that have been disabled in the config, so already scheduled jobs will not execute although they have been deleted
3. deletes scheduled cron jobs that do not match their cron expression anymore, because it has been altered in the configuration.
4. changes the order of execution from running, generating, cleaning to cleaning, generating, running so that clean jobs will not run and generated jobs will run immediately.

This fixes #3380 (moved to forums)

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#3380: Remove scheduled jobs after changing cron settings

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Truncate the `cron_schedule` table
1. Run the `bin/magento cron:run` command
2. Look inside the `cron_schedule` table to see that `catalog_product_outdated_price_values_cleanup` is scheduled every minute
3. Open `app/code/Magento/Catalog/etc/crontab.xml` and change the cron expression from `* * * * *` to `*/10 * * * *`
4. Flush cache
5. Run the `bin/magento cron:run` command
6. See that all pending entries not matching the new expression have been removed, and nothing else
7. Change `catalog_product_outdated_price_values_cleanup` back to `* * * * *` and truncate the `cron_schedule` table
8. Run the `bin/magento cron:run` command
9. Look inside the `cron_schedule` table to see that `catalog_product_outdated_price_values_cleanup` is scheduled every minute
10. Open `app/code/Magento/Catalog/etc/crontab.xml` and remove the cron expression tag
11. Flush cache
12. Run the `bin/magento cron:run` command
13. See that all pending entries of `catalog_product_outdated_price_values_cleanup` have been removed, and nothing else

You can also play around with enabling/disabling the sitemap generator or another cron job that has configuration for enable/disable and schedules.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
