### PR TITLE
Update max length for attribute_code (30 to 255)

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute.php
@@ -23,7 +23,7 @@ class Attribute extends \Magento\Eav\Model\Entity\Attribute\AbstractAttribute im
     /**
      * Attribute code max length
      */
-    const ATTRIBUTE_CODE_MAX_LENGTH = 30;
+    const ATTRIBUTE_CODE_MAX_LENGTH = 255;
 
     /**
      * Cache tag


### PR DESCRIPTION
### Description

According with 'attribute_code' (size 255) see in https://github.com/magento/magento2/blob/develop/app/code/Magento/Eav/Setup/InstallSchema.php#L644 , I update the ATTRIBUTE_CODE_MAX_LENGTH constant value from 30 to 255;

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
