### PR TITLE
Feature/add config for varnish exclude parameters

### DIFF
--- a/app/code/Magento/PageCache/Console/Command/GenerateVclCommand.php
+++ b/app/code/Magento/PageCache/Console/Command/GenerateVclCommand.php
@@ -289,5 +289,4 @@ class GenerateVclCommand extends Command
 
         return $expressions ? $this->serializer->unserialize($expressions) : [];
     }
-
 }

--- a/app/code/Magento/PageCache/Console/Command/GenerateVclCommand.php
+++ b/app/code/Magento/PageCache/Console/Command/GenerateVclCommand.php
@@ -52,6 +52,11 @@ class GenerateVclCommand extends Command
     const GRACE_PERIOD_OPTION = 'grace-period';
 
     /**
+     * Normalize parameters
+     */
+    const NORMALIZE_PARAMS_OPTION = 'normalize-params';
+
+    /**
      * Output file option name
      */
     const OUTPUT_FILE_OPTION = 'output-file';
@@ -74,6 +79,7 @@ class GenerateVclCommand extends Command
         self::BACKEND_PORT_OPTION => 'backendPort',
         self::BACKEND_HOST_OPTION => 'backendHost',
         self::GRACE_PERIOD_OPTION => 'gracePeriod',
+        self::NORMALIZE_PARAMS_OPTION => 'normalizeParams',
     ];
 
     /**
@@ -200,6 +206,14 @@ class GenerateVclCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Grace period in seconds',
                 300
+            ),
+            new InputOption(
+                self::NORMALIZE_PARAMS_OPTION,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'A comma separated list of query string parameters which should be stripped from the varnish request url
+                when determining a match for the page.',
+                'gclid,gclsrc,utm_content,utm_term,utm_campaign,utm_medium,utm_source,_ga'
             ),
             new InputOption(
                 self::OUTPUT_FILE_OPTION,

--- a/app/code/Magento/PageCache/Console/Command/GenerateVclCommand.php
+++ b/app/code/Magento/PageCache/Console/Command/GenerateVclCommand.php
@@ -289,4 +289,5 @@ class GenerateVclCommand extends Command
 
         return $expressions ? $this->serializer->unserialize($expressions) : [];
     }
+
 }

--- a/app/code/Magento/PageCache/Model/Config.php
+++ b/app/code/Magento/PageCache/Model/Config.php
@@ -43,6 +43,8 @@ class Config
 
     const XML_VARNISH_PAGECACHE_DESIGN_THEME_REGEX = 'design/theme/ua_regexp';
 
+    const XML_VARNISH_PAGECACHE_NORMALIZE_PARAMS = 'system/full_page_cache/varnish/normalize_params';
+
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
@@ -183,7 +185,8 @@ class Config
                 '-',
                 $this->_scopeConfig->getValue(\Magento\Framework\HTTP\PhpEnvironment\Request::XML_PATH_OFFLOADER_HEADER)
             ),
-            '/* {{ grace_period }} */' => $this->_scopeConfig->getValue(self::XML_VARNISH_PAGECACHE_GRACE_PERIOD)
+            '/* {{ grace_period }} */' => $this->_scopeConfig->getValue(self::XML_VARNISH_PAGECACHE_GRACE_PERIOD),
+            '/* {{ normalize_params }} */' => $this->_getNormaliseParams()
         ];
     }
 
@@ -248,6 +251,30 @@ class Config
         }
         return $result;
     }
