### PR TITLE
Fixed: Product attributes labels are not translated on product edit page

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/ui_component/design_config_form.xml
+++ b/app/code/Magento/Backend/view/adminhtml/ui_component/design_config_form.xml
@@ -43,7 +43,7 @@
                     <item name="componentType" xsi:type="string">dynamicRows</item>
                     <item name="recordTemplate" xsi:type="string">record</item>
                     <item name="deleteButtonLabel" xsi:type="string">Remove</item>
-                    <item name="addButtonLabel" xsi:type="string">Add New User Agent Rule</item>
+                    <item name="addButtonLabel" xsi:type="string" translate="true">Add New User Agent Rule</item>
                     <item name="deleteProperty" xsi:type="boolean">false</item>
                     <item name="dndConfig" xsi:type="array">
                         <item name="enabled" xsi:type="boolean">false</item>
@@ -67,7 +67,7 @@
                             <item name="dataType" xsi:type="string">text</item>
                             <item name="dataScope" xsi:type="string">search</item>
                             <item name="fit" xsi:type="boolean">false</item>
-                            <item name="label" xsi:type="string">Search String</item>
+                            <item name="label" xsi:type="string" translate="true">Search String</item>
                             <item name="showFallbackReset" xsi:type="boolean">false</item>
                         </item>
                     </argument>
@@ -80,7 +80,7 @@
                             <item name="dataType" xsi:type="string">text</item>
                             <item name="dataScope" xsi:type="string">value</item>
                             <item name="fit" xsi:type="boolean">false</item>
-                            <item name="label" xsi:type="string">Theme Name</item>
+                            <item name="label" xsi:type="string" translate="true">Theme Name</item>
                             <item name="showFallbackReset" xsi:type="boolean">false</item>
                         </item>
                     </argument>
@@ -91,7 +91,7 @@
                             <item name="componentType" xsi:type="string">actionDelete</item>
                             <item name="dataType" xsi:type="string">text</item>
                             <item name="fit" xsi:type="boolean">false</item>
-                            <item name="label" xsi:type="string">Actions</item>
+                            <item name="label" xsi:type="string" translate="true">Actions</item>
                             <item name="sortOrder" xsi:type="string">50</item>
                             <item name="additionalClasses" xsi:type="string">data-grid-actions-cell</item>
                             <item name="template" xsi:type="string">Magento_Backend/dynamic-rows/cells/action-delete</item>

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Eav.php
@@ -244,7 +244,7 @@ class Eav extends AbstractModifier
             if ($attributes) {
                 $meta[$groupCode]['children'] = $this->getAttributesMeta($attributes, $groupCode);
                 $meta[$groupCode]['arguments']['data']['config']['componentType'] = Fieldset::NAME;
-                $meta[$groupCode]['arguments']['data']['config']['label'] = __('%1', $group->getAttributeGroupName());
+                $meta[$groupCode]['arguments']['data']['config']['label'] = __('%1', __($group->getAttributeGroupName()));
                 $meta[$groupCode]['arguments']['data']['config']['collapsible'] = true;
                 $meta[$groupCode]['arguments']['data']['config']['dataScope'] = self::DATA_SCOPE_PRODUCT;
                 $meta[$groupCode]['arguments']['data']['config']['sortOrder'] =
@@ -546,7 +546,7 @@ class Eav extends AbstractModifier
             'required' => $attribute->getIsRequired(),
             'notice' => $attribute->getNote(),
             'default' => $attribute->getDefaultValue(),
-            'label' => $attribute->getDefaultFrontendLabel(),
+            'label' => __($attribute->getDefaultFrontendLabel()),
             'code' => $attribute->getAttributeCode(),
             'source' => $groupCode,
             'scopeLabel' => $this->getScopeLabel($attribute),
@@ -650,7 +650,7 @@ class Eav extends AbstractModifier
                 'formElement' => 'container',
                 'componentType' => 'container',
                 'breakLine' => false,
-                'label' => $attribute->getDefaultFrontendLabel(),
+                'label' => __($attribute->getDefaultFrontendLabel()),
                 'required' => $attribute->getIsRequired(),
             ]
         );

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
@@ -33,7 +33,17 @@
                 <item name="sticky" xsi:type="boolean">true</item>
             </item>
         </argument>
-        <bookmark name="bookmarks"/>
+        <container name="bookmarks">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="component" xsi:type="string">Magento_Ui/js/grid/controls/bookmarks/bookmarks</item>
+                    <item name="displayArea" xsi:type="string">dataGridActions</item>
+                    <item name="storageConfig" xsi:type="array">
+                        <item name="provider" xsi:type="string">localStorage</item>
+                    </item>
+                </item>
+            </argument>
+        </container>
         <columnsControls name="columns_controls"/>
         <filters name="listing_filters">
             <filterSelect name="store_id">

