### PR TITLE
Ubuntu Trusty 14.04 images update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 dist: trusty
+group: edge
 addons:
   apt:
     packages:


### PR DESCRIPTION
On Wednesday, June 21st 2017, Travis is going to update all their Ubuntu Trusty 14.04 images. The tests are running on a Trusty, sudo: required environment which will be updated on Wednesday

### Description

> Sudo-enabled Trusty images
> At 14:30 UTC on Wednesday, we will first update our sudo-enabled Ubuntu Trusty 14.04 images. This new generation of Trusty images is already available in production and can be used by adding group: edge in your .travis.yml file:
> 

```
sudo: required
dist: trusty

group: edge  # Add this
```

> We advise you all to try this out in preparation of the release that will happen on Wednesday and please reach out to support@travis-ci.com for any issues you might encounter with the new Trusty images.


https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
