### PR TITLE
Fix wrong ACL for Developer Section

### DIFF
--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -108,7 +108,7 @@
         <section id="dev" translate="label" type="text" sortOrder="920" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Developer</label>
             <tab>advanced</tab>
-            <resource>Magento_Backend::dev</resource>
+            <resource>Magento_Config::dev</resource>
             <group id="debug" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Debug</label>
                 <field id="template_hints_storefront" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
### Description
Correct the ACL for the Developer Section

### Fixed Issues (if relevant)
1. magento/magento2#10148: Developer ACL incorrect

### Manual testing scenarios
1. Create a new role in the backend
2. Give the role access to the resource 'Developer Section'
3. Create a new account
4. Give the account the new role
5. Login with the new account and go to Stores -> Configuration -> Advanced -> Developer
6. Verify that account can see the menu and has access to it.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
