### PR TITLE
Added public methods to make Sitemap model plugin friendly

### DIFF
--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -7,8 +7,10 @@
 // @codingStandardsIgnoreFile
 
 namespace Magento\Sitemap\Model;
+
 use Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\DataObject;
 
 /**
  * Sitemap model
@@ -225,55 +227,78 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel
     }
 
     /**
-     * Initialize sitemap items
+     * Add a sitemap item to the array of sitemap items
+     *
+     * @param DataObject $sitemapItem
+     * @return $this
+     */
+    public function addSitemapItem(DataObject $sitemapItem)
+    {
+        $this->_sitemapItems[] = $sitemapItem;
+
+        return $this;
+    }
+
+    /**
+     * Collect all sitemap items
      *
      * @return void
      */
-    protected function _initSitemapItems()
+    public function collectSitemapItems()
     {
         /** @var $helper \Magento\Sitemap\Helper\Data */
         $helper = $this->_sitemapData;
         $storeId = $this->getStoreId();
 
-        $this->_sitemapItems[] = new \Magento\Framework\DataObject(
+        $this->addSitemapItem(new DataObject(
             [
                 'changefreq' => $helper->getCategoryChangefreq($storeId),
                 'priority' => $helper->getCategoryPriority($storeId),
                 'collection' => $this->_categoryFactory->create()->getCollection($storeId),
             ]
-        );
+        ));
 
-        $this->_sitemapItems[] = new \Magento\Framework\DataObject(
+        $this->addSitemapItem(new DataObject(
             [
                 'changefreq' => $helper->getProductChangefreq($storeId),
                 'priority' => $helper->getProductPriority($storeId),
                 'collection' => $this->_productFactory->create()->getCollection($storeId),
             ]
-        );
+        ));
 
-        $this->_sitemapItems[] = new \Magento\Framework\DataObject(
+        $this->addSitemapItem(new DataObject(
             [
                 'changefreq' => $helper->getPageChangefreq($storeId),
                 'priority' => $helper->getPagePriority($storeId),
                 'collection' => $this->_cmsFactory->create()->getCollection($storeId),
             ]
-        );
+        ));
+    }
+
+    /**
+     * Initialize sitemap
+     *
+     * @return void
+     */
+    protected function _initSitemapItems()
+    {
+        $this->collectSitemapItems();
 
         $this->_tags = [
             self::TYPE_INDEX => [
                 self::OPEN_TAG_KEY => '<?xml version="1.0" encoding="UTF-8"?>' .
-                PHP_EOL .
-                '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
-                PHP_EOL,
+                    PHP_EOL .
+                    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
+                    PHP_EOL,
                 self::CLOSE_TAG_KEY => '</sitemapindex>',
             ],
             self::TYPE_URL => [
                 self::OPEN_TAG_KEY => '<?xml version="1.0" encoding="UTF-8"?>' .
-                PHP_EOL .
-                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"' .
-                ' xmlns:content="http://www.google.com/schemas/sitemap-content/1.0"' .
-                ' xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' .
-                PHP_EOL,
+                    PHP_EOL .
+                    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"' .
+                    ' xmlns:content="http://www.google.com/schemas/sitemap-content/1.0"' .
+                    ' xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' .
+                    PHP_EOL,
                 self::CLOSE_TAG_KEY => '</urlset>',
             ],
         ];
@@ -341,6 +366,7 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel
     public function generateXml()
     {
         $this->_initSitemapItems();
+
         /** @var $sitemapItem \Magento\Framework\DataObject */
         foreach ($this->_sitemapItems as $sitemapItem) {
             $changefreq = $sitemapItem->getChangefreq();


### PR DESCRIPTION
### Description
I have added two public methods to the `\Magento\Sitemap\Model\Sitemap` to be able to add other 'sitemap items' via a plugin.

I encountered this problem when I had a third party module already overriding (via preference) the Sitemap model and I ended up doing a classical rewrite conflict fix.

Plugins could prevent rewrite conflicts, but the class that is the subject of these plugins should have public methods to target.

I added the public methods `collectSitemapItems()` and `addSitemapItem()`. I kept the protected method `_initSitemapItems()` in the code (instead of replacing `_initSitemapItems()` with `collectSitemapItems()`) to maintain backwards compatibility for extensions that already do rewrite the whole `\Magento\Sitemap\Model\Sitemap` model and override the `_initSitemapItems()` to be able to add sitemap items.

### Fixed issue/PR
1. magento/magento2#9530: Alter Sitemap's items with results from new event

### Manual testing scenarios
1. Add a plugin targeting the Sitemap model (`<type name="Magento\Sitemap\Model\Sitemap"><plugin ... /></type>`)
2. Add an `afterCollectSitemapItems(\Magento\Sitemap\Model\Sitemap $subject)` method
3. Use the `\Magento\Sitemap\Model\Sitemap::addSitemapItem(\Magento\Framework\DataObject $sitemapItem)` method to add new sitemap items
4. Generate a sitemap. This should now also contain your custom sitemap URLs

Example: 

    class SitemapPlugin {
        /**
         * Add custom sitemap items
         * @param \Magento\Sitemap\Model\Sitemap $subject
         */
        public function afterCollectSitemapItems(\Magento\Sitemap\Model\Sitemap $subject) {
            $sitemapItem = new \Magento\Framework\DataObject([
                'changefreq' => $this->getSitemapChangeFrequency($storeId),
                'priority' => $this->getSitemapPriority($storeId),
                'collection' => /** ... insert array of \Magento\Framework\DataObject here ... */,
            ]);
            $subject->addSitemapItem($sitemapItem);
        }
    }

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
