### PR TITLE
Backport of MAGETWO-54243 for Magento 2.1

### DIFF
--- a/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
@@ -85,7 +85,7 @@ class Conditions extends Template implements RendererInterface
         $widget = $this->registry->registry('current_widget_instance');
         if ($widget) {
             $widgetParameters = $widget->getWidgetParameters();
-        } elseif($widgetOptions = $this->getLayout()->getBlock('wysiwyg_widget.options')) {
+        } elseif ($widgetOptions = $this->getLayout()->getBlock('wysiwyg_widget.options')) {
             $widgetParameters = $widgetOptions->getWidgetValues();
         }
 

--- a/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/Widget/Conditions.php
@@ -81,12 +81,16 @@ class Conditions extends Template implements RendererInterface
      */
     protected function _construct()
     {
+        $widgetParameters = [];
         $widget = $this->registry->registry('current_widget_instance');
         if ($widget) {
             $widgetParameters = $widget->getWidgetParameters();
-            if (isset($widgetParameters['conditions'])) {
-                $this->rule->loadPost($widgetParameters);
-            }
+        } elseif($widgetOptions = $this->getLayout()->getBlock('wysiwyg_widget.options')) {
+            $widgetParameters = $widgetOptions->getWidgetValues();
+        }
+
+        if (isset($widgetParameters['conditions'])) {
+            $this->rule->loadPost($widgetParameters);
         }
     }
 

