### PR TITLE
Add referrerPolicy to Vimeo Video iframe to allow domain-restricted videos

### DIFF
--- a/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
@@ -332,6 +332,7 @@ define(['jquery', 'jquery/ui'], function ($) {
                     .attr('webkitallowfullscreen', '')
                     .attr('mozallowfullscreen', '')
                     .attr('allowfullscreen', '')
+                    .attr('referrerPolicy', 'origin')
             );
             this._player = window.$f(this.element.children(':first')[0]);
 


### PR DESCRIPTION
### Description
When Vimeo videos are domain restricted, (see [Vimeo](https://help.vimeo.com/hc/en-us/articles/224819527-Changing-the-privacy-settings-of-your-videos) ) they require that the video iFrame passes a referrer header. This is missing from the existing implementation and domain restricted videos will not play.

Setting the `referrerPolicy` ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy)) the iFrame correctly sends the referrer header with the video request.

### Fixed Issues (if relevant)
n/a 


### Manual testing scenarios
1. Embedd a domain restricted Vimeo video against a product.
2. Check the video displays correctly on the frontend

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
