### PR TITLE
Fix width & height mapping during image upload

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
@@ -389,8 +389,8 @@ define([
         onPreviewLoad: function (file, e) {
             var img = e.currentTarget;
 
-            file.previewWidth = img.naturalHeight;
-            file.previewHeight = img.naturalWidth;
+            file.previewWidth = img.naturalWidth;
+            file.previewHeight = img.naturalHeight;
         },
 
         /**


### PR DESCRIPTION
### Description
Width & height are shown incorrectly during image upload.
See #10124 for detailed description

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/10124 Wrong order of "width" x "height" when uploading image to admin under Content>Design Config

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