+
+   /**
+   * Get a pipe separated list of query string parameters that Varnish should strip off incoming requests
+   * when determining a match for the page. This can be used to strip tracking parameters off urls
+   * e.g. gclid, gtm_source, gtm_medium etc.
+   *
+   * @return string|null
+   */
+  protected function _getNormaliseParams()
+  {
+      $normaliseParams = $this->_scopeConfig->getValue(
+          self::XML_VARNISH_PAGECACHE_NORMALIZE_PARAMS,
+          \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+      );
+
+      if (empty($normaliseParams)) {
+          return $normaliseParams;
+      }
+
+      # strip carriage returns and trailing comma if present and swap out for pipes.
+      $normaliseParams = preg_replace("/(\r|\n)*|\|$/","",str_replace(",","|",$normaliseParams));
+
+      return $normaliseParams;
+  }
 
     /**
      * Whether a cache type is enabled in Cache Management Grid

--- a/app/code/Magento/PageCache/Model/Config.php
+++ b/app/code/Magento/PageCache/Model/Config.php
@@ -43,6 +43,8 @@ class Config
 
     const XML_VARNISH_PAGECACHE_DESIGN_THEME_REGEX = 'design/theme/ua_regexp';
 
+    const XML_VARNISH_PAGECACHE_NORMALIZE_PARAMS = 'system/full_page_cache/varnish/normalize_params';
+
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
@@ -158,6 +160,7 @@ class Config
             'designExceptions' => $designExceptions ? $this->serializer->unserialize($designExceptions) : [],
             'sslOffloadedHeader' => $sslOffloadedHeader,
             'gracePeriod' => $this->_scopeConfig->getValue(self::XML_VARNISH_PAGECACHE_GRACE_PERIOD),
+            'normalizeParams' => $this->_scopeConfig->getValue(self::XML_VARNISH_PAGECACHE_NORMALIZE_PARAMS)
         ]);
         return $vclGenerator->generateVcl($version);
     }

--- a/app/code/Magento/PageCache/Model/Config.php
+++ b/app/code/Magento/PageCache/Model/Config.php
@@ -43,8 +43,6 @@ class Config
 
     const XML_VARNISH_PAGECACHE_DESIGN_THEME_REGEX = 'design/theme/ua_regexp';
 
-    const XML_VARNISH_PAGECACHE_NORMALIZE_PARAMS = 'system/full_page_cache/varnish/normalize_params';
-
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
@@ -159,7 +157,7 @@ class Config
             'accessList' => $accessList ? explode(',', $accessList) : [],
             'designExceptions' => $designExceptions ? $this->serializer->unserialize($designExceptions) : [],
             'sslOffloadedHeader' => $sslOffloadedHeader,
-            'gracePeriod' => $this->_scopeConfig->getValue(self::XML_VARNISH_PAGECACHE_GRACE_PERIOD)
+            'gracePeriod' => $this->_scopeConfig->getValue(self::XML_VARNISH_PAGECACHE_GRACE_PERIOD),
         ]);
         return $vclGenerator->generateVcl($version);
     }
@@ -185,8 +183,7 @@ class Config
                 '-',
                 $this->_scopeConfig->getValue(\Magento\Framework\HTTP\PhpEnvironment\Request::XML_PATH_OFFLOADER_HEADER)
             ),
-            '/* {{ grace_period }} */' => $this->_scopeConfig->getValue(self::XML_VARNISH_PAGECACHE_GRACE_PERIOD),
-            '/* {{ normalize_params }} */' => $this->_getNormaliseParams()
+            '/* {{ grace_period }} */' => $this->_scopeConfig->getValue(self::XML_VARNISH_PAGECACHE_GRACE_PERIOD)
         ];
     }
 
@@ -251,30 +248,6 @@ class Config
         }
         return $result;
     }
-
-   /**
-   * Get a pipe separated list of query string parameters that Varnish should strip off incoming requests
-   * when determining a match for the page. This can be used to strip tracking parameters off urls
-   * e.g. gclid, gtm_source, gtm_medium etc.
-   *
-   * @return string|null
-   */
-  protected function _getNormaliseParams()
-  {
-      $normaliseParams = $this->_scopeConfig->getValue(
-          self::XML_VARNISH_PAGECACHE_NORMALIZE_PARAMS,
-          \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-      );
-
-      if (empty($normaliseParams)) {
-          return $normaliseParams;
-      }
-
-      # strip carriage returns and trailing comma if present and swap out for pipes.
-      $normaliseParams = preg_replace("/(\r|\n)*|\|$/","",str_replace(",","|",$normaliseParams));
-
-      return $normaliseParams;
-  }
 
     /**
      * Whether a cache type is enabled in Cache Management Grid

--- a/app/code/Magento/PageCache/Model/Varnish/VclGenerator.php
+++ b/app/code/Magento/PageCache/Model/Varnish/VclGenerator.php
@@ -130,7 +130,7 @@ class VclGenerator implements VclGeneratorInterface
         }
 
         # convert comma separated list of normalised params into a pipe separated list ready for the regular expression
-        $normalizeParams = preg_replace("/(\r|\n)*|\|$/","",str_replace(",","|",$this->normalizeParams));
+        $normalizeParams = preg_replace("/(\r|\n)*|\|$/", "", str_replace(",", "|", $this->normalizeParams));
 
         # add parameters into regular expression
         $tpl  = "# strip normalized parameters from query string\n";

--- a/app/code/Magento/PageCache/Model/Varnish/VclGenerator.php
+++ b/app/code/Magento/PageCache/Model/Varnish/VclGenerator.php
@@ -59,6 +59,7 @@ class VclGenerator implements VclGeneratorInterface
      * @param int $backendPort
      * @param array $accessList
      * @param int $gracePeriod
+     * @param string $normalizeParams
      * @param string $sslOffloadedHeader
      * @param array $designExceptions
      */
