### PR TITLE
Include attribute code in error message

### DIFF
--- a/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
@@ -40,8 +40,8 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
      * @var array
      */
     protected $_messageTemplates = [
-        self::ERROR_ATTRIBUTE_CODE_IS_NOT_SUPER => 'Attribute with this code is not super',
-        self::ERROR_INVALID_OPTION_VALUE => 'Invalid option value',
+        self::ERROR_ATTRIBUTE_CODE_IS_NOT_SUPER => 'Attribute with code "%s" is not super',
+        self::ERROR_INVALID_OPTION_VALUE => 'Invalid option value for attribute "%s"',
         self::ERROR_INVALID_WEBSITE => 'Invalid website code for super attribute',
         self::ERROR_DUPLICATED_VARIATIONS => 'SKU %s contains duplicated variations',
     ];
@@ -291,12 +291,12 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
 
             if (!$this->_isAttributeSuper($superAttrCode)) {
                 // check attribute superity
-                $this->_entityModel->addRowError(self::ERROR_ATTRIBUTE_CODE_IS_NOT_SUPER, $rowNum);
+                $this->_entityModel->addRowError(self::ERROR_ATTRIBUTE_CODE_IS_NOT_SUPER, $rowNum, $superAttrCode);
                 return false;
             } elseif (isset($rowData['_super_attribute_option']) && strlen($rowData['_super_attribute_option'])) {
                 $optionKey = strtolower($rowData['_super_attribute_option']);
                 if (!isset($this->_superAttributes[$superAttrCode]['options'][$optionKey])) {
-                    $this->_entityModel->addRowError(self::ERROR_INVALID_OPTION_VALUE, $rowNum);
+                    $this->_entityModel->addRowError(self::ERROR_INVALID_OPTION_VALUE, $rowNum, $superAttrCode);
                     return false;
                 }
             }


### PR DESCRIPTION
### Description
The error message during import of a configurable product(s) is slightly vague if the configurable product(s) contain multiple super attributes

### Manual testing scenarios
1. Create an import file that would create a configurable product with more than one attribute set to be a super attribute (ensure that one of the attributes is **not** actually setup properly for use as a super attribute.  eg type=text or attribute not included in attribute_set)
2. Attempt to import the file

### Before
Error message reads: **Attribute with this code is not super in rows: 1, 2, 3...**

### After
Error message reads: **Attribute with code "color" is not super in rows: 1, 2, 3...**
