### PR TITLE
Fix for isoneof condition in catalogrule

### DIFF
--- a/app/code/Magento/CatalogRule/Block/Adminhtml/Promo/Catalog/Edit/Tab/Conditions.php
+++ b/app/code/Magento/CatalogRule/Block/Adminhtml/Promo/Catalog/Edit/Tab/Conditions.php
@@ -187,7 +187,6 @@ class Conditions extends Generic implements TabInterface
     private function setConditionFormName(\Magento\Rule\Model\Condition\AbstractCondition $conditions, $formName)
     {
         $conditions->setFormName($formName);
-        $conditions->setJsFormObject($formName);
         if ($conditions->getConditions() && is_array($conditions->getConditions())) {
             foreach ($conditions->getConditions() as $condition) {
                 $this->setConditionFormName($condition, $formName);


### PR DESCRIPTION
### Description
When comparing the SalesRule module with the CatalogRule module, i noticed a small difference in the setConditionFormName function. The SetJsFormObject wasn't called in the SalesRule module. When removing it from the CatalogRule module, the error disappeared. Probably had to do with setting the wrong object on the tree. It called the unchecked function on the form instead of the condition.

 This should solve the problem.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6396: Cart Price Rules: Category selection UI for Conditions do not come up.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->

1. Create price rule with condition 'category is one of ...'
2. Save the rule
3. Re-open the rule and try to change the category id value

Following Javascript error will appear 
`Uncaught ReferenceError: catalog_rule_form is not defined
    at Ext.tree.TreePanel.Enhanced.eval (eval at <anonymous> (legacy-build.min.js:1), <anonymous>:156:9)
    at Ext.util.Event.fire (ext-tree.js:29)
    at Ext.tree.TreePanel.Enhanced.fireEvent (ext-tree.js:29)
    at Ext.tree.CheckboxNodeUI.check (ext-tree-checkbox.js:193)
    at El.Flyweight.<anonymous> (ext-tree.js:9)
    at HTMLInputElement.h (ext-tree.js:33)
    at HTMLInputElement.M (legacy-build.min.js:8)`


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