--- a/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/Widget/ConditionsTest.php
+++ b/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/Widget/ConditionsTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\CatalogWidget\Test\Unit\Block\Product\Widget;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\CatalogWidget\Block\Product\Widget\Conditions;
+use Magento\Framework\Registry;
+use Magento\Backend\Block\Template\Context;
+use Magento\CatalogWidget\Model\Rule;
+use Magento\Framework\View\LayoutInterface;
+use Magento\Framework\View\Element\BlockInterface;
+
+/**
+ * Test class for \Magento\CatalogWidget\Block\Product\Widget\Conditions
+ */
+class ConditionsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ObjectManagerHelper
+     */
+    private $objectManagerHelper;
+
+    /**
+     * @var Registry|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $registryMock;
+
+    /**
+     * @var Context|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $contextMock;
+
+    /**
+     * @var Rule|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $ruleMock;
+
+    /**
+     * @var LayoutInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $layoutMock;
+
+    /**
+     * @var BlockInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $blockMock;
+
+    /**
+     * @var Conditions
+     */
+    private $widgetConditions;
+
+    /**
+     * return void
+     */
+    protected function setUp()
+    {
+        $this->objectManagerHelper = new ObjectManagerHelper($this);
+        $this->ruleMock = $this->getMockBuilder(Rule::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->registryMock = $this->getMockBuilder(Registry::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->layoutMock = $this->getMockForAbstractClass(LayoutInterface::class);
+        $this->blockMock = $this->getMockBuilder(BlockInterface::class)
+            ->setMethods(['getWidgetValues'])
+            ->getMockForAbstractClass();
+        $this->contextMock = $this->getMockBuilder(Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->contextMock->expects($this->once())
+            ->method('getLayout')
+            ->willReturn($this->layoutMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testConstructWithEmptyData()
+    {
+        $this->registryMock->expects($this->once())
+            ->method('registry')
+            ->with('current_widget_instance')
+            ->willReturn(null);
+        $this->layoutMock->expects($this->once())
+            ->method('getBlock')
+            ->with('wysiwyg_widget.options')
+            ->willReturn(null);
+        $this->blockMock->expects($this->never())
+            ->method('getWidgetValues');
+        $this->ruleMock->expects($this->never())
+            ->method('loadPost');
+
+        $this->objectManagerHelper->getObject(
+            Conditions::class,
+            [
+                'context' => $this->contextMock,
+                'registry' => $this->registryMock,
+                'rule' => $this->ruleMock,
+            ]
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testConstructWithWidgetInstance()
+    {
+        $widgetParams = ['conditions' => 'some conditions'];
+
+        /** @var \Magento\Widget\Model\Widget\Instance|\PHPUnit_Framework_MockObject_MockObject $widgetMock */
+        $widgetMock = $this->getMockBuilder(\Magento\Widget\Model\Widget\Instance::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $widgetMock->expects($this->once())
+            ->method('getWidgetParameters')
+            ->willReturn($widgetParams);
+
+        $this->layoutMock->expects($this->never())
+            ->method('getBlock');
+        $this->blockMock->expects($this->never())
+            ->method('getWidgetValues');
+        $this->registryMock->expects($this->once())
+            ->method('registry')
+            ->with('current_widget_instance')
+            ->willReturn($widgetMock);
+        $this->ruleMock->expects($this->once())
+            ->method('loadPost')
+            ->with($widgetParams)
+            ->willReturnSelf();
+
+        $this->objectManagerHelper->getObject(
+            Conditions::class,
+            [
+                'context' => $this->contextMock,
+                'registry' => $this->registryMock,
+                'rule' => $this->ruleMock,
+            ]
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testConstructWithParamsFromBlock()
+    {
+        $widgetParams = ['conditions' => 'some conditions'];
+
+        $this->registryMock->expects($this->once())
+            ->method('registry')
+            ->with('current_widget_instance')
+            ->willReturn(null);
+        $this->layoutMock->expects($this->once())
+            ->method('getBlock')
+            ->with('wysiwyg_widget.options')
+            ->willReturn($this->blockMock);
+        $this->blockMock->expects($this->once())
+            ->method('getWidgetValues')
+            ->willReturn($widgetParams);
+        $this->ruleMock->expects($this->once())
+            ->method('loadPost')
+            ->with($widgetParams)
+            ->willReturnSelf();
+
+        $this->objectManagerHelper->getObject(
+            Conditions::class,
+            [
+                'context' => $this->contextMock,
+                'registry' => $this->registryMock,
+                'rule' => $this->ruleMock,
+            ]
+        );
+    }
+}

--- a/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/Widget/ConditionsTest.php
+++ b/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/Widget/ConditionsTest.php
@@ -49,11 +49,6 @@ class ConditionsTest extends \PHPUnit_Framework_TestCase
     private $blockMock;
 
     /**
-     * @var Conditions
-     */
-    private $widgetConditions;
-
-    /**
      * return void
      */
     protected function setUp()

--- a/app/code/Magento/Widget/Controller/Adminhtml/Widget/LoadOptions.php
+++ b/app/code/Magento/Widget/Controller/Adminhtml/Widget/LoadOptions.php
@@ -6,8 +6,15 @@
  */
 namespace Magento\Widget\Controller\Adminhtml\Widget;
 
+use Magento\Framework\App\ObjectManager;
+
 class LoadOptions extends \Magento\Backend\App\Action
 {
+    /**
+     * @var \Magento\Widget\Helper\Conditions
+     */
+    private $conditionsHelper;
+    
     /**
      * Ajax responder for loading plugin options form
      *
@@ -18,13 +25,19 @@ class LoadOptions extends \Magento\Backend\App\Action
         try {
             $this->_view->loadLayout();
             if ($paramsJson = $this->getRequest()->getParam('widget')) {
-                $request = $this->_objectManager->get('Magento\Framework\Json\Helper\Data')->jsonDecode($paramsJson);
+                $request = $this->_objectManager->get(\Magento\Framework\Json\Helper\Data::class)
+                    ->jsonDecode($paramsJson);
                 if (is_array($request)) {
                     $optionsBlock = $this->_view->getLayout()->getBlock('wysiwyg_widget.options');
                     if (isset($request['widget_type'])) {
                         $optionsBlock->setWidgetType($request['widget_type']);
                     }
                     if (isset($request['values'])) {
+                        $request['values'] = array_map('htmlspecialchars_decode', $request['values']);
+                        if (isset($request['values']['conditions_encoded'])) {
+                            $request['values']['conditions'] =
+                                $this->getConditionsHelper()->decode($request['values']['conditions_encoded']);
+                        }
                         $optionsBlock->setWidgetValues($request['values']);
                     }
                 }
@@ -33,8 +46,21 @@ class LoadOptions extends \Magento\Backend\App\Action
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $result = ['error' => true, 'message' => $e->getMessage()];
             $this->getResponse()->representJson(
-                $this->_objectManager->get('Magento\Framework\Json\Helper\Data')->jsonEncode($result)
+                $this->_objectManager->get(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($result)
             );
         }
+    }
+    
+    /**
+     * @return \Magento\Widget\Helper\Conditions
+     * @deprecated
+     */
+    private function getConditionsHelper()
+    {
+        if (!$this->conditionsHelper) {
+            $this->conditionsHelper = ObjectManager::getInstance()->get(\Magento\Widget\Helper\Conditions::class);
+        }
+
+        return $this->conditionsHelper;
     }
 }

--- a/app/code/Magento/Widget/Model/Widget.php
+++ b/app/code/Magento/Widget/Model/Widget.php
@@ -314,7 +314,7 @@ class Widget
                 }
             }
             if ($value) {
-                $directive .= sprintf(' %s="%s"', $name, $value);
+                $directive .= sprintf(' %s="%s"', $name, $this->escaper->escapeQuote($value));
             }
         }
 

--- a/app/code/Magento/Widget/Test/Unit/Controller/Adminhtml/Widget/LoadOptionsTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Controller/Adminhtml/Widget/LoadOptionsTest.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Widget\Test\Unit\Controller\Adminhtml\Widget;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Widget\Controller\Adminhtml\Widget\LoadOptions;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\ViewInterface;
+use Magento\Widget\Helper\Conditions as ConditionsHelper;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\App\RequestInterface;
+
+/**
+ * Test class for \Magento\Widget\Controller\Adminhtml\Widget\LoadOptions
+ */
+class LoadOptionsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ObjectManagerHelper
+     */
+    private $objectManagerHelper;
+
+    /**
+     * @var Context|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $contextMock;
+
+    /**
+     * @var ViewInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $viewMock;
+
+    /**
+     * @var ConditionsHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $conditionsHelperMock;
+
+    /**
+     * @var ResponseInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $responseMock;
+
+    /**
+     * @var ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $objectManagerMock;
+
+    /**
+     * @var RequestInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $requestMock;
+
+    /**
+     * @var LoadOptions
+     */
+    private $loadOptions;
+
+    /**
+     * return void
+     */
+    protected function setUp()
+    {
+        $this->objectManagerHelper = new ObjectManagerHelper($this);
+        $this->objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
+        $this->viewMock = $this->getMockForAbstractClass(ViewInterface::class);
+        $this->requestMock = $this->getMockForAbstractClass(RequestInterface::class);
+        $this->responseMock = $this->getMockBuilder(ResponseInterface::class)
+            ->setMethods(['representJson'])
+            ->getMockForAbstractClass();
+        $this->contextMock = $this->getMockBuilder(Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->contextMock->expects($this->once())
+            ->method('getView')
+            ->willReturn($this->viewMock);
+        $this->contextMock->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($this->requestMock);
+        $this->contextMock->expects($this->once())
+            ->method('getResponse')
+            ->willReturn($this->responseMock);
+        $this->contextMock->expects($this->once())
+            ->method('getObjectManager')
+            ->willReturn($this->objectManagerMock);
+        $this->conditionsHelperMock = $this->getMockBuilder(ConditionsHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->loadOptions = $this->objectManagerHelper->getObject(
+            LoadOptions::class,
+            ['context' => $this->contextMock]
+        );
+        $this->objectManagerHelper->setBackwardCompatibleProperty(
+            $this->loadOptions,
+            'conditionsHelper',
+            $this->conditionsHelperMock
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function dtestExecuteWithException()
+    {
+        $jsonResult = '{"error":true,"message":"Some error"}';
+        $errorMessage = 'Some error';
+
+        /** @var \Magento\Framework\Json\Helper\Data|\PHPUnit_Framework_MockObject_MockObject $jsonDataHelperMock */
+        $jsonDataHelperMock = $this->getMockBuilder('Magento\Framework\Json\Helper\Data')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $jsonDataHelperMock->expects($this->once())
+            ->method('jsonEncode')
+            ->with(['error' => true, 'message' => $errorMessage])
+            ->willReturn($jsonResult);
+
+        $this->viewMock->expects($this->once())
+            ->method('loadLayout')
+            ->willThrowException(new LocalizedException(__($errorMessage)));
+        $this->objectManagerMock->expects($this->once())
+            ->method('get')
+            ->with('Magento\Framework\Json\Helper\Data')
+            ->willReturn($jsonDataHelperMock);
+        $this->responseMock->expects($this->once())
+            ->method('representJson')
+            ->with($jsonResult)
+            ->willReturnArgument(0);
+
+        $this->loadOptions->execute();
+    }
+
+    /**
+     * @return void
+     */
+    public function testExecute()
+    {
+        $widgetType = 'Magento\SomeWidget';
+        $conditionsEncoded = 'a:3:{s:5:"value";i:1;s:8:"operator";s:2:"==";s:9:"attribute";s:2:"id";}';
+        $conditionsDecoded = [
+            'value' => 1,
+            'operator' => '==',
+            'attribute' => 'id',
+        ];
+        $widgetJsonParams = '{"widget_type":"Magento\\Widget","values":{"title":"&quot;Test&quot;", "":}}';
+        $widgetArrayParams = [
+            'widget_type' => $widgetType,
+            'values' => [
+                'title' => '&quot;Test&quot;',
+                'conditions_encoded' => $conditionsEncoded,
+            ],
+        ];
+        $resultWidgetArrayParams = [
+            'widget_type' => $widgetType,
+            'values' => [
+                'title' => '"Test"',
+                'conditions_encoded' => $conditionsEncoded,
+                'conditions' => $conditionsDecoded,
+            ],
+        ];
+
+        /** @var \Magento\Framework\Json\Helper\Data|\PHPUnit_Framework_MockObject_MockObject $jsonDataHelperMock */
+        $jsonDataHelperMock = $this->getMockBuilder('Magento\Framework\Json\Helper\Data')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $jsonDataHelperMock->expects($this->once())
+            ->method('jsonDecode')
+            ->with($widgetJsonParams)
+            ->willReturn($widgetArrayParams);
+
+        $this->viewMock->expects($this->once())
+            ->method('loadLayout');
+        $this->requestMock->expects($this->once())
+            ->method('getParam')
+            ->with('widget')
+            ->willReturn($widgetJsonParams);
+        $this->objectManagerMock->expects($this->once())
+            ->method('get')
+            ->with('Magento\Framework\Json\Helper\Data')
+            ->willReturn($jsonDataHelperMock);
+
+        /** @var \Magento\Framework\View\Element\BlockInterface|\PHPUnit_Framework_MockObject_MockObject $blockMock */
+        $blockMock = $this->getMockBuilder(\Magento\Framework\View\Element\BlockInterface::class)
+            ->setMethods(['setWidgetType', 'setWidgetValues'])
+            ->getMockForAbstractClass();
+        $blockMock->expects($this->once())
+            ->method('setWidgetType')
+            ->with($widgetType)
+            ->willReturnSelf();
+        $blockMock->expects($this->once())
+            ->method('setWidgetValues')
+            ->with($resultWidgetArrayParams['values'])
+            ->willReturnSelf();
+
+        /** @var \Magento\Framework\View\LayoutInterface|\PHPUnit_Framework_MockObject_MockObject $layoutMock */
+        $layoutMock = $this->getMockForAbstractClass(\Magento\Framework\View\LayoutInterface::class);
+        $layoutMock->expects($this->once())
+            ->method('getBlock')
+            ->with('wysiwyg_widget.options')
+            ->willReturn($blockMock);
+
+        $this->conditionsHelperMock->expects($this->once())
+            ->method('decode')
+            ->with($conditionsEncoded)
+            ->willReturn($conditionsDecoded);
+        $this->viewMock->expects($this->once())
+            ->method('getLayout')
+            ->willReturn($layoutMock);
+        $this->viewMock->expects($this->once())
+            ->method('renderLayout');
+
+        $this->loadOptions->execute();
+    }
+}

--- a/app/code/Magento/Widget/Test/Unit/Model/WidgetTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/WidgetTest.php
@@ -5,12 +5,20 @@
  */
 namespace Magento\Widget\Test\Unit\Model;
 
+/**
+ * Test class for \Magento\Widget\Model\Widget
+ */
 class WidgetTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Magento\Widget\Model\Config\Data|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $dataStorageMock;
+
+    /**
+     * @var \Magento\Framework\Escaper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $escaperMock;
 
     /**
      * @var \Magento\Widget\Model\Widget
@@ -24,17 +32,24 @@ class WidgetTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->dataStorageMock = $this->getMockBuilder('Magento\Widget\Model\Config\Data')
+        $this->dataStorageMock = $this->getMockBuilder(\Magento\Widget\Model\Config\Data::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->conditionsHelper = $this->getMockBuilder('\Magento\Widget\Helper\Conditions')
+        $this->conditionsHelper = $this->getMockBuilder(\Magento\Widget\Helper\Conditions::class)
             ->setMethods(['encode'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->escaperMock = $this->getMockBuilder(\Magento\Framework\Escaper::class)
             ->disableOriginalConstructor()
             ->getMock();
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->widget = $objectManagerHelper->getObject(
-            'Magento\Widget\Model\Widget',
-            ['dataStorage' => $this->dataStorageMock, 'conditionsHelper' => $this->conditionsHelper]
+            \Magento\Widget\Model\Widget::class,
+            [
+                'dataStorage' => $this->dataStorageMock,
+                'conditionsHelper' => $this->conditionsHelper,
+                'escaper' => $this->escaperMock,
+            ]
         );
     }
 
@@ -147,7 +162,7 @@ class WidgetTest extends \PHPUnit_Framework_TestCase
             ]
         ];
         $params = [
-            'title' => 'my widget',
+            'title' => 'my "widget"',
             'show_pager' => '1',
             'products_per_page' => '5',
             'products_count' => '10',
@@ -157,8 +172,20 @@ class WidgetTest extends \PHPUnit_Framework_TestCase
 
         $this->conditionsHelper->expects($this->once())->method('encode')->with($conditions)
             ->willReturn('encoded-conditions-string');
+        $this->escaperMock->expects($this->atLeastOnce())
+            ->method('escapeQuote')
+            ->willReturnMap([
+                ['my "widget"', false, 'my &quot;widget&quot;'],
+                ['1', false, '1'],
+                ['5', false, '5'],
+                ['10', false, '10'],
+                ['product/widget/content/grid.phtml', false, 'product/widget/content/grid.phtml'],
+                ['encoded-conditions-string', false, 'encoded-conditions-string'],
+            ]);
+
         $result = $this->widget->getWidgetDeclaration('Magento\CatalogWidget\Block\Product\ProductsList', $params);
         $this->assertContains('{{widget type="Magento\CatalogWidget\Block\Product\ProductsList"', $result);
+        $this->assertContains('title="my &quot;widget&quot;"', $result);
         $this->assertContains('conditions_encoded="encoded-conditions-string"', $result);
         $this->assertContains('page_var_name="pasdf"}}', $result);
     }


### PR DESCRIPTION
### Description
This is a backport of MAGETWO-54243 for Magento 2.1
See the commit message to see from which commits I cherry-picked this.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/3860: Directive values are not quote-escaped
2. https://github.com/magento/magento2/issues/7661: Backend CMS Widgets: Umlauts and "Catalog Products List"-Conditions fail to insert

@KrystynaKabannyk mentioned that this was planned for Magento 2.1.9, so if this PR can speed this up, then I'm happy to do so :)

