### PR TITLE
Make page title in layout files translatable

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config/Reader/Head.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Reader/Head.php
@@ -86,7 +86,7 @@ class Head implements Layout\ReaderInterface
                     break;
 
                 case self::HEAD_TITLE:
-                    $pageConfigStructure->setTitle($node);
+                    $pageConfigStructure->setTitle(__($node));
                     break;
 
                 case self::HEAD_META:


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

Make it possible to translate page titles that are provided in the layout xml files.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6337: Not able to translate page layout head titles

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. translate one of the page titles that have been altered in this pull request
2. flush the cache 
3. visit the page
4. see that the title is translated

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