@@ -118,13 +119,13 @@ class VclGenerator implements VclGeneratorInterface
 
     /**
      * turn a comma separated list of string parameters that Varnish should strip off incoming requests
-     * into a varnish regular expresion command
+     * into a varnish regular expression command
      *
      * @return string
      */
     private function getNormalizeParams()
     {
-        if (empty($this->normalizeParams)) {
+        if (empty(trim($this->normalizeParams))) {
             return false;
         }
 
@@ -132,12 +133,11 @@ class VclGenerator implements VclGeneratorInterface
         $normalizeParams = preg_replace("/(\r|\n)*|\|$/","",str_replace(",","|",$this->normalizeParams));
 
         # add parameters into regular expression
-        $tpl  = "    # strip normalized parameters from query string \n";
+        $tpl  = "# strip normalized parameters from query string \n";
         $tpl .= "    set req.url = regsuball(req.url, \"((\?)|&)(%s)=[^&]*\", \"\2\"); \n";
         $tpl .= "    set req.url = regsub(req.url, \"(\?&|\?|&)$\", \"\"); \n";
 
         return sprintf($tpl, $normalizeParams);
-
     }
 
     /**

--- a/app/code/Magento/PageCache/Model/Varnish/VclGenerator.php
+++ b/app/code/Magento/PageCache/Model/Varnish/VclGenerator.php
@@ -133,9 +133,9 @@ class VclGenerator implements VclGeneratorInterface
         $normalizeParams = preg_replace("/(\r|\n)*|\|$/","",str_replace(",","|",$this->normalizeParams));
 
         # add parameters into regular expression
-        $tpl  = "# strip normalized parameters from query string \n";
-        $tpl .= "    set req.url = regsuball(req.url, \"((\?)|&)(%s)=[^&]*\", \"\2\"); \n";
-        $tpl .= "    set req.url = regsub(req.url, \"(\?&|\?|&)$\", \"\"); \n";
+        $tpl  = "# strip normalized parameters from query string\n";
+        $tpl .= "    set req.url = regsuball(req.url, \"((\?)|&)(%s)=[^&]*\", \"\2\");\n";
+        $tpl .= "    set req.url = regsub(req.url, \"(\?&|\?|&)$\", \"\");\n";
 
         return sprintf($tpl, $normalizeParams);
     }

--- a/app/code/Magento/PageCache/Model/Varnish/VclGenerator.php
+++ b/app/code/Magento/PageCache/Model/Varnish/VclGenerator.php
@@ -32,6 +32,11 @@ class VclGenerator implements VclGeneratorInterface
     private $gracePeriod;
 
     /**
+     * @var string|null
+     */
+    private $normalizeParams;
+
+    /**
      * @var VclTemplateLocatorInterface
      */
     private $vclTemplateLocator;
@@ -63,6 +68,7 @@ class VclGenerator implements VclGeneratorInterface
         $backendPort,
         $accessList,
         $gracePeriod,
+        $normalizeParams,
         $sslOffloadedHeader,
         $designExceptions = []
     ) {
@@ -70,6 +76,7 @@ class VclGenerator implements VclGeneratorInterface
         $this->backendPort = $backendPort;
         $this->accessList = $accessList;
         $this->gracePeriod = $gracePeriod;
+        $this->normalizeParams = $normalizeParams;
         $this->vclTemplateLocator = $vclTemplateLocator;
         $this->sslOffloadedHeader = $sslOffloadedHeader;
         $this->designExceptions = $designExceptions;
@@ -105,7 +112,32 @@ class VclGenerator implements VclGeneratorInterface
             // Apache and Nginx drop all headers with underlines by default.
             '/* {{ ssl_offloaded_header }} */' => str_replace('_', '-', $this->getSslOffloadedHeader()),
             '/* {{ grace_period }} */' => $this->getGracePeriod(),
+            '/* {{ normalize_params }} */' => $this->getNormalizeParams(),
         ];
