### PR TITLE
magento/magento2:#6175 Fixed Unable to generate unsecure URL if current URL is secure

### DIFF
--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -361,7 +361,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
      */
     protected function _isSecure()
     {
-        if ($this->_request->isSecure() && !$this->getRouteParamsResolver()->hasData('secure')) {
+        if ($this->_request->isSecure()) {
             if($this->getRouteParamsResolver()->hasData('secure')){
                 return (bool) $this->getRouteParamsResolver()->getData('secure');
             }

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -361,8 +361,12 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
      */
     protected function _isSecure()
     {
-        if ($this->_request->isSecure()) {
+        if ($this->_request->isSecure() && !$this->getRouteParamsResolver()->hasData('secure')) {
             return true;
+        }
+
+        if($this->getRouteParamsResolver()->hasData('secure')){
+            return (bool) $this->getRouteParamsResolver()->getData('secure');
         }
 
         if ($this->getRouteParamsResolver()->hasData('secure_is_forced')) {

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -362,11 +362,10 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
     protected function _isSecure()
     {
         if ($this->_request->isSecure() && !$this->getRouteParamsResolver()->hasData('secure')) {
+            if($this->getRouteParamsResolver()->hasData('secure')){
+                return (bool) $this->getRouteParamsResolver()->getData('secure');
+            }
             return true;
-        }
-
-        if($this->getRouteParamsResolver()->hasData('secure')){
-            return (bool) $this->getRouteParamsResolver()->getData('secure');
         }
 
         if ($this->getRouteParamsResolver()->hasData('secure_is_forced')) {


### PR DESCRIPTION
### Description
When calling getUrl from a secure connection ( HTTPS ) with param _secure = false we are getting secure URL instead of unsecured.

### Fixed Issues (if relevant)
1. magento/magento2#6175: Unable to generate unsecure URL if current URL is secure

### Manual testing scenarios
###Preconditions

Magento 2 version 2.1.0
Use \Magento\Framework\Url::getUrl() from secure area of the store

###Steps to reproduce

Make sure code is executed in secure area of the store (HTTPS)
Generate URL in code
    /**
     * @var \Magento\Framework\Url
     */
    protected $url;
...
    $this->url->getUrl(
        'test/test/test',
        [
            '_secure' => false
        ]
    )

Expected result
http://example.com/test/test/test

Actual result
http://example.com/test/test/test

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