--- a/app/code/Magento/CatalogRule/view/adminhtml/ui_component/catalog_rule_form.xml
+++ b/app/code/Magento/CatalogRule/view/adminhtml/ui_component/catalog_rule_form.xml
@@ -72,7 +72,7 @@
         <field name="name">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">Rule Name</item>
+                    <item name="label" xsi:type="string" translate="true">Rule Name</item>
                     <item name="visible" xsi:type="boolean">true</item>
                     <item name="dataType" xsi:type="string">text</item>
                     <item name="formElement" xsi:type="string">input</item>
@@ -87,7 +87,7 @@
         <field name="description">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">Description</item>
+                    <item name="label" xsi:type="string" translate="true">Description</item>
                     <item name="visible" xsi:type="boolean">true</item>
                     <item name="dataType" xsi:type="string">text</item>
                     <item name="formElement" xsi:type="string">textarea</item>
@@ -99,7 +99,7 @@
         <field name="is_active">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">Status</item>
+                    <item name="label" xsi:type="string" translate="true">Status</item>
                     <item name="visible" xsi:type="boolean">true</item>
                     <item name="dataType" xsi:type="string">number</item>
                     <item name="formElement" xsi:type="string">select</item>
@@ -121,7 +121,7 @@
         <field name="website_ids">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">Websites</item>
+                    <item name="label" xsi:type="string" translate="true">Websites</item>
                     <item name="dataType" xsi:type="string">number</item>
                     <item name="formElement" xsi:type="string">multiselect</item>
                     <item name="validation" xsi:type="array">
@@ -140,7 +140,7 @@
         <field name="customer_group_ids">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">Customer Groups</item>
+                    <item name="label" xsi:type="string" translate="true">Customer Groups</item>
                     <item name="dataType" xsi:type="string">number</item>
                     <item name="formElement" xsi:type="string">multiselect</item>
                     <item name="validation" xsi:type="array">
@@ -155,7 +155,7 @@
         <field name="from_date">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">From</item>
+                    <item name="label" xsi:type="string" translate="true">From</item>
                     <item name="visible" xsi:type="boolean">true</item>
                     <item name="dataType" xsi:type="string">text</item>
                     <item name="formElement" xsi:type="string">date</item>
@@ -170,7 +170,7 @@
         <field name="to_date">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">To</item>
+                    <item name="label" xsi:type="string" translate="true">To</item>
                     <item name="visible" xsi:type="boolean">true</item>
                     <item name="dataType" xsi:type="string">text</item>
                     <item name="formElement" xsi:type="string">date</item>
@@ -185,7 +185,7 @@
         <field name="sort_order">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">Priority</item>
+                    <item name="label" xsi:type="string" translate="true">Priority</item>
                     <item name="dataType" xsi:type="string">text</item>
                     <item name="formElement" xsi:type="string">input</item>
                     <item name="source" xsi:type="string">catalog_rule</item>
@@ -205,7 +205,7 @@
         <field name="simple_action">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">Apply</item>
+                    <item name="label" xsi:type="string" translate="true">Apply</item>
                     <item name="dataType" xsi:type="string">number</item>
                     <item name="formElement" xsi:type="string">select</item>
                     <item name="source" xsi:type="string">catalog_rule</item>
@@ -274,7 +274,7 @@
         <field name="discount_amount">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">Discount Amount</item>
+                    <item name="label" xsi:type="string" translate="true">Discount Amount</item>
                     <item name="dataType" xsi:type="string">text</item>
                     <item name="formElement" xsi:type="string">input</item>
                     <item name="source" xsi:type="string">catalog_rule</item>
@@ -288,7 +288,7 @@
         <field name="stop_rules_processing">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="label" xsi:type="string">Discard subsequent rules</item>
+                    <item name="label" xsi:type="string" translate="true">Discard subsequent rules</item>
                     <item name="fieldGroup" xsi:type="string">bool</item>
                     <item name="dataType" xsi:type="string">number</item>
                     <item name="formElement" xsi:type="string">select</item>

--- a/app/code/Magento/Theme/view/adminhtml/templates/title.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/title.phtml
@@ -15,6 +15,6 @@ $title = $block->escapeHtml($block->getPageTitle());
 ?>
 
 <div class="page-title-wrapper<?php /* @escapeNotVerified */ echo $titleClass; ?>">
-    <h1 class="page-title"<?php /* @escapeNotVerified */ echo $titleId?>><?php /* @escapeNotVerified */ echo $title ?></h1>
+    <h1 class="page-title"<?php /* @escapeNotVerified */ echo $titleId?>><?php /* @escapeNotVerified */ echo __($title) ?></h1>
     <?php echo $block->getChildHtml(); ?>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

The attributes on product page can't be translated.

### Description
<!--- Provide a description of the changes proposed in the pull request -->

I found where the data is provided and I simple changed the return of function add the "___()", to be can be able translation by csv file.

Page: http://prntscr.com/fswiix
Code: http://prntscr.com/fswivh
CSV: http://prntscr.com/fswjdj

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#1980: Issue title: Product attributes' labels are not translated on product edit page

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
