### PR TITLE
Use identifier fields instead of link fields as key for attribute values

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
@@ -376,11 +376,11 @@ class AbstractAction
         $attributesType = ['varchar', 'int', 'decimal', 'text', 'datetime'];
         foreach ($attributesType as $type) {
             foreach ($this->getAttributeTypeValues($type, $entityIds, $storeId) as $row) {
-                if (isset($row[$this->getCategoryMetadata()->getLinkField()]) && isset($row['attribute_id'])) {
+                if (isset($row[$this->getCategoryMetadata()->getIdentifierField()]) && isset($row['attribute_id'])) {
                     $attributeId = $row['attribute_id'];
                     if (isset($attributes[$attributeId])) {
                         $attributeCode = $attributes[$attributeId]['attribute_code'];
-                        $values[$row[$this->getCategoryMetadata()->getLinkField()]][$attributeCode] = $row['value'];
+                        $values[$row[$this->getCategoryMetadata()->getIdentifierField()]][$attributeCode] = $row['value'];
                     }
                 }
             }

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
@@ -372,15 +372,16 @@ class AbstractAction
         foreach ($entityIds as $entityId) {
             $values[$entityId] = [];
         }
+        $identifierField = $this->getCategoryMetadata()->getIdentifierField();
         $attributes = $this->getAttributes();
         $attributesType = ['varchar', 'int', 'decimal', 'text', 'datetime'];
         foreach ($attributesType as $type) {
             foreach ($this->getAttributeTypeValues($type, $entityIds, $storeId) as $row) {
-                if (isset($row[$this->getCategoryMetadata()->getIdentifierField()]) && isset($row['attribute_id'])) {
+                if (isset($row[$identifierField]) && isset($row['attribute_id'])) {
                     $attributeId = $row['attribute_id'];
                     if (isset($attributes[$attributeId])) {
                         $attributeCode = $attributes[$attributeId]['attribute_code'];
-                        $values[$row[$this->getCategoryMetadata()->getIdentifierField()]][$attributeCode] = $row['value'];
+                        $values[$row[$identifierField]][$attributeCode] = $row['value'];
                     }
                 }
             }

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Full.php
@@ -38,7 +38,7 @@ class Full extends \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction
      */
     protected function populateFlatTables(array $stores)
     {
-        $identifierField = $this->categoryMetadata->getIdentifierField();
+        $identifierField = $this->getCategoryMetadata()->getIdentifierField();
         $rootId = \Magento\Catalog\Model\Category::TREE_ROOT_ID;
         $categories = [];
         $categoriesIds = [];

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Full.php
@@ -38,7 +38,6 @@ class Full extends \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction
      */
     protected function populateFlatTables(array $stores)
     {
-        $identifierField = $this->getCategoryMetadata()->getIdentifierField();
         $rootId = \Magento\Catalog\Model\Category::TREE_ROOT_ID;
         $categories = [];
         $categoriesIds = [];
@@ -69,12 +68,12 @@ class Full extends \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction
                 $attributesData = $this->getAttributeValues($categoriesIdsChunk, $store->getId());
                 $data = [];
                 foreach ($categories[$store->getRootCategoryId()] as $category) {
-                    if (!isset($attributesData[$category[$identifierField]])) {
+                    if (!isset($attributesData[$category['entity_id']])) {
                         continue;
                     }
                     $category['store_id'] = $store->getId();
                     $data[] = $this->prepareValuesToInsert(
-                        array_merge($category, $attributesData[$category[$identifierField]])
+                        array_merge($category, $attributesData[$category['entity_id']])
                     );
                 }
                 $this->connection->insertMultiple(

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Full.php
@@ -68,12 +68,12 @@ class Full extends \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction
                 $attributesData = $this->getAttributeValues($categoriesIdsChunk, $store->getId());
                 $data = [];
                 foreach ($categories[$store->getRootCategoryId()] as $category) {
-                    if (!isset($attributesData[$category[$this->categoryMetadata->getLinkField()]])) {
+                    if (!isset($attributesData[$category[$this->categoryMetadata->getIdentifierField()]])) {
                         continue;
                     }
                     $category['store_id'] = $store->getId();
                     $data[] = $this->prepareValuesToInsert(
-                        array_merge($category, $attributesData[$category[$this->categoryMetadata->getLinkField()]])
+                        array_merge($category, $attributesData[$category[$this->categoryMetadata->getIdentifierField()]])
                     );
                 }
                 $this->connection->insertMultiple(

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Action/Full.php
@@ -38,6 +38,7 @@ class Full extends \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction
      */
     protected function populateFlatTables(array $stores)
     {
+        $identifierField = $this->categoryMetadata->getIdentifierField();
         $rootId = \Magento\Catalog\Model\Category::TREE_ROOT_ID;
         $categories = [];
         $categoriesIds = [];
@@ -68,12 +69,12 @@ class Full extends \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction
                 $attributesData = $this->getAttributeValues($categoriesIdsChunk, $store->getId());
                 $data = [];
                 foreach ($categories[$store->getRootCategoryId()] as $category) {
-                    if (!isset($attributesData[$category[$this->categoryMetadata->getIdentifierField()]])) {
+                    if (!isset($attributesData[$category[$identifierField]])) {
                         continue;
                     }
                     $category['store_id'] = $store->getId();
                     $data[] = $this->prepareValuesToInsert(
-                        array_merge($category, $attributesData[$category[$this->categoryMetadata->getIdentifierField()]])
+                        array_merge($category, $attributesData[$category[$identifierField]])
                     );
                 }
                 $this->connection->insertMultiple(


### PR DESCRIPTION
### Description
We are using 2.1.7 EE and we experienced duplicate entry issue with the category flat indexer, after we had created some staged categories. Since the module is same in the CE, I made this PR here.

Origin of the issue is in \Magento\Catalog\Model\Indexer\Category\Flat\AbstractAction::getAttributeValues() where attribute values are collected to array which has link field as a key, but the attribute value array is initialized with entity_id as a key. This can lead up to invalid duplicate entries when the category data is merged with attribute values in \Magento\Catalog\Model\Indexer\Category\Flat\Action\Full::populateFlatTables().

```
foreach ($entityIds as $entityId) {
    $values[$entityId] = [];
}
$attributes = $this->getAttributes();
$attributesType = ['varchar', 'int', 'decimal', 'text', 'datetime'];
foreach ($attributesType as $type) {
    foreach ($this->getAttributeTypeValues($type, $entityIds, $storeId) as $row) {
        if (isset($row[$this->getCategoryMetadata()->getLinkField()]) && isset($row['attribute_id'])) {
            $attributeId = $row['attribute_id'];
            if (isset($attributes[$attributeId])) {
                $attributeCode = $attributes[$attributeId]['attribute_code'];
                $values[$row[$this->getCategoryMetadata()->getLinkField()]][$attributeCode] = $row['value'];
            }
        }
    }
}
```
## Solution
Change methods mentioned above to use identifier fields.
```
foreach ($this->getAttributeTypeValues($type, $entityIds, $storeId) as $row) {
    if (isset($row[$this->getCategoryMetadata()->getIdentifierField()]) && isset($row['attribute_id'])) {
        $attributeId = $row['attribute_id'];
        if (isset($attributes[$attributeId])) {
            $attributeCode = $attributes[$attributeId]['attribute_code'];
            $values[$row[$this->getCategoryMetadata()->getIdentifierField()]][$attributeCode] = $row['value'];
        }
    }
}
```
```
foreach ($categoriesIdsChunks as $categoriesIdsChunk) {
    $attributesData = $this->getAttributeValues($categoriesIdsChunk, $store->getId());
    $data = [];
    foreach ($categories[$store->getRootCategoryId()] as $category) {
        if (!isset($attributesData[$category[$this->categoryMetadata->getIdentifierField()]])) {
            continue;
        }
        $category['store_id'] = $store->getId();
        $data[] = $this->prepareValuesToInsert(
            array_merge($category, $attributesData[$category[$this->categoryMetadata->getIdentifierField()]])
        );
    }
    $this->connection->insertMultiple(
        $this->addTemporaryTableSuffix($this->getMainStoreTable($store->getId())),
        $data
    );
}
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

```