### PR TITLE
[2.1-backport] Customer-data is not updates after login when full page cache disabled

### DIFF
--- a/app/code/Magento/PageCache/Model/App/FrontController/BuiltinPlugin.php
+++ b/app/code/Magento/PageCache/Model/App/FrontController/BuiltinPlugin.php
@@ -64,10 +64,10 @@ class BuiltinPlugin
         \Closure $proceed,
         \Magento\Framework\App\RequestInterface $request
     ) {
+        $this->version->process();
         if (!$this->config->isEnabled() || $this->config->getType() != \Magento\PageCache\Model\Config::BUILT_IN) {
             return $proceed($request);
         }
-        $this->version->process();
         $result = $this->kernel->load();
         if ($result === false) {
             $result = $proceed($request);

--- a/app/code/Magento/PageCache/Test/Unit/Model/App/FrontController/BuiltinPluginTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Model/App/FrontController/BuiltinPluginTest.php
@@ -219,7 +219,7 @@ class BuiltinPluginTest extends \PHPUnit_Framework_TestCase
             ->method('isEnabled')
             ->will($this->returnValue(true));
         $this->versionMock
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('process');
         $this->stateMock->expects($this->any())
             ->method('getMode')


### PR DESCRIPTION
### Description
If you disable full page cache (tested with built-in) - after login 
### Preconditions
1. Magento 2.1.1
2. Full page cache is in "Disabled" state (via php bin/magento cache:disable full_page)
3. Google Chrome latest
### Steps to reproduce
1. Go to magento website
2. Try to login
3. See welcome message
### Expected result
1. Welcome message should be "Welcome, <username>!"
2. Customer data should contains customer information
### Actual result
1. Welcome message is "Default welcome msg!"
   ![image](https://cloud.githubusercontent.com/assets/1873745/18205339/28af2f5c-712a-11e6-80ec-b8402356fa34.png)
2. Customer data isn't contains customer information

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/4170 : Magento2 Mini Cart Items Issue
2. https://github.com/magento/magento2/issues/6882 : Minicart empty if FPC disabled in Magneto 2.1.1
3. https://github.com/magento/magento2/issues/5377: "No items" in minicart in 2.1
4. https://github.com/magento/magento2/pull/6473 : Customer-data is not updates after login when full page cache disabled

**These changes were already applied in develop branch, so this PR will fix this issue for 2.1.x.**

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
