### PR TITLE
Update attribute vat_id frontend_label to make it translatable

### DIFF
--- a/app/code/Magento/Customer/Setup/UpgradeData.php
+++ b/app/code/Magento/Customer/Setup/UpgradeData.php
@@ -155,6 +155,10 @@ class UpgradeData implements UpgradeDataInterface
             );
         }
 
+        if (version_compare($context->getVersion(), '2.0.12', '<')) {
+            $this->upgradeVersionTwoZeroTwelve($customerSetup);
+        }
+
         $indexer = $this->indexerRegistry->get(Customer::CUSTOMER_GRID_INDEXER_ID);
         $indexer->reindexAll();
         $this->eavConfig->clear();
@@ -634,6 +638,15 @@ class UpgradeData implements UpgradeDataInterface
                 'system' => true,
             ]
         );
+    }
+
+    /**
+     * @param CustomerSetup $customerSetup
+     * @return void
+     */
+    private function upgradeVersionTwoZeroTwelve($customerSetup)
+    {
+        $customerSetup->updateAttribute('customer_address', 'vat_id', 'frontend_label', 'VAT Number');
     }
 
     /**

--- a/app/code/Magento/Customer/Setup/UpgradeData.php
+++ b/app/code/Magento/Customer/Setup/UpgradeData.php
@@ -644,7 +644,7 @@ class UpgradeData implements UpgradeDataInterface
      * @param CustomerSetup $customerSetup
      * @return void
      */
-    private function upgradeVersionTwoZeroTwelve($customerSetup)
+    private function upgradeVersionTwoZeroTwelve(CustomerSetup $customerSetup)
     {
         $customerSetup->updateAttribute('customer_address', 'vat_id', 'frontend_label', 'VAT Number');
     }

--- a/app/code/Magento/Customer/etc/module.xml
+++ b/app/code/Magento/Customer/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Customer" setup_version="2.0.11">
+    <module name="Magento_Customer" setup_version="2.0.12">
         <sequence>
             <module name="Magento_Eav"/>
             <module name="Magento_Directory"/>


### PR DESCRIPTION
### Description
`VAT Number` field in checkout isn't translated because label is `VAT number`. This PR will update the `frontend_label` of `vat_id` to make it translatable again.

### Fixed Issues (if relevant)
1. None that I could find.

### Manual testing scenarios
1. Install for example https://github.com/ho-nl/magento2-nl_NL (Source of strings is Crowdin).
2. On checkout page `VAT Number` isn't translated.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
