### PR TITLE
Added try-catch block in getSwatchAttributeImage

### DIFF
--- a/app/code/Magento/Swatches/Helper/Media.php
+++ b/app/code/Magento/Swatches/Helper/Media.php
@@ -109,7 +109,11 @@ class Media extends \Magento\Framework\App\Helper\AbstractHelper
         $absoluteImagePath = $this->mediaDirectory
             ->getAbsolutePath($this->getSwatchMediaPath() . '/' . $generationPath);
         if (!file_exists($absoluteImagePath)) {
-            $this->generateSwatchVariations($file);
+            try {
+                $this->generateSwatchVariations($file);
+            } catch (\Exception $e) {
+                return '';
+            }
         }
         return $this->getSwatchMediaUrl() . '/' . $generationPath;
     }


### PR DESCRIPTION
### Description
getSwatchAttributeImage calls generateSwatchVariations($file), which throws an Exception when the file $file does not exist in the file system (see line 189: $image = $this->imageFactory->create($absoluteImagePath), which calls Image->__construct() and then  Image->open, throwing an Exception on !file_exists($file)). This leads to the rest of the page not being rendered, when just one swatch image is missing. Not great. This fixes it and returns an empty file url (could also return the intended one, or a placeholder).

### Manual testing scenarios
Delete one or more of the images that are used for swatches (alternatively, copy a database from a productive system to a local machine without getting the files, too), then try to visit a category or product page using swatches.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)