### PR TITLE
Fix date format in adminhtml order grid

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
@@ -187,7 +187,7 @@
                     <item name="component" xsi:type="string">Magento_Ui/js/grid/columns/date</item>
                     <item name="dataType" xsi:type="string">date</item>
                     <item name="label" xsi:type="string" translate="true">Purchase Date</item>
-                    <item name="dateFormat" xsi:type="string">MMM dd, YYYY, H:MM:SS A</item>
+                    <item name="dateFormat" xsi:type="string">MMM dd, YYYY, H:mm:SS A</item>
                 </item>
             </argument>
         </column>


### PR DESCRIPTION
Due to an error in the date format of the purchase date in the adminhtml order grid, the date displayed shows the month number in place of the minutes.

### Manual testing scenarios
1. Submit an order
2. Check the order date in the adminhtml order grid