+    }
+
+    /**
+     * turn a comma separated list of string parameters that Varnish should strip off incoming requests
+     * into a varnish regular expresion command
+     *
+     * @return string
+     */
+    private function getNormalizeParams()
+    {
+        if (empty($this->normalizeParams)) {
+            return false;
+        }
+
+        # convert comma separated list of normalised params into a pipe separated list ready for the regular expression
+        $normalizeParams = preg_replace("/(\r|\n)*|\|$/","",str_replace(",","|",$this->normalizeParams));
+
+        # add parameters into regular expression
+        $tpl  = "    # strip normalized parameters from query string \n";
+        $tpl .= "    set req.url = regsuball(req.url, \"((\?)|&)(%s)=[^&]*\", \"\2\"); \n";
+        $tpl .= "    set req.url = regsub(req.url, \"(\?&|\?|&)$\", \"\"); \n";
+
+        return sprintf($tpl, $normalizeParams);
+
     }
 
     /**

--- a/app/code/Magento/PageCache/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Model/ConfigTest.php
@@ -120,6 +120,12 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                         null,
                         120
                     ],
+                    [
+                        \Magento\PageCache\Model\Config::XML_VARNISH_PAGECACHE_NORMALIZE_PARAMS,
+                        \Magento\Framework\App\Config\ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+                        null,
+                        'gclid,gclsrc,utm_content,utm_term,utm_campaign,utm_medium,utm_source,_ga'
+                    ],
                 ]
             )
         );
@@ -146,7 +152,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'accessList' =>  explode(',', '127.0.0.1, 192.168.0.1,127.0.0.2'),
             'designExceptions' => [['regexp' => '(?i)pattern', 'value' => 'value_for_pattern']],
             'sslOffloadedHeader' => 'X_Forwarded_Proto: https',
-            'gracePeriod' => 120
+            'gracePeriod' => 120,
+            'normalizeParams' => 'gclid,gclsrc,utm_content,utm_term,utm_campaign,utm_medium,utm_source,_ga'
         ];
         $vclGeneratorFactory->expects($this->any())
             ->method('create')
@@ -157,6 +164,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 '8080',
                 explode(',', '127.0.0.1,192.168.0.1,127.0.0.2'),
                 120,
+                'gclid,gclsrc,utm_content,utm_term,utm_campaign,utm_medium,utm_source,_ga',
                 'X_Forwarded_Proto: https',
                 [['regexp' => '(?i)pattern', 'value' => 'value_for_pattern']]
             )));

--- a/app/code/Magento/PageCache/Test/Unit/Model/_files/result.vcl
+++ b/app/code/Magento/PageCache/Test/Unit/Model/_files/result.vcl
@@ -17,3 +17,8 @@
 
     grace:
     120
+
+    normalize parameters:
+    # strip normalized parameters from query string
+    set req.url = regsuball(req.url, "((\?)|&)(gclid|gclsrc|utm_content|utm_term|utm_campaign|utm_medium|utm_source|_ga)=[^&]*", "");
+    set req.url = regsub(req.url, "(\?&|\?|&)$", "");

--- a/app/code/Magento/PageCache/Test/Unit/Model/_files/test.vcl
+++ b/app/code/Magento/PageCache/Test/Unit/Model/_files/test.vcl
@@ -1,15 +1,24 @@
 //  Copyright © Magento, Inc. All rights reserved.
 //  See COPYING.txt for license details.
-    /* {{ host }} */:/* {{ port }} */
+    example.com:8080
 
     by ips:
-/* {{ ips }} */
+    "127.0.0.1";
+    "192.168.0.1";
+    "127.0.0.2";
 
     design exceptions:
-    /* {{ design_exceptions_code }} */
+    if (req.http.user-agent ~ "(?pattern)?i") {
+        hash_data("value_for_pattern");
+    }
 
     ssl offloaded header:
-    /* {{ ssl_offloaded_header }} */
+    X-Forwarded-Proto: https
 
     grace:
-    /* {{ grace_period }} */
+    120
+
+    normalize parameters:
+    # strip normalized parameters from query string
+    set req.url = regsuball(req.url, "((\?)|&)(gclid|gclsrc|utm_content|utm_term|utm_campaign|utm_medium|utm_source|_ga)=[^&]*", "");
+    set req.url = regsub(req.url, "(\?&|\?|&)$", "");

