### PR TITLE
Fixed coding standard violations in the Magento\Backend namespace 

### DIFF
--- a/app/code/Magento/Backend/App/Config.php
+++ b/app/code/Magento/Backend/App/Config.php
@@ -6,8 +6,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\App;
 
 use Magento\Config\App\Config\Type\System;

--- a/app/code/Magento/Backend/Block/Dashboard.php
+++ b/app/code/Magento/Backend/Block/Dashboard.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block;
 
 /**

--- a/app/code/Magento/Backend/Block/Dashboard/AbstractDashboard.php
+++ b/app/code/Magento/Backend/Block/Dashboard/AbstractDashboard.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Backend\Block\Dashboard;
 
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+
 /**
  * Adminhtml dashboard tab abstract
  *
@@ -38,7 +40,7 @@ abstract class AbstractDashboard extends \Magento\Backend\Block\Widget
     }
 
     /**
-     * @return array|\Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection|\Magento\Eav\Model\Entity\Collection\Abstract
+     * @return array|AbstractCollection|\Magento\Eav\Model\Entity\Collection\Abstract
      */
     public function getCollection()
     {

--- a/app/code/Magento/Backend/Block/Dashboard/AbstractDashboard.php
+++ b/app/code/Magento/Backend/Block/Dashboard/AbstractDashboard.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Dashboard;
 
 /**

--- a/app/code/Magento/Backend/Block/Menu.php
+++ b/app/code/Magento/Backend/Block/Menu.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block;
 
 /**
@@ -411,7 +409,7 @@ class Menu extends \Magento\Backend\Block\Template
      */
     public function getActiveItemModel()
     {
-        if (is_null($this->_activeItemModel)) {
+        if ($this->_activeItemModel === null) {
             $this->_activeItemModel = $this->getMenuModel()->get($this->getActive());
             if (false == $this->_activeItemModel instanceof \Magento\Backend\Model\Menu\Item) {
                 $this->_activeItemModel = false;

--- a/app/code/Magento/Backend/Block/Menu.php
+++ b/app/code/Magento/Backend/Block/Menu.php
@@ -4,6 +4,8 @@
  * See COPYING.txt for license details.
  */
 
+// @codingStandardsIgnoreFile
+
 namespace Magento\Backend\Block;
 
 /**
@@ -146,11 +148,13 @@ class Menu extends \Magento\Backend\Block\Template
     protected function _renderItemCssClass($menuItem, $level)
     {
         $isLast = 0 == $level && (bool)$this->getMenuModel()->isLast($menuItem) ? 'last' : '';
-        $output = ($this->menuItemChecker->isItemActive(
+        $isItemActive = $this->menuItemChecker->isItemActive(
             $this->getActiveItemModel(),
-                $menuItem,
-                $level
-            ) ? '_current _active' : '') .
+            $menuItem,
+            $level
+        ) ? '_current _active' : '';
+
+        $output =  $isItemActive .
             ' ' .
             ($menuItem->hasChildren() ? 'parent' : '') .
             ' ' .

--- a/app/code/Magento/Backend/Block/Page/Header.php
+++ b/app/code/Magento/Backend/Block/Page/Header.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Page;
 
 /**
@@ -81,6 +79,9 @@ class Header extends \Magento\Backend\Block\Template
      */
     public function displayNoscriptNotice()
     {
-        return $this->_scopeConfig->getValue('web/browser_capabilities/javascript', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $this->_scopeConfig->getValue(
+            'web/browser_capabilities/javascript',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
     }
 }

--- a/app/code/Magento/Backend/Block/Page/Notices.php
+++ b/app/code/Magento/Backend/Block/Page/Notices.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Adminhtml header notices block
  *
@@ -25,7 +23,10 @@ class Notices extends \Magento\Backend\Block\Template
      */
     public function displayNoscriptNotice()
     {
-        return $this->_scopeConfig->getValue('web/browser_capabilities/javascript', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $this->_scopeConfig->getValue(
+            'web/browser_capabilities/javascript',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
     }
 
     /**
@@ -35,6 +36,9 @@ class Notices extends \Magento\Backend\Block\Template
      */
     public function displayDemoNotice()
     {
-        return $this->_scopeConfig->getValue('design/head/demonotice', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $this->_scopeConfig->getValue(
+            'design/head/demonotice',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
     }
 }

--- a/app/code/Magento/Backend/Block/Page/System/Config/Robots/Reset.php
+++ b/app/code/Magento/Backend/Block/Page/System/Config/Robots/Reset.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Page\System\Config\Robots;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;

--- a/app/code/Magento/Backend/Block/Page/System/Config/Robots/Reset.php
+++ b/app/code/Magento/Backend/Block/Page/System/Config/Robots/Reset.php
@@ -51,7 +51,8 @@ class Reset extends \Magento\Config\Block\System\Config\Form\Field
     public function getRobotsDefaultCustomInstructions()
     {
         return trim((string)$this->_scopeConfig->getValue(
-            self::XML_PATH_ROBOTS_DEFAULT_CUSTOM_INSTRUCTIONS, ScopeConfigInterface::SCOPE_TYPE_DEFAULT
+            self::XML_PATH_ROBOTS_DEFAULT_CUSTOM_INSTRUCTIONS,
+            ScopeConfigInterface::SCOPE_TYPE_DEFAULT
         ));
     }
 

--- a/app/code/Magento/Backend/Block/Store/Switcher/Form/Renderer/Fieldset.php
+++ b/app/code/Magento/Backend/Block/Store/Switcher/Form/Renderer/Fieldset.php
@@ -4,14 +4,14 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Store\Switcher\Form\Renderer;
+
+use \Magento\Framework\Data\Form\Element\Renderer\RendererInterface;
 
 /**
  * Form fieldset renderer
  */
-class Fieldset extends \Magento\Backend\Block\Template implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Fieldset extends \Magento\Backend\Block\Template implements RendererInterface
 {
     /**
      * Form element which re-rendering

--- a/app/code/Magento/Backend/Block/System/Design/Edit/Tab/General.php
+++ b/app/code/Magento/Backend/Block/System/Design/Edit/Tab/General.php
@@ -64,7 +64,7 @@ class General extends \Magento\Backend\Block\Widget\Form\Generic
                 ]
             );
             $renderer = $this->getLayout()->createBlock(
-                 \Magento\Backend\Block\Store\Switcher\Form\Renderer\Fieldset\Element::class
+                \Magento\Backend\Block\Store\Switcher\Form\Renderer\Fieldset\Element::class
             );
             $field->setRenderer($renderer);
         } else {

--- a/app/code/Magento/Backend/Block/System/Design/Edit/Tab/General.php
+++ b/app/code/Magento/Backend/Block/System/Design/Edit/Tab/General.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\System\Design\Edit\Tab;
 
 class General extends \Magento\Backend\Block\Widget\Form\Generic

--- a/app/code/Magento/Backend/Block/Widget/Form/Renderer/Element.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Renderer/Element.php
@@ -4,18 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Widget\Form\Renderer;
 
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Framework\Data\Form\Element\Renderer\RendererInterface;
 
 /**
  * Form element default renderer
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Element extends \Magento\Backend\Block\Template implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Element extends \Magento\Backend\Block\Template implements RendererInterface
 {
     /**
      * @var AbstractElement

--- a/app/code/Magento/Backend/Block/Widget/Form/Renderer/Fieldset.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Renderer/Fieldset.php
@@ -4,11 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Widget\Form\Renderer;
 
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Framework\Data\Form\Element\Renderer\RendererInterface;
 
 /**
  * Form fieldset default renderer
@@ -16,7 +15,7 @@ use Magento\Framework\Data\Form\Element\AbstractElement;
  * @api
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Fieldset extends \Magento\Backend\Block\Template implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Fieldset extends \Magento\Backend\Block\Template implements RendererInterface
 {
     /**
      * @var AbstractElement

--- a/app/code/Magento/Backend/Block/Widget/Form/Renderer/Fieldset/Element.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Renderer/Fieldset/Element.php
@@ -4,18 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Widget\Form\Renderer\Fieldset;
 
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use \Magento\Framework\Data\Form\Element\Renderer\RendererInterface;
 
 /**
  * Fieldset element renderer
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Element extends \Magento\Backend\Block\Template implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Element extends \Magento\Backend\Block\Template implements RendererInterface
 {
     /**
      * @var AbstractElement

--- a/app/code/Magento/Backend/Block/Widget/Grid.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Widget;
 
 /**
@@ -351,7 +349,7 @@ class Grid extends \Magento\Backend\Block\Widget
             $dir = $this->getParam($this->getVarNameDir(), $this->_defaultDir);
             $filter = $this->getParam($this->getVarNameFilter(), null);
 
-            if (is_null($filter)) {
+            if ($filter === null) {
                 $filter = $this->_defaultFilter;
             }
 

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Datetime.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Datetime.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Widget\Grid\Column\Filter;
 
 /**

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Action.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Action.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Widget\Grid\Column\Renderer;
 
 /**

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Action.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Action.php
@@ -153,7 +153,8 @@ class Action extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Text
                     break;
 
                 case 'popup':
-                    $action['onclick'] = 'popWin(this.href,\'_blank\',\'width=800,height=700,resizable=1,scrollbars=1\');return false;';
+                    $action['onclick'] = 'popWin(this.href,\'_blank\',\'width=800,height=700,resizable=1,'
+                        . 'scrollbars=1\');return false;';
                     break;
             }
         }

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Currency.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Currency.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Widget\Grid\Column\Renderer;
 
 /**

--- a/app/code/Magento/Backend/Block/Widget/Grid/Export.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Export.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Block\Widget\Grid;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -263,7 +261,7 @@ class Export extends \Magento\Backend\Block\Widget implements \Magento\Backend\B
             $originalCollection->setPageSize($this->getExportPageSize());
             $originalCollection->setCurPage($page);
             $originalCollection->load();
-            if (is_null($count)) {
+            if ($count === null) {
                 $count = $originalCollection->getSize();
                 $lPage = $originalCollection->getLastPageNumber();
             }
@@ -286,8 +284,10 @@ class Export extends \Magento\Backend\Block\Widget implements \Magento\Backend\B
      * @param \Magento\Framework\Filesystem\File\WriteInterface $stream
      * @return void
      */
-    protected function _exportCsvItem(\Magento\Framework\DataObject $item, \Magento\Framework\Filesystem\File\WriteInterface $stream)
-    {
+    protected function _exportCsvItem(
+        \Magento\Framework\DataObject $item,
+        \Magento\Framework\Filesystem\File\WriteInterface $stream
+    ) {
         $row = [];
         foreach ($this->_getColumns() as $column) {
             if (!$column->getIsSystem()) {

--- a/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/System/Store.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Controller\Adminhtml\System;
 
 use Magento\Backend\App\Action;
@@ -129,7 +127,9 @@ abstract class Store extends Action
     {
         $this->messageManager->addNotice(
             __(
-                'Deleting a %1 will not delete the information associated with the %1 (e.g. categories, products, etc.), but the %1 will not be able to be restored. It is suggested that you create a database backup before deleting the %1.',
+                'Deleting a %1 will not delete the information associated with the %1 (e.g. categories, products, etc.)'
+                . ', but the %1 will not be able to be restored. It is suggested that you create a database backup '
+                . 'before deleting the %1.',
                 $typeTitle
             )
         );

--- a/app/code/Magento/Backend/Model/Menu/Director/Director.php
+++ b/app/code/Magento/Backend/Model/Menu/Director/Director.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Model\Menu\Director;
 
 class Director extends \Magento\Backend\Model\Menu\AbstractDirector
@@ -43,8 +41,11 @@ class Director extends \Magento\Backend\Model\Menu\AbstractDirector
      * @param \Psr\Log\LoggerInterface $logger
      * @return void
      */
-    public function direct(array $config, \Magento\Backend\Model\Menu\Builder $builder, \Psr\Log\LoggerInterface $logger)
-    {
+    public function direct(
+        array $config,
+        \Magento\Backend\Model\Menu\Builder $builder,
+        \Psr\Log\LoggerInterface $logger
+    ) {
         foreach ($config as $data) {
             $builder->processCommand($this->_getCommand($data, $logger));
         }

--- a/app/code/Magento/Backend/Model/Widget/Grid/AbstractTotals.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/AbstractTotals.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Model\Widget\Grid;
 
 abstract class AbstractTotals implements \Magento\Backend\Model\Widget\Grid\TotalsInterface
@@ -46,8 +44,10 @@ abstract class AbstractTotals implements \Magento\Backend\Model\Widget\Grid\Tota
      * @param \Magento\Framework\DataObject\Factory $factory
      * @param \Magento\Backend\Model\Widget\Grid\Parser $parser
      */
-    public function __construct(\Magento\Framework\DataObject\Factory $factory, \Magento\Backend\Model\Widget\Grid\Parser $parser)
-    {
+    public function __construct(
+        \Magento\Framework\DataObject\Factory $factory,
+        \Magento\Backend\Model\Widget\Grid\Parser $parser
+    ) {
         $this->_factory = $factory;
         $this->_parser = $parser;
     }

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/ColumnSetTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/ColumnSetTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Test\Unit\Block\Widget\Grid;
 
 /**

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/ColumnSetTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/ColumnSetTest.php
@@ -322,7 +322,8 @@ class ColumnSetTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            new \Magento\Framework\DataObject(['test1' => '3', 'test2' => '2']), $this->_block->getTotals()
+            new \Magento\Framework\DataObject(['test1' => '3', 'test2' => '2']),
+            $this->_block->getTotals()
         );
     }
 

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanMediaTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanMediaTest.php
@@ -76,8 +76,7 @@ class CleanMediaTest extends \PHPUnit_Framework_TestCase
 
         $messageManager->expects($this->once())
             ->method('addSuccess')
-            ->with('The JavaScript/CSS cache has been cleaned.'
-        );
+            ->with('The JavaScript/CSS cache has been cleaned.');
 
         $valueMap = [
             [\Magento\Framework\View\Asset\MergeService::class, $mergeService],

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanMediaTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanMediaTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Test\Unit\Controller\Adminhtml\Cache;
 
 /**

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanStaticFilesTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanStaticFilesTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Test\Unit\Controller\Adminhtml\Cache;
 
 class CleanStaticFilesTest extends \PHPUnit_Framework_TestCase

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanStaticFilesTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/CleanStaticFilesTest.php
@@ -58,7 +58,7 @@ class CleanStaticFilesTest extends \PHPUnit_Framework_TestCase
 
         $this->controller = $objectHelper->getObject(
             \Magento\Backend\Controller\Adminhtml\Cache\CleanStaticFiles::class,
-            ['context' => $context,]
+            ['context' => $context]
         );
     }
 

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/AbstractTestCase.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/AbstractTestCase.php
@@ -23,19 +23,31 @@ class AbstractTestCase extends \PHPUnit_Framework_TestCase
         $outPut = "data";
         $resultRawMock = $this->getMock(
             \Magento\Framework\Controller\Result\Raw::class,
-            ['setContents'], [], '', false)
-        ;
+            ['setContents'],
+            [],
+            '',
+            false
+        );
         $resultRawFactoryMock = $this->getMock(
             \Magento\Framework\Controller\Result\RawFactory::class,
-            ['create'], [], '', false
+            ['create'],
+            [],
+            '',
+            false
         );
         $layoutFactoryMock = $this->getMock(
             \Magento\Framework\View\LayoutFactory::class,
-            ['create'], [], '', false
+            ['create'],
+            [],
+            '',
+            false
         );
         $layoutMock = $this->getMock(
             \Magento\Framework\View\Layout::class,
-            ['createBlock', 'toHtml'], [], '', false
+            ['createBlock', 'toHtml'],
+            [],
+            '',
+            false
         );
         $layoutFactoryMock->expects($this->once())->method('create')->will($this->returnValue($layoutMock));
         $layoutMock->expects($this->once())->method('createBlock')->with($blockName)->will($this->returnSelf());

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/AbstractTestCase.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/AbstractTestCase.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Test\Unit\Controller\Adminhtml\Dashboard;
 
 /**

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/CustomersMostTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/CustomersMostTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Test\Unit\Controller\Adminhtml\Dashboard;
 
 /**

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/CustomersNewestTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/CustomersNewestTest.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backend\Test\Unit\Controller\Adminhtml\Dashboard;
 
 /**


### PR DESCRIPTION
Fixed coding standard violations in the Magento Backend namespace
- Removed @codingstandardsignorefile from files
- Changed is_null to === null
- Line exceeds maximum limit of characters
- Multi-line function call not indented correctly
- Only one argument is allowed per line in a multi-line function call
- No space found after comma in function call