### PR TITLE
Add target attribute to Magento_Ui grid

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/actions.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/actions.js
@@ -188,7 +188,7 @@ define([
             }
 
             return "_self";
-        }
+        },
 
         /**
          * Checks if specified action requires a handler function.

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/actions.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/actions.js
@@ -187,7 +187,7 @@ define([
                 return action.target;
             }
 
-            return "_self";
+            return '_self';
         },
 
         /**

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/actions.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/actions.js
@@ -177,6 +177,20 @@ define([
         },
 
         /**
+         * Returns target of action if it's been set.
+         *
+         * @param {Object} action - Action object.
+         * @returns {String}
+         */
+        getTarget: function (action) {
+            if (action.target) {
+                return action.target;
+            }
+
+            return "_self";
+        }
+
+        /**
          * Checks if specified action requires a handler function.
          *
          * @param {String} actionIndex - Actions' identifier.

--- a/app/code/Magento/Ui/view/base/web/templates/grid/cells/actions.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/cells/actions.html
@@ -10,13 +10,13 @@
     repeat="foreach: $col.getVisibleActions($row()._rowIndex), item: '$action'"
     click="$col.getActionHandler($action())"
     text="$action().label"
-    attr="href: $action().href"/>
+    attr="target: $col.getTarget($action()), href: $action().href"/>
 
 <div class="action-select-wrap" if="$col.isMultiple($row()._rowIndex)" collapsible>
     <button class="action-select" translate="'Select'" toggleCollapsible/>
     <ul class="action-menu" css="_active: $collapsible.opened">
         <li repeat="foreach: $col.getVisibleActions($row()._rowIndex), item: '$action'">
-            <a class="action-menu-item" click="$col.getActionHandler($action())" text="$action().label" attr="href: $action().href, 'data-action': 'item-' + $action().index"/>
+            <a class="action-menu-item" click="$col.getActionHandler($action())" text="$action().label" attr="target: $col.getTarget($action()), href: $action().href, 'data-action': 'item-' + $action().index"/>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
When creating a Magento_Ui grid actionColumn, currently, it is not possible for links to have a target attribute. They can only open in the current browser tab ie. their target is always _self. This change expands that, allowing a target attribute to be added when using the prepareDataSource function of a custom Column module.
### Description
<!--- Provide a description of the changes proposed in the pull request -->
added method getTarget to actions.js - it returns "_self" by default or the attribute set when using prepareDataSource.
added code to set link's target attribute to getTarget() in the actions.html template

Code example - when populating the column in a Magento_Ui grid, using a custom class to expand Magento\Ui\Component\Listing\Columns\Column, you can set the target attribute for the links created in your prepareDataSource function, as below.
```
$item[$name]['edit'] = [
    'href' => $this->_urlBuilder->getUrl(
                          $this->_editUrl,
                            ['id' => $item['id']]
                        ),
                        'label' => __('Edit'),
		'target' => "_blank"
];

```
### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. write module to create a Magento_Ui grid control
2. modify the prepareDataSource function to add a target "_blank" attribute (as the example above)
3. test grid by clicking on link
### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
