### PR TITLE
Backport 7279 to 2.1

### DIFF
--- a/app/code/Magento/Quote/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Quote/Setup/UpgradeSchema.php
@@ -46,8 +46,16 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
         }
-
-        if (version_compare($context->getVersion(), '2.0.2', '<')) {
+        //drop foreign key for single DB case
+        if (version_compare($context->getVersion(), '2.0.3', '<')
+            && $setup->tableExists($setup->getTable('quote_item'))
+        ) {
+            $setup->getConnection()->dropForeignKey(
+                $setup->getTable('quote_item'),
+                $setup->getFkName('quote_item', 'product_id', 'catalog_product_entity', 'entity_id')
+            );
+        }
+        if (version_compare($context->getVersion(), '2.0.5', '<')) {
             $setup->getConnection(self::$connectionName)->changeColumn(
                 $setup->getTable('quote_address', self::$connectionName),
                 'firstname',
@@ -58,8 +66,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'comment' => 'Firstname'
                 ]
             );
-        }
-        if (version_compare($context->getVersion(), '2.0.2', '<')) {
             $setup->getConnection(self::$connectionName)->changeColumn(
                 $setup->getTable('quote_address', self::$connectionName),
                 'middlename',
@@ -70,8 +76,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'comment' => 'Middlename'
                 ]
             );
-        }
-        if (version_compare($context->getVersion(), '2.0.2', '<')) {
             $setup->getConnection(self::$connectionName)->changeColumn(
                 $setup->getTable('quote_address', self::$connectionName),
                 'lastname',
@@ -81,15 +85,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'length' => 255,
                     'comment' => 'Lastname'
                 ]
-            );
-        }
-        //drop foreign key for single DB case
-        if (version_compare($context->getVersion(), '2.0.3', '<')
-            && $setup->tableExists($setup->getTable('quote_item'))
-        ) {
-            $setup->getConnection()->dropForeignKey(
-                $setup->getTable('quote_item'),
-                $setup->getFkName('quote_item', 'product_id', 'catalog_product_entity', 'entity_id')
             );
         }
         $setup->endSetup();

--- a/app/code/Magento/Quote/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Quote/Setup/UpgradeSchema.php
@@ -46,6 +46,43 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
         }
+
+        if (version_compare($context->getVersion(), '2.0.2', '<')) {
+            $setup->getConnection(self::$connectionName)->changeColumn(
+                $setup->getTable('quote_address', self::$connectionName),
+                'firstname',
+                'firstname',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'length' => 255,
+                    'comment' => 'Firstname'
+                ]
+            );
+        }
+        if (version_compare($context->getVersion(), '2.0.2', '<')) {
+            $setup->getConnection(self::$connectionName)->changeColumn(
+                $setup->getTable('quote_address', self::$connectionName),
+                'middlename',
+                'middlename',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'length' => 40,
+                    'comment' => 'Middlename'
+                ]
+            );
+        }
+        if (version_compare($context->getVersion(), '2.0.2', '<')) {
+            $setup->getConnection(self::$connectionName)->changeColumn(
+                $setup->getTable('quote_address', self::$connectionName),
+                'lastname',
+                'lastname',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'length' => 255,
+                    'comment' => 'Lastname'
+                ]
+            );
+        }
         //drop foreign key for single DB case
         if (version_compare($context->getVersion(), '2.0.3', '<')
             && $setup->tableExists($setup->getTable('quote_item'))

--- a/app/code/Magento/Quote/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Quote/Setup/UpgradeSchema.php
@@ -55,7 +55,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 $setup->getFkName('quote_item', 'product_id', 'catalog_product_entity', 'entity_id')
             );
         }
-        if (version_compare($context->getVersion(), '2.0.5', '<')) {
+        if (version_compare($context->getVersion(), '2.0.4', '<')) {
             $setup->getConnection(self::$connectionName)->changeColumn(
                 $setup->getTable('quote_address', self::$connectionName),
                 'firstname',

--- a/app/code/Magento/Quote/etc/module.xml
+++ b/app/code/Magento/Quote/etc/module.xml
@@ -6,6 +6,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Quote" setup_version="2.0.3">
+    <module name="Magento_Quote" setup_version="2.0.5">
     </module>
 </config>

--- a/app/code/Magento/Quote/etc/module.xml
+++ b/app/code/Magento/Quote/etc/module.xml
@@ -6,6 +6,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Quote" setup_version="2.0.5">
+    <module name="Magento_Quote" setup_version="2.0.4">
     </module>
 </config>


### PR DESCRIPTION
### Description
This backports #7279 to 2.1.  The version number comparison in the upgrade script and the module.xml vary slightly to allow for other updates to potentially be backported.  As this change is non-destructive there should be no issue with a store upgrading from 2.1.x to 2.2 and having these updates run again.