--- a/app/code/Magento/PageCache/Test/Unit/Model/_files/test.vcl
+++ b/app/code/Magento/PageCache/Test/Unit/Model/_files/test.vcl
@@ -1,24 +1,18 @@
 //  Copyright © Magento, Inc. All rights reserved.
 //  See COPYING.txt for license details.
-    example.com:8080
+    /* {{ host }} */:/* {{ port }} */
 
     by ips:
-    "127.0.0.1";
-    "192.168.0.1";
-    "127.0.0.2";
+/* {{ ips }} */
 
     design exceptions:
-    if (req.http.user-agent ~ "(?pattern)?i") {
-        hash_data("value_for_pattern");
-    }
+    /* {{ design_exceptions_code }} */
 
     ssl offloaded header:
-    X-Forwarded-Proto: https
+    /* {{ ssl_offloaded_header }} */
 
     grace:
-    120
+    /* {{ grace_period }} */
 
     normalize parameters:
-    # strip normalized parameters from query string
-    set req.url = regsuball(req.url, "((\?)|&)(gclid|gclsrc|utm_content|utm_term|utm_campaign|utm_medium|utm_source|_ga)=[^&]*", "");
-    set req.url = regsub(req.url, "(\?&|\?|&)$", "");
+    /* {{ normalize_params }} */

--- a/app/code/Magento/PageCache/etc/adminhtml/system.xml
+++ b/app/code/Magento/PageCache/etc/adminhtml/system.xml
@@ -49,6 +49,14 @@
                             <field id="caching_application">1</field>
                         </depends>
                     </field>
+                    <field id="normalize_params" type="textarea" translate="label comment" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+                        <label>Normalize Parameters</label>
+                        <comment>Comma separated list of query string parameters that Varnish should cleanse from the request URL.</comment>
+                        <backend_model>Magento\PageCache\Model\System\Config\Backend\Varnish</backend_model>
+                        <depends>
+                            <field id="caching_application">1</field>
+                        </depends>
+                    </field>
                     <field id="export_button_version4" type="button" sortOrder="35" showInDefault="1" showInWebsite="0" showInStore="0">
                         <label>Export Configuration</label>
                         <frontend_model>Magento\PageCache\Block\System\Config\Form\Field\Export\Varnish4</frontend_model>

--- a/app/code/Magento/PageCache/etc/config.xml
+++ b/app/code/Magento/PageCache/etc/config.xml
@@ -28,6 +28,7 @@
                     <backend_port>8080</backend_port>
                     <ttl>86400</ttl>
                     <grace_period>300</grace_period>
+                    <normalize_params>gclid,gclsrc,utm_content,utm_term,utm_campaign,utm_medium,utm_source,_ga</normalize_params>
                 </default>
             </full_page_cache>
         </system>

