### PR TITLE
Return URL in getThumbnailUrl instead of nothing

### DIFF
--- a/app/code/Magento/Catalog/Helper/Product.php
+++ b/app/code/Magento/Catalog/Helper/Product.php
@@ -256,7 +256,14 @@ class Product extends \Magento\Framework\Url\Helper\Data
      */
     public function getThumbnailUrl($product)
     {
-        return '';
+        $url = false;
+        $attribute = $product->getResource()->getAttribute('thumbnail');
+        if (!$product->getThumbnail()) {
+            $url = $this->_assetRepo->getUrl('Magento_Catalog::images/product/placeholder/thumbnail.jpg');
+        } elseif ($attribute) {
+            $url = $attribute->getFrontend()->getUrl($product);
+        }
+        return $url;
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Catalog/Helper/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Helper/ProductTest.php
@@ -90,13 +90,13 @@ class ProductTest extends \PHPUnit_Framework_TestCase
 
     public function testGetThumbnailUrl()
     {
-        $this->assertEmpty(
-            $this->helper->getThumbnailUrl(
-                \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-                    \Magento\Catalog\Model\Product::class
-                )
-            )
+        /** @var $product \Magento\Catalog\Model\Product */
+        $product = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Catalog\Model\Product::class
         );
+        $this->assertStringEndsWith('placeholder/thumbnail.jpg', $this->helper->getThumbnailUrl($product));
+        $product->setThumbnail('test_image.png');
+        $this->assertStringEndsWith('/test_image.png', $this->helper->getThumbnailUrl($product));
     }
 
     public function testGetEmailToFriendUrl()


### PR DESCRIPTION
In Magento/Catalog/Helper/Product the getThumbnailUrl method currently only returns an empty string, this should, of course, return the Product Thumbnail Url.

### Fixed Issues (if relevant)
n/a

### Manual testing scenarios
$this->productHelper->getThumbnailUrl($product);

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)