### PR TITLE
Fixed coding standard violations in the Magento\Authorization Magento\Backup Magento\Captcha Magento\CurrencySymbol and Magento\Dhl namespace

### DIFF
--- a/app/code/Magento/Authorization/Model/ResourceModel/Rules.php
+++ b/app/code/Magento/Authorization/Model/ResourceModel/Rules.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Authorization\Model\ResourceModel;
 
 use Magento\Framework\App\ObjectManager;
@@ -101,7 +99,10 @@ class Rules extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
                 // If all was selected save it only and nothing else.
                 if ($postedResources === [$this->_rootResource->getId()]) {
-                    $insertData = $this->_prepareDataForTable(new \Magento\Framework\DataObject($row), $this->getMainTable());
+                    $insertData = $this->_prepareDataForTable(
+                        new \Magento\Framework\DataObject($row),
+                        $this->getMainTable()
+                    );
 
                     $connection->insert($this->getMainTable(), $insertData);
                 } else {
@@ -113,7 +114,10 @@ class Rules extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                         $row['permission'] = in_array($resourceId, $postedResources) ? 'allow' : 'deny';
                         $row['resource_id'] = $resourceId;
 
-                        $insertData = $this->_prepareDataForTable(new \Magento\Framework\DataObject($row), $this->getMainTable());
+                        $insertData = $this->_prepareDataForTable(
+                            new \Magento\Framework\DataObject($row),
+                            $this->getMainTable()
+                        );
                         $connection->insert($this->getMainTable(), $insertData);
                     }
                 }

--- a/app/code/Magento/Backup/Model/ResourceModel/Helper.php
+++ b/app/code/Magento/Backup/Model/ResourceModel/Helper.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Backup\Model\ResourceModel;
 
 class Helper extends \Magento\Framework\DB\Helper
@@ -176,7 +174,9 @@ class Helper extends \Magento\Framework\DB\Helper
         $dbConfig = $this->getConnection()->getConfig();
 
         $versionRow = $this->getConnection()->fetchRow('SHOW VARIABLES LIKE \'version\'');
-        $hostName = !empty($dbConfig['unix_socket']) ? $dbConfig['unix_socket'] : (!empty($dbConfig['host']) ? $dbConfig['host'] : 'localhost');
+        $hostName = !empty($dbConfig['unix_socket'])
+            ? $dbConfig['unix_socket']
+            : (!empty($dbConfig['host']) ? $dbConfig['host'] : 'localhost');
 
         $header = "-- Magento DB backup\n" .
             "--\n" .

--- a/app/code/Magento/Captcha/Model/Config/Form/AbstractForm.php
+++ b/app/code/Magento/Captcha/Model/Config/Form/AbstractForm.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Data source to fill "Forms" field
  *
@@ -13,7 +11,9 @@
  */
 namespace Magento\Captcha\Model\Config\Form;
 
-abstract class AbstractForm extends \Magento\Framework\App\Config\Value implements \Magento\Framework\Option\ArrayInterface
+use Magento\Framework\App\Config\Value;
+
+abstract class AbstractForm extends Value implements \Magento\Framework\Option\ArrayInterface
 {
     /**
      * @var string

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
@@ -21,9 +21,8 @@ class SaveRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Curr
             try {
                 foreach ($data as $currencyCode => $rate) {
                     foreach ($rate as $currencyTo => $value) {
-                        $value = abs($this->_objectManager->get(
-                            \Magento\Framework\Locale\FormatInterface::class)->getNumber($value)
-                        );
+                        $value = abs($this->_objectManager->get(\Magento\Framework\Locale\FormatInterface::class)
+                            ->getNumber($value));
                         $data[$currencyCode][$currencyTo] = $value;
                         if ($value == 0) {
                             $this->messageManager->addWarning(

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
@@ -22,7 +22,8 @@ class SaveRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Curr
                 foreach ($data as $currencyCode => $rate) {
                     foreach ($rate as $currencyTo => $value) {
                         $value = abs($this->_objectManager->get(
-                            \Magento\Framework\Locale\FormatInterface::class)->getNumber($value));
+                            \Magento\Framework\Locale\FormatInterface::class)->getNumber($value)
+                        );
                         $data[$currencyCode][$currencyTo] = $value;
                         if ($value == 0) {
                             $this->messageManager->addWarning(

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
@@ -21,8 +21,9 @@ class SaveRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Curr
             try {
                 foreach ($data as $currencyCode => $rate) {
                     foreach ($rate as $currencyTo => $value) {
-                        $value = abs($this->_objectManager->get(\Magento\Framework\Locale\FormatInterface::class)
-                            ->getNumber($value));
+                        $value = abs($this->_objectManager->get(
+                            \Magento\Framework\Locale\FormatInterface::class
+                        )->getNumber($value));
                         $data[$currencyCode][$currencyTo] = $value;
                         if ($value == 0) {
                             $this->messageManager->addWarning(

--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
@@ -5,8 +5,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\CurrencySymbol\Controller\Adminhtml\System\Currency;
 
 class SaveRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Currency

--- a/app/code/Magento/Dhl/Model/Carrier.php
+++ b/app/code/Magento/Dhl/Model/Carrier.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 namespace Magento\Dhl\Model;
 
 use Magento\Catalog\Model\Product\Type;


### PR DESCRIPTION
Fixed coding standard violations:
- Removed @codingstanardignorefile from head of file
- Fixed line length
- Fixed Closing parenthesis of a multi-line function call must be on a line by itself