### PR TITLE
Allow option disabling for optgroup binding

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/optgroup.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/optgroup.js
@@ -302,9 +302,8 @@ define([
                         space = '\u2007\u2007\u2007';
 
                     obj[optionTitle] = applyToObject(option, optionsText + 'title', value);
-                    
-                    if(disabled) {
-                        obj['disabled'] = disabled;
+                    if (disabled) {
+                        obj.disabled = disabled;
                     }
 
                     label = label.replace(nbspRe, '').trim();

--- a/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/optgroup.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/optgroup.js
@@ -302,7 +302,7 @@ define([
                         space = '\u2007\u2007\u2007';
 
                     obj[optionTitle] = applyToObject(option, optionsText + 'title', value);
-                    
+
                     if (disabled) {
                         obj.disabled = disabled;
                     }

--- a/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/optgroup.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/optgroup.js
@@ -297,10 +297,15 @@ define([
                 ko.utils.arrayForEach(options, function (option) {
                     var value = applyToObject(option, optionsValue, option),
                         label = applyToObject(option, optionsText, value) || '',
+                        disabled = applyToObject(option, 'disabled', false) || false,
                         obj = {},
                         space = '\u2007\u2007\u2007';
 
                     obj[optionTitle] = applyToObject(option, optionsText + 'title', value);
+                    
+                    if(disabled) {
+                        obj['disabled'] = disabled;
+                    }
 
                     label = label.replace(nbspRe, '').trim();
 

--- a/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/optgroup.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/optgroup.js
@@ -302,6 +302,7 @@ define([
                         space = '\u2007\u2007\u2007';
 
                     obj[optionTitle] = applyToObject(option, optionsText + 'title', value);
+                    
                     if (disabled) {
                         obj.disabled = disabled;
                     }


### PR DESCRIPTION
The optgroup Knockout binding formats its options before usage in the optionsAfterRender of the form/element/select.html knockout template. In this process all extra data of the options will be stripped and the optionsAfterRenderer cannot access the "disabled" value of any option. Because of this the delimiter option in the country_id select in checkout is choosable by the customer which is not the intended behaviour.