### PR TITLE
Fixed coding standard violations in the Magento\Cms namespace 

### DIFF
--- a/app/code/Magento/Cms/Block/Block.php
+++ b/app/code/Magento/Cms/Block/Block.php
@@ -4,14 +4,14 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Cms\Block;
+
+use Magento\Framework\View\Element\AbstractBlock;
 
 /**
  * Cms block content block
  */
-class Block extends \Magento\Framework\View\Element\AbstractBlock implements \Magento\Framework\DataObject\IdentityInterface
+class Block extends AbstractBlock implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * @var \Magento\Cms\Model\Template\FilterProvider

--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage/Collection.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage/Collection.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Cms\Model\Wysiwyg\Images\Storage;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -26,8 +24,10 @@ class Collection extends \Magento\Framework\Data\Collection\Filesystem
      * @param \Magento\Framework\Data\Collection\EntityFactory $entityFactory
      * @param \Magento\Framework\Filesystem $filesystem
      */
-    public function __construct(\Magento\Framework\Data\Collection\EntityFactory $entityFactory, \Magento\Framework\Filesystem $filesystem)
-    {
+    public function __construct(
+        \Magento\Framework\Data\Collection\EntityFactory $entityFactory,
+        \Magento\Framework\Filesystem $filesystem
+    ) {
         $this->_filesystem = $filesystem;
         parent::__construct($entityFactory);
     }


### PR DESCRIPTION
Fix coding standard in Magento\Cms namespace:
- Removed @codingstandardIgnoreFile from files
- Fixed line length