### PR TITLE
Fix Widget saving non-XML entities to layout_update

### DIFF
--- a/app/code/Magento/Widget/Model/Widget/Instance.php
+++ b/app/code/Magento/Widget/Model/Widget/Instance.php
@@ -595,6 +595,7 @@ class Instance extends \Magento\Framework\Model\AbstractModel
                 $value = implode(',', $value);
             }
             if ($name && strlen((string)$value)) {
+                $value = html_entity_decode($value);
                 $xml .= '<action method="setData">' .
                     '<argument name="name" xsi:type="string">' .
                     $name .


### PR DESCRIPTION
When saving a widget containing `&nbsp;` characters, layout merging fails.

### Description
When saving a widget containing `&nbsp;` characters in the data, layout merging fails. Currently, `\Magento\Widget\Model\Widget\Instance`  escapes the HTML when saving the data to the `layout_update` table. That's not sufficient, because it won't prevent characters like `&nbsp;` being added to the XML. As a side note: the supported character entities in XML are very limited. 
[More about this topic can be found here](https://stackoverflow.com/a/3805097/2117444).

By using `html_entity_decode` before escaping the HTML, there won't be incompatible character entities in the HTML when escaping it.

The use case of having `&nbsp;` in the widget fields may seem a bit extraordinary. My use case(and many other's) is having added a WYSIWYG block to a custom widget. A WYSIWYG produces quite some &nbsp; characters when being used.

### Fixed Issues
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#6594: Magento 2.1 EE: simplexml_load_string() error in custom widget

### Steps to reproduce the problem
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a widget instance containing a text field
2. In that field enter `&nbsp;`
3. Save it
4. Go to an area in the frontend where the widget should appear
5. Crash

### Manual testing procedure
Follow the Steps to reproduce after applying this fix.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