--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -96,7 +96,7 @@ sub vcl_recv {
 
     # second pass to ensure after params have been stripped we're not left with ?!,?,& causing a cache miss
     set req.url = regsub(req.url, "(\?&|\?|&)$", "");
-    
+
     # Static files caching
     if (req.url ~ "^/(pub/)?(media|static)/.*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|html|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|otf|ogg|ogm|opus|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|tiff|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)$") {
         # Static files should not be cached by default
@@ -181,6 +181,8 @@ sub vcl_backend_response {
 
 sub vcl_deliver {
     if (resp.http.X-Magento-Debug) {
+      # set the normalised request url as a http header if magento is in debug mode for easy debugging
+      set resp.http.X-Magento-Cache-Debug-Request-Url = req.url;
         if (resp.http.x-varnish ~ " ") {
             set resp.http.X-Magento-Cache-Debug = "HIT";
             set resp.http.Grace = req.http.grace;

--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -91,11 +91,7 @@ sub vcl_recv {
         }
     }
 
-    # normalize query string parameters that Varnish should not vary cache for
-    set req.url = regsuball(req.url, "((\?)|&)(/* {{ normalize_params }} */)=[^&]*", "\2");
-
-    # second pass to ensure after params have been stripped we're not left with ?!,?,& causing a cache miss
-    set req.url = regsub(req.url, "(\?&|\?|&)$", "");
+    /* {{ normalize_params }} */
 
     # Static files caching
     if (req.url ~ "^/(pub/)?(media|static)/.*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|html|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|otf|ogg|ogm|opus|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|tiff|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)$") {
@@ -181,7 +177,7 @@ sub vcl_backend_response {
 
 sub vcl_deliver {
     if (resp.http.X-Magento-Debug) {
-      # set the normalised request url as a http header if magento is in debug mode for easy debugging
+      # set the normalized request url as a http header if magento is in debug mode for easy debugging
       set resp.http.X-Magento-Cache-Debug-Request-Url = req.url;
         if (resp.http.x-varnish ~ " ") {
             set resp.http.X-Magento-Cache-Debug = "HIT";

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -92,10 +92,11 @@ sub vcl_recv {
         }
     }
 
-    # Remove Google gclid parameters to minimize the cache objects
-    set req.url = regsuball(req.url,"\?gclid=[^&]+$",""); # strips when QS = "?gclid=AAA"
-    set req.url = regsuball(req.url,"\?gclid=[^&]+&","?"); # strips when QS = "?gclid=AAA&foo=bar"
-    set req.url = regsuball(req.url,"&gclid=[^&]+",""); # strips when QS = "?foo=bar&gclid=AAA" or QS = "?foo=bar&gclid=AAA&bar=baz"
+    # normalize query string parameters that Varnish should not vary cache for
+    set req.url = regsuball(req.url, "((\?)|&)(/* {{ normalize_params }} */)=[^&]*", "\2");
+
+    # second pass to ensure after params have been stripped we're not left with ?!,?,& causing a cache miss
+    set req.url = regsub(req.url, "(\?&|\?|&)$", "");
 
     # Static files caching
     if (req.url ~ "^/(pub/)?(media|static)/.*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|html|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|otf|ogg|ogm|opus|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|tiff|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)$") {

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -181,6 +181,8 @@ sub vcl_backend_response {
 }
 
 sub vcl_deliver {
+    # set the normalised request url as a http header if magento is in debug mode for easy debugging
+    set resp.http.X-Magento-Cache-Debug-Request-Url = req.url;
     if (resp.http.X-Magento-Debug) {
         if (resp.http.x-varnish ~ " ") {
             set resp.http.X-Magento-Cache-Debug = "HIT";

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -92,11 +92,7 @@ sub vcl_recv {
         }
     }
 
-    # normalize query string parameters that Varnish should not vary cache for
-    set req.url = regsuball(req.url, "((\?)|&)(/* {{ normalize_params }} */)=[^&]*", "\2");
-
-    # second pass to ensure after params have been stripped we're not left with ?!,?,& causing a cache miss
-    set req.url = regsub(req.url, "(\?&|\?|&)$", "");
+    /* {{ normalize_params }} */
 
     # Static files caching
     if (req.url ~ "^/(pub/)?(media|static)/.*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|html|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|otf|ogg|ogm|opus|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|tiff|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)$") {
@@ -181,7 +177,7 @@ sub vcl_backend_response {
 }
 
 sub vcl_deliver {
-    # set the normalised request url as a http header if magento is in debug mode for easy debugging
+    # set the normalized request url as a http header if magento is in debug mode for easy debugging
     set resp.http.X-Magento-Cache-Debug-Request-Url = req.url;
     if (resp.http.X-Magento-Debug) {
         if (resp.http.x-varnish ~ " ") {

--- a/app/code/Magento/PageCache/i18n/en_US.csv
+++ b/app/code/Magento/PageCache/i18n/en_US.csv
@@ -17,3 +17,5 @@
 "Public content cache lifetime in seconds. If field is empty default value 86400 will be saved. ","Public content cache lifetime in seconds. If field is empty default value 86400 will be saved. "
 "Page Cache","Page Cache"
 "Full page caching","Full page caching"
+"Normalize Parameters","Normalize Parameters"
+"Comma separated list of query string parameters that Varnish should cleanse from the request URL.","Comma separated list of query string parameters that Varnish should cleanse from the request URL."

--- a/dev/tests/integration/testsuite/Magento/PageCache/Model/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/PageCache/Model/ConfigTest.php
@@ -63,7 +63,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'accessList' =>  explode(',', '127.0.0.1,192.168.0.1,127.0.0.2'),
             'designExceptions' => json_decode('{"_":{"regexp":"\/firefox\/i","value":"Magento\/blank"}}', true),
             'sslOffloadedHeader' => 'X-Forwarded-Proto',
-            'gracePeriod' => null
+            'gracePeriod' => null,
+            'normalizeParams' => 'gclid,gclsrc,utm_content,utm_term,utm_campaign,utm_medium,utm_source,_ga'
         ];
         $vclGeneratorFactory->expects($this->any())
             ->method('create')
@@ -74,6 +75,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 '8080',
                 explode(',', '127.0.0.1,192.168.0.1,127.0.0.2'),
                 null,
+                'gclid,gclsrc,utm_content,utm_term,utm_campaign,utm_medium,utm_source,_ga',
                 'X-Forwarded-Proto',
                 json_decode('{"_":{"regexp":"\/firefox\/i","value":"Magento\/blank"}}', true)
             )));
@@ -90,6 +92,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
      * @magentoConfigFixture default/system/full_page_cache/varnish/backend_host example.com
      * @magentoConfigFixture default/system/full_page_cache/varnish/backend_port 8080
      * @magentoConfigFixture default/system/full_page_cache/varnish/access_list 127.0.0.1,192.168.0.1,127.0.0.2
+     * @magentoConfigFixture default/system/full_page_cache/varnish/normalize_params gclid,gclsrc,utm_content,utm_term,utm_campaign,utm_medium,utm_source,_ga
      * @magentoConfigFixture current_store design/theme/ua_regexp {"_":{"regexp":"\/firefox\/i","value":"Magento\/blank"}}
      * @magentoAppIsolation enabled
      */

--- a/dev/tests/integration/testsuite/Magento/PageCache/Model/_files/result.vcl
+++ b/dev/tests/integration/testsuite/Magento/PageCache/Model/_files/result.vcl
@@ -10,3 +10,8 @@
     if (req.http.user-agent ~ "(?i)firefox") {
         hash_data("Magento/blank");
     }
+
+    normalize parameters:
+    # strip normalized parameters from query string
+    set req.url = regsuball(req.url, "((\?)|&)(gclid|gclsrc|utm_content|utm_term|utm_campaign|utm_medium|utm_source|_ga)=[^&]*", "");
+    set req.url = regsub(req.url, "(\?&|\?|&)$", "");

--- a/dev/tests/integration/testsuite/Magento/PageCache/Model/_files/test.vcl
+++ b/dev/tests/integration/testsuite/Magento/PageCache/Model/_files/test.vcl
@@ -6,3 +6,6 @@
 /* {{ ips }} */
 
     /* {{ design_exceptions_code }} */
+
+    normalize parameters:
+    /* {{ normalize_params }} */


### PR DESCRIPTION
References Issue #10087 

### Description
Merchants will often use acquisition campaigns to drive traffic to their website and wish to record this information in Google Analytics.

Whilst the standard Varnish 4 VCL file produced by Magento contains exclusion rules for the 'gclid' parameter often seen in paid ad campaigns; it does not provide website administrators with easy access to extend these parameters.

Acquisition campaigns and re-marketing services often depend on assigning custom query string parameters to the link back to the users website such as www.mywebsite.com?medium=facebook&campaign=summer

When these query string parameters are applied to a url this causes a cache miss in varnish.

A list of common offenders can be seen here: https://github.com/mpchadwick/tracking-query-params-registry/blob/master/data.csv 

### The Fix

This fix provides a couple of things: 

1. The default configuration includes all of the common campaign url's that google uses.
2. It provides website administrators with the option to add in their own custom parameters that should be ignored when determining a match for the page. 
3. It add support for specifying normalize parameters when using the new varnish:vcl:generate command
4. If Magento is in debug mode it will add an additional header to the page 'X-Magento-Cache-Debug-Request-Url' which shows the normalised request url which is useful for debugging during development.

### Fixed Issues (if relevant)
1. magento/magento2#10087 : Varnish VCL: does not exclude Google Campaign URLS

### Manual testing scenarios
1. Install Magento and enable varnish caching using the default normalize parameters
2. Load the website initially (so it is cached in varnish)
3. Load the website again using one of the newly added normalize parameters such as www.mywebsite.com?utm_source=facebook
4. Observe the Varnish headers and see that the page is now cached. 
5. In the admin add some additional normalize parameters of your choosing. 
6. After clearing caches load the page again using the new parameter you have added 
7. Observe that you are still seeing a cache hit in varnish.

### Contribution checklist
 - [x ] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [x ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x ] All automated tests passed successfully (all builds on Travis CI are green)
