### PR TITLE
Fix for file category image uploader

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
@@ -330,7 +330,7 @@ define([
 
             if (allowed.passed) {
                 target.on('fileuploadsend', function (event, postData) {
-                    postData.data.set('param_name', this.paramName);
+                    postData.data.append('param_name', this.paramName);
                 }.bind(data));
 
                 target.fileupload('process', data).done(function () {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Changes that were made on https://github.com/magento/magento2/commit/70d3468b24ffbbd4233123c8d60916a440975b39 commit broke category image uploading in many browsers, as FormData.set() is onnly supported in Chrome and Firefox (in Firefox it also depends on user browser settings)
2. New implementation (changing set() into append()) is working correctly, because such element doesn't exists in FormData at the time of sending, and it is well supported across browsers.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
