### PR TITLE
Fixes an error during compilation process

### DIFF
--- a/app/code/Magento/Braintree/Controller/Paypal/Review.php
+++ b/app/code/Magento/Braintree/Controller/Paypal/Review.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\Braintree\Controller\Paypal;
+namespace Magento\Braintree\Controller\PayPal;
 
 use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\Context;


### PR DESCRIPTION
Got the following error:

PHP Fatal error:  Class 'Magento\Braintree\Controller\Paypal\AbstractAction' not found in [base_path]/vendor/magento/module-braintree/Controller/PayPal/Review.php on line